### PR TITLE
Move to C#'s lightweight property syntax.

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/CSharpEditAndContinueTestHelpers.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.EditAndContinue
         internal static readonly CSharpEditAndContinueTestHelpers Instance = new CSharpEditAndContinueTestHelpers();
         private static readonly CSharpEditAndContinueAnalyzer s_analyzer = new CSharpEditAndContinueAnalyzer();
 
-        public override AbstractEditAndContinueAnalyzer Analyzer { get { return s_analyzer; } }
+        public override AbstractEditAndContinueAnalyzer Analyzer => s_analyzer;
 
         public override Compilation CreateLibraryCompilation(string name, IEnumerable<SyntaxTree> trees)
         {

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -170,10 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 }
             }
 
-            public override string Language
-            {
-                get { return LanguageNames.CSharp; }
-            }
+            public override string Language => LanguageNames.CSharp;
 
             public override TLanguageService GetService<TLanguageService>()
             {

--- a/src/EditorFeatures/Core/Commands/NavigateToHighlightedReferenceCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/NavigateToHighlightedReferenceCommandArgs.cs
@@ -29,6 +29,6 @@ namespace Microsoft.CodeAnalysis.Editor.Commands
             _direction = direction;
         }
 
-        public NavigateDirection Direction { get { return _direction; } }
+        public NavigateDirection Direction => _direction;
     }
 }

--- a/src/EditorFeatures/Core/Commands/TypeCharCommandArgs.cs
+++ b/src/EditorFeatures/Core/Commands/TypeCharCommandArgs.cs
@@ -23,9 +23,6 @@ namespace Microsoft.CodeAnalysis.Editor.Commands
         /// <summary>
         /// The character that was typed.
         /// </summary>
-        public char TypedChar
-        {
-            get { return _typedChar; }
-        }
+        public char TypedChar => _typedChar;
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -47,13 +47,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 }
             }
 
-            public TextSpan SourceSpan
-            {
-                get
-                {
-                    return _location.SourceSpan;
-                }
-            }
+            public TextSpan SourceSpan => _location.SourceSpan;
 
             public ImmutableArray<INavigableItem> ChildItems => ImmutableArray<INavigableItem>.Empty;
         }

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyDetail.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyDetail.cs
@@ -39,45 +39,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             return location.SourceTree.GetText().GetSubText(TextSpan.FromBounds(start, end)).ToString();
         }
 
-        public int EndColumn
-        {
-            get
-            {
-                return _endColumn;
-            }
-        }
+        public int EndColumn => _endColumn;
 
-        public int EndLine
-        {
-            get
-            {
-                return _endLine;
-            }
-        }
+        public int EndLine => _endLine;
 
-        public string File
-        {
-            get
-            {
-                return _sourceFile;
-            }
-        }
+        public string File => _sourceFile;
 
-        public int StartColumn
-        {
-            get
-            {
-                return _startColumn;
-            }
-        }
+        public int StartColumn => _startColumn;
 
-        public int StartLine
-        {
-            get
-            {
-                return _startLine;
-            }
-        }
+        public int StartLine => _startLine;
 
         public bool SupportsNavigateTo
         {
@@ -87,13 +57,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             }
         }
 
-        public string Text
-        {
-            get
-            {
-                return _text;
-            }
-        }
+        public string Text => _text;
 
         public void NavigateTo()
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyItem.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyItem.cs
@@ -75,29 +75,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             }
         }
 
-        public string ContainingNamespaceName
-        {
-            get
-            {
-                return _containingNamespaceName;
-            }
-        }
+        public string ContainingNamespaceName => _containingNamespaceName;
 
-        public string ContainingTypeName
-        {
-            get
-            {
-                return _containingTypeName;
-            }
-        }
+        public string ContainingTypeName => _containingTypeName;
 
-        public IEnumerable<ICallHierarchyItemDetails> Details
-        {
-            get
-            {
-                return _callsites;
-            }
-        }
+        public IEnumerable<ICallHierarchyItemDetails> Details => _callsites;
 
         public ImageSource DisplayGlyph
         {
@@ -107,13 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             }
         }
 
-        public string MemberName
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string MemberName => _name;
 
         public string NameSeparator
         {
@@ -123,13 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             }
         }
 
-        public string SortText
-        {
-            get
-            {
-                return _sortText;
-            }
-        }
+        public string SortText => _sortText;
 
         public IEnumerable<CallHierarchySearchCategory> SupportedSearchCategories
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/FieldInitializerItem.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/FieldInitializerItem.cs
@@ -21,36 +21,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             _details = details;
         }
 
-        public IEnumerable<ICallHierarchyItemDetails> Details
-        {
-            get
-            {
-                return _details;
-            }
-        }
+        public IEnumerable<ICallHierarchyItemDetails> Details => _details;
 
-        public ImageSource DisplayGlyph
-        {
-            get
-            {
-                return _displayGlyph;
-            }
-        }
+        public ImageSource DisplayGlyph => _displayGlyph;
 
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name => _name;
 
-        public string SortText
-        {
-            get
-            {
-                return _sortText;
-            }
-        }
+        public string SortText => _sortText;
     }
 }

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/AbstractCallFinder.cs
@@ -41,13 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
 
         public abstract string DisplayName { get; }
 
-        public virtual string SearchCategory
-        {
-            get
-            {
-                return DisplayName;
-            }
-        }
+        public virtual string SearchCategory => DisplayName;
 
         public void CancelSearch()
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/BaseMemberFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/BaseMemberFinder.cs
@@ -20,13 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
             _text = string.Format(EditorFeaturesResources.CallsToBaseMember, symbol.ToDisplayString());
         }
 
-        public override string DisplayName
-        {
-            get
-            {
-                return _text;
-            }
-        }
+        public override string DisplayName => _text;
 
         protected override async Task<IEnumerable<SymbolCallerInfo>> GetCallers(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/CallToOverrideFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/CallToOverrideFinder.cs
@@ -16,13 +16,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
         {
         }
 
-        public override string DisplayName
-        {
-            get
-            {
-                return EditorFeaturesResources.CallsToOverrides;
-            }
-        }
+        public override string DisplayName => EditorFeaturesResources.CallsToOverrides;
 
         protected override async Task<IEnumerable<SymbolCallerInfo>> GetCallers(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/InterfaceImplementationCallFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/InterfaceImplementationCallFinder.cs
@@ -21,21 +21,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
             _text = string.Format(EditorFeaturesResources.CallsToInterfaceImplementation, symbol.ToDisplayString());
         }
 
-        public override string DisplayName
-        {
-            get
-            {
-                return _text;
-            }
-        }
+        public override string DisplayName => _text;
 
-        public override string SearchCategory
-        {
-            get
-            {
-                return CallHierarchyPredefinedSearchCategoryNames.InterfaceImplementations;
-            }
-        }
+        public override string SearchCategory => CallHierarchyPredefinedSearchCategoryNames.InterfaceImplementations;
 
         protected override async Task<IEnumerable<SymbolCallerInfo>> GetCallers(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/MethodCallFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/MethodCallFinder.cs
@@ -26,13 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
             }
         }
 
-        public override string SearchCategory
-        {
-            get
-            {
-                return CallHierarchyPredefinedSearchCategoryNames.Callers;
-            }
-        }
+        public override string SearchCategory => CallHierarchyPredefinedSearchCategoryNames.Callers;
 
         protected override async Task<IEnumerable<SymbolCallerInfo>> GetCallers(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/OverridingMemberFinder.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/Finders/OverridingMemberFinder.cs
@@ -20,21 +20,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy.Finders
         {
         }
 
-        public override string DisplayName
-        {
-            get
-            {
-                return EditorFeaturesResources.Overrides;
-            }
-        }
+        public override string DisplayName => EditorFeaturesResources.Overrides;
 
-        public override string SearchCategory
-        {
-            get
-            {
-                return CallHierarchyPredefinedSearchCategoryNames.Overrides;
-            }
-        }
+        public override string SearchCategory => CallHierarchyPredefinedSearchCategoryNames.Overrides;
 
         protected override Task<IEnumerable<SymbolCallerInfo>> GetCallers(ISymbol symbol, Project project, IImmutableSet<Document> documents, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
+++ b/src/EditorFeatures/Core/Implementation/CodeActions/CodeActionEditHandlerService.cs
@@ -33,10 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CodeActions
             _associatedViewService = associatedViewService;
         }
 
-        public ITextBufferAssociatedViewService AssociatedViewService
-        {
-            get { return _associatedViewService; }
-        }
+        public ITextBufferAssociatedViewService AssociatedViewService => _associatedViewService;
 
         public SolutionPreviewResult GetPreviews(Workspace workspace, IEnumerable<CodeActionOperation> operations, CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -124,10 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             {
             }
 
-            public override string BuildTool
-            {
-                get { return PredefinedBuildTools.EnC; }
-            }
+            public override string BuildTool => PredefinedBuildTools.EnC;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/ReadOnlyDocumentTracker.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/ReadOnlyDocumentTracker.cs
@@ -40,10 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             }
         }
 
-        public Workspace Workspace
-        {
-            get { return _workspace; }
-        }
+        public Workspace Workspace => _workspace;
 
         private void OnDocumentOpened(object sender, DocumentEventArgs e)
         {

--- a/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
+++ b/src/EditorFeatures/Core/Implementation/ForegroundNotification/ForegroundNotificationService.cs
@@ -67,13 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ForegroundNotification
             _workQueue.Enqueue(new PendingWork(current + delay, action, asyncToken, cancellationToken));
         }
 
-        public bool IsEmpty_TestOnly
-        {
-            get
-            {
-                return _workQueue.IsEmpty;
-            }
-        }
+        public bool IsEmpty_TestOnly => _workQueue.IsEmpty;
 
         private async Task ProcessAsync()
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameReplacementInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.InlineRenameReplacementInfo.cs
@@ -26,13 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            public Solution NewSolution
-            {
-                get
-                {
-                    return _conflicts.NewSolution;
-                }
-            }
+            public Solution NewSolution => _conflicts.NewSolution;
 
             public IEnumerable<RelatedLocationType> Resolutions
             {
@@ -42,13 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 }
             }
 
-            public bool ReplacementTextValid
-            {
-                get
-                {
-                    return _conflicts.ReplacementTextValid;
-                }
-            }
+            public bool ReplacementTextValid => _conflicts.ReplacementTextValid;
 
             public IEnumerable<InlineRenameReplacement> GetReplacements(DocumentId documentId)
             {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.SymbolRenameInfo.cs
@@ -169,13 +169,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return false;
             }
 
-            public string DisplayName
-            {
-                get
-                {
-                    return this.RenameSymbol.Name;
-                }
-            }
+            public string DisplayName => this.RenameSymbol.Name;
 
             public string FullDisplayName
             {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/Dashboard.xaml.cs
@@ -205,14 +205,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             PositionDashboard();
         }
 
-        public string RenameOverloads { get { return EditorFeaturesResources.RenameOverloads; } }
-        public Visibility RenameOverloadsVisibility { get { return _model.RenameOverloadsVisibility; } }
-        public bool IsRenameOverloadsEditable { get { return _model.IsRenameOverloadsEditable; } }
-        public string SearchInComments { get { return EditorFeaturesResources.SearchInComments; } }
-        public string SearchInStrings { get { return EditorFeaturesResources.SearchInStrings; } }
-        public string ApplyRename { get { return EditorFeaturesResources.ApplyRename; } }
-        public string PreviewChanges { get { return EditorFeaturesResources.RenamePreviewChanges; } }
-        public string RenameInstructions { get { return EditorFeaturesResources.InlineRenameInstructions; } }
+        public string RenameOverloads => EditorFeaturesResources.RenameOverloads;
+        public Visibility RenameOverloadsVisibility => _model.RenameOverloadsVisibility;
+        public bool IsRenameOverloadsEditable => _model.IsRenameOverloadsEditable;
+        public string SearchInComments => EditorFeaturesResources.SearchInComments;
+        public string SearchInStrings => EditorFeaturesResources.SearchInStrings;
+        public string ApplyRename => EditorFeaturesResources.ApplyRename;
+        public string PreviewChanges => EditorFeaturesResources.RenamePreviewChanges;
+        public string RenameInstructions => EditorFeaturesResources.InlineRenameInstructions;
         public string ApplyToolTip { get { return EditorFeaturesResources.RenameApplyToolTip + " (Enter)"; } }
         public string CancelToolTip { get { return EditorFeaturesResources.RenameCancelToolTip + " (Esc)"; } }
 

--- a/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/Dashboard/DashboardViewModel.cs
@@ -146,15 +146,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        public InlineRenameSession Session
-        {
-            get { return _session; }
-        }
+        public InlineRenameSession Session => _session;
 
-        public DashboardSeverity Severity
-        {
-            get { return _severity; }
-        }
+        public DashboardSeverity Severity => _severity;
 
         public string HeaderText
         {
@@ -188,10 +182,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        public string SearchText
-        {
-            get { return _searchText; }
-        }
+        public string SearchText => _searchText;
 
         public bool HasResolvableConflicts
         {
@@ -228,20 +219,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             get { return _errorText != null; }
         }
 
-        public string ErrorText
-        {
-            get { return _errorText; }
-        }
+        public string ErrorText => _errorText;
 
-        public Visibility RenameOverloadsVisibility
-        {
-            get { return _renameOverloadsVisibility; }
-        }
+        public Visibility RenameOverloadsVisibility => _renameOverloadsVisibility;
 
-        public bool IsRenameOverloadsEditable
-        {
-            get { return _isRenameOverloadsEditable; }
-        }
+        public bool IsRenameOverloadsEditable => _isRenameOverloadsEditable;
 
         public bool DefaultRenameOverloadFlag
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameService.cs
@@ -73,13 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             return new InlineRenameSessionInfo(ActiveSession);
         }
 
-        IInlineRenameSession IInlineRenameService.ActiveSession
-        {
-            get
-            {
-                return _activeRenameSession;
-            }
-        }
+        IInlineRenameSession IInlineRenameService.ActiveSession => _activeRenameSession;
 
         internal InlineRenameSession ActiveSession
         {

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -150,13 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             }
         }
 
-        public string OriginalSymbolName
-        {
-            get
-            {
-                return _renameInfo.DisplayName;
-            }
-        }
+        public string OriginalSymbolName => _renameInfo.DisplayName;
 
         private void InitializeOpenBuffers(SnapshotSpan triggerSpan)
         {
@@ -258,10 +252,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
             UpdateConflictResolutionTask();
         }
 
-        public Workspace Workspace { get { return _workspace; } }
-        public OptionSet OptionSet { get { return _optionSet; } }
-        public bool HasRenameOverloads { get { return _renameInfo.HasOverloads; } }
-        public bool ForceRenameOverloads { get { return _renameInfo.ForceRenameOverloads; } }
+        public Workspace Workspace => _workspace;
+        public OptionSet OptionSet => _optionSet;
+        public bool HasRenameOverloads => _renameInfo.HasOverloads;
+        public bool ForceRenameOverloads => _renameInfo.ForceRenameOverloads;
 
         public IInlineRenameUndoManager UndoManager { get; }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Model.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
     internal class Model
     {
         private readonly DisconnectedBufferGraph _disconnectedBufferGraph;
-        public ITextSnapshot TriggerSnapshot { get { return _disconnectedBufferGraph.SubjectBufferSnapshot; } }
+        public ITextSnapshot TriggerSnapshot => _disconnectedBufferGraph.SubjectBufferSnapshot;
 
         public IList<CompletionItem> TotalItems { get; }
         public IList<CompletionItem> FilteredItems { get; }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
@@ -41,13 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
             _completionPresenterSession.OnCompletionItemCommitted(CompletionItem);
         }
 
-        public override string DisplayText
-        {
-            get
-            {
-                return _displayText;
-            }
-        }
+        public override string DisplayText => _displayText;
 
         public override string InsertionText
         {
@@ -97,13 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
                 ?? defaultHighlightedTextRunProperties;
         }
 
-        public override ImageMoniker IconMoniker
-        {
-            get
-            {
-                return _imageMoniker;
-            }
-        }
+        public override ImageMoniker IconMoniker => _imageMoniker;
 
         public override string IconAutomationText
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Presentation/CustomCommitCompletion.cs
@@ -43,13 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion.P
 
         public override string DisplayText => _displayText;
 
-        public override string InsertionText
-        {
-            get
-            {
-                return _displayText; // [sic] Same as DisplayText
-            }
-        }
+        public override string InsertionText => _displayText; // [sic] Same as DisplayText
 
         public override string Description
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/QuickInfoDisplayDeferredContent.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/QuickInfoDisplayDeferredContent.cs
@@ -80,13 +80,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
             }
         }
 
-        internal IDeferredQuickInfoContent Documentation
-        {
-            get
-            {
-                return _documentation;
-            }
-        }
+        internal IDeferredQuickInfoContent Documentation => _documentation;
 
         internal ClassifiableDeferredContent TypeParameterMap
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/SymbolGlyphDeferredContent.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/QuickInfo/DeferredContent/SymbolGlyphDeferredContent.cs
@@ -43,9 +43,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.QuickInfo
         }
 
         // For Testing.
-        internal Glyph Glyph
-        {
-            get { return _glyph; }
-        }
+        internal Glyph Glyph => _glyph;
     }
 }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Session.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense
             this.PresenterSession.Dismissed += OnPresenterSessionDismissed;
         }
 
-        public TModel InitialUnfilteredModel { get { return this.Computation.InitialUnfilteredModel; } }
+        public TModel InitialUnfilteredModel => this.Computation.InitialUnfilteredModel;
 
         private void OnPresenterSessionDismissed(object sender, EventArgs e)
         {

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -24,8 +24,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
                     _selectedParameter = selectedParameter;
                 }
 
-                public int? SelectedParameter { get { return _selectedParameter; } }
-                public SignatureHelpItem SelectedItem { get { return _selectedItem; } }
+                public int? SelectedParameter => _selectedParameter;
+                public SignatureHelpItem SelectedItem => _selectedItem;
             }
 
             internal static class DefaultSignatureHelpSelector

--- a/src/EditorFeatures/Core/Implementation/LineSeparators/GraphicsResult.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/GraphicsResult.cs
@@ -26,12 +26,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
             }
         }
 
-        public UIElement VisualElement
-        {
-            get
-            {
-                return _visualElement;
-            }
-        }
+        public UIElement VisualElement => _visualElement;
     }
 }

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceGeneratedFileInfo.cs
@@ -33,10 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             this.TemporaryFilePath = Path.Combine(rootPath, directoryName, topLevelNamedType.Name + extension);
         }
 
-        public Encoding Encoding
-        {
-            get { return Encoding.UTF8; }
-        }
+        public Encoding Encoding => Encoding.UTF8;
 
         /// <summary>
         /// Creates a ProjectInfo to represent the fake project created for metadata as source documents.

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.NavigateToItemDisplay.cs
@@ -26,13 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 _iconFactory = iconFactory;
             }
 
-            public string AdditionalInformation
-            {
-                get
-                {
-                    return _searchResult.AdditionalInformation;
-                }
-            }
+            public string AdditionalInformation => _searchResult.AdditionalInformation;
 
             public string Description
             {
@@ -106,13 +100,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 }
             }
 
-            public string Name
-            {
-                get
-                {
-                    return _searchResult.NavigableItem.DisplayString;
-                }
-            }
+            public string Name => _searchResult.NavigableItem.DisplayString;
 
             public void NavigateTo()
             {

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 _undoHistoryRegistry = undoHistoryRegistry;
             }
 
-            public override string Title { get { return _title; } }
+            public override string Title => _title;
 
             protected override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
             {

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.StateMachine.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             private int _refCount;
 
             public TrackingSession TrackingSession { get; private set; }
-            public ITextBuffer Buffer { get { return _buffer; } }
+            public ITextBuffer Buffer => _buffer;
 
             public event Action TrackingSessionUpdated = delegate { };
             public event Action<ITrackingSpan> TrackingSessionCleared = delegate { };

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             private Task<bool> _newIdentifierBindsTask = SpecializedTasks.False;
 
             private readonly string _originalName;
-            public string OriginalName { get { return _originalName; } }
+            public string OriginalName => _originalName; 
 
             private readonly ITrackingSpan _trackingSpan;
             public ITrackingSpan TrackingSpan => _trackingSpan;

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -43,10 +43,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
             public string OriginalName { get { return _originalName; } }
 
             private readonly ITrackingSpan _trackingSpan;
-            public ITrackingSpan TrackingSpan { get { return _trackingSpan; } }
+            public ITrackingSpan TrackingSpan => _trackingSpan;
 
             private bool _forceRenameOverloads;
-            public bool ForceRenameOverloads { get { return _forceRenameOverloads; } }
+            public bool ForceRenameOverloads => _forceRenameOverloads;
 
             public TrackingSession(StateMachine stateMachine, SnapshotSpan snapshotSpan, IAsynchronousOperationListener asyncListener)
             {

--- a/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesCodeAction.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/PreviewChangesCodeAction.cs
@@ -21,13 +21,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             _changeSummary = changeSummary;
         }
 
-        public override string Title
-        {
-            get
-            {
-                return EditorFeaturesResources.PreviewChangesSummaryText;
-            }
-        }
+        public override string Title => EditorFeaturesResources.PreviewChangesSummaryText;
 
         protected override async Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
         {

--- a/src/EditorFeatures/Core/Implementation/TextStructureNavigation/AbstractTextStructureNavigatorProvider.TextStructureNavigator.cs
+++ b/src/EditorFeatures/Core/Implementation/TextStructureNavigation/AbstractTextStructureNavigatorProvider.TextStructureNavigator.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TextStructureNavigation
                 _waitIndicator = waitIndicator;
             }
 
-            public IContentType ContentType
-            {
-                get { return _subjectBuffer.ContentType; }
-            }
+            public IContentType ContentType => _subjectBuffer.ContentType;
 
             public TextExtent GetExtentOfWord(SnapshotPoint currentPosition)
             {

--- a/src/EditorFeatures/Core/MetadataAsSourceFile.cs
+++ b/src/EditorFeatures/Core/MetadataAsSourceFile.cs
@@ -18,9 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor
             _documentTooltip = documentTooltip;
         }
 
-        public string FilePath { get { return _filePath; } }
-        public Location IdentifierLocation { get { return _identifierLocation; } }
-        public string DocumentTitle { get { return _documentTitle; } }
-        public string DocumentTooltip { get { return _documentTooltip; } }
+        public string FilePath => _filePath;
+        public Location IdentifierLocation => _identifierLocation;
+        public string DocumentTitle => _documentTitle;
+        public string DocumentTooltip => _documentTooltip;
     }
 }

--- a/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/Utilities/TagSpanIntervalTree.cs
@@ -37,21 +37,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
             _tree = IntervalTree.Create(introspector, nodeValues);
         }
 
-        public ITextBuffer Buffer
-        {
-            get
-            {
-                return _textBuffer;
-            }
-        }
+        public ITextBuffer Buffer => _textBuffer;
 
-        public SpanTrackingMode SpanTrackingMode
-        {
-            get
-            {
-                return _spanTrackingMode;
-            }
-        }
+        public SpanTrackingMode SpanTrackingMode => _spanTrackingMode;
 
         public IList<ITagSpan<TTag>> GetIntersectingSpans(SnapshotSpan snapshotSpan)
         {

--- a/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
+++ b/src/EditorFeatures/Core/Shared/Threading/AsynchronousSerialWorkQueue.cs
@@ -52,13 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Threading
             _currentBackgroundTask = SpecializedTasks.EmptyTask;
         }
 
-        public CancellationToken CancellationToken
-        {
-            get
-            {
-                return _cancellationTokenSource.Token;
-            }
-        }
+        public CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
         public void CancelCurrentWork()
         {

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -60,20 +60,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
-        internal ForegroundThreadData ForegroundThreadData
-        {
-            get { return _foregroundThreadData; }
-        }
+        internal ForegroundThreadData ForegroundThreadData => _foregroundThreadData;
 
-        internal Thread ForegroundThread
-        {
-            get { return _foregroundThreadData.Thread; }
-        }
+        internal Thread ForegroundThread => _foregroundThreadData.Thread;
 
-        internal TaskScheduler ForegroundTaskScheduler
-        {
-            get { return _foregroundThreadData.TaskScheduler; }
-        }
+        internal TaskScheduler ForegroundTaskScheduler => _foregroundThreadData.TaskScheduler;
 
         // HACK: This is a dangerous way of establishing the 'foreground' thread affinity of an 
         // AppDomain.  This method should be deleted in favor of forcing derivations of this type

--- a/src/EditorFeatures/Core/Shared/Utilities/HACK_TextUndoTransactionThatRollsBackProperly.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/HACK_TextUndoTransactionThatRollsBackProperly.cs
@@ -28,21 +28,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             _undoPrimitive = new RollbackDetectingUndoPrimitive();
         }
 
-        public bool CanRedo
-        {
-            get
-            {
-                return _innerTransaction.CanRedo;
-            }
-        }
+        public bool CanRedo => _innerTransaction.CanRedo;
 
-        public bool CanUndo
-        {
-            get
-            {
-                return _innerTransaction.CanUndo;
-            }
-        }
+        public bool CanUndo => _innerTransaction.CanUndo;
 
         public string Description
         {
@@ -57,13 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
-        public ITextUndoHistory History
-        {
-            get
-            {
-                return _innerTransaction.History;
-            }
-        }
+        public ITextUndoHistory History => _innerTransaction.History;
 
         public IMergeTextUndoTransactionPolicy MergePolicy
         {
@@ -78,29 +60,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
-        public ITextUndoTransaction Parent
-        {
-            get
-            {
-                return _innerTransaction.Parent;
-            }
-        }
+        public ITextUndoTransaction Parent => _innerTransaction.Parent;
 
-        public UndoTransactionState State
-        {
-            get
-            {
-                return _innerTransaction.State;
-            }
-        }
+        public UndoTransactionState State => _innerTransaction.State;
 
-        public IList<ITextUndoPrimitive> UndoPrimitives
-        {
-            get
-            {
-                return _innerTransaction.UndoPrimitives;
-            }
-        }
+        public IList<ITextUndoPrimitive> UndoPrimitives => _innerTransaction.UndoPrimitives;
 
         public void AddUndo(ITextUndoPrimitive undo)
         {

--- a/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ResettableDelay.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
-        public Task Task { get { return _taskCompletionSource.Task; } }
+        public Task Task => _taskCompletionSource.Task;
 
         public void Reset()
         {

--- a/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
@@ -60,25 +60,13 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             get { return _virtualSpaces != 0; }
         }
 
-        public int Position
-        {
-            get { return _position; }
-        }
+        public int Position => _position;
 
-        public int VirtualSpaces
-        {
-            get { return _virtualSpaces; }
-        }
+        public int VirtualSpaces => _virtualSpaces;
 
-        public SourceText Text
-        {
-            get { return _text; }
-        }
+        public SourceText Text => _text;
 
-        public SyntaxTree Tree
-        {
-            get { return _tree; }
-        }
+        public SyntaxTree Tree => _tree;
 
         public int CompareTo(VirtualTreePoint other)
         {

--- a/src/EditorFeatures/Core/SymbolMapping/SymbolMappingResult.cs
+++ b/src/EditorFeatures/Core/SymbolMapping/SymbolMappingResult.cs
@@ -13,12 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.SymbolMapping
             this.Symbol = symbol;
         }
 
-        public Solution Solution
-        {
-            get
-            {
-                return this.Project.Solution;
-            }
-        }
+        public Solution Solution => this.Project.Solution;
     }
 }

--- a/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
+++ b/src/EditorFeatures/Test/AbstractCommandHandlerTestState.cs
@@ -143,15 +143,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
             return MinimalTestExportProvider.CreateExportProvider(baseCatalog.WithParts(extraParts));
         }
 
-        public virtual ITextView TextView
-        {
-            get { return _textView; }
-        }
+        public virtual ITextView TextView => _textView;
 
-        public virtual ITextBuffer SubjectBuffer
-        {
-            get { return _subjectBuffer; }
-        }
+        public virtual ITextBuffer SubjectBuffer => _subjectBuffer;
 
         #region MEF
         public Lazy<TExport, TMetadata> GetExport<TExport, TMetadata>()

--- a/src/EditorFeatures/Test/Classification/AbstractClassifierTests.cs
+++ b/src/EditorFeatures/Test/Classification/AbstractClassifierTests.cs
@@ -104,19 +104,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             return ClassificationBuilder.Number(value);
         }
 
-        protected ClassificationBuilder.PunctuationClassificationTypes Punctuation
-        {
-            get { return ClassificationBuilder.Punctuation; }
-        }
+        protected ClassificationBuilder.PunctuationClassificationTypes Punctuation => ClassificationBuilder.Punctuation;
 
-        protected ClassificationBuilder.OperatorClassificationTypes Operators
-        {
-            get { return ClassificationBuilder.Operator; }
-        }
+        protected ClassificationBuilder.OperatorClassificationTypes Operators => ClassificationBuilder.Operator;
 
-        protected ClassificationBuilder.XmlDocClassificationTypes XmlDoc
-        {
-            get { return ClassificationBuilder.XmlDoc; }
-        }
+        protected ClassificationBuilder.XmlDocClassificationTypes XmlDoc => ClassificationBuilder.XmlDoc;
     }
 }

--- a/src/EditorFeatures/Test/Classification/ClassificationBuilder.cs
+++ b/src/EditorFeatures/Test/Classification/ClassificationBuilder.cs
@@ -188,19 +188,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
             return Tuple.Create(value, ClassificationTypeNames.XmlLiteralEntityReference);
         }
 
-        public PunctuationClassificationTypes Punctuation
-        {
-            get { return _punctuation; }
-        }
+        public PunctuationClassificationTypes Punctuation => _punctuation;
 
-        public OperatorClassificationTypes Operator
-        {
-            get { return _operator; }
-        }
+        public OperatorClassificationTypes Operator => _operator;
 
-        public XmlDocClassificationTypes XmlDoc
-        {
-            get { return _xmlDoc; }
-        }
+        public XmlDocClassificationTypes XmlDoc => _xmlDoc;
     }
 }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 return new TestContext(initial, expected, compareTokens, ignoreResult, language, workspace, semanticModel);
             }
 
-            public Solution Solution { get { return _workspace.CurrentSolution; } }
+            public Solution Solution => _workspace.CurrentSolution;
 
             public SyntaxNode GetDestinationNode()
             {

--- a/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
+++ b/src/EditorFeatures/Test/CommentSelection/CommentUncommentSelectionCommandHandlerTests.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CommentSelection
                 get { return "//"; }
             }
 
-            public override bool SupportsBlockComment
-            {
-                get { return _supportBlockComments; }
-            }
+            public override bool SupportsBlockComment => _supportBlockComments;
 
             public override string BlockCommentStartString
             {

--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticServiceTests.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
                 _diagnosticData = (diagnosticData ?? Array.Empty<DiagnosticData>()).ToImmutableArray();
             }
 
-            public bool SupportGetDiagnostics { get { return _support; } }
+            public bool SupportGetDiagnostics => _support;
             public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
 
             public ImmutableArray<DiagnosticData> GetDiagnostics(Workspace workspace, ProjectId projectId, DocumentId documentId, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))

--- a/src/EditorFeatures/Test/Diagnostics/TestAnalyzerReferenceByLanguage.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestAnalyzerReferenceByLanguage.cs
@@ -30,13 +30,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public override object Id
-        {
-            get
-            {
-                return Display;
-            }
-        }
+        public override object Id => Display;
 
         public override ImmutableArray<DiagnosticAnalyzer> GetAnalyzersForAllLanguages()
         {

--- a/src/EditorFeatures/Test/Diagnostics/TestHostDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Test/Diagnostics/TestHostDiagnosticUpdateSource.cs
@@ -13,13 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             _workspace = workspace;
         }
 
-        public override Workspace Workspace
-        {
-            get
-            {
-                return _workspace;
-            }
-        }
+        public override Workspace Workspace => _workspace;
 
         public override int GetHashCode()
         {

--- a/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
+++ b/src/EditorFeatures/Test/MetadataAsSource/AbstractMetadataAsSourceTests.TestContext.cs
@@ -46,10 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MetadataAsSource
                 _textBufferFactoryService = _workspace.GetService<ITextBufferFactoryService>();
             }
 
-            public Solution CurrentSolution
-            {
-                get { return _workspace.CurrentSolution; }
-            }
+            public Solution CurrentSolution => _workspace.CurrentSolution;
 
             public Project DefaultProject
             {

--- a/src/EditorFeatures/Test/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/Test/MinimalTestExportProvider.cs
@@ -20,13 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
         private static readonly PartDiscovery s_partDiscovery = CreatePartDiscovery(Resolver.DefaultInstance);
         private static readonly Lazy<ComposableCatalog> s_lazyLanguageNeutralCatalog = new Lazy<ComposableCatalog>(() => CreateAssemblyCatalog(GetVisualStudioAssemblies()).WithParts(CreateAssemblyCatalog(GetLanguageNeutralTypes().Select(t => t.Assembly).Distinct())));
 
-        public static ComposableCatalog LanguageNeutralCatalog
-        {
-            get
-            {
-                return s_lazyLanguageNeutralCatalog.Value;
-            }
-        }
+        public static ComposableCatalog LanguageNeutralCatalog => s_lazyLanguageNeutralCatalog.Value;
 
         public static Type[] GetLanguageNeutralTypes()
         {

--- a/src/EditorFeatures/Test/NavigateTo/NavigateToTestAggregator.Callback.cs
+++ b/src/EditorFeatures/Test/NavigateTo/NavigateToTestAggregator.Callback.cs
@@ -61,10 +61,7 @@ namespace Roslyn.Test.EditorUtilities.NavigateTo
                 return items;
             }
 
-            public INavigateToOptions Options
-            {
-                get { return _options; }
-            }
+            public INavigateToOptions Options => _options;
 
             public void ReportProgress(int current, int maximum)
             {

--- a/src/EditorFeatures/Test/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/Test/QuickInfo/AbstractSemanticQuickInfoSourceTests.cs
@@ -129,20 +129,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.QuickInfo
             return ClassificationBuilder.Number(value);
         }
 
-        protected ClassificationBuilder.PunctuationClassificationTypes Punctuation
-        {
-            get { return ClassificationBuilder.Punctuation; }
-        }
+        protected ClassificationBuilder.PunctuationClassificationTypes Punctuation => ClassificationBuilder.Punctuation;
 
-        protected ClassificationBuilder.OperatorClassificationTypes Operators
-        {
-            get { return ClassificationBuilder.Operator; }
-        }
+        protected ClassificationBuilder.OperatorClassificationTypes Operators => ClassificationBuilder.Operator;
 
-        protected ClassificationBuilder.XmlDocClassificationTypes XmlDoc
-        {
-            get { return ClassificationBuilder.XmlDoc; }
-        }
+        protected ClassificationBuilder.XmlDocClassificationTypes XmlDoc => ClassificationBuilder.XmlDoc;
 
         protected string Lines(params string[] lines)
         {

--- a/src/EditorFeatures/Test/RenameTracking/MockRefactorNotifyService.cs
+++ b/src/EditorFeatures/Test/RenameTracking/MockRefactorNotifyService.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
         private int _onBeforeSymbolRenamedCount = 0;
         private int _onAfterSymbolRenamedCount = 0;
 
-        public int OnBeforeSymbolRenamedCount { get { return _onBeforeSymbolRenamedCount; } }
-        public int OnAfterSymbolRenamedCount { get { return _onAfterSymbolRenamedCount; } }
+        public int OnBeforeSymbolRenamedCount => _onBeforeSymbolRenamedCount;
+        public int OnAfterSymbolRenamedCount => _onAfterSymbolRenamedCount;
 
         public bool OnBeforeSymbolRenamedReturnValue { get; set; }
         public bool OnAfterSymbolRenamedReturnValue { get; set; }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -38,13 +38,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
         private string _notificationMessage = null;
 
         private readonly TestHostDocument _hostDocument;
-        public TestHostDocument HostDocument { get { return _hostDocument; } }
+        public TestHostDocument HostDocument => _hostDocument;
 
         private readonly IEditorOperations _editorOperations;
-        public IEditorOperations EditorOperations { get { return _editorOperations; } }
+        public IEditorOperations EditorOperations => _editorOperations;
 
         private readonly MockRefactorNotifyService _mockRefactorNotifyService;
-        public MockRefactorNotifyService RefactorNotifyService { get { return _mockRefactorNotifyService; } }
+        public MockRefactorNotifyService RefactorNotifyService => _mockRefactorNotifyService;
 
         private readonly CodeFixProvider _codeFixProvider;
         private readonly RenameTrackingCancellationCommandHandler _commandHandler = new RenameTrackingCancellationCommandHandler();

--- a/src/EditorFeatures/Test/Utilities/TestWaitContext.cs
+++ b/src/EditorFeatures/Test/Utilities/TestWaitContext.cs
@@ -18,15 +18,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
             _maxUpdates = maxUpdates;
         }
 
-        public int Updates
-        {
-            get { return _updates; }
-        }
+        public int Updates => _updates;
 
-        public CancellationToken CancellationToken
-        {
-            get { return _cancellationTokenSource.Token; }
-        }
+        public CancellationToken CancellationToken => _cancellationTokenSource.Token;
 
         public void UpdateProgress()
         {

--- a/src/EditorFeatures/Test/Utilities/TestWaitIndicator.cs
+++ b/src/EditorFeatures/Test/Utilities/TestWaitIndicator.cs
@@ -67,10 +67,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 
         private sealed class UncancellableWaitContext : IWaitContext, VisualStudioIndicator.IWaitContext
         {
-            public CancellationToken CancellationToken
-            {
-                get { return CancellationToken.None; }
-            }
+            public CancellationToken CancellationToken => CancellationToken.None;
 
             public void UpdateProgress()
             {

--- a/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostDocument.cs
@@ -34,45 +34,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         private readonly IReadOnlyList<string> _folders;
         private readonly TextLoader _loader;
 
-        public DocumentId Id
-        {
-            get
-            {
-                return _id;
-            }
-        }
+        public DocumentId Id => _id;
 
-        public TestHostProject Project
-        {
-            get
-            {
-                return _project;
-            }
-        }
+        public TestHostProject Project => _project;
 
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name => _name;
 
-        public SourceCodeKind SourceCodeKind
-        {
-            get
-            {
-                return _sourceCodeKind;
-            }
-        }
+        public SourceCodeKind SourceCodeKind => _sourceCodeKind;
 
-        public string FilePath
-        {
-            get
-            {
-                return _filePath;
-            }
-        }
+        public string FilePath => _filePath;
 
         public bool IsGenerated
         {
@@ -82,13 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
-        public TextLoader Loader
-        {
-            get
-            {
-                return _loader;
-            }
-        }
+        public TextLoader Loader => _loader;
 
         public int? CursorPosition { get; }
         public IList<TextSpan> SelectedSpans { get; }
@@ -193,13 +157,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
         }
 
-        public IContentType ContentType
-        {
-            get
-            {
-                return this.TextBuffer.ContentType;
-            }
-        }
+        public IContentType ContentType => this.TextBuffer.ContentType;
 
         public IWpfTextView GetTextView()
         {

--- a/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestHostProject.cs
@@ -34,106 +34,31 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         public IEnumerable<TestHostDocument> Documents;
         public IEnumerable<TestHostDocument> AdditionalDocuments;
 
-        public string Name
-        {
-            get
-            {
-                return _name;
-            }
-        }
+        public string Name => _name;
 
-        public IEnumerable<ProjectReference> ProjectReferences
-        {
-            get
-            {
-                return _projectReferences;
-            }
-        }
+        public IEnumerable<ProjectReference> ProjectReferences => _projectReferences;
 
-        public IEnumerable<MetadataReference> MetadataReferences
-        {
-            get
-            {
-                return _metadataReferences;
-            }
-        }
+        public IEnumerable<MetadataReference> MetadataReferences => _metadataReferences;
 
-        public IEnumerable<AnalyzerReference> AnalyzerReferences
-        {
-            get
-            {
-                return _analyzerReferences;
-            }
-        }
+        public IEnumerable<AnalyzerReference> AnalyzerReferences => _analyzerReferences;
 
-        public CompilationOptions CompilationOptions
-        {
-            get
-            {
-                return _compilationOptions;
-            }
-        }
+        public CompilationOptions CompilationOptions => _compilationOptions;
 
-        public ParseOptions ParseOptions
-        {
-            get
-            {
-                return _parseOptions;
-            }
-        }
+        public ParseOptions ParseOptions => _parseOptions;
 
-        public ProjectId Id
-        {
-            get
-            {
-                return _id;
-            }
-        }
+        public ProjectId Id => _id;
 
-        public bool IsSubmission
-        {
-            get
-            {
-                return _isSubmission;
-            }
-        }
+        public bool IsSubmission => _isSubmission;
 
-        public string AssemblyName
-        {
-            get
-            {
-                return _assemblyName;
-            }
-        }
+        public string AssemblyName => _assemblyName;
 
-        public Type HostObjectType
-        {
-            get
-            {
-                return _hostObjectType;
-            }
-        }
+        public Type HostObjectType => _hostObjectType;
 
-        public VersionStamp Version
-        {
-            get
-            {
-                return _version;
-            }
-        }
+        public VersionStamp Version => _version;
 
-        public string FilePath
-        {
-            get
-            {
-                return _filePath;
-            }
-        }
+        public string FilePath => _filePath;
 
-        public string OutputFilePath
-        {
-            get { return _outputFilePath; }
-        }
+        public string OutputFilePath => _outputFilePath;
 
         internal TestHostProject(
             HostLanguageServices languageServices,
@@ -287,21 +212,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             this.AdditionalDocuments = this.AdditionalDocuments.Where(d => d != document);
         }
 
-        public string Language
-        {
-            get
-            {
-                return _languageServices.Language;
-            }
-        }
+        public string Language => _languageServices.Language;
 
-        internal HostLanguageServices LanguageServiceProvider
-        {
-            get
-            {
-                return _languageServices;
-            }
-        }
+        internal HostLanguageServices LanguageServiceProvider => _languageServices;
 
         public ProjectInfo ToProjectInfo()
         {

--- a/src/EditorFeatures/TestUtilities/Async/Checkpoint.cs
+++ b/src/EditorFeatures/TestUtilities/Async/Checkpoint.cs
@@ -11,7 +11,7 @@ namespace Roslyn.Test.Utilities
     public class Checkpoint
     {
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
-        public Task Task { get { return _tcs.Task; } }
+        public Task Task => _tcs.Task;
 
         public void Release()
         {

--- a/src/EditorFeatures/TestUtilities/BlindAggregatorFactory.cs
+++ b/src/EditorFeatures/TestUtilities/BlindAggregatorFactory.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 // underlying native memory will be freed when finalizers run at shutdown.
                 private static readonly CoTaskMemPtr s_instance = new CoTaskMemPtr();
 
-                public static IntPtr AddressOfVTable { get { return s_instance.VTablePtr; } }
+                public static IntPtr AddressOfVTable => s_instance.VTablePtr;
             }
 
             private const int S_OK = 0;

--- a/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
+++ b/src/EditorFeatures/TestUtilities/Threading/StaTaskScheduler.cs
@@ -95,13 +95,7 @@ namespace Roslyn.Test.Utilities
         }
 
         /// <summary>Gets the maximum concurrency level supported by this scheduler.</summary>
-        public override int MaximumConcurrencyLevel
-        {
-            get
-            {
-                return _threads.Length;
-            }
-        }
+        public override int MaximumConcurrencyLevel => _threads.Length;
 
         /// <summary>
         /// Cleans up the scheduler by indicating that no more tasks will be queued.

--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -96,10 +96,7 @@ namespace Microsoft.CodeAnalysis.Text
                 return text;
             }
 
-            public override Encoding Encoding
-            {
-                get { return _encodingOpt; }
-            }
+            public override Encoding Encoding => _encodingOpt;
 
             public ITextSnapshot EditorSnapshot
             {
@@ -158,10 +155,7 @@ namespace Microsoft.CodeAnalysis.Text
                     _text = text;
                 }
 
-                public override int Count
-                {
-                    get { return _text.RoslynSnapshot.LineCount; }
-                }
+                public override int Count => _text.RoslynSnapshot.LineCount;
 
                 public override TextLine this[int index]
                 {

--- a/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/HideBase/HideBaseCodeFixProvider.AddNewKeywordAction.cs
@@ -14,13 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.HideBase
             private Document _document;
             private SyntaxNode _node;
 
-            public override string Title
-            {
-                get
-                {
-                    return CSharpFeaturesResources.HideBase;
-                }
-            }
+            public override string Title => CSharpFeaturesResources.HideBase;
 
             public AddNewKeywordAction(Document document, SyntaxNode node)
             {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.cs
@@ -17,13 +17,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.RemoveUnnecessaryCast
     {
         private static readonly ImmutableArray<SyntaxKind> s_kindsOfInterest = ImmutableArray.Create(SyntaxKind.CastExpression);
 
-        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest
-        {
-            get
-            {
-                return s_kindsOfInterest;
-            }
-        }
+        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => s_kindsOfInterest;
 
         protected override bool IsUnnecessaryCast(SemanticModel model, SyntaxNode node, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -21,13 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
 
         private static readonly ImmutableArray<SyntaxKind> s_kindsOfInterest = ImmutableArray.Create(SyntaxKind.IncompleteMember, SyntaxKind.ParenthesizedLambdaExpression, SyntaxKind.SimpleLambdaExpression);
 
-        protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest
-        {
-            get
-            {
-                return s_kindsOfInterest;
-            }
-        }
+        protected override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => s_kindsOfInterest;
 
         protected override DiagnosticDescriptor DiagnosticDescriptor => GetDiagnosticDescriptor(NameNotInContext, _nameNotInContextMessageFormat);
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -52,10 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     return Visit(_outmostCallSiteContainer);
                 }
 
-                private SyntaxNode ContainerOfStatementsOrFieldToReplace
-                {
-                    get { return _firstStatementOrFieldToReplace.Parent; }
-                }
+                private SyntaxNode ContainerOfStatementsOrFieldToReplace => _firstStatementOrFieldToReplace.Parent;
 
                 public override SyntaxNode VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
                 {

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -223,15 +223,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
                     method.ToAwaitableParts(SyntaxFacts.GetText(SyntaxKind.AwaitKeyword), "x", semanticModel, position));
             }
 
-            protected override SymbolDisplayFormat MinimallyQualifiedFormat
-            {
-                get { return s_minimallyQualifiedFormat; }
-            }
+            protected override SymbolDisplayFormat MinimallyQualifiedFormat => s_minimallyQualifiedFormat;
 
-            protected override SymbolDisplayFormat MinimallyQualifiedFormatWithConstants
-            {
-                get { return s_minimallyQualifiedFormatWithConstants; }
-            }
+            protected override SymbolDisplayFormat MinimallyQualifiedFormatWithConstants => s_minimallyQualifiedFormatWithConstants;
         }
     }
 }

--- a/src/Features/CSharp/Portable/OrganizeImports/CSharpOrganizeImportsService.cs
+++ b/src/Features/CSharp/Portable/OrganizeImports/CSharpOrganizeImportsService.cs
@@ -22,36 +22,12 @@ namespace Microsoft.CodeAnalysis.CSharp.OrganizeImports
             return document.WithSyntaxRoot(newRoot);
         }
 
-        public string OrganizeImportsDisplayStringWithAccelerator
-        {
-            get
-            {
-                return CSharpFeaturesResources.OrganizeUsingsWithAccelerator;
-            }
-        }
+        public string OrganizeImportsDisplayStringWithAccelerator => CSharpFeaturesResources.OrganizeUsingsWithAccelerator;
 
-        public string SortImportsDisplayStringWithAccelerator
-        {
-            get
-            {
-                return CSharpFeaturesResources.SortUsingsWithAccelerator;
-            }
-        }
+        public string SortImportsDisplayStringWithAccelerator => CSharpFeaturesResources.SortUsingsWithAccelerator;
 
-        public string RemoveUnusedImportsDisplayStringWithAccelerator
-        {
-            get
-            {
-                return CSharpFeaturesResources.RemoveUnnecessaryUsingsWithAccelerator;
-            }
-        }
+        public string RemoveUnusedImportsDisplayStringWithAccelerator => CSharpFeaturesResources.RemoveUnnecessaryUsingsWithAccelerator;
 
-        public string SortAndRemoveUnusedImportsDisplayStringWithAccelerator
-        {
-            get
-            {
-                return CSharpFeaturesResources.RemoveAndSortUsingsWithAccelerator;
-            }
-        }
+        public string SortAndRemoveUnusedImportsDisplayStringWithAccelerator => CSharpFeaturesResources.RemoveAndSortUsingsWithAccelerator;
     }
 }

--- a/src/Features/Core/Portable/AddMissingReference/CodeAction.cs
+++ b/src/Features/Core/Portable/AddMissingReference/CodeAction.cs
@@ -66,10 +66,7 @@ namespace Microsoft.CodeAnalysis.AddMissingReference
             _missingAssemblyIdentity = missingAssemblyIdentity;
         }
 
-        public override string Title
-        {
-            get { return _title; }
-        }
+        public override string Title => _title;
 
         protected override Task<IEnumerable<CodeActionOperation>> ComputeOperationsAsync(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -19,10 +19,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             _context = context;
         }
 
-        public override string Title
-        {
-            get { return FeaturesResources.ChangeSignature; }
-        }
+        public override string Title => FeaturesResources.ChangeSignature;
 
         public override object GetOptions(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixAllCodeActionContext.cs
+++ b/src/Features/Core/Portable/CodeFixes/FixAllOccurrences/FixAllCodeActionContext.cs
@@ -84,20 +84,11 @@ namespace Microsoft.CodeAnalysis.CodeFixes
                 .Select(d => d.Id);
         }
 
-        public IEnumerable<Diagnostic> OriginalDiagnostics
-        {
-            get { return _originalFixDiagnostics; }
-        }
+        public IEnumerable<Diagnostic> OriginalDiagnostics => _originalFixDiagnostics;
 
-        public FixAllProvider FixAllProvider
-        {
-            get { return _fixAllProviderInfo.FixAllProvider; }
-        }
+        public FixAllProvider FixAllProvider => _fixAllProviderInfo.FixAllProvider;
 
-        public IEnumerable<FixAllScope> SupportedScopes
-        {
-            get { return _fixAllProviderInfo.SupportedScopes; }
-        }
+        public IEnumerable<FixAllScope> SupportedScopes => _fixAllProviderInfo.SupportedScopes;
 
         /// <summary>
         /// Transforms this context into the public <see cref="FixAllContext"/> to be used for <see cref="FixAllProvider.GetFixAsync(FixAllContext)"/> invocation.

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoring.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoring.cs
@@ -16,10 +16,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         private readonly CodeRefactoringProvider _provider;
         private readonly IReadOnlyList<CodeAction> _actions;
 
-        public CodeRefactoringProvider Provider
-        {
-            get { return _provider; }
-        }
+        public CodeRefactoringProvider Provider => _provider;
 
         /// <summary>
         /// List of possible actions that can be used to transform the code.

--- a/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/CodeRefactoringService.cs
@@ -49,13 +49,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
             }
         }
 
-        private ImmutableDictionary<string, Lazy<IEnumerable<CodeRefactoringProvider>>> LanguageToProvidersMap
-        {
-            get
-            {
-                return _lazyLanguageToProvidersMap.Value;
-            }
-        }
+        private ImmutableDictionary<string, Lazy<IEnumerable<CodeRefactoringProvider>>> LanguageToProvidersMap => _lazyLanguageToProvidersMap.Value;
 
         private IEnumerable<CodeRefactoringProvider> GetProviders(Document document)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
@@ -13,13 +13,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     internal class RudeEditDiagnosticAnalyzer : DocumentDiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return RudeEditDiagnosticDescriptors.AllDescriptors;
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => RudeEditDiagnosticDescriptors.AllDescriptors;
 
         public override Task AnalyzeSyntaxAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -112,13 +112,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             }
         }
 
-        public CancellationToken CancellationToken
-        {
-            get
-            {
-                return _cancellationToken;
-            }
-        }
+        public CancellationToken CancellationToken => _cancellationToken;
 
         private CompilationWithAnalyzers GetCompilationWithAnalyzers(Compilation compilation)
         {

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.DiagnosticState.cs
@@ -38,18 +38,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             /// <summary>
             /// Only For Testing
             /// </summary>
-            internal string Name_TestingOnly
-            {
-                get { return _stateName; }
-            }
+            internal string Name_TestingOnly => _stateName;
 
             /// <summary>
             /// Only For Testing
             /// </summary>
-            internal string Language_TestingOnly
-            {
-                get { return _language; }
-            }
+            internal string Language_TestingOnly => _language;
 
             protected override object GetCacheKey(object value)
             {

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.NestedTypes.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return new AnalysisData(TextVersion, DataVersion, Items);
             }
 
-            public bool FromCache
-            {
-                get { return this.OldItems.IsDefault; }
-            }
+            public bool FromCache => this.OldItems.IsDefault;
         }
 
         public struct SolutionArgument
@@ -93,13 +90,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 _analyzerPackageName = analyzerPackageName;
             }
 
-            public override string BuildTool
-            {
-                get
-                {
-                    return _analyzerPackageName;
-                }
-            }
+            public override string BuildTool => _analyzerPackageName;
         }
 
         public class ArgumentKey : AnalyzerUpdateArgsId

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 _projectStates = new ProjectStates(this);
             }
 
-            private HostAnalyzerManager AnalyzerManager { get { return _analyzerManager; } }
+            private HostAnalyzerManager AnalyzerManager => _analyzerManager;
 
             /// <summary>
             /// This will be raised whenever <see cref="StateManager"/> finds <see cref="Project.AnalyzerReferences"/> change

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -92,10 +92,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 _builder = null;
             }
 
-            protected StateManager StateManager
-            {
-                get { return this.Owner._stateManager; }
-            }
+            protected StateManager StateManager => this.Owner._stateManager;
 
             protected abstract Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken);
             protected abstract Task AppendProjectStateDiagnosticsAsync(Project project, Document document, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken);
@@ -524,10 +521,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return (Project)documentOrProject;
             }
 
-            private DiagnosticLogAggregator DiagnosticLogAggregator
-            {
-                get { return this.Owner.DiagnosticLogAggregator; }
-            }
+            private DiagnosticLogAggregator DiagnosticLogAggregator => this.Owner.DiagnosticLogAggregator;
         }
 
         private class IDELatestDiagnosticGetter : LatestDiagnosticsGetter
@@ -629,10 +623,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 }
             }
 
-            protected AnalyzerExecutor AnalyzerExecutor
-            {
-                get { return this.Owner._executor; }
-            }
+            protected AnalyzerExecutor AnalyzerExecutor => this.Owner._executor;
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
+++ b/src/Features/Core/Portable/Diagnostics/Log/DiagnosticLogAggregator.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Log
             _analyzerInfoMap = ImmutableDictionary<Type, AnalyzerInfo>.Empty;
         }
 
-        public IEnumerable<KeyValuePair<Type, AnalyzerInfo>> AnalyzerInfoMap
-        {
-            get { return _analyzerInfoMap; }
-        }
+        public IEnumerable<KeyValuePair<Type, AnalyzerInfo>> AnalyzerInfoMap => _analyzerInfoMap;
 
         public void UpdateAnalyzerTypeCount(DiagnosticAnalyzer analyzer, AnalyzerTelemetryInfo analyzerTelemetryInfo, Project projectOpt)
         {

--- a/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DebuggingSession.cs
@@ -18,9 +18,6 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _initialSolution = initialSolution;
         }
 
-        internal Solution InitialSolution
-        {
-            get { return _initialSolution; }
-        }
+        internal Solution InitialSolution => _initialSolution;
     }
 }

--- a/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
+++ b/src/Features/Core/Portable/EditAndContinue/DocumentAnalysisResults.cs
@@ -116,13 +116,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _hasCompilationErrors = hasSemanticErrors;
         }
 
-        public bool HasChanges
-        {
-            get
-            {
-                return _hasCompilationErrors.HasValue;
-            }
-        }
+        public bool HasChanges => _hasCompilationErrors.HasValue;
 
         public bool HasChangesAndErrors
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditAndContinueWorkspaceService.cs
@@ -23,21 +23,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _diagnosticService = diagnosticService;
         }
 
-        public DebuggingSession DebuggingSession
-        {
-            get
-            {
-                return _debuggingSession;
-            }
-        }
+        public DebuggingSession DebuggingSession => _debuggingSession;
 
-        public EditSession EditSession
-        {
-            get
-            {
-                return _editSession;
-            }
-        }
+        public EditSession EditSession => _editSession;
 
         public void OnBeforeDebuggingStateChanged(DebuggingState before, DebuggingState after)
         {

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -102,44 +102,17 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             _documentsWithReportedRudeEdits = new HashSet<DocumentId>();
         }
 
-        internal CancellationTokenSource Cancellation
-        {
-            get { return _cancellation; }
-        }
+        internal CancellationTokenSource Cancellation => _cancellation;
 
-        internal Solution BaseSolution
-        {
-            get
-            {
-                return _baseSolution;
-            }
-        }
+        internal Solution BaseSolution => _baseSolution;
 
-        internal IReadOnlyDictionary<DocumentId, ImmutableArray<ActiveStatementSpan>> BaseActiveStatements
-        {
-            get
-            {
-                return _baseActiveStatements;
-            }
-        }
+        internal IReadOnlyDictionary<DocumentId, ImmutableArray<ActiveStatementSpan>> BaseActiveStatements => _baseActiveStatements;
 
-        private Solution CurrentSolution
-        {
-            get
-            {
-                return _baseSolution.Workspace.CurrentSolution;
-            }
-        }
+        private Solution CurrentSolution => _baseSolution.Workspace.CurrentSolution;
 
-        public bool StoppedAtException
-        {
-            get { return _stoppedAtException; }
-        }
+        public bool StoppedAtException => _stoppedAtException;
 
-        public IReadOnlyDictionary<ProjectId, ProjectReadOnlyReason> Projects
-        {
-            get { return _projects; }
-        }
+        public IReadOnlyDictionary<ProjectId, ProjectReadOnlyReason> Projects => _projects;
 
         internal bool HasProject(ProjectId id)
         {

--- a/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldCodeAction.cs
+++ b/src/Features/Core/Portable/EncapsulateField/EncapsulateFieldCodeAction.cs
@@ -17,10 +17,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
             _title = title;
         }
 
-        public override string Title
-        {
-            get { return _title; }
-        }
+        public override string Title => _title;
 
         protected override Task<Solution> GetChangedSolutionAsync(CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
@@ -56,9 +56,6 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
             return Task.FromResult(operations);
         }
 
-        public override string Title
-        {
-            get { return FeaturesResources.ExtractInterface; }
-        }
+        public override string Title => FeaturesResources.ExtractInterface;
     }
 }

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 _triviaList = triviaList;
             }
 
-            public SyntaxNode Root
-            {
-                get { return _root; }
-            }
+            public SyntaxNode Root => _root;
 
             public SyntaxNode RestoreTrivia(
                 SyntaxNode root,

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableInfo.cs
@@ -103,15 +103,9 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 _variableSymbol.AddIdentifierTokenAnnotationPair(annotations, cancellationToken);
             }
 
-            public string Name
-            {
-                get { return _variableSymbol.Name; }
-            }
+            public string Name => _variableSymbol.Name;
 
-            public bool OriginalTypeHadAnonymousTypeOrDelegate
-            {
-                get { return _variableSymbol.OriginalTypeHadAnonymousTypeOrDelegate; }
-            }
+            public bool OriginalTypeHadAnonymousTypeOrDelegate => _variableSymbol.OriginalTypeHadAnonymousTypeOrDelegate;
 
             public ITypeSymbol GetVariableType(SemanticDocument document)
             {

--- a/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
+++ b/src/Features/Core/Portable/ExtractMethod/MethodExtractor.VariableSymbol.cs
@@ -245,10 +245,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 return token;
             }
 
-            public override SyntaxAnnotation IdentifierTokenAnnotation
-            {
-                get { return _annotation; }
-            }
+            public override SyntaxAnnotation IdentifierTokenAnnotation => _annotation;
 
             public override void AddIdentifierTokenAnnotationPair(
                 List<Tuple<SyntaxToken, SyntaxAnnotation>> annotations, CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/GenerateMember/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateDefaultConstructors/AbstractGenerateDefaultConstructorsService.AbstractCodeAction.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateDefaultConstructors
                 _title = title;
             }
 
-            public override string Title
-            {
-                get { return _title; }
-            }
+            public override string Title => _title;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.CodeAction.cs
@@ -102,13 +102,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 }
             }
 
-            public override string EquivalenceKey
-            {
-                get
-                {
-                    return _equivalenceKey;
-                }
-            }
+            public override string EquivalenceKey => _equivalenceKey;
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.CodeAction.cs
@@ -196,13 +196,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 }
             }
 
-            public override string EquivalenceKey
-            {
-                get
-                {
-                    return _equivalenceKey;
-                }
-            }
+            public override string EquivalenceKey => _equivalenceKey;
         }
     }
 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.CodeAction.cs
@@ -83,13 +83,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 }
             }
 
-            public override string EquivalenceKey
-            {
-                get
-                {
-                    return _equivalenceKey;
-                }
-            }
+            public override string EquivalenceKey => _equivalenceKey;
         }
 
         private class GenerateTypeCodeActionWithOption : CodeActionWithOptions
@@ -105,21 +99,9 @@ namespace Microsoft.CodeAnalysis.GenerateType
                 _state = state;
             }
 
-            public override string Title
-            {
-                get
-                {
-                    return FeaturesResources.GenerateNewType;
-                }
-            }
+            public override string Title => FeaturesResources.GenerateNewType;
 
-            public override string EquivalenceKey
-            {
-                get
-                {
-                    return _state.Name;
-                }
-            }
+            public override string EquivalenceKey => _state.Name;
 
             public override object GetOptions(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -137,13 +137,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     codeActionTypeName;
             }
 
-            public override string EquivalenceKey
-            {
-                get
-                {
-                    return _equivalenceKey;
-                }
-            }
+            public override string EquivalenceKey => _equivalenceKey;
 
             private static string GetDescription(ISymbol throughMember)
             {

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.AbstractIntroduceVariableCodeAction.cs
@@ -43,10 +43,7 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
                 _title = CreateDisplayText(expression);
             }
 
-            public override string Title
-            {
-                get { return _title; }
-            }
+            public override string Title => _title;
 
             protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedNamespaceOrTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedNamespaceOrTypeSymbol.cs
@@ -23,21 +23,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
             public abstract ImmutableArray<INamedTypeSymbol> GetTypeMembers(string name);
             public abstract ImmutableArray<INamedTypeSymbol> GetTypeMembers(string name, int arity);
 
-            public bool IsNamespace
-            {
-                get
-                {
-                    return _symbol.IsNamespace;
-                }
-            }
+            public bool IsNamespace => _symbol.IsNamespace;
 
-            public bool IsType
-            {
-                get
-                {
-                    return _symbol.IsType;
-                }
-            }
+            public bool IsType => _symbol.IsType;
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
@@ -36,13 +36,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public Accessibility DeclaredAccessibility => _symbol.DeclaredAccessibility;
 
-            public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-            {
-                get
-                {
-                    return _symbol.DeclaringSyntaxReferences;
-                }
-            }
+            public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => _symbol.DeclaringSyntaxReferences;
 
             public bool IsAbstract
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.AbstractWrappedSymbol.cs
@@ -22,61 +22,19 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 this.DocCommentFormattingService = docCommentFormattingService;
             }
 
-            public bool CanBeReferencedByName
-            {
-                get
-                {
-                    return _symbol.CanBeReferencedByName;
-                }
-            }
+            public bool CanBeReferencedByName => _symbol.CanBeReferencedByName;
 
-            public IAssemblySymbol ContainingAssembly
-            {
-                get
-                {
-                    return _symbol.ContainingAssembly;
-                }
-            }
+            public IAssemblySymbol ContainingAssembly => _symbol.ContainingAssembly;
 
-            public IModuleSymbol ContainingModule
-            {
-                get
-                {
-                    return _symbol.ContainingModule;
-                }
-            }
+            public IModuleSymbol ContainingModule => _symbol.ContainingModule;
 
-            public INamespaceSymbol ContainingNamespace
-            {
-                get
-                {
-                    return _symbol.ContainingNamespace;
-                }
-            }
+            public INamespaceSymbol ContainingNamespace => _symbol.ContainingNamespace;
 
-            public ISymbol ContainingSymbol
-            {
-                get
-                {
-                    return _symbol.ContainingSymbol;
-                }
-            }
+            public ISymbol ContainingSymbol => _symbol.ContainingSymbol;
 
-            public INamedTypeSymbol ContainingType
-            {
-                get
-                {
-                    return _symbol.ContainingType;
-                }
-            }
+            public INamedTypeSymbol ContainingType => _symbol.ContainingType;
 
-            public Accessibility DeclaredAccessibility
-            {
-                get
-                {
-                    return _symbol.DeclaredAccessibility;
-                }
-            }
+            public Accessibility DeclaredAccessibility => _symbol.DeclaredAccessibility;
 
             public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
             {
@@ -110,101 +68,29 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public bool IsImplicitlyDeclared
-            {
-                get
-                {
-                    return _symbol.IsImplicitlyDeclared;
-                }
-            }
+            public bool IsImplicitlyDeclared => _symbol.IsImplicitlyDeclared;
 
-            public bool IsOverride
-            {
-                get
-                {
-                    return _symbol.IsOverride;
-                }
-            }
+            public bool IsOverride => _symbol.IsOverride;
 
-            public bool IsSealed
-            {
-                get
-                {
-                    return _symbol.IsSealed;
-                }
-            }
+            public bool IsSealed => _symbol.IsSealed;
 
-            public bool IsStatic
-            {
-                get
-                {
-                    return _symbol.IsStatic;
-                }
-            }
+            public bool IsStatic => _symbol.IsStatic;
 
-            public bool IsVirtual
-            {
-                get
-                {
-                    return _symbol.IsVirtual;
-                }
-            }
+            public bool IsVirtual => _symbol.IsVirtual;
 
-            public SymbolKind Kind
-            {
-                get
-                {
-                    return _symbol.Kind;
-                }
-            }
+            public SymbolKind Kind => _symbol.Kind;
 
-            public string Language
-            {
-                get
-                {
-                    return _symbol.Language;
-                }
-            }
+            public string Language => _symbol.Language;
 
-            public ImmutableArray<Location> Locations
-            {
-                get
-                {
-                    return _symbol.Locations;
-                }
-            }
+            public ImmutableArray<Location> Locations => _symbol.Locations;
 
-            public string MetadataName
-            {
-                get
-                {
-                    return _symbol.MetadataName;
-                }
-            }
+            public string MetadataName => _symbol.MetadataName;
 
-            public string Name
-            {
-                get
-                {
-                    return _symbol.Name;
-                }
-            }
+            public string Name => _symbol.Name;
 
-            public ISymbol OriginalDefinition
-            {
-                get
-                {
-                    return _symbol.OriginalDefinition;
-                }
-            }
+            public ISymbol OriginalDefinition => _symbol.OriginalDefinition;
 
-            public bool HasUnsupportedMetadata
-            {
-                get
-                {
-                    return _symbol.HasUnsupportedMetadata;
-                }
-            }
+            public bool HasUnsupportedMetadata => _symbol.HasUnsupportedMetadata;
 
             public void Accept(SymbolVisitor visitor)
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
@@ -17,13 +17,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 _symbol = eventSymbol;
             }
 
-            public IMethodSymbol AddMethod
-            {
-                get
-                {
-                    return _symbol.AddMethod;
-                }
-            }
+            public IMethodSymbol AddMethod => _symbol.AddMethod;
 
             public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations
             {
@@ -35,53 +29,17 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public bool IsWindowsRuntimeEvent
-            {
-                get
-                {
-                    return _symbol.IsWindowsRuntimeEvent;
-                }
-            }
+            public bool IsWindowsRuntimeEvent => _symbol.IsWindowsRuntimeEvent;
 
-            public new IEventSymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
+            public new IEventSymbol OriginalDefinition => this;
 
-            public IEventSymbol OverriddenEvent
-            {
-                get
-                {
-                    return _symbol.OverriddenEvent;
-                }
-            }
+            public IEventSymbol OverriddenEvent => _symbol.OverriddenEvent;
 
-            public IMethodSymbol RaiseMethod
-            {
-                get
-                {
-                    return _symbol.RaiseMethod;
-                }
-            }
+            public IMethodSymbol RaiseMethod => _symbol.RaiseMethod;
 
-            public IMethodSymbol RemoveMethod
-            {
-                get
-                {
-                    return _symbol.RemoveMethod;
-                }
-            }
+            public IMethodSymbol RemoveMethod => _symbol.RemoveMethod;
 
-            public ITypeSymbol Type
-            {
-                get
-                {
-                    return _symbol.Type;
-                }
-            }
+            public ITypeSymbol Type => _symbol.Type;
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedFieldSymbol.cs
@@ -17,77 +17,23 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 _symbol = fieldSymbol;
             }
 
-            public new IFieldSymbol OriginalDefinition
-            {
-                get
-                {
-                    return _symbol.OriginalDefinition;
-                }
-            }
+            public new IFieldSymbol OriginalDefinition => _symbol.OriginalDefinition;
 
-            public ISymbol AssociatedSymbol
-            {
-                get
-                {
-                    return _symbol.AssociatedSymbol;
-                }
-            }
+            public ISymbol AssociatedSymbol => _symbol.AssociatedSymbol;
 
-            public object ConstantValue
-            {
-                get
-                {
-                    return _symbol.ConstantValue;
-                }
-            }
+            public object ConstantValue => _symbol.ConstantValue;
 
-            public ImmutableArray<CustomModifier> CustomModifiers
-            {
-                get
-                {
-                    return _symbol.CustomModifiers;
-                }
-            }
+            public ImmutableArray<CustomModifier> CustomModifiers => _symbol.CustomModifiers;
 
-            public bool HasConstantValue
-            {
-                get
-                {
-                    return _symbol.HasConstantValue;
-                }
-            }
+            public bool HasConstantValue => _symbol.HasConstantValue;
 
-            public bool IsConst
-            {
-                get
-                {
-                    return _symbol.IsConst;
-                }
-            }
+            public bool IsConst => _symbol.IsConst;
 
-            public bool IsReadOnly
-            {
-                get
-                {
-                    return _symbol.IsReadOnly;
-                }
-            }
+            public bool IsReadOnly => _symbol.IsReadOnly;
 
-            public bool IsVolatile
-            {
-                get
-                {
-                    return _symbol.IsVolatile;
-                }
-            }
+            public bool IsVolatile => _symbol.IsVolatile;
 
-            public ITypeSymbol Type
-            {
-                get
-                {
-                    return _symbol.Type;
-                }
-            }
+            public ITypeSymbol Type => _symbol.Type;
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -47,13 +47,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public new IMethodSymbol OriginalDefinition => this;
 
-            public IMethodSymbol OverriddenMethod
-            {
-                get
-                {
-                    return _symbol.OverriddenMethod;
-                }
-            }
+            public IMethodSymbol OverriddenMethod => _symbol.OverriddenMethod;
 
             public ImmutableArray<IParameterSymbol> Parameters => _symbol.Parameters;
 

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedMethodSymbol.cs
@@ -17,37 +17,13 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 _symbol = methodSymbol;
             }
 
-            public int Arity
-            {
-                get
-                {
-                    return _symbol.Arity;
-                }
-            }
+            public int Arity => _symbol.Arity;
 
-            public ISymbol AssociatedSymbol
-            {
-                get
-                {
-                    return _symbol.AssociatedSymbol;
-                }
-            }
+            public ISymbol AssociatedSymbol => _symbol.AssociatedSymbol;
 
-            public INamedTypeSymbol AssociatedAnonymousDelegate
-            {
-                get
-                {
-                    return _symbol.AssociatedAnonymousDelegate;
-                }
-            }
+            public INamedTypeSymbol AssociatedAnonymousDelegate => _symbol.AssociatedAnonymousDelegate;
 
-            public IMethodSymbol ConstructedFrom
-            {
-                get
-                {
-                    return _symbol.ConstructedFrom;
-                }
-            }
+            public IMethodSymbol ConstructedFrom => _symbol.ConstructedFrom;
 
             public ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations
             {
@@ -59,53 +35,17 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public bool HidesBaseMethodsByName
-            {
-                get
-                {
-                    return _symbol.HidesBaseMethodsByName;
-                }
-            }
+            public bool HidesBaseMethodsByName => _symbol.HidesBaseMethodsByName;
 
-            public bool IsExtensionMethod
-            {
-                get
-                {
-                    return _symbol.IsExtensionMethod;
-                }
-            }
+            public bool IsExtensionMethod => _symbol.IsExtensionMethod;
 
-            public bool IsGenericMethod
-            {
-                get
-                {
-                    return _symbol.IsGenericMethod;
-                }
-            }
+            public bool IsGenericMethod => _symbol.IsGenericMethod;
 
-            public bool IsAsync
-            {
-                get
-                {
-                    return _symbol.IsAsync;
-                }
-            }
+            public bool IsAsync => _symbol.IsAsync;
 
-            public MethodKind MethodKind
-            {
-                get
-                {
-                    return _symbol.MethodKind;
-                }
-            }
+            public MethodKind MethodKind => _symbol.MethodKind;
 
-            public new IMethodSymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
+            public new IMethodSymbol OriginalDefinition => this;
 
             public IMethodSymbol OverriddenMethod
             {
@@ -115,37 +55,13 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public ImmutableArray<IParameterSymbol> Parameters
-            {
-                get
-                {
-                    return _symbol.Parameters;
-                }
-            }
+            public ImmutableArray<IParameterSymbol> Parameters => _symbol.Parameters;
 
-            public IMethodSymbol PartialDefinitionPart
-            {
-                get
-                {
-                    return _symbol.PartialDefinitionPart;
-                }
-            }
+            public IMethodSymbol PartialDefinitionPart => _symbol.PartialDefinitionPart;
 
-            public IMethodSymbol PartialImplementationPart
-            {
-                get
-                {
-                    return _symbol.PartialImplementationPart;
-                }
-            }
+            public IMethodSymbol PartialImplementationPart => _symbol.PartialImplementationPart;
 
-            public ITypeSymbol ReceiverType
-            {
-                get
-                {
-                    return _symbol.ReceiverType;
-                }
-            }
+            public ITypeSymbol ReceiverType => _symbol.ReceiverType;
 
             public IMethodSymbol ReducedFrom
             {
@@ -162,50 +78,20 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 return _symbol.GetTypeInferredDuringReduction(reducedFromTypeParameter);
             }
 
-            public bool ReturnsVoid
-            {
-                get
-                {
-                    return _symbol.ReturnsVoid;
-                }
-            }
+            public bool ReturnsVoid => _symbol.ReturnsVoid;
 
-            public ITypeSymbol ReturnType
-            {
-                get
-                {
-                    return _symbol.ReturnType;
-                }
-            }
+            public ITypeSymbol ReturnType => _symbol.ReturnType;
 
             public ImmutableArray<AttributeData> GetReturnTypeAttributes()
             {
                 return _symbol.GetReturnTypeAttributes();
             }
 
-            public ImmutableArray<CustomModifier> ReturnTypeCustomModifiers
-            {
-                get
-                {
-                    return _symbol.ReturnTypeCustomModifiers;
-                }
-            }
+            public ImmutableArray<CustomModifier> ReturnTypeCustomModifiers => _symbol.ReturnTypeCustomModifiers;
 
-            public ImmutableArray<ITypeSymbol> TypeArguments
-            {
-                get
-                {
-                    return _symbol.TypeArguments;
-                }
-            }
+            public ImmutableArray<ITypeSymbol> TypeArguments => _symbol.TypeArguments;
 
-            public ImmutableArray<ITypeParameterSymbol> TypeParameters
-            {
-                get
-                {
-                    return _symbol.TypeParameters;
-                }
-            }
+            public ImmutableArray<ITypeParameterSymbol> TypeParameters => _symbol.TypeParameters;
 
             public IMethodSymbol Construct(params ITypeSymbol[] typeArguments)
             {
@@ -223,21 +109,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 return _symbol.ReduceExtensionMethod(receiverType);
             }
 
-            public bool IsVararg
-            {
-                get
-                {
-                    return _symbol.IsVararg;
-                }
-            }
+            public bool IsVararg => _symbol.IsVararg;
 
-            public bool IsCheckedBuiltin
-            {
-                get
-                {
-                    return _symbol.IsCheckedBuiltin;
-                }
-            }
+            public bool IsCheckedBuiltin => _symbol.IsCheckedBuiltin;
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -60,21 +60,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 throw ExceptionUtilities.Unreachable;
             }
 
-            public int Arity
-            {
-                get
-                {
-                    return _symbol.Arity;
-                }
-            }
+            public int Arity => _symbol.Arity;
 
-            public bool IsGenericType
-            {
-                get
-                {
-                    return _symbol.IsGenericType;
-                }
-            }
+            public bool IsGenericType => _symbol.IsGenericType;
 
             public bool IsUnboundGenericType
             {
@@ -84,21 +72,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public bool IsScriptClass
-            {
-                get
-                {
-                    return _symbol.IsScriptClass;
-                }
-            }
+            public bool IsScriptClass => _symbol.IsScriptClass;
 
-            public bool IsImplicitClass
-            {
-                get
-                {
-                    return _symbol.IsImplicitClass;
-                }
-            }
+            public bool IsImplicitClass => _symbol.IsImplicitClass;
 
             public IEnumerable<string> MemberNames
             {
@@ -108,45 +84,15 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public ImmutableArray<ITypeParameterSymbol> TypeParameters
-            {
-                get
-                {
-                    return _symbol.TypeParameters;
-                }
-            }
+            public ImmutableArray<ITypeParameterSymbol> TypeParameters => _symbol.TypeParameters;
 
-            public ImmutableArray<ITypeSymbol> TypeArguments
-            {
-                get
-                {
-                    return _symbol.TypeArguments;
-                }
-            }
+            public ImmutableArray<ITypeSymbol> TypeArguments => _symbol.TypeArguments;
 
-            public IMethodSymbol DelegateInvokeMethod
-            {
-                get
-                {
-                    return _symbol.DelegateInvokeMethod;
-                }
-            }
+            public IMethodSymbol DelegateInvokeMethod => _symbol.DelegateInvokeMethod;
 
-            public INamedTypeSymbol EnumUnderlyingType
-            {
-                get
-                {
-                    return _symbol.EnumUnderlyingType;
-                }
-            }
+            public INamedTypeSymbol EnumUnderlyingType => _symbol.EnumUnderlyingType;
 
-            public INamedTypeSymbol ConstructedFrom
-            {
-                get
-                {
-                    return _symbol.ConstructedFrom;
-                }
-            }
+            public INamedTypeSymbol ConstructedFrom => _symbol.ConstructedFrom;
 
             public INamedTypeSymbol Construct(params ITypeSymbol[] typeArguments)
             {
@@ -158,53 +104,17 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 return _symbol.ConstructUnboundGenericType();
             }
 
-            public ImmutableArray<IMethodSymbol> InstanceConstructors
-            {
-                get
-                {
-                    return _symbol.InstanceConstructors;
-                }
-            }
+            public ImmutableArray<IMethodSymbol> InstanceConstructors => _symbol.InstanceConstructors;
 
-            public ImmutableArray<IMethodSymbol> StaticConstructors
-            {
-                get
-                {
-                    return _symbol.StaticConstructors;
-                }
-            }
+            public ImmutableArray<IMethodSymbol> StaticConstructors => _symbol.StaticConstructors;
 
-            public ImmutableArray<IMethodSymbol> Constructors
-            {
-                get
-                {
-                    return _symbol.Constructors;
-                }
-            }
+            public ImmutableArray<IMethodSymbol> Constructors => _symbol.Constructors;
 
-            public ISymbol AssociatedSymbol
-            {
-                get
-                {
-                    return _symbol.AssociatedSymbol;
-                }
-            }
+            public ISymbol AssociatedSymbol => _symbol.AssociatedSymbol;
 
-            public TypeKind TypeKind
-            {
-                get
-                {
-                    return _symbol.TypeKind;
-                }
-            }
+            public TypeKind TypeKind => _symbol.TypeKind;
 
-            public INamedTypeSymbol BaseType
-            {
-                get
-                {
-                    return _symbol.BaseType;
-                }
-            }
+            public INamedTypeSymbol BaseType => _symbol.BaseType;
 
             public ImmutableArray<INamedTypeSymbol> Interfaces
             {

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -64,13 +64,7 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public bool IsGenericType => _symbol.IsGenericType;
 
-            public bool IsUnboundGenericType
-            {
-                get
-                {
-                    return _symbol.IsUnboundGenericType;
-                }
-            }
+            public bool IsUnboundGenericType => _symbol.IsUnboundGenericType;
 
             public bool IsScriptClass => _symbol.IsScriptClass;
 
@@ -116,58 +110,19 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
 
             public INamedTypeSymbol BaseType => _symbol.BaseType;
 
-            public ImmutableArray<INamedTypeSymbol> Interfaces
-            {
-                get
-                {
-                    return _symbol.Interfaces;
-                }
-            }
+            public ImmutableArray<INamedTypeSymbol> Interfaces => _symbol.Interfaces;
 
-            public ImmutableArray<INamedTypeSymbol> AllInterfaces
-            {
-                get { return _symbol.AllInterfaces; }
-            }
+            public ImmutableArray<INamedTypeSymbol> AllInterfaces => _symbol.AllInterfaces; 
 
-            public bool IsReferenceType
-            {
-                get
-                {
-                    return _symbol.IsReferenceType;
-                }
-            }
+            public bool IsReferenceType => _symbol.IsReferenceType;
 
-            public bool IsValueType
-            {
-                get
-                {
-                    return _symbol.IsValueType;
-                }
-            }
+            public bool IsValueType => _symbol.IsValueType;
 
-            public bool IsAnonymousType
-            {
-                get
-                {
-                    return _symbol.IsAnonymousType;
-                }
-            }
+            public bool IsAnonymousType => _symbol.IsAnonymousType;
 
-            ITypeSymbol ITypeSymbol.OriginalDefinition
-            {
-                get
-                {
-                    return _symbol.OriginalDefinition;
-                }
-            }
+            ITypeSymbol ITypeSymbol.OriginalDefinition => _symbol.OriginalDefinition;
 
-            public SpecialType SpecialType
-            {
-                get
-                {
-                    return _symbol.SpecialType;
-                }
-            }
+            public SpecialType SpecialType => _symbol.SpecialType;
 
             public ISymbol FindImplementationForInterfaceMember(ISymbol interfaceMember)
             {
@@ -199,18 +154,9 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 throw new NotImplementedException();
             }
 
-            public new INamedTypeSymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
+            public new INamedTypeSymbol OriginalDefinition => this;
 
-            public bool MightContainExtensionMethods
-            {
-                get { return _symbol.MightContainExtensionMethods; }
-            }
+            public bool MightContainExtensionMethods => _symbol.MightContainExtensionMethods; 
         }
     }
 }

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedPropertySymbol.cs
@@ -27,101 +27,29 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public IMethodSymbol GetMethod
-            {
-                get
-                {
-                    return _symbol.GetMethod;
-                }
-            }
+            public IMethodSymbol GetMethod => _symbol.GetMethod;
 
-            public bool IsIndexer
-            {
-                get
-                {
-                    return _symbol.IsIndexer;
-                }
-            }
+            public bool IsIndexer => _symbol.IsIndexer;
 
-            public bool IsReadOnly
-            {
-                get
-                {
-                    return _symbol.IsReadOnly;
-                }
-            }
+            public bool IsReadOnly => _symbol.IsReadOnly;
 
-            public bool IsWithEvents
-            {
-                get
-                {
-                    return _symbol.IsWithEvents;
-                }
-            }
+            public bool IsWithEvents => _symbol.IsWithEvents;
 
-            public bool IsWriteOnly
-            {
-                get
-                {
-                    return _symbol.IsWriteOnly;
-                }
-            }
+            public bool IsWriteOnly => _symbol.IsWriteOnly;
 
-            public IPropertySymbol OverriddenProperty
-            {
-                get
-                {
-                    return _symbol.OverriddenProperty;
-                }
-            }
+            public IPropertySymbol OverriddenProperty => _symbol.OverriddenProperty;
 
-            public ImmutableArray<IParameterSymbol> Parameters
-            {
-                get
-                {
-                    return _symbol.Parameters;
-                }
-            }
+            public ImmutableArray<IParameterSymbol> Parameters => _symbol.Parameters;
 
-            public IMethodSymbol SetMethod
-            {
-                get
-                {
-                    return _symbol.SetMethod;
-                }
-            }
+            public IMethodSymbol SetMethod => _symbol.SetMethod;
 
-            public ITypeSymbol Type
-            {
-                get
-                {
-                    return _symbol.Type;
-                }
-            }
+            public ITypeSymbol Type => _symbol.Type;
 
-            public ImmutableArray<CustomModifier> TypeCustomModifiers
-            {
-                get
-                {
-                    return _symbol.TypeCustomModifiers;
-                }
-            }
+            public ImmutableArray<CustomModifier> TypeCustomModifiers => _symbol.TypeCustomModifiers;
 
-            ISymbol ISymbol.OriginalDefinition
-            {
-                get
-                {
-                    return _symbol.OriginalDefinition;
-                }
-            }
+            ISymbol ISymbol.OriginalDefinition => _symbol.OriginalDefinition;
 
-            public new IPropertySymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
+            public new IPropertySymbol OriginalDefinition => this;
         }
     }
 }

--- a/src/Features/Core/Portable/Shared/Options/OrganizerOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/OrganizerOptions.cs
@@ -9,10 +9,7 @@ namespace Microsoft.CodeAnalysis.Shared.Options
     {
         public const string FeatureName = "Organizer";
 
-        public static PerLanguageOption<bool> PlaceSystemNamespaceFirst
-        {
-            get { return Editing.GenerationOptions.PlaceSystemNamespaceFirst; }
-        }
+        public static PerLanguageOption<bool> PlaceSystemNamespaceFirst => Editing.GenerationOptions.PlaceSystemNamespaceFirst;
 
         /// <summary>
         /// This option is currently unused by Roslyn, but we might want to implement it in the 

--- a/src/Features/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
+++ b/src/Features/Core/Portable/Shared/TestHooks/FeatureAttribute.cs
@@ -16,9 +16,6 @@ namespace Microsoft.CodeAnalysis.Shared.TestHooks
             _featureName = featureName;
         }
 
-        public string FeatureName
-        {
-            get { return _featureName; }
-        }
+        public string FeatureName => _featureName;
     }
 }

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -140,10 +140,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 ProgressReporter = progressReporter;
             }
 
-            public Solution CurrentSolution
-            {
-                get { return Workspace.CurrentSolution; }
-            }
+            public Solution CurrentSolution => Workspace.CurrentSolution;
 
             public TService GetService<TService>() where TService : IWorkspaceService
             {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncDocumentWorkItemQueue.cs
@@ -20,13 +20,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                 }
 
-                protected override int WorkItemCount_NoLock
-                {
-                    get
-                    {
-                        return _documentWorkQueue.Count;
-                    }
-                }
+                protected override int WorkItemCount_NoLock => _documentWorkQueue.Count;
 
                 protected override bool TryTake_NoLock(DocumentId key, out WorkItem workInfo)
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.AsyncProjectWorkItemQueue.cs
@@ -20,13 +20,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 {
                 }
 
-                protected override int WorkItemCount_NoLock
-                {
-                    get
-                    {
-                        return _projectWorkQueue.Count;
-                    }
-                }
+                protected override int WorkItemCount_NoLock => _projectWorkQueue.Count;
 
                 public override Task WaitAsync(CancellationToken cancellationToken)
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.GlobalOperationAwareIdleProcessor.cs
@@ -69,13 +69,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         this.UpdateLastAccessTime();
                     }
 
-                    protected Task GlobalOperationTask
-                    {
-                        get
-                        {
-                            return _globalOperationTask;
-                        }
-                    }
+                    protected Task GlobalOperationTask => _globalOperationTask;
 
                     protected abstract void PauseOnGlobalOperation();
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.HighPriorityProcessor.cs
@@ -43,29 +43,11 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Start();
                     }
 
-                    private ImmutableArray<IIncrementalAnalyzer> Analyzers
-                    {
-                        get
-                        {
-                            return _lazyAnalyzers.Value;
-                        }
-                    }
+                    private ImmutableArray<IIncrementalAnalyzer> Analyzers => _lazyAnalyzers.Value;
 
-                    public Task Running
-                    {
-                        get
-                        {
-                            return _running;
-                        }
-                    }
+                    public Task Running => _running;
 
-                    public bool HasAnyWork
-                    {
-                        get
-                        {
-                            return _workItemQueue.HasAnyWork;
-                        }
-                    }
+                    public bool HasAnyWork => _workItemQueue.HasAnyWork;
 
                     public void Enqueue(WorkItem item)
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -120,13 +120,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     diagnosticAnalyzer.TurnOff(useV2Engine);
                 }
 
-                public ImmutableArray<IIncrementalAnalyzer> Analyzers
-                {
-                    get
-                    {
-                        return _normalPriorityProcessor.Analyzers;
-                    }
-                }
+                public ImmutableArray<IIncrementalAnalyzer> Analyzers => _normalPriorityProcessor.Analyzers;
 
                 public Task AsyncProcessorTask
                 {
@@ -139,13 +133,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                     }
                 }
 
-                private Solution CurrentSolution
-                {
-                    get
-                    {
-                        return _registration.CurrentSolution;
-                    }
-                }
+                private Solution CurrentSolution => _registration.CurrentSolution;
 
                 private IDisposable EnableCaching(ProjectId projectId)
                 {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.LowPriorityProcessor.cs
@@ -39,13 +39,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Start();
                     }
 
-                    internal ImmutableArray<IIncrementalAnalyzer> Analyzers
-                    {
-                        get
-                        {
-                            return _lazyAnalyzers.Value;
-                        }
-                    }
+                    internal ImmutableArray<IIncrementalAnalyzer> Analyzers => _lazyAnalyzers.Value;
 
                     protected override Task WaitAsync(CancellationToken cancellationToken)
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.NormalPriorityProcessor.cs
@@ -64,13 +64,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         Start();
                     }
 
-                    internal ImmutableArray<IIncrementalAnalyzer> Analyzers
-                    {
-                        get
-                        {
-                            return _lazyAnalyzers.Value;
-                        }
-                    }
+                    internal ImmutableArray<IIncrementalAnalyzer> Analyzers => _lazyAnalyzers.Value;
 
                     public void Enqueue(WorkItem item)
                     {
@@ -131,21 +125,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         return _workItemQueue.WaitAsync(cancellationToken);
                     }
 
-                    public Task Running
-                    {
-                        get
-                        {
-                            return _running;
-                        }
-                    }
+                    public Task Running => _running;
 
-                    public bool HasAnyWork
-                    {
-                        get
-                        {
-                            return _workItemQueue.HasAnyWork;
-                        }
-                    }
+                    public bool HasAnyWork => _workItemQueue.HasAnyWork;
 
                     protected override async Task ExecuteAsync()
                     {
@@ -202,21 +184,9 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                         }
                     }
 
-                    protected override Task HigherQueueOperationTask
-                    {
-                        get
-                        {
-                            return this.Processor._highPriorityProcessor.Running;
-                        }
-                    }
+                    protected override Task HigherQueueOperationTask => this.Processor._highPriorityProcessor.Running;
 
-                    protected override bool HigherQueueHasWorkItem
-                    {
-                        get
-                        {
-                            return this.Processor._highPriorityProcessor.HasAnyWork;
-                        }
-                    }
+                    protected override bool HigherQueueHasWorkItem => this.Processor._highPriorityProcessor.HasAnyWork;
 
                     protected override void PauseOnGlobalOperation()
                     {

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -77,10 +77,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 }
             }
 
-            public int CorrelationId
-            {
-                get { return _registration.CorrelationId; }
-            }
+            public int CorrelationId => _registration.CorrelationId;
 
             public void Shutdown(bool blockingShutdown)
             {

--- a/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
+++ b/src/Test/Diagnostics/PerfMargin/ActivityLevel.cs
@@ -98,9 +98,6 @@ namespace Roslyn.Hosting.Diagnostics.PerfMargin
             this.IsActiveChanged?.Invoke(this, EventArgs.Empty);
         }
 
-        public IReadOnlyCollection<ActivityLevel> Children
-        {
-            get { return _children; }
-        }
+        public IReadOnlyCollection<ActivityLevel> Children => _children;
     }
 }

--- a/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
+++ b/src/Test/PdbUtilities/Pdb/Token2SourceLineExporter.cs
@@ -59,10 +59,7 @@ namespace Roslyn.Test.PdbUtilities
                 _buffer = new byte[capacity];
             }
 
-            internal byte[] Buffer
-            {
-                get { return _buffer; }
-            }
+            internal byte[] Buffer => _buffer;
             private byte[] _buffer;
 
             internal void FillBuffer(Stream stream, int capacity)
@@ -946,10 +943,7 @@ namespace Roslyn.Test.PdbUtilities
                 }
             }
 
-            internal int Length
-            {
-                get { return contentSize; }
-            }
+            internal int Length => contentSize;
 
             internal readonly int contentSize;
             internal readonly int[] pages;

--- a/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
@@ -50,25 +50,13 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 return new CompilationVerifier(_test, _compilation, _dependencies);
             }
 
-            internal CompilationTestData TestData
-            {
-                get { return _testData; }
-            }
+            internal CompilationTestData TestData => _testData;
 
-            public Compilation Compilation
-            {
-                get { return _compilation; }
-            }
+            public Compilation Compilation => _compilation;
 
-            public TempRoot Temp
-            {
-                get { return _test.Temp; }
-            }
+            public TempRoot Temp => _test.Temp;
 
-            internal ImmutableArray<Diagnostic> Diagnostics
-            {
-                get { return _diagnostics; }
-            }
+            internal ImmutableArray<Diagnostic> Diagnostics => _diagnostics;
 
             internal ImmutableArray<ModuleMetadata> GetAllModuleMetadata()
             {

--- a/src/Test/Utilities/Shared/Assert/WorkItemAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/WorkItemAttribute.cs
@@ -13,15 +13,9 @@ namespace Roslyn.Test.Utilities
         private readonly int _id;
         private readonly string _description;
 
-        public int Id
-        {
-            get { return _id; }
-        }
+        public int Id => _id;
 
-        public string Description
-        {
-            get { return _description; }
-        }
+        public string Description => _description;
 
         public WorkItemAttribute(int id, string description)
         {

--- a/src/Test/Utilities/Shared/Compilation/CompilationDifference.cs
+++ b/src/Test/Utilities/Shared/Compilation/CompilationDifference.cs
@@ -43,13 +43,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             this.UpdatedMethods = methodHandles;
         }
 
-        public EmitBaseline NextGeneration
-        {
-            get
-            {
-                return EmitResult.Baseline;
-            }
-        }
+        public EmitBaseline NextGeneration => EmitResult.Baseline;
 
         public PinnedMetadata GetMetadata()
         {

--- a/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -50,10 +50,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _callLog.Enqueue(new Entry(abstractMemberName, callerName, node, symbol));
         }
 
-        public IEnumerable<Entry> CallLog
-        {
-            get { return _callLog; }
-        }
+        public IEnumerable<Entry> CallLog => _callLog;
 
         #endregion
 

--- a/src/Test/Utilities/Shared/Mocks/TestMetadataReference.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMetadataReference.cs
@@ -19,13 +19,7 @@ namespace Roslyn.Test.Utilities
             _display = display;
         }
 
-        public override string Display
-        {
-            get
-            {
-                return _display;
-            }
-        }
+        public override string Display => _display;
 
         protected override DocumentationProvider CreateDocumentationProvider()
         {
@@ -65,13 +59,7 @@ namespace Roslyn.Test.Utilities
             _display = display;
         }
 
-        public override string Display
-        {
-            get
-            {
-                return _display;
-            }
-        }
+        public override string Display => _display;
 
         protected override DocumentationProvider CreateDocumentationProvider()
         {

--- a/src/Test/Utilities/Shared/Syntax/NodeInfo.FieldInfo.cs
+++ b/src/Test/Utilities/Shared/Syntax/NodeInfo.FieldInfo.cs
@@ -13,29 +13,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             private readonly string _propertyName;
             private readonly Type _fieldType;
             private readonly object _value;
-            public string PropertyName
-            {
-                get
-                {
-                    return _propertyName;
-                }
-            }
+            public string PropertyName => _propertyName;
 
-            public Type FieldType
-            {
-                get
-                {
-                    return _fieldType;
-                }
-            }
+            public Type FieldType => _fieldType;
 
-            public object Value
-            {
-                get
-                {
-                    return _value;
-                }
-            }
+            public object Value => _value;
 
             public FieldInfo(string propertyName, Type fieldType, object value)
             {

--- a/src/Test/Utilities/Shared/Syntax/NodeInfo.cs
+++ b/src/Test/Utilities/Shared/Syntax/NodeInfo.cs
@@ -12,13 +12,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         private readonly FieldInfo[] _fieldInfos;
         private static readonly FieldInfo[] s_emptyFieldInfos = { };
 
-        public string ClassName
-        {
-            get
-            {
-                return _className;
-            }
-        }
+        public string ClassName => _className;
 
         public FieldInfo[] FieldInfos
         {

--- a/src/Test/Utilities/Shared/TempFiles/TempDirectory.cs
+++ b/src/Test/Utilities/Shared/TempFiles/TempDirectory.cs
@@ -42,10 +42,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        public string Path
-        {
-            get { return _path; }
-        }
+        public string Path => _path;
 
         /// <summary>
         /// Creates a file in this directory.

--- a/src/Test/Utilities/Shared/TempFiles/TempFile.cs
+++ b/src/Test/Utilities/Shared/TempFiles/TempFile.cs
@@ -58,10 +58,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return new FileStream(_path, FileMode.Open, access);
         }
 
-        public string Path
-        {
-            get { return _path; }
-        }
+        public string Path => _path;
 
         public TempFile WriteAllText(string content, Encoding encoding)
         {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/AbstractFileWriter.cs
@@ -29,9 +29,9 @@ namespace CSharpSyntaxGenerator
             _childMap = tree.Types.ToLookup(n => n.Base, n => n.Name);
         }
 
-        protected IDictionary<string, string> ParentMap { get { return _parentMap; } }
-        protected ILookup<string, string> ChildMap { get { return _childMap; } }
-        protected Tree Tree { get { return _tree; } }
+        protected IDictionary<string, string> ParentMap => _parentMap;
+        protected ILookup<string, string> ChildMap => _childMap;
+        protected Tree Tree => _tree;
 
         #region Output helpers
 

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -15,20 +15,11 @@ namespace RunTests
         private readonly IList<string> _outputLines;
         private readonly IList<string> _errorLines;
 
-        public int ExitCode
-        {
-            get { return _exitCode; }
-        }
+        public int ExitCode => _exitCode;
 
-        public IList<string> OutputLines
-        {
-            get { return _outputLines; }
-        }
+        public IList<string> OutputLines => _outputLines;
 
-        public IList<string> ErrorLines
-        {
-            get { return _errorLines; }
-        }
+        public IList<string> ErrorLines => _errorLines;
 
         public ProcessOutput(int exitCode, IList<string> outputLines, IList<string> errorLines)
         {

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -148,12 +148,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
                 CSharpParseOptions.Default);
         }
 
-        protected override string RoslynLanguageName
-        {
-            get
-            {
-                return LanguageNames.CSharp;
-            }
-        }
+        protected override string RoslynLanguageName => LanguageNames.CSharp;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.NodeLocator.cs
@@ -28,10 +28,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             {
             }
 
-            protected override EnvDTE.vsCMPart DefaultPart
-            {
-                get { return EnvDTE.vsCMPart.vsCMPartWholeWithAttributes; }
-            }
+            protected override EnvDTE.vsCMPart DefaultPart => EnvDTE.vsCMPart.vsCMPartWholeWithAttributes;
 
             protected override VirtualTreePoint? GetStartPoint(SourceText text, SyntaxNode node, EnvDTE.vsCMPart part)
             {

--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -486,10 +486,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             }
         }
 
-        public override string Language
-        {
-            get { return EnvDTE.CodeModelLanguageConstants.vsCMLanguageCSharp; }
-        }
+        public override string Language => EnvDTE.CodeModelLanguageConstants.vsCMLanguageCSharp;
 
         public override string AssemblyAttributeString
         {

--- a/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/AutoImplementedPropertyExtender.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/AutoImplementedPropertyExtender.cs
@@ -23,9 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.Extenders
             _isAutoImplemented = isAutoImplemented;
         }
 
-        public bool IsAutoImplemented
-        {
-            get { return _isAutoImplemented; }
-        }
+        public bool IsAutoImplemented => _isAutoImplemented;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/CodeTypeLocationExtender.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/CodeTypeLocationExtender.cs
@@ -23,12 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.Extenders
             _externalLocation = externalLocation;
         }
 
-        public string ExternalLocation
-        {
-            get
-            {
-                return _externalLocation;
-            }
-        }
+        public string ExternalLocation => _externalLocation;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/ExtensionMethodExtender.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/ExtensionMethodExtender.cs
@@ -23,9 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.Extenders
             _isExtension = isExtension;
         }
 
-        public bool IsExtension
-        {
-            get { return _isExtension; }
-        }
+        public bool IsExtension => _isExtension;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/PartialMethodExtender.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/Extenders/PartialMethodExtender.cs
@@ -27,19 +27,10 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.Extenders
             _hasOtherPart = hasOtherPart;
         }
 
-        public bool IsPartial
-        {
-            get { return _isPartial; }
-        }
+        public bool IsPartial => _isPartial;
 
-        public bool IsDeclaration
-        {
-            get { return _isDeclaration; }
-        }
+        public bool IsDeclaration => _isDeclaration;
 
-        public bool HasOtherPart
-        {
-            get { return _hasOtherPart; }
-        }
+        public bool HasOtherPart => _hasOtherPart;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService.cs
@@ -26,45 +26,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
         {
         }
 
-        protected override Guid DebuggerLanguageId
-        {
-            get
-            {
-                return Guids.CSharpDebuggerLanguageId;
-            }
-        }
+        protected override Guid DebuggerLanguageId => Guids.CSharpDebuggerLanguageId;
 
-        protected override string ContentTypeName
-        {
-            get
-            {
-                return ContentTypeNames.CSharpContentType;
-            }
-        }
+        protected override string ContentTypeName => ContentTypeNames.CSharpContentType;
 
-        public override Guid LanguageServiceId
-        {
-            get
-            {
-                return Guids.CSharpLanguageServiceId;
-            }
-        }
+        public override Guid LanguageServiceId => Guids.CSharpLanguageServiceId;
 
-        protected override string LanguageName
-        {
-            get
-            {
-                return CSharpVSResources.C;
-            }
-        }
+        protected override string LanguageName => CSharpVSResources.C;
 
-        protected override string RoslynLanguageName
-        {
-            get
-            {
-                return LanguageNames.CSharp;
-            }
-        }
+        protected override string RoslynLanguageName => LanguageNames.CSharp;
 
         protected override AbstractDebuggerIntelliSenseContext CreateContext(
             IWpfTextView view,

--- a/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AdvancedOptionPageStrings.cs
@@ -4,114 +4,48 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
     internal static class AdvancedOptionPageStrings
     {
-        public static string Option_AllowMovingDeclaration
-        {
-            get { return CSharpVSResources.Option_AllowMovingDeclaration; }
-        }
+        public static string Option_AllowMovingDeclaration => CSharpVSResources.Option_AllowMovingDeclaration;
 
-        public static string Option_ClosedFileDiagnostics
-        {
-            get { return CSharpVSResources.Option_ClosedFileDiagnostics; }
-        }
+        public static string Option_ClosedFileDiagnostics => CSharpVSResources.Option_ClosedFileDiagnostics;
 
-        public static string Option_RenameTrackingPreview
-        {
-            get { return CSharpVSResources.Option_RenameTrackingPreview; }
-        }
+        public static string Option_RenameTrackingPreview => CSharpVSResources.Option_RenameTrackingPreview;
 
-        public static string Option_DisplayLineSeparators
-        {
-            get { return CSharpVSResources.Option_DisplayLineSeparators; }
-        }
+        public static string Option_DisplayLineSeparators => CSharpVSResources.Option_DisplayLineSeparators;
 
-        public static string Option_DontPutOutOrRefOnStruct
-        {
-            get { return CSharpVSResources.Option_DontPutOutOrRefOnStruct; }
-        }
+        public static string Option_DontPutOutOrRefOnStruct => CSharpVSResources.Option_DontPutOutOrRefOnStruct;
 
-        public static string Option_EditorHelp
-        {
-            get { return CSharpVSResources.Option_EditorHelp; }
-        }
+        public static string Option_EditorHelp => CSharpVSResources.Option_EditorHelp;
 
-        public static string Option_EnableHighlightKeywords
-        {
-            get { return CSharpVSResources.Option_EnableHighlightKeywords; }
-        }
+        public static string Option_EnableHighlightKeywords => CSharpVSResources.Option_EnableHighlightKeywords;
 
-        public static string Option_EnableHighlightReferences
-        {
-            get { return CSharpVSResources.Option_EnableHighlightReferences; }
-        }
+        public static string Option_EnableHighlightReferences => CSharpVSResources.Option_EnableHighlightReferences;
 
-        public static string Option_EnterOutliningMode
-        {
-            get { return CSharpVSResources.Option_EnterOutliningMode; }
-        }
+        public static string Option_EnterOutliningMode => CSharpVSResources.Option_EnterOutliningMode;
 
-        public static string Option_ExtractMethod
-        {
-            get { return CSharpVSResources.Option_ExtractMethod; }
-        }
+        public static string Option_ExtractMethod => CSharpVSResources.Option_ExtractMethod;
 
-        public static string Option_GenerateXmlDocCommentsForTripleSlash
-        {
-            get { return CSharpVSResources.Option_GenerateXmlDocCommentsForTripleSlash; }
-        }
+        public static string Option_GenerateXmlDocCommentsForTripleSlash => CSharpVSResources.Option_GenerateXmlDocCommentsForTripleSlash;
 
-        public static string Option_InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments
-        {
-            get { return CSharpVSResources.Option_InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments; }
-        }
+        public static string Option_InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments => CSharpVSResources.Option_InsertAsteriskAtTheStartOfNewLinesWhenWritingBlockComments;
 
-        public static string Option_Highlighting
-        {
-            get { return CSharpVSResources.Option_Highlighting; }
-        }
+        public static string Option_Highlighting => CSharpVSResources.Option_Highlighting;
 
-        public static string Option_OptimizeForSolutionSize
-        {
-            get { return CSharpVSResources.Option_OptimizeForSolutionSize; }
-        }
+        public static string Option_OptimizeForSolutionSize => CSharpVSResources.Option_OptimizeForSolutionSize;
 
-        public static string Option_OptimizeForSolutionSize_Large
-        {
-            get { return CSharpVSResources.Option_OptimizeForSolutionSize_Large; }
-        }
+        public static string Option_OptimizeForSolutionSize_Large => CSharpVSResources.Option_OptimizeForSolutionSize_Large;
 
-        public static string Option_OptimizeForSolutionSize_Regular
-        {
-            get { return CSharpVSResources.Option_OptimizeForSolutionSize_Regular; }
-        }
+        public static string Option_OptimizeForSolutionSize_Regular => CSharpVSResources.Option_OptimizeForSolutionSize_Regular;
 
-        public static string Option_OptimizeForSolutionSize_Small
-        {
-            get { return CSharpVSResources.Option_OptimizeForSolutionSize_Small; }
-        }
+        public static string Option_OptimizeForSolutionSize_Small => CSharpVSResources.Option_OptimizeForSolutionSize_Small;
 
-        public static string Option_OrganizeUsings
-        {
-            get { return CSharpVSResources.Option_OrganizeUsings; }
-        }
+        public static string Option_OrganizeUsings => CSharpVSResources.Option_OrganizeUsings;
 
-        public static string Option_Outlining
-        {
-            get { return CSharpVSResources.Option_Outlining; }
-        }
+        public static string Option_Outlining => CSharpVSResources.Option_Outlining;
 
-        public static string Option_Performance
-        {
-            get { return CSharpVSResources.Option_Performance; }
-        }
+        public static string Option_Performance => CSharpVSResources.Option_Performance;
 
-        public static string Option_PlaceSystemNamespaceFirst
-        {
-            get { return CSharpVSResources.Option_PlaceSystemNamespaceFirst; }
-        }
+        public static string Option_PlaceSystemNamespaceFirst => CSharpVSResources.Option_PlaceSystemNamespaceFirst;
 
-        public static string Option_WarnOnBuildErrors
-        {
-            get { return CSharpVSResources.Option_WarnOnBuildErrors; }
-        }
+        public static string Option_WarnOnBuildErrors => CSharpVSResources.Option_WarnOnBuildErrors;
     }
 }

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
@@ -99,7 +99,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             return result.ToImmutable();
         }
 
-        protected override string LanguageName { get { return LanguageNames.CSharp; } }
+        protected override string LanguageName => LanguageNames.CSharp;
 
         protected override string SettingStorageRoot { get { return "TextEditor.CSharp.Specific."; } }
 

--- a/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/IntelliSenseOptionPageStrings.cs
@@ -4,34 +4,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 {
     internal static class IntelliSenseOptionPageStrings
     {
-        public static string Option_BringUpOnIdentifier
-        {
-            get { return CSharpVSResources.Option_BringUpOnIdentifier; }
-        }
+        public static string Option_BringUpOnIdentifier => CSharpVSResources.Option_BringUpOnIdentifier;
 
-        public static string Option_CompletionLists
-        {
-            get { return CSharpVSResources.Option_CompletionLists; }
-        }
+        public static string Option_CompletionLists => CSharpVSResources.Option_CompletionLists;
 
-        public static string Option_InsertNewlineOnEnterWithWholeWord
-        {
-            get { return CSharpVSResources.Option_InsertNewlineOnEnterWithWholeWord; }
-        }
+        public static string Option_InsertNewlineOnEnterWithWholeWord => CSharpVSResources.Option_InsertNewlineOnEnterWithWholeWord;
 
-        public static string Option_SelectionInCompletionList
-        {
-            get { return CSharpVSResources.Option_SelectionInCompletionList; }
-        }
+        public static string Option_SelectionInCompletionList => CSharpVSResources.Option_SelectionInCompletionList;
 
-        public static string Option_ShowKeywords
-        {
-            get { return CSharpVSResources.Option_ShowKeywords; }
-        }
+        public static string Option_ShowKeywords => CSharpVSResources.Option_ShowKeywords;
 
-        public static string Option_ShowSnippets
-        {
-            get { return CSharpVSResources.Option_ShowSnippets; }
-        }
+        public static string Option_ShowSnippets => CSharpVSResources.Option_ShowSnippets;
     }
 }

--- a/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowPackage.cs
@@ -24,15 +24,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
         private const string IdString = "CA8CC5C7-0231-406A-95CD-AA5ED6AC0190";
         internal static readonly Guid Id = new Guid(IdString);
 
-        protected override Guid ToolWindowId
-        {
-            get { return Id; }
-        }
+        protected override Guid ToolWindowId => Id;
 
-        protected override Guid LanguageServiceGuid
-        {
-            get { return LanguageServiceGuids.CSharpLanguageServiceId; }
-        }
+        protected override Guid LanguageServiceGuid => LanguageServiceGuids.CSharpLanguageServiceId;
 
         protected override void InitializeMenuCommands(OleMenuCommandService menuCommandService)
         {

--- a/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/CSharp/Repl/CSharpVsInteractiveWindowProvider.cs
@@ -32,15 +32,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
         {
         }
 
-        protected override Guid LanguageServiceGuid
-        {
-            get { return LanguageServiceGuids.CSharpLanguageServiceId; }
-        }
+        protected override Guid LanguageServiceGuid => LanguageServiceGuids.CSharpLanguageServiceId;
 
-        protected override Guid Id
-        {
-            get { return CSharpVsInteractiveWindowPackage.Id; }
-        }
+        protected override Guid Id => CSharpVsInteractiveWindowPackage.Id;
 
         protected override string Title
         {
@@ -64,12 +58,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Interactive
                 CommonVsUtils.GetWorkingDirectory());
         }
 
-        protected override FunctionId InteractiveWindowFunctionId
-        {
-            get
-            {
-                return FunctionId.CSharp_Interactive_Window;
-            }
-        }
+        protected override FunctionId InteractiveWindowFunctionId => FunctionId.CSharp_Interactive_Window;
     }
 }

--- a/src/VisualStudio/CSharp/Test/CodeModel/MockTextManagerAdapter.TextPoint.cs
+++ b/src/VisualStudio/CSharp/Test/CodeModel/MockTextManagerAdapter.TextPoint.cs
@@ -18,10 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.UnitTests.CodeModel
                 _point = point;
             }
 
-            public int AbsoluteCharOffset
-            {
-                get { return _point.Position; }
-            }
+            public int AbsoluteCharOffset => _point.Position;
 
             public bool AtEndOfDocument
             {

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/AnalyzersTests.cs
@@ -28,10 +28,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
                 File.Delete(_filePath);
             }
 
-            public string Path
-            {
-                get { return _filePath; }
-            }
+            public string Path => _filePath;
         }
 
         [Fact]

--- a/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractEditorFactory.cs
@@ -47,21 +47,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _waitIndicator = _componentModel.GetService<IWaitIndicator>();
         }
 
-        protected IServiceProvider ServiceProvider
-        {
-            get
-            {
-                return _package;
-            }
-        }
+        protected IServiceProvider ServiceProvider => _package;
 
-        protected IComponentModel ComponentModel
-        {
-            get
-            {
-                return _componentModel;
-            }
-        }
+        protected IComponentModel ComponentModel => _componentModel;
 
         protected abstract string ContentTypeName { get; }
 

--- a/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AbstractOleCommandTarget.cs
@@ -48,18 +48,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             _serviceProvider = serviceProvider;
         }
 
-        public IVsEditorAdaptersFactoryService EditorAdaptersFactory
-        {
-            get { return _editorAdaptersFactory; }
-        }
+        public IVsEditorAdaptersFactoryService EditorAdaptersFactory => _editorAdaptersFactory;
 
         /// <summary>
         /// The IWpfTextView that this command filter is attached to.
         /// </summary>
-        public IWpfTextView WpfTextView
-        {
-            get { return _wpfTextView; }
-        }
+        public IWpfTextView WpfTextView => _wpfTextView;
 
         /// <summary>
         /// The command handler service to use for dispatching commands. This is set by

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialog.xaml.cs
@@ -25,14 +25,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
         internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
-        public string ChangeSignatureDialogTitle { get { return ServicesVSResources.ChangeSignature; } }
-        public string Parameters { get { return ServicesVSResources.Parameters; } }
-        public string PreviewMethodSignature { get { return ServicesVSResources.PreviewMethodSignature; } }
-        public string PreviewReferenceChanges { get { return ServicesVSResources.PreviewReferenceChanges; } }
-        public string Remove { get { return ServicesVSResources.Remove; } }
-        public string Restore { get { return ServicesVSResources.Restore; } }
-        public string OK { get { return ServicesVSResources.OK; } }
-        public string Cancel { get { return ServicesVSResources.Cancel; } }
+        public string ChangeSignatureDialogTitle => ServicesVSResources.ChangeSignature;
+        public string Parameters => ServicesVSResources.Parameters;
+        public string PreviewMethodSignature => ServicesVSResources.PreviewMethodSignature;
+        public string PreviewReferenceChanges => ServicesVSResources.PreviewReferenceChanges;
+        public string Remove => ServicesVSResources.Remove;
+        public string Restore => ServicesVSResources.Restore;
+        public string OK => ServicesVSResources.OK;
+        public string Cancel => ServicesVSResources.Cancel;
 
         public Brush ParameterText { get; }
         public Brush RemovedParameterText { get; }

--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
@@ -368,10 +368,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
             private readonly IParameterSymbol _parameter;
             private ChangeSignatureDialogViewModel _changeSignatureDialogViewModel;
 
-            public IParameterSymbol ParameterSymbol
-            {
-                get { return _parameter; }
-            }
+            public IParameterSymbol ParameterSymbol => _parameter;
 
             public ParameterViewModel(ChangeSignatureDialogViewModel changeSignatureDialogViewModel, IParameterSymbol parameter)
             {
@@ -412,10 +409,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 get { return _parameter.Type.ToDisplayString(s_parameterDisplayFormat); }
             }
 
-            public string Parameter
-            {
-                get { return _parameter.Name; }
-            }
+            public string Parameter => _parameter.Name;
 
             public string Default
             {

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/AbstractDebuggerIntelliSenseContext.cs
@@ -80,13 +80,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             _isImmediateWindow = isImmediateWindow;
         }
 
-        public IVsTextLines DebuggerTextLines { get { return _debuggerTextLines; } }
+        public IVsTextLines DebuggerTextLines => _debuggerTextLines;
 
-        public ITextView DebuggerTextView { get { return _debuggerTextView; } }
+        public ITextView DebuggerTextView => _debuggerTextView;
 
-        public ITextBuffer Buffer { get { return _projectionBuffer; } }
+        public ITextBuffer Buffer => _projectionBuffer;
 
-        public IContentType ContentType { get { return _contentType; } }
+        public IContentType ContentType => _contentType;
 
         protected bool InImmediateWindow { get { return _immediateWindowContext != null; } }
 

--- a/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DebuggerIntelliSense/DebuggerTextView.cs
@@ -60,50 +60,23 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             get;
         }
 
-        public ITextCaret Caret
-        {
-            get { return _innerTextView.Caret; }
-        }
+        public ITextCaret Caret => _innerTextView.Caret;
 
-        public bool HasAggregateFocus
-        {
-            get { return _innerTextView.HasAggregateFocus; }
-        }
+        public bool HasAggregateFocus => _innerTextView.HasAggregateFocus;
 
-        public bool InLayout
-        {
-            get { return _innerTextView.InLayout; }
-        }
+        public bool InLayout => _innerTextView.InLayout;
 
-        public bool IsClosed
-        {
-            get { return _innerTextView.IsClosed; }
-        }
+        public bool IsClosed => _innerTextView.IsClosed;
 
-        public bool IsMouseOverViewOrAdornments
-        {
-            get { return _innerTextView.IsMouseOverViewOrAdornments; }
-        }
+        public bool IsMouseOverViewOrAdornments => _innerTextView.IsMouseOverViewOrAdornments;
 
-        public double LineHeight
-        {
-            get { return _innerTextView.LineHeight; }
-        }
+        public double LineHeight => _innerTextView.LineHeight;
 
-        public double MaxTextRightCoordinate
-        {
-            get { return _innerTextView.MaxTextRightCoordinate; }
-        }
+        public double MaxTextRightCoordinate => _innerTextView.MaxTextRightCoordinate;
 
-        public IEditorOptions Options
-        {
-            get { return _innerTextView.Options; }
-        }
+        public IEditorOptions Options => _innerTextView.Options;
 
-        public PropertyCollection Properties
-        {
-            get { return _innerTextView.Properties; }
-        }
+        public PropertyCollection Properties => _innerTextView.Properties;
 
         public ITrackingSpan ProvisionalTextHighlight
         {
@@ -118,40 +91,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
         }
 
-        public ITextViewRoleSet Roles
-        {
-            get { return _innerTextView.Roles; }
-        }
+        public ITextViewRoleSet Roles => _innerTextView.Roles;
 
-        public ITextSelection Selection
-        {
-            get { return _innerTextView.Selection; }
-        }
+        public ITextSelection Selection => _innerTextView.Selection;
 
-        public ITextViewLineCollection TextViewLines
-        {
-            get { return _innerTextView.TextViewLines; }
-        }
+        public ITextViewLineCollection TextViewLines => _innerTextView.TextViewLines;
 
-        public ITextViewModel TextViewModel
-        {
-            get { return _innerTextView.TextViewModel; }
-        }
+        public ITextViewModel TextViewModel => _innerTextView.TextViewModel;
 
-        public IViewScroller ViewScroller
-        {
-            get { return _innerTextView.ViewScroller; }
-        }
+        public IViewScroller ViewScroller => _innerTextView.ViewScroller;
 
-        public double ViewportBottom
-        {
-            get { return _innerTextView.ViewportBottom; }
-        }
+        public double ViewportBottom => _innerTextView.ViewportBottom;
 
-        public double ViewportHeight
-        {
-            get { return _innerTextView.ViewportHeight; }
-        }
+        public double ViewportHeight => _innerTextView.ViewportHeight;
 
         public double ViewportLeft
         {
@@ -166,25 +118,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
         }
 
-        public double ViewportRight
-        {
-            get { return _innerTextView.ViewportRight; }
-        }
+        public double ViewportRight => _innerTextView.ViewportRight;
 
-        public double ViewportTop
-        {
-            get { return _innerTextView.ViewportTop; }
-        }
+        public double ViewportTop => _innerTextView.ViewportTop;
 
-        public double ViewportWidth
-        {
-            get { return _innerTextView.ViewportWidth; }
-        }
+        public double ViewportWidth => _innerTextView.ViewportWidth;
 
-        public ITextSnapshot VisualSnapshot
-        {
-            get { return _innerTextView.VisualSnapshot; }
-        }
+        public ITextSnapshot VisualSnapshot => _innerTextView.VisualSnapshot;
 
         public ITextDataModel TextDataModel
         {
@@ -194,29 +134,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
         }
 
-        public ITextBuffer TextBuffer
-        {
-            get
-            {
-                return _innerTextView.TextBuffer;
-            }
-        }
+        public ITextBuffer TextBuffer => _innerTextView.TextBuffer;
 
-        public ITextSnapshot TextSnapshot
-        {
-            get
-            {
-                return _innerTextView.TextSnapshot;
-            }
-        }
+        public ITextSnapshot TextSnapshot => _innerTextView.TextSnapshot;
 
-        public FrameworkElement VisualElement
-        {
-            get
-            {
-                return _innerTextView.VisualElement;
-            }
-        }
+        public FrameworkElement VisualElement => _innerTextView.VisualElement;
 
         public Brush Background
         {
@@ -231,29 +153,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelli
             }
         }
 
-        IWpfTextViewLineCollection IWpfTextView.TextViewLines
-        {
-            get
-            {
-                return _innerTextView.TextViewLines;
-            }
-        }
+        IWpfTextViewLineCollection IWpfTextView.TextViewLines => _innerTextView.TextViewLines;
 
-        public IFormattedLineSource FormattedLineSource
-        {
-            get
-            {
-                return _innerTextView.FormattedLineSource;
-            }
-        }
+        public IFormattedLineSource FormattedLineSource => _innerTextView.FormattedLineSource;
 
-        public ILineTransformSource LineTransformSource
-        {
-            get
-            {
-                return _innerTextView.LineTransformSource;
-            }
-        }
+        public ILineTransformSource LineTransformSource => _innerTextView.LineTransformSource;
 
         public double ZoomLevel
         {

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -167,13 +167,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
                 {
                 }
 
-                public override string BuildTool
-                {
-                    get
-                    {
-                        return PredefinedBuildTools.Live;
-                    }
-                }
+                public override string BuildTool => PredefinedBuildTools.Live;
 
                 public override bool Equals(object obj)
                 {

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsReadOnlyDocumentTracker.cs
@@ -39,10 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             UpdateWorkspaceDocuments();
         }
 
-        public Workspace Workspace
-        {
-            get { return _workspace; }
-        }
+        public Workspace Workspace => _workspace;
 
         private void OnDocumentOpened(object sender, DocumentEventArgs e)
         {

--- a/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ExtractInterface/ExtractInterfaceDialog.xaml.cs
@@ -24,15 +24,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ExtractInterfac
         internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
-        public string ExtractInterfaceDialogTitle { get { return ServicesVSResources.ExtractInterface; } }
-        public string NewInterfaceName { get { return ServicesVSResources.NewInterfaceName; } }
-        public string GeneratedName { get { return ServicesVSResources.GeneratedName; } }
-        public string NewFileName { get { return ServicesVSResources.NewFileName; } }
-        public string SelectPublicMembersToFormInterface { get { return ServicesVSResources.SelectPublicMembersToFormInterface; } }
-        public string SelectAll { get { return ServicesVSResources.SelectAll; } }
-        public string DeselectAll { get { return ServicesVSResources.DeselectAll; } }
-        public string OK { get { return ServicesVSResources.OK; } }
-        public string Cancel { get { return ServicesVSResources.Cancel; } }
+        public string ExtractInterfaceDialogTitle => ServicesVSResources.ExtractInterface;
+        public string NewInterfaceName => ServicesVSResources.NewInterfaceName;
+        public string GeneratedName => ServicesVSResources.GeneratedName;
+        public string NewFileName => ServicesVSResources.NewFileName;
+        public string SelectPublicMembersToFormInterface => ServicesVSResources.SelectPublicMembersToFormInterface;
+        public string SelectAll => ServicesVSResources.SelectAll;
+        public string DeselectAll => ServicesVSResources.DeselectAll;
+        public string OK => ServicesVSResources.OK;
+        public string Cancel => ServicesVSResources.Cancel;
 
         // Use C# Extract Interface helpTopic for C# and VB.
         internal ExtractInterfaceDialog(ExtractInterfaceDialogViewModel viewModel)

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialog.xaml.cs
@@ -32,18 +32,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
         internal static event Action TEST_DialogLoaded;
 
         // Expose localized strings for binding
-        public string GenerateTypeDialogTitle { get { return ServicesVSResources.GenerateType; } }
-        public string TypeDetails { get { return ServicesVSResources.TypeDetails; } }
-        public string Access { get { return ServicesVSResources.Access; } }
-        public string Kind { get { return ServicesVSResources.Kind; } }
-        public string NameLabel { get { return ServicesVSResources.Name; } }
-        public string Location { get { return ServicesVSResources.Location; } }
-        public string Project { get { return ServicesVSResources.Project; } }
-        public string FileName { get { return ServicesVSResources.FileName; } }
-        public string CreateNewFile { get { return ServicesVSResources.CreateNewFile; } }
-        public string AddToExistingFile { get { return ServicesVSResources.AddToExistingFile; } }
-        public string OK { get { return ServicesVSResources.OK; } }
-        public string Cancel { get { return ServicesVSResources.Cancel; } }
+        public string GenerateTypeDialogTitle => ServicesVSResources.GenerateType;
+        public string TypeDetails => ServicesVSResources.TypeDetails;
+        public string Access => ServicesVSResources.Access;
+        public string Kind => ServicesVSResources.Kind;
+        public string NameLabel => ServicesVSResources.Name;
+        public string Location => ServicesVSResources.Location;
+        public string Project => ServicesVSResources.Project;
+        public string FileName => ServicesVSResources.FileName;
+        public string CreateNewFile => ServicesVSResources.CreateNewFile;
+        public string AddToExistingFile => ServicesVSResources.AddToExistingFile;
+        public string OK => ServicesVSResources.OK;
+        public string Cancel => ServicesVSResources.Cancel;
 
         public GenerateTypeDialog(GenerateTypeDialogViewModel viewModel)
             : base("vsl.GenerateFromUsage")

--- a/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/GenerateType/GenerateTypeDialogViewModel.cs
@@ -796,21 +796,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
         {
             private Project _project;
 
-            public string Name
-            {
-                get
-                {
-                    return _project.Name;
-                }
-            }
+            public string Name => _project.Name;
 
-            public Project Project
-            {
-                get
-                {
-                    return _project;
-                }
-            }
+            public Project Project => _project;
 
             public ProjectSelectItem(Project project)
             {
@@ -821,22 +809,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.GenerateType
         public class DocumentSelectItem
         {
             private Document _document;
-            public Document Document
-            {
-                get
-                {
-                    return _document;
-                }
-            }
+            public Document Document => _document;
 
             private string _name;
-            public string Name
-            {
-                get
-                {
-                    return _name;
-                }
-            }
+            public string Name => _name;
 
             public DocumentSelectItem(Document document, string documentName)
             {

--- a/src/VisualStudio/Core/Def/Implementation/Interop/ComHandle.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Interop/ComHandle.cs
@@ -85,13 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Interop
         /// <summary>
         /// Return the managed object
         /// </summary>
-        public TObject Object
-        {
-            get
-            {
-                return _managedObject;
-            }
-        }
+        public TObject Object => _managedObject;
 
         public ComHandle<TNewHandle, TNewObject> Cast<TNewHandle, TNewObject>()
             where TNewHandle : class

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`2.cs
@@ -59,13 +59,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             this.Package = package;
         }
 
-        public override IServiceProvider SystemServiceProvider
-        {
-            get
-            {
-                return this.Package;
-            }
-        }
+        public override IServiceProvider SystemServiceProvider => this.Package;
 
         /// <summary>
         /// Setup and TearDown go in reverse order.

--- a/src/VisualStudio/Core/Def/Implementation/Library/AbstractLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/AbstractLibraryManager.cs
@@ -28,14 +28,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library
             }
         }
 
-        public IServiceProvider ServiceProvider
-        {
-            get { return _serviceProvider; }
-        }
+        public IServiceProvider ServiceProvider => _serviceProvider;
 
-        public IntPtr ImageListPtr
-        {
-            get { return _imageListPtr; }
-        }
+        public IntPtr ImageListPtr => _imageListPtr;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -129,10 +129,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             }
         }
 
-        internal uint PackageVersion
-        {
-            get { return _packageVersion; }
-        }
+        internal uint PackageVersion => _packageVersion;
 
         internal void UpdateClassAndMemberVersions()
         {

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/FolderListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/FolderListItem.cs
@@ -15,19 +15,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _displayText = displayText;
         }
 
-        public override string DisplayText
-        {
-            get { return _displayText; }
-        }
+        public override string DisplayText => _displayText;
 
-        public override string FullNameText
-        {
-            get { return _displayText; }
-        }
+        public override string FullNameText => _displayText;
 
-        public override string SearchText
-        {
-            get { return _displayText; }
-        }
+        public override string SearchText => _displayText;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/MemberListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/MemberListItem.cs
@@ -56,14 +56,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             }
         }
 
-        public bool IsInherited
-        {
-            get { return _isInherited; }
-        }
+        public bool IsInherited => _isInherited;
 
-        public MemberKind Kind
-        {
-            get { return _kind; }
-        }
+        public MemberKind Kind => _kind;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ProjectListItem.cs
@@ -29,19 +29,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             }
         }
 
-        public override string DisplayText
-        {
-            get { return _displayText; }
-        }
+        public override string DisplayText => _displayText;
 
-        public override string FullNameText
-        {
-            get { return _displayText; }
-        }
+        public override string FullNameText => _displayText;
 
-        public override string SearchText
-        {
-            get { return _displayText; }
-        }
+        public override string SearchText => _displayText;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ReferenceListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/ReferenceListItem.cs
@@ -17,25 +17,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _reference = reference;
         }
 
-        public override string DisplayText
-        {
-            get { return _name; }
-        }
+        public override string DisplayText => _name;
 
-        public override string FullNameText
-        {
-            get { return _name; }
-        }
+        public override string FullNameText => _name;
 
-        public override string SearchText
-        {
-            get { return _name; }
-        }
+        public override string SearchText => _name;
 
-        public MetadataReference MetadataReference
-        {
-            get { return _reference; }
-        }
+        public MetadataReference MetadataReference => _reference;
 
         public IAssemblySymbol GetAssembly(Compilation compilation)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/SymbolListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/SymbolListItem.cs
@@ -33,35 +33,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _supportsFindAllReferences = symbol.Kind != SymbolKind.Namespace;
         }
 
-        public Accessibility Accessibility
-        {
-            get { return _accessibility; }
-        }
+        public Accessibility Accessibility => _accessibility;
 
-        public override string DisplayText
-        {
-            get { return _displayText; }
-        }
+        public override string DisplayText => _displayText;
 
-        public override string FullNameText
-        {
-            get { return _fullNameText; }
-        }
+        public override string FullNameText => _fullNameText;
 
-        public override string SearchText
-        {
-            get { return _searchText; }
-        }
+        public override string SearchText => _searchText;
 
-        public override bool SupportsGoToDefinition
-        {
-            get { return _supportsGoToDefinition; }
-        }
+        public override bool SupportsGoToDefinition => _supportsGoToDefinition;
 
-        public override bool SupportsFindAllReferences
-        {
-            get { return _supportsFindAllReferences; }
-        }
+        public override bool SupportsFindAllReferences => _supportsFindAllReferences;
 
         public ISymbol ResolveSymbol(Compilation compilation)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/TypeListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/Lists/TypeListItem.cs
@@ -14,9 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             _typeKind = typeSymbol.TypeKind;
         }
 
-        public TypeKind Kind
-        {
-            get { return _typeKind; }
-        }
+        public TypeKind Kind => _typeKind;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectList.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectList.cs
@@ -975,10 +975,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             return true;
         }
 
-        public ObjectListKind Kind
-        {
-            get { return _kind; }
-        }
+        public ObjectListKind Kind => _kind;
 
         public ObjectListKind ParentKind
         {
@@ -990,9 +987,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             }
         }
 
-        public ObjectListItem ParentListItem
-        {
-            get { return _parentListItem; }
-        }
+        public ObjectListItem ParentListItem => _parentListItem;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectListItem.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/ObjectListItem.cs
@@ -57,10 +57,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             return DisplayText;
         }
 
-        public ObjectList ParentList
-        {
-            get { return _parentList; }
-        }
+        public ObjectList ParentList => _parentList;
 
         public ObjectListKind ParentListKind
         {
@@ -72,13 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             }
         }
 
-        public ProjectId ProjectId
-        {
-            get
-            {
-                return _projectId;
-            }
-        }
+        public ProjectId ProjectId => _projectId;
 
         public Compilation GetCompilation(Workspace workspace)
         {
@@ -93,14 +84,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                 .WaitAndGetResult_ObjectBrowser(CancellationToken.None);
         }
 
-        public ushort GlyphIndex
-        {
-            get { return _glyphIndex; }
-        }
+        public ushort GlyphIndex => _glyphIndex;
 
-        public bool IsHidden
-        {
-            get { return _isHidden; }
-        }
+        public bool IsHidden => _isHidden;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Preview/ReferenceChange.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Preview/ReferenceChange.cs
@@ -67,9 +67,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Preview
             }
         }
 
-        protected ProjectId ProjectId { get { return _projectId; } }
-        internal bool IsAddedReference { get { return _isAddedReference; } }
-        protected string ProjectName { get { return _projectName; } }
+        protected ProjectId ProjectId => _projectId;
+        internal bool IsAddedReference => _isAddedReference;
+        protected string ProjectName => _projectName;
 
         protected abstract string GetDisplayText();
         internal abstract Solution AddToSolution(Solution solution);

--- a/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/GraphBuilder.cs
@@ -716,13 +716,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             }
         }
 
-        public Graph Graph
-        {
-            get
-            {
-                return _graph;
-            }
-        }
+        public Graph Graph => _graph;
 
         public IEnumerable<GraphNode> CreatedNodes
         {

--- a/src/VisualStudio/Core/Def/Implementation/Progression/IProgressionPrimaryWorkspaceProvider.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Progression/IProgressionPrimaryWorkspaceProvider.cs
@@ -22,12 +22,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Progression
             _workspace = workspace;
         }
 
-        public Workspace PrimaryWorkspace
-        {
-            get
-            {
-                return _workspace;
-            }
-        }
+        public Workspace PrimaryWorkspace => _workspace;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -284,25 +284,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// matches the display name of the project the user actually sees in the solution explorer.
         /// These can be assumed to be unique within the Visual Studio workspace.
         /// </summary>
-        public string ProjectSystemName
-        {
-            get { return _projectSystemName; }
-        }
+        public string ProjectSystemName => _projectSystemName;
 
-        protected DocumentProvider DocumentProvider
-        {
-            get { return this.ProjectTracker.DocumentProvider; }
-        }
+        protected DocumentProvider DocumentProvider => this.ProjectTracker.DocumentProvider;
 
-        protected VisualStudioMetadataReferenceManager MetadataReferenceProvider
-        {
-            get { return this.ProjectTracker.MetadataReferenceProvider; }
-        }
+        protected VisualStudioMetadataReferenceManager MetadataReferenceProvider => this.ProjectTracker.MetadataReferenceProvider;
 
-        protected IContentTypeRegistryService ContentTypeRegistryService
-        {
-            get { return _contentTypeRegistryService; }
-        }
+        protected IContentTypeRegistryService ContentTypeRegistryService => _contentTypeRegistryService;
 
         public ProjectInfo CreateProjectInfoForCurrentState()
         {
@@ -1130,13 +1118,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             StartPushingToWorkspaceAndNotifyOfOpenDocuments(this);
         }
 
-        internal bool PushingChangesToWorkspaceHosts
-        {
-            get
-            {
-                return _pushingChangesToWorkspaceHosts;
-            }
-        }
+        internal bool PushingChangesToWorkspaceHosts => _pushingChangesToWorkspaceHosts;
 
         protected void UpdateRuleSetError(IRuleSetFile ruleSetFile)
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentKey.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentKey.cs
@@ -19,8 +19,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         private readonly IVisualStudioHostProject _hostProject;
         private readonly string _moniker;
 
-        public IVisualStudioHostProject HostProject { get { return _hostProject; } }
-        public string Moniker { get { return _moniker; } }
+        public IVisualStudioHostProject HostProject => _hostProject;
+        public string Moniker => _moniker;
 
         public DocumentKey(IVisualStudioHostProject hostProject, string moniker)
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/DocumentProvider.StandardTextDocument.cs
@@ -90,10 +90,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 get { return _openTextBuffer != null; }
             }
 
-            public string FilePath
-            {
-                get { return Key.Moniker; }
-            }
+            public string FilePath => Key.Moniker;
 
             public string Name
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/FileChangeTracker.cs
@@ -44,10 +44,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        public string FilePath
-        {
-            get { return _filePath; }
-        }
+        public string FilePath => _filePath;
 
         public void AssertUnsubscription()
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/InvisibleEditor.cs
@@ -77,13 +77,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
-        public IVsTextLines VsTextLines
-        {
-            get
-            {
-                return _vsTextLines;
-            }
-        }
+        public IVsTextLines VsTextLines => _vsTextLines;
 
         public ITextBuffer TextBuffer
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReference.cs
@@ -39,20 +39,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _fileChangeTracker.StartFileChangeListeningAsync();
         }
 
-        public string FilePath
-        {
-            get { return _fileChangeTracker.FilePath; }
-        }
+        public string FilePath => _fileChangeTracker.FilePath;
 
-        public IVisualStudioHostProject Project
-        {
-            get { return _hostProject; }
-        }
+        public IVisualStudioHostProject Project => _hostProject;
 
-        public MetadataReferenceProperties Properties
-        {
-            get { return _properties; }
-        }
+        public MetadataReferenceProperties Properties => _properties;
 
         public PortableExecutableReference CurrentSnapshot
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -90,15 +90,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }).Select(FileUtilities.NormalizeDirectoryPath).ToImmutableArray();
         }
 
-        internal IVsXMLMemberIndexService XmlMemberIndexService
-        {
-            get { return _xmlMemberIndexService; }
-        }
+        internal IVsXMLMemberIndexService XmlMemberIndexService => _xmlMemberIndexService;
 
-        internal IVsFileChangeEx FileChangeService
-        {
-            get { return _fileChangeService; }
-        }
+        internal IVsFileChangeEx FileChangeService => _fileChangeService;
 
         /// <exception cref="IOException"/>
         /// <exception cref="BadImageFormatException" />

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/RuleSets/VisualStudioRuleSetManager.RuleSetFile.cs
@@ -61,10 +61,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             public event EventHandler UpdatedOnDisk;
 
-            public string FilePath
-            {
-                get { return _filePath; }
-            }
+            public string FilePath => _filePath;
 
             public Exception GetException()
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/ViewEventArgs.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/ViewEventArgs.cs
@@ -14,6 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _textView = textView;
         }
 
-        public IVsTextView TextView { get { return _textView; } }
+        public IVsTextView TextView => _textView;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioAnalyzer.cs
@@ -39,10 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _language = language;
         }
 
-        public string FullPath
-        {
-            get { return _fullPath; }
-        }
+        public string FullPath => _fullPath;
 
         public bool HasLoadErrors
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.WorkspaceHostState.cs
@@ -32,7 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _solutionAdded = false;
             }
 
-            public IVisualStudioWorkspaceHost Host { get { return _workspaceHost; } }
+            public IVisualStudioWorkspaceHost Host => _workspaceHost;
 
             /// <summary>
             /// Whether or not the project tracker has been notified that it should start to push state

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -50,7 +50,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// </summary>
         private bool _solutionLoadComplete = false;
 
-        internal IEnumerable<AbstractProject> Projects { get { return _projectMap.Values; } }
+        internal IEnumerable<AbstractProject> Projects => _projectMap.Values;
 
         IEnumerable<IVisualStudioHostProject> IVisualStudioHostProjectContainer.GetProjects()
         {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -110,13 +110,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             _projectTracker = projectTracker;
         }
 
-        internal VisualStudioProjectTracker ProjectTracker
-        {
-            get
-            {
-                return _projectTracker;
-            }
-        }
+        internal VisualStudioProjectTracker ProjectTracker => _projectTracker;
 
         internal void ClearReferenceCache()
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQEvent.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQEvent.cs
@@ -8,9 +8,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             : base(containingType, memberName)
         { }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.Event; }
-        }
+        protected override string RQKeyword => RQNameStrings.Event;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQExplicitInterfaceMemberName.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQExplicitInterfaceMemberName.cs
@@ -20,10 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.Name = name;
         }
 
-        public override string OrdinaryNameValue
-        {
-            get { return Name.OrdinaryNameValue; }
-        }
+        public override string OrdinaryNameValue => Name.OrdinaryNameValue;
 
         public override SimpleGroupNode ToSimpleTree()
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMemberParameterIndex.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMemberParameterIndex.cs
@@ -20,10 +20,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.ParameterIndex = parameterIndex;
         }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.MemberParamIndex; }
-        }
+        protected override string RQKeyword => RQNameStrings.MemberParamIndex;
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMemberVariable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMemberVariable.cs
@@ -15,15 +15,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.Name = name;
         }
 
-        public override string MemberName
-        {
-            get { return this.Name; }
-        }
+        public override string MemberName => this.Name;
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.MembVar; }
-        }
+        protected override string RQKeyword => RQNameStrings.MembVar;
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMethodBase.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMethodBase.cs
@@ -14,9 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             : base(containingType, memberName, typeParameterCount, parameters)
         { }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.Meth; }
-        }
+        protected override string RQKeyword => RQNameStrings.Meth;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMethodPropertyOrEvent.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQMethodPropertyOrEvent.cs
@@ -15,10 +15,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.RqMemberName = memberName;
         }
 
-        public override string MemberName
-        {
-            get { return this.RqMemberName.OrdinaryNameValue; }
-        }
+        public override string MemberName => this.RqMemberName.OrdinaryNameValue;
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQNamespace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQNamespace.cs
@@ -9,9 +9,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
     {
         public RQNamespace(IList<string> namespaceNames) : base(namespaceNames) { }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.Namespace; }
-        }
+        protected override string RQKeyword => RQNameStrings.Namespace;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQOrdinaryMethodPropertyOrEventName.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQOrdinaryMethodPropertyOrEventName.cs
@@ -18,10 +18,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.Name = name;
         }
 
-        public override string OrdinaryNameValue
-        {
-            get { return Name; }
-        }
+        public override string OrdinaryNameValue => Name;
 
         public static RQOrdinaryMethodPropertyOrEventName CreateConstructorName()
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQPropertyBase.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQPropertyBase.cs
@@ -14,9 +14,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             : base(containingType, memberName, typeParameterCount, parameters)
         { }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.Prop; }
-        }
+        protected override string RQKeyword => RQNameStrings.Prop;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQUnconstructedType.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/Nodes/RQUnconstructedType.cs
@@ -19,10 +19,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.Nodes
             this.TypeInfos = new ReadOnlyCollection<RQUnconstructedTypeInfo>(typeInfos);
         }
 
-        protected override string RQKeyword
-        {
-            get { return RQNameStrings.Agg; }
-        }
+        protected override string RQKeyword => RQNameStrings.Agg;
 
         protected override void AppendChildren(List<SimpleTreeNode> childList)
         {

--- a/src/VisualStudio/Core/Def/Implementation/RQName/SimpleTree/SimpleGroupNode.cs
+++ b/src/VisualStudio/Core/Def/Implementation/RQName/SimpleTree/SimpleGroupNode.cs
@@ -21,10 +21,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.RQName.SimpleTr
 
         public SimpleGroupNode(string text, params SimpleTreeNode[] children) : this(text, children.ToList()) { }
 
-        public IList<SimpleTreeNode> Children { get { return _children; } }
+        public IList<SimpleTreeNode> Children => _children;
 
         public SimpleTreeNode this[int index] { get { return Children[index]; } }
 
-        public int Count { get { return Children.Count; } }
+        public int Count => Children.Count;
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableDataSource.cs
@@ -271,10 +271,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             }
         }
 
-        internal int NumberOfSubscription_TestOnly
-        {
-            get { return _subscriptions.Length; }
-        }
+        internal int NumberOfSubscription_TestOnly => _subscriptions.Length;
 
         protected class SubscriptionWithoutLock : IDisposable
         {

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/AbstractTableEntriesSnapshot.cs
@@ -36,21 +36,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
         public abstract bool TryGetValue(int index, string columnName, out object content);
         protected abstract bool IsEquivalent(TData item1, TData item2);
 
-        public int VersionNumber
-        {
-            get
-            {
-                return _version;
-            }
-        }
+        public int VersionNumber => _version;
 
-        public int Count
-        {
-            get
-            {
-                return _items.Length;
-            }
-        }
+        public int Count => _items.Length;
 
         public int IndexOf(int index, ITableEntriesSnapshot newerSnapshot)
         {

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -516,10 +516,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             {
             }
 
-            public override string BuildTool
-            {
-                get { return PredefinedBuildTools.Build; }
-            }
+            public override string BuildTool => PredefinedBuildTools.Build;
 
             public override bool Equals(object obj)
             {

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -29,13 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
             registrationService.Register(this);
         }
 
-        public override Workspace Workspace
-        {
-            get
-            {
-                return _workspace;
-            }
-        }
+        public override Workspace Workspace => _workspace;
 
         private void RaiseDiagnosticsCreatedForProject(ProjectId projectId, object key, IEnumerable<DiagnosticData> items)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -72,7 +72,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly IFormattingRule _vbHelperFormattingRule;
         private readonly string _itemMoniker;
 
-        public AbstractProject Project { get { return _containedLanguage.Project; } }
+        public AbstractProject Project => _containedLanguage.Project;
         public bool SupportsRename { get { return _hostType == HostType.Razor; } }
 
         public DocumentId Id { get; }
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
 #pragma warning restore 67
 
-        IVisualStudioHostProject IVisualStudioHostDocument.Project { get { return this.Project; } }
+        IVisualStudioHostProject IVisualStudioHostDocument.Project => this.Project;
 
         public ITextBuffer GetOpenTextBuffer()
         {
@@ -200,13 +200,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             return this.GetOpenTextBuffer().AsTextContainer();
         }
 
-        public IContentType ContentType
-        {
-            get
-            {
-                return _containedLanguage.SubjectBuffer.ContentType;
-            }
-        }
+        public IContentType ContentType => _containedLanguage.SubjectBuffer.ContentType;
 
         public string Name
         {
@@ -223,29 +217,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             }
         }
 
-        public SourceCodeKind SourceCodeKind
-        {
-            get
-            {
-                return _sourceCodeKind;
-            }
-        }
+        public SourceCodeKind SourceCodeKind => _sourceCodeKind;
 
-        public string FilePath
-        {
-            get
-            {
-                return Key.Moniker;
-            }
-        }
+        public string FilePath => Key.Moniker;
 
-        public AbstractContainedLanguage ContainedLanguage
-        {
-            get
-            {
-                return _containedLanguage;
-            }
-        }
+        public AbstractContainedLanguage ContainedLanguage => _containedLanguage;
 
         public void Dispose()
         {

--- a/src/VisualStudio/Core/Def/Implementation/Watson/Watson.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Watson/Watson.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Watson
             [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 255)]
             internal string Component;
 
-            internal string EventType { get { return _pszEventTypeName; } }
+            internal string EventType => _pszEventTypeName;
 
             internal IEnumerable<KeyValuePair<string, string>> Parameters
             {

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentStorage.AbstractTableAccessor.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentStorage.AbstractTableAccessor.cs
@@ -68,13 +68,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
                 _updater = new Update(_session.SessionId, TableId, mode);
             }
 
-            protected JET_SESID SessionId
-            {
-                get
-                {
-                    return _session.SessionId;
-                }
-            }
+            protected JET_SESID SessionId => _session.SessionId;
 
             protected JET_TABLEID TableId
             {

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentStorage.OpenSession.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentStorage.OpenSession.cs
@@ -42,8 +42,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
                 _cancellationTokenRegistration = shutdownCancellationToken.Register(() => Dispose(), useSynchronizationContext: false);
             }
 
-            public JET_SESID SessionId { get { return _session.JetSesid; } }
-            public JET_DBID DatabaseId { get { return _databaseId; } }
+            public JET_SESID SessionId => _session.JetSesid;
+            public JET_DBID DatabaseId => _databaseId;
 
             public void Dispose()
             {

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelObject.cs
@@ -29,10 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _state = state;
         }
 
-        protected bool IsZombied
-        {
-            get { return _zombied; }
-        }
+        protected bool IsZombied => _zombied;
 
         internal CodeModelState State
         {
@@ -48,30 +45,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
         }
 
-        internal ICodeGenerationService CodeGenerationService
-        {
-            get { return this.State.CodeGenerator; }
-        }
+        internal ICodeGenerationService CodeGenerationService => this.State.CodeGenerator;
 
-        internal ICodeModelService CodeModelService
-        {
-            get { return this.State.CodeModelService; }
-        }
+        internal ICodeModelService CodeModelService => this.State.CodeModelService;
 
-        internal IServiceProvider ServiceProvider
-        {
-            get { return this.State.ServiceProvider; }
-        }
+        internal IServiceProvider ServiceProvider => this.State.ServiceProvider;
 
-        internal ISyntaxFactsService SyntaxFactsService
-        {
-            get { return this.State.SyntaxFactsService; }
-        }
+        internal ISyntaxFactsService SyntaxFactsService => this.State.SyntaxFactsService;
 
-        internal VisualStudioWorkspace Workspace
-        {
-            get { return this.State.Workspace; }
-        }
+        internal VisualStudioWorkspace Workspace => this.State.Workspace;
 
         internal virtual void Shutdown()
         {
@@ -84,10 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             get { return (DTE)this.ServiceProvider.GetService(typeof(SDTE)); }
         }
 
-        public string Language
-        {
-            get { return this.CodeModelService.Language; }
-        }
+        public string Language => this.CodeModelService.Language;
 
         protected EnvDTE.CodeElements GetCollection<T>(object parentObject)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelEventQueue.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelEventQueue.cs
@@ -67,9 +67,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _eventQueue.Dequeue();
         }
 
-        public int Count
-        {
-            get { return _eventQueue.Count; }
-        }
+        public int Count => _eventQueue.Count;
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.CacheEntry.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.CacheEntry.cs
@@ -31,26 +31,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 _fileCodeModelWeakComHandle = new WeakComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>(handle);
             }
 
-            public EnvDTE80.FileCodeModel2 FileCodeModelRcw
-            {
-                get
-                {
-                    return _fileCodeModelWeakComHandle.ComAggregateObject;
-                }
-            }
+            public EnvDTE80.FileCodeModel2 FileCodeModelRcw => _fileCodeModelWeakComHandle.ComAggregateObject;
 
             internal bool TryGetFileCodeModelInstanceWithoutCaringWhetherRcwIsAlive(out FileCodeModel fileCodeModel)
             {
                 return _fileCodeModelWeakComHandle.TryGetManagedObjectWithoutCaringWhetherNativeObjectIsAlive(out fileCodeModel);
             }
 
-            public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>? ComHandle
-            {
-                get
-                {
-                    return _fileCodeModelWeakComHandle.ComHandle;
-                }
-            }
+            public ComHandle<EnvDTE80.FileCodeModel2, FileCodeModel>? ComHandle => _fileCodeModelWeakComHandle.ComHandle;
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeModelProjectCache.cs
@@ -32,10 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _state = new CodeModelState(serviceProvider, languageServices, workspace);
         }
 
-        private bool IsZombied
-        {
-            get { return _zombied; }
-        }
+        private bool IsZombied => _zombied;
 
         /// <summary>
         /// Look for an existing instance of FileCodeModel in our cache.

--- a/src/VisualStudio/Core/Impl/CodeModel/CodeTypeRef.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/CodeTypeRef.cs
@@ -119,10 +119,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
         }
 
-        public object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public object Parent => _parentHandle.Value;
 
         public int Rank
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/AbstractCodeElementCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/AbstractCodeElementCollection.cs
@@ -62,13 +62,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return VSConstants.E_INVALIDARG;
         }
 
-        public object Parent
-        {
-            get
-            {
-                return _parentHandle.Value;
-            }
-        }
+        public object Parent => _parentHandle.Value;
 
         public bool CreateUniqueID(string prefix, ref string newName)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/AttributeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/AttributeCollection.cs
@@ -33,10 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             get { return (AbstractCodeElement)Parent; }
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return this.ParentElement.FileCodeModel; }
-        }
+        private FileCodeModel FileCodeModel => this.ParentElement.FileCodeModel;
 
         private SyntaxNode LookupNode()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/BasesCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/BasesCollection.cs
@@ -47,10 +47,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _interfaces = interfaces;
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        private FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         private SyntaxNode LookupNode()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/CodeElementSnapshot.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/CodeElementSnapshot.cs
@@ -34,10 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _elements = elements;
         }
 
-        public override int Count
-        {
-            get { return _elements.Length; }
-        }
+        public override int Count => _elements.Length;
 
         public override EnvDTE.CodeElement this[int index]
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalNamespaceEnumerator.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalNamespaceEnumerator.cs
@@ -35,13 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
 
         private readonly IEnumerator<EnvDTE.CodeElement> _childEnumerator;
 
-        public object Current
-        {
-            get
-            {
-                return _childEnumerator.Current;
-            }
-        }
+        public object Current => _childEnumerator.Current;
 
         public object Clone()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalTypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/ExternalTypeCollection.cs
@@ -59,9 +59,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return false;
         }
 
-        public override int Count
-        {
-            get { return _typeSymbols.Length; }
-        }
+        public override int Count => _typeSymbols.Length;
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/InheritsImplementsCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/InheritsImplementsCollection.cs
@@ -41,10 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _nodeKey = nodeKey;
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        private FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         private SyntaxNode LookupNode()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/NamespaceCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/NamespaceCollection.cs
@@ -41,10 +41,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _nodeKey = nodeKey;
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        private FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         private bool IsRootNamespace
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/NodeSnapshot.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/NodeSnapshot.cs
@@ -31,15 +31,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _nodes = nodes;
         }
 
-        private ICodeModelService CodeModelService
-        {
-            get { return _state.CodeModelService; }
-        }
+        private ICodeModelService CodeModelService => _state.CodeModelService;
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        private FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         private EnvDTE.CodeElement CreateCodeOptionsStatement(SyntaxNode node)
         {
@@ -75,10 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             return (EnvDTE.CodeElement)CodeParameter.Create(_state, (AbstractCodeMember)_parentElement, name);
         }
 
-        public override int Count
-        {
-            get { return _nodes.Length; }
-        }
+        public override int Count => _nodes.Length;
 
         public override EnvDTE.CodeElement this[int index]
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/Collections/TypeCollection.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Collections/TypeCollection.cs
@@ -42,10 +42,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Colle
             _nodeKey = nodeKey;
         }
 
-        private FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        private FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         private SyntaxNode LookupNode()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeElement.cs
@@ -253,10 +253,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             throw Exceptions.ThrowEFail();
         }
 
-        public EnvDTE.vsCMInfoLocation InfoLocation
-        {
-            get { return EnvDTE.vsCMInfoLocation.vsCMInfoLocationExternal; }
-        }
+        public EnvDTE.vsCMInfoLocation InfoLocation => EnvDTE.vsCMInfoLocation.vsCMInfoLocationExternal;
 
         public virtual bool IsCodeType
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeType.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/AbstractExternalCodeType.cs
@@ -81,20 +81,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             get { throw Exceptions.ThrowENotImpl(); }
         }
 
-        public bool IsAbstract
-        {
-            get { return TypeSymbol.IsAbstract; }
-        }
+        public bool IsAbstract => TypeSymbol.IsAbstract;
 
         public override bool IsCodeType
         {
             get { return true; }
         }
 
-        public bool IsSealed
-        {
-            get { return TypeSymbol.IsSealed; }
-        }
+        public bool IsSealed => TypeSymbol.IsSealed;
 
         public EnvDTE.CodeElements Members
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeAccessorFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeAccessorFunction.cs
@@ -87,10 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return _parentHandle.Value;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementFunction; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementFunction;
 
         public EnvDTE.vsCMFunction FunctionKind
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeClass.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeClass.cs
@@ -24,10 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementClass; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementClass;
 
         public EnvDTE80.vsCMClassKind ClassKind
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeDelegate.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeDelegate.cs
@@ -23,10 +23,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementDelegate; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementDelegate;
 
         public EnvDTE.CodeClass BaseClass
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeEnum.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeEnum.cs
@@ -25,10 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
         }
 
-        public override vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementEnum; }
-        }
+        public override vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementEnum;
 
         public EnvDTE.CodeVariable AddMember(string name, object value, object position)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeEvent.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeEvent.cs
@@ -33,10 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             throw new NotImplementedException();
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementEvent; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementEvent;
 
         public EnvDTE.CodeFunction Adder
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeFunction.cs
@@ -34,10 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return this.Parameters;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementFunction; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementFunction;
 
         public EnvDTE.vsCMFunction FunctionKind
         {
@@ -103,10 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             }
         }
 
-        public bool IsGeneric
-        {
-            get { return MethodSymbol.IsGenericMethod; }
-        }
+        public bool IsGeneric => MethodSymbol.IsGenericMethod;
 
         public EnvDTE80.vsCMOverrideKind OverrideKind
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeInterface.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeInterface.cs
@@ -24,10 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementInterface; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementInterface;
 
         #region EnvDTE.CodeInterface members
 

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeNamespace.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeNamespace.cs
@@ -35,10 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return string.Empty;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementNamespace; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementNamespace;
 
         public EnvDTE.CodeElements Members
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeParameter.cs
@@ -35,10 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return GetCollection<ExternalCodeParameter>(this.Parent);
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementParameter; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementParameter;
 
         protected override string GetDocComment()
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
@@ -40,10 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             throw new NotImplementedException();
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementProperty; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementProperty;
 
         public EnvDTE.CodeFunction Getter
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeStruct.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeStruct.cs
@@ -24,10 +24,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementStruct; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementStruct;
 
         public EnvDTE80.vsCMDataTypeKind DataTypeKind
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeUnknown.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeUnknown.cs
@@ -25,9 +25,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             _name = typeSymbol.Name;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementOther; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementOther;
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeVariable.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeVariable.cs
@@ -40,10 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementVariable; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementVariable;
 
         public object InitExpression
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/FileCodeModel.cs
@@ -81,10 +81,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             _lastSyntaxTree = GetSyntaxTree();
         }
 
-        internal ITextManagerAdapter TextManagerAdapter
-        {
-            get { return _textManagerAdapter; }
-        }
+        internal ITextManagerAdapter TextManagerAdapter => _textManagerAdapter;
 
         /// <summary>
         /// Internally, we store the DocumentId for the document that the FileCodeModel represents. If the underlying file

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractCodeElement.cs
@@ -29,10 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             _nodeKind = nodeKind;
         }
 
-        internal FileCodeModel FileCodeModel
-        {
-            get { return _fileCodeModel.Object; }
-        }
+        internal FileCodeModel FileCodeModel => _fileCodeModel.Object;
 
         protected SyntaxTree GetSyntaxTree()
         {
@@ -214,10 +211,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             get { return false; }
         }
 
-        public EnvDTE.ProjectItem ProjectItem
-        {
-            get { return FileCodeModel.Parent; }
-        }
+        public EnvDTE.ProjectItem ProjectItem => FileCodeModel.Parent;
 
         public string ExtenderCATID
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/AbstractKeyedCodeElement.cs
@@ -40,10 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             _name = name;
         }
 
-        internal SyntaxNodeKey NodeKey
-        {
-            get { return _nodeKey; }
-        }
+        internal SyntaxNodeKey NodeKey => _nodeKey;
 
         internal bool IsUnknown
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAccessorFunction.cs
@@ -35,10 +35,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             _kind = kind;
         }
 
-        private AbstractCodeMember ParentMember
-        {
-            get { return _parentHandle.Value; }
-        }
+        private AbstractCodeMember ParentMember => _parentHandle.Value;
 
         private bool IsPropertyAccessor()
         {
@@ -65,15 +62,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementFunction; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementFunction;
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value;
 
         public override EnvDTE.CodeElements Children
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttribute.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttribute.cs
@@ -70,10 +70,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementAttribute; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementAttribute;
 
         public override object Parent
         {
@@ -90,10 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             get { return AttributeArgumentCollection.Create(this.State, this); }
         }
 
-        public override EnvDTE.CodeElements Children
-        {
-            get { return Arguments; }
-        }
+        public override EnvDTE.CodeElements Children => Arguments;
 
         protected override void SetName(string value)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttributeArgument.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeAttributeArgument.cs
@@ -78,10 +78,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value;
 
         public override EnvDTE.CodeElements Children
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeDelegate.cs
@@ -69,10 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return ImmutableArray.CreateRange(CodeModelService.GetParameterNodes(LookupNode()));
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementDelegate; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementDelegate;
 
         public EnvDTE.CodeClass BaseClass
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEnum.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEnum.cs
@@ -51,10 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementEnum; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementEnum;
 
         public EnvDTE.CodeVariable AddMember(string name, object value, object position)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEvent.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeEvent.cs
@@ -59,15 +59,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             get { return (IEventSymbol)LookupSymbol(); }
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementEvent; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementEvent;
 
-        public override EnvDTE.CodeElements Children
-        {
-            get { return this.Attributes; }
-        }
+        public override EnvDTE.CodeElements Children => this.Attributes;
 
         public EnvDTE.CodeFunction Adder
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunction.cs
@@ -87,10 +87,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return CodeModelService.GetFunctionExtender(name, LookupNode(), LookupSymbol());
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementFunction; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementFunction;
 
         public bool CanOverride
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunctionDeclareDecl.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeFunctionDeclareDecl.cs
@@ -56,9 +56,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
         }
 
-        public override vsCMElement Kind
-        {
-            get { return vsCMElement.vsCMElementDeclareDecl; }
-        }
+        public override vsCMElement Kind => vsCMElement.vsCMElementDeclareDecl;
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeImplementsStatement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeImplementsStatement.cs
@@ -80,15 +80,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementImplementsStmt; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementImplementsStmt;
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value;
 
         public override EnvDTE.CodeElements Children
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeImport.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeImport.cs
@@ -89,10 +89,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             throw new InvalidOperationException();
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementImportStmt; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementImportStmt;
 
         public override object Parent
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInheritsStatement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInheritsStatement.cs
@@ -80,15 +80,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementInheritsStmt; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementInheritsStmt;
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value;
 
         public override EnvDTE.CodeElements Children
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInterface.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeInterface.cs
@@ -52,10 +52,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementInterface; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementInterface;
 
         public EnvDTE.CodeFunction AddFunction(string name, EnvDTE.vsCMFunction kind, object type, object position, EnvDTE.vsCMAccess access)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeNamespace.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeNamespace.cs
@@ -120,10 +120,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementNamespace; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementNamespace;
 
         public EnvDTE.CodeClass AddClass(string name, object position, object bases, object implementedInterfaces, EnvDTE.vsCMAccess access = EnvDTE.vsCMAccess.vsCMAccessDefault)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeOptionsStatement.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeOptionsStatement.cs
@@ -78,15 +78,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementOptionStmt; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementOptionStmt;
 
-        public override object Parent
-        {
-            get { return this.FileCodeModel; }
-        }
+        public override object Parent => this.FileCodeModel;
 
         public override EnvDTE.CodeElements Children
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -100,10 +100,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementParameter;
 
-        public override object Parent
-        {
-            get { return _parentHandle.Value; }
-        }
+        public override object Parent => _parentHandle.Value; 
 
         EnvDTE.CodeElement EnvDTE.CodeParameter.Parent
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -98,10 +98,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return node != null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementParameter; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementParameter;
 
         public override object Parent
         {
@@ -118,10 +115,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             get { return (EnvDTE.CodeElement)Parent; }
         }
 
-        public override EnvDTE.CodeElements Children
-        {
-            get { return this.Attributes; }
-        }
+        public override EnvDTE.CodeElements Children => this.Attributes;
 
         public EnvDTE.CodeElements Attributes
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeProperty.cs
@@ -85,10 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return CodeModelService.GetPropertyExtender(name, LookupNode(), LookupSymbol());
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementProperty; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementProperty;
 
         public override object Parent
         {
@@ -138,10 +135,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        public override EnvDTE.CodeElements Children
-        {
-            get { return this.Attributes; }
-        }
+        public override EnvDTE.CodeElements Children => this.Attributes;
 
         private bool HasAccessorNode(MethodKind methodKind)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeStruct.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeStruct.cs
@@ -53,10 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementStruct; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementStruct;
 
         public bool IsAbstract
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeVariable.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeVariable.cs
@@ -71,10 +71,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             return null;
         }
 
-        public override EnvDTE.vsCMElement Kind
-        {
-            get { return EnvDTE.vsCMElement.vsCMElementVariable; }
-        }
+        public override EnvDTE.vsCMElement Kind => EnvDTE.vsCMElement.vsCMElementVariable;
 
         public EnvDTE80.vsCMConstKind ConstKind
         {
@@ -89,10 +86,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             }
         }
 
-        public override EnvDTE.CodeElements Children
-        {
-            get { return Attributes; }
-        }
+        public override EnvDTE.CodeElements Children => Attributes;
 
         public object InitExpression
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/RootCodeModel.cs
@@ -97,10 +97,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             get { return (EnvDTE.Project)_parentHandle.Value; }
         }
 
-        public bool IsCaseSensitive
-        {
-            get { return SyntaxFactsService.IsCaseSensitive; }
-        }
+        public bool IsCaseSensitive => SyntaxFactsService.IsCaseSensitive;
 
         public EnvDTE.CodeAttribute AddAttribute(string name, object location, string value, object position)
         {

--- a/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/SyntaxNodeKey.cs
@@ -61,15 +61,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             return $"{{{_name}, {_ordinal}}}";
         }
 
-        public string Name
-        {
-            get { return _name; }
-        }
+        public string Name => _name;
 
-        public int Ordinal
-        {
-            get { return _ordinal; }
-        }
+        public int Ordinal => _ordinal;
 
         public bool IsEmpty
         {

--- a/src/VisualStudio/Core/Impl/Options/AbstractSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractSettingsManagerOptionSerializer.cs
@@ -93,13 +93,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         protected abstract ImmutableDictionary<string, IOption> CreateStorageKeyToOptionMap();
 
-        protected ImmutableDictionary<string, IOption> StorageKeyToOptionMap
-        {
-            get
-            {
-                return _storageKeyToOptionMap.Value;
-            }
-        }
+        protected ImmutableDictionary<string, IOption> StorageKeyToOptionMap => _storageKeyToOptionMap.Value;
 
         protected KeyValuePair<string, IOption> GetOptionInfo(FieldInfo fieldInfo)
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.BrowseObject.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.BrowseObject.cs
@@ -17,22 +17,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.AnalyzerItemNameDisplayName))]
-            public string Name
-            {
-                get
-                {
-                    return _analyzerItem.AnalyzerReference.Display;
-                }
-            }
+            public string Name => _analyzerItem.AnalyzerReference.Display;
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.AnalyzerItemPathDisplayName))]
-            public string Path
-            {
-                get
-                {
-                    return _analyzerItem.AnalyzerReference.FullPath;
-                }
-            }
+            public string Path => _analyzerItem.AnalyzerReference.FullPath;
 
             public override string GetClassName()
             {
@@ -45,10 +33,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [Browsable(false)]
-            public AnalyzerItem AnalyzerItem
-            {
-                get { return _analyzerItem; }
-            }
+            public AnalyzerItem AnalyzerItem => _analyzerItem;
         }
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItem.cs
@@ -21,21 +21,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _contextMenuController = contextMenuController;
         }
 
-        public override ImageMoniker IconMoniker
-        {
-            get
-            {
-                return KnownMonikers.CodeInformation;
-            }
-        }
+        public override ImageMoniker IconMoniker => KnownMonikers.CodeInformation;
 
-        public override ImageMoniker ExpandedIconMoniker
-        {
-            get
-            {
-                return KnownMonikers.CodeInformation;
-            }
-        }
+        public override ImageMoniker ExpandedIconMoniker => KnownMonikers.CodeInformation;
 
         public override ImageMoniker OverlayIconMoniker
         {
@@ -57,20 +45,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             return new BrowseObject(this);
         }
 
-        public AnalyzerReference AnalyzerReference
-        {
-            get { return _analyzerReference; }
-        }
+        public AnalyzerReference AnalyzerReference => _analyzerReference;
 
-        public override IContextMenuController ContextMenuController
-        {
-            get { return _contextMenuController; }
-        }
+        public override IContextMenuController ContextMenuController => _contextMenuController;
 
-        public AnalyzersFolderItem AnalyzersFolder
-        {
-            get { return _analyzersFolder; }
-        }
+        public AnalyzersFolderItem AnalyzersFolder => _analyzersFolder;
 
         /// <summary>
         /// Remove this AnalyzerItem from it's folder.

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzerItem/AnalyzerItemSource.cs
@@ -173,12 +173,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
         }
 
-        public object SourceItem
-        {
-            get
-            {
-                return _analyzersFolder;
-            }
-        }
+        public object SourceItem => _analyzersFolder;
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.BrowseObject.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.BrowseObject.cs
@@ -27,10 +27,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [Browsable(false)]
-            public AnalyzersFolderItem Folder
-            {
-                get { return _analyzersFolderItem; }
-            }
+            public AnalyzersFolderItem Folder => _analyzersFolderItem;
         }
     }
 }

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItem.cs
@@ -33,46 +33,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _contextMenuController = contextMenuController;
         }
 
-        public override ImageMoniker IconMoniker
-        {
-            get
-            {
-                return KnownMonikers.CodeInformation;
-            }
-        }
+        public override ImageMoniker IconMoniker => KnownMonikers.CodeInformation;
 
-        public override ImageMoniker ExpandedIconMoniker
-        {
-            get
-            {
-                return KnownMonikers.CodeInformation;
-            }
-        }
+        public override ImageMoniker ExpandedIconMoniker => KnownMonikers.CodeInformation;
 
-        public Workspace Workspace
-        {
-            get { return _workspace; }
-        }
+        public Workspace Workspace => _workspace;
 
-        public ProjectId ProjectId
-        {
-            get { return _projectId; }
-        }
+        public ProjectId ProjectId => _projectId;
 
-        public IVsHierarchyItem ParentItem
-        {
-            get { return _parentItem; }
-        }
+        public IVsHierarchyItem ParentItem => _parentItem;
 
         public override object GetBrowseObject()
         {
             return new BrowseObject(this);
         }
 
-        public override IContextMenuController ContextMenuController
-        {
-            get { return _contextMenuController; }
-        }
+        public override IContextMenuController ContextMenuController => _contextMenuController;
 
         /// <summary>
         /// Get the DTE object for the Project.

--- a/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/AnalyzersFolderItem/AnalyzersFolderItemSource.cs
@@ -36,21 +36,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
         }
 
-        public IEnumerable Items
-        {
-            get
-            {
-                return _folderItems;
-            }
-        }
+        public IEnumerable Items => _folderItems;
 
-        public object SourceItem
-        {
-            get
-            {
-                return _projectHierarchyItem;
-            }
-        }
+        public object SourceItem => _projectHierarchyItem;
 
         internal void Update()
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
@@ -130,20 +130,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             return Text;
         }
 
-        public string Text
-        {
-            get { return _name; }
-        }
+        public string Text => _name;
 
         public object ToolTipContent
         {
             get { return null; }
         }
 
-        public string ToolTipText
-        {
-            get { return _name; }
-        }
+        public string ToolTipText => _name;
 
         private static readonly HashSet<Type> s_supportedPatterns = new HashSet<Type>()
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/BaseItem.cs
@@ -55,10 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
         }
 
-        public FontStyle FontStyle
-        {
-            get { return FontStyles.Normal; }
-        }
+        public FontStyle FontStyle => FontStyles.Normal; 
 
         public FontWeight FontWeight
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.BrowseObject.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.BrowseObject.cs
@@ -21,13 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemIDDisplayName))]
-            public string Id
-            {
-                get
-                {
-                    return _diagnosticItem.Descriptor.Id;
-                }
-            }
+            public string Id => _diagnosticItem.Descriptor.Id;
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemTitleDisplayName))]
             public string Title
@@ -57,13 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemCategoryDisplayName))]
-            public string Category
-            {
-                get
-                {
-                    return _diagnosticItem.Descriptor.Category;
-                }
-            }
+            public string Category => _diagnosticItem.Descriptor.Category;
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemDefaultSeverityDisplayName))]
             public string DefaultSeverity
@@ -75,13 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemEnabledByDefaultDisplayName))]
-            public bool EnabledByDefault
-            {
-                get
-                {
-                    return _diagnosticItem.Descriptor.IsEnabledByDefault;
-                }
-            }
+            public bool EnabledByDefault => _diagnosticItem.Descriptor.IsEnabledByDefault;
 
             [BrowseObjectDisplayName(nameof(SolutionExplorerShim.DiagnosticItemMessageDisplayName))]
             public string Message
@@ -121,10 +103,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
 
             [Browsable(false)]
-            public DiagnosticItem DiagnosticItem
-            {
-                get { return _diagnosticItem; }
-            }
+            public DiagnosticItem DiagnosticItem => _diagnosticItem;
 
             private string MapDiagnosticSeverityToText(DiagnosticSeverity severity)
             {

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItem.cs
@@ -41,42 +41,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             }
         }
 
-        public AnalyzerItem AnalyzerItem
-        {
-            get
-            {
-                return _analyzerItem;
-            }
-        }
+        public AnalyzerItem AnalyzerItem => _analyzerItem;
 
-        public DiagnosticDescriptor Descriptor
-        {
-            get
-            {
-                return _descriptor;
-            }
-        }
+        public DiagnosticDescriptor Descriptor => _descriptor;
 
-        public ReportDiagnostic EffectiveSeverity
-        {
-            get
-            {
-                return _effectiveSeverity;
-            }
-        }
+        public ReportDiagnostic EffectiveSeverity => _effectiveSeverity;
 
         public override object GetBrowseObject()
         {
             return new BrowseObject(this);
         }
 
-        public override IContextMenuController ContextMenuController
-        {
-            get
-            {
-                return _contextMenuController;
-            }
-        }
+        public override IContextMenuController ContextMenuController => _contextMenuController;
 
         public Uri GetHelpLink()
         {

--- a/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
+++ b/src/VisualStudio/Core/SolutionExplorerShim/DiagnosticItem/DiagnosticItemSource.cs
@@ -34,13 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.SolutionExplore
             _diagnosticAnalyzerService = diagnosticAnalyzerService;
         }
 
-        public object SourceItem
-        {
-            get
-            {
-                return _item;
-            }
-        }
+        public object SourceItem => _item;
 
         public bool HasItems
         {

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowPackage.cs
@@ -53,10 +53,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
             InitializeMenuCommands(menuCommandService);
         }
 
-        protected TVsInteractiveWindowProvider InteractiveWindowProvider
-        {
-            get { return _interactiveWindowProvider; }
-        }
+        protected TVsInteractiveWindowProvider InteractiveWindowProvider => _interactiveWindowProvider;
 
         /// <summary>
         /// When a VSPackage supports multi-instance tool windows, each window uses the same rguidPersistenceSlot.

--- a/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
+++ b/src/VisualStudio/InteractiveServices/Interactive/VsInteractiveWindowProvider.cs
@@ -63,21 +63,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Interactive
         protected abstract string Title { get; }
         protected abstract core::Microsoft.CodeAnalysis.Internal.Log.FunctionId InteractiveWindowFunctionId { get; }
 
-        protected IInteractiveWindowCommandsFactory CommandsFactory
-        {
-            get
-            {
-                return _commandsFactory;
-            }
-        }
+        protected IInteractiveWindowCommandsFactory CommandsFactory => _commandsFactory;
 
-        protected ImmutableArray<IInteractiveWindowCommand> Commands
-        {
-            get
-            {
-                return _commands;
-            }
-        }
+        protected ImmutableArray<IInteractiveWindowCommand> Commands => _commands;
 
         public void Create(int instanceId)
         {

--- a/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ModifiedComplexTrivia.cs
@@ -41,10 +41,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 }
             }
 
-            public override bool TreatAsElastic
-            {
-                get { return _original.TreatAsElastic; }
-            }
+            public override bool TreatAsElastic => _original.TreatAsElastic;
 
             public override bool IsWhitespaceOnlyTrivia
             {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactory.PathSyntaxReference.cs
@@ -33,21 +33,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _pathFromRoot = ComputePathFromRoot(node);
                 }
 
-                public override SyntaxTree SyntaxTree
-                {
-                    get
-                    {
-                        return _tree;
-                    }
-                }
+                public override SyntaxTree SyntaxTree => _tree;
 
-                public override TextSpan Span
-                {
-                    get
-                    {
-                        return _textSpan;
-                    }
-                }
+                public override TextSpan Span => _textSpan;
 
                 private ImmutableArray<int> ComputePathFromRoot(SyntaxNode node)
                 {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.NullSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.NullSyntaxReference.cs
@@ -25,13 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     _tree = tree;
                 }
 
-                public override SyntaxTree SyntaxTree
-                {
-                    get
-                    {
-                        return _tree;
-                    }
-                }
+                public override SyntaxTree SyntaxTree => _tree;
 
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
                 {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.PositionalSyntaxReference.cs
@@ -33,21 +33,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     System.Diagnostics.Debug.Assert(_textSpan.Length > 0);
                 }
 
-                public override SyntaxTree SyntaxTree
-                {
-                    get
-                    {
-                        return _tree;
-                    }
-                }
+                public override SyntaxTree SyntaxTree => _tree;
 
-                public override TextSpan Span
-                {
-                    get
-                    {
-                        return _textSpan;
-                    }
-                }
+                public override TextSpan Span => _textSpan;
 
                 public override SyntaxNode GetSyntax(CancellationToken cancellationToken)
                 {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
@@ -53,10 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new RecoverableSyntaxTree(service, cacheKey, root, new SyntaxTreeInfo(filePath, options, text, encoding, root.FullSpan.Length));
                 }
 
-                public override string FilePath
-                {
-                    get { return _info.FilePath; }
-                }
+                public override string FilePath => _info.FilePath; 
 
                 public override CSharpParseOptions Options
                 {

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxTreeFactoryService.RecoverableSyntaxTree.cs
@@ -63,10 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     get { return (CSharpParseOptions)_info.Options; }
                 }
 
-                public override int Length
-                {
-                    get { return _info.Length; }
-                }
+                public override int Length => _info.Length;
 
                 public override bool TryGetText(out SourceText text)
                 {
@@ -83,10 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return _info.GetTextAsync(cancellationToken);
                 }
 
-                public override Encoding Encoding
-                {
-                    get { return _info.Encoding; }
-                }
+                public override Encoding Encoding => _info.Encoding;
 
                 private CompilationUnitSyntax CacheRootNode(CompilationUnitSyntax node)
                 {

--- a/src/Workspaces/CSharp/Portable/Rename/LabelConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LabelConflictVisitor.cs
@@ -44,12 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
             _tracker.RemoveIdentifiers(tokens);
         }
 
-        public IEnumerable<SyntaxToken> ConflictingTokens
-        {
-            get
-            {
-                return _tracker.ConflictingTokens;
-            }
-        }
+        public IEnumerable<SyntaxToken> ConflictingTokens => _tracker.ConflictingTokens;
     }
 }

--- a/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Rename/LocalConflictVisitor.cs
@@ -183,12 +183,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Rename
             _tracker.RemoveIdentifier(node.Identifier);
         }
 
-        public IEnumerable<SyntaxToken> ConflictingTokens
-        {
-            get
-            {
-                return _tracker.ConflictingTokens;
-            }
-        }
+        public IEnumerable<SyntaxToken> ConflictingTokens => _tracker.ConflictingTokens;
     }
 }

--- a/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/FileTextLoader.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Absolute path of the file.
         /// </summary>
-        public string Path
-        {
-            get { return _path; }
-        }
+        public string Path => _path;
 
         /// <summary>
         /// Specifies an encoding to be used if the actual encoding of the file 
@@ -50,10 +47,7 @@ namespace Microsoft.CodeAnalysis
         /// If these heuristics fail the decoding is assumed to be <see cref="Encoding.Default"/>.
         /// Note that if the stream starts with Byte Order Mark the value of <see cref="DefaultEncoding"/> is ignored.
         /// </summary>
-        public Encoding DefaultEncoding
-        {
-            get { return _defaultEncoding; }
-        }
+        public Encoding DefaultEncoding => _defaultEncoding;
 
         protected virtual SourceText CreateText(Stream stream, Workspace workspace)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/CSharp/CSharpProjectFileLoader.cs
@@ -15,10 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
         }
 
-        public override string Language
-        {
-            get { return LanguageNames.CSharp; }
-        }
+        public override string Language => LanguageNames.CSharp;
 
         protected override ProjectFile CreateProjectFile(MSB.Evaluation.Project loadedProject)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
@@ -47,10 +47,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// The MSBuild properties used when interpreting project files.
         /// These are the same properties that are passed to msbuild via the /property:&lt;n&gt;=&lt;v&gt; command line argument.
         /// </summary>
-        public ImmutableDictionary<string, string> Properties
-        {
-            get { return _properties; }
-        }
+        public ImmutableDictionary<string, string> Properties => _properties;
 
         /// <summary>
         /// Determines if metadata from existing output assemblies is loaded instead of opening referenced projects.
@@ -284,10 +281,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 return _projectIdToProjectInfoMap.TryGetValue(id, out info);
             }
 
-            public IReadOnlyList<ProjectInfo> Projects
-            {
-                get { return _projectInfoList; }
-            }
+            public IReadOnlyList<ProjectInfo> Projects => _projectInfoList;
 
             public ProjectId GetProjectId(string fullProjectPath)
             {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildWorkspace.cs
@@ -94,10 +94,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
         /// The MSBuild properties used when interpreting project files.
         /// These are the same properties that are passed to msbuild via the /property:&lt;n&gt;=&lt;v&gt; command line argument.
         /// </summary>
-        public ImmutableDictionary<string, string> Properties
-        {
-            get { return _loader.Properties; }
-        }
+        public ImmutableDictionary<string, string> Properties => _loader.Properties;
 
         /// <summary>
         /// Determines if metadata from existing output assemblies is loaded instead of opening referenced projects.

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/ProjectFile/ProjectFile.cs
@@ -38,10 +38,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             }
         }
 
-        public virtual string FilePath
-        {
-            get { return _loadedProject.FullPath; }
-        }
+        public virtual string FilePath => _loadedProject.FullPath;
 
         public string GetPropertyValue(string name)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/ProjectBlock.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/ProjectBlock.cs
@@ -35,30 +35,15 @@ namespace Microsoft.CodeAnalysis.MSBuild
             _projectSections = projectSections.ToList().AsReadOnly();
         }
 
-        public Guid ProjectTypeGuid
-        {
-            get { return _projectTypeGuid; }
-        }
+        public Guid ProjectTypeGuid => _projectTypeGuid;
 
-        public string ProjectName
-        {
-            get { return _projectName; }
-        }
+        public string ProjectName => _projectName;
 
-        public string ProjectPath
-        {
-            get { return _projectPath; }
-        }
+        public string ProjectPath => _projectPath;
 
-        public Guid ProjectGuid
-        {
-            get { return _projectGuid; }
-        }
+        public Guid ProjectGuid => _projectGuid;
 
-        public IEnumerable<SectionBlock> ProjectSections
-        {
-            get { return _projectSections; }
-        }
+        public IEnumerable<SectionBlock> ProjectSections => _projectSections;
 
         internal string GetText()
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SectionBlock.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SectionBlock.cs
@@ -46,25 +46,13 @@ namespace Microsoft.CodeAnalysis.MSBuild
             _keyValuePairs = keyValuePairs.ToList().AsReadOnly();
         }
 
-        public string Type
-        {
-            get { return _type; }
-        }
+        public string Type => _type;
 
-        public string ParenthesizedName
-        {
-            get { return _parenthesizedName; }
-        }
+        public string ParenthesizedName => _parenthesizedName;
 
-        public string Value
-        {
-            get { return _value; }
-        }
+        public string Value => _value;
 
-        public IEnumerable<KeyValuePair<string, string>> KeyValuePairs
-        {
-            get { return _keyValuePairs; }
-        }
+        public IEnumerable<KeyValuePair<string, string>> KeyValuePairs => _keyValuePairs;
 
         internal string GetText(int indent)
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SolutionFile.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/SolutionFile/SolutionFile.cs
@@ -46,30 +46,15 @@ namespace Microsoft.CodeAnalysis.MSBuild
             _globalSectionBlocks = globalSectionBlocks.ToList().AsReadOnly();
         }
 
-        public IEnumerable<string> HeaderLines
-        {
-            get { return _headerLines; }
-        }
+        public IEnumerable<string> HeaderLines => _headerLines;
 
-        public string VisualStudioVersionLineOpt
-        {
-            get { return _visualStudioVersionLineOpt; }
-        }
+        public string VisualStudioVersionLineOpt => _visualStudioVersionLineOpt;
 
-        public string MinimumVisualStudioVersionLineOpt
-        {
-            get { return _minimumVisualStudioVersionLineOpt; }
-        }
+        public string MinimumVisualStudioVersionLineOpt => _minimumVisualStudioVersionLineOpt;
 
-        public IEnumerable<ProjectBlock> ProjectBlocks
-        {
-            get { return _projectBlocks; }
-        }
+        public IEnumerable<ProjectBlock> ProjectBlocks => _projectBlocks;
 
-        public IEnumerable<SectionBlock> GlobalSectionBlocks
-        {
-            get { return _globalSectionBlocks; }
-        }
+        public IEnumerable<SectionBlock> GlobalSectionBlocks => _globalSectionBlocks;
 
         public string GetText()
         {

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
@@ -215,10 +215,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic
                     _outputDirectory = projectFile.GetOutputDirectory();
                 }
 
-                public bool Initialized
-                {
-                    get { return _initialized; }
-                }
+                public bool Initialized => _initialized; 
 
                 public List<string> CommandLineArgs => _commandLineArgs;
 

--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/VisualBasic/VisualBasicProjectFileLoader.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic
 {
     internal class VisualBasicProjectFileLoader : ProjectFileLoader
     {
-        public override string Language
-        {
-            get { return LanguageNames.VisualBasic; }
-        }
+        public override string Language => LanguageNames.VisualBasic;
 
         internal VisualBasicProjectFileLoader()
         {
@@ -223,35 +220,17 @@ namespace Microsoft.CodeAnalysis.VisualBasic
                     get { return _initialized; }
                 }
 
-                public List<string> CommandLineArgs
-                {
-                    get { return _commandLineArgs; }
-                }
+                public List<string> CommandLineArgs => _commandLineArgs;
 
-                public IEnumerable<ITaskItem> Sources
-                {
-                    get { return _sources; }
-                }
+                public IEnumerable<ITaskItem> Sources => _sources;
 
-                public IEnumerable<ITaskItem> AdditionalFiles
-                {
-                    get { return _additionalFiles; }
-                }
+                public IEnumerable<ITaskItem> AdditionalFiles => _additionalFiles;
 
-                public string OutputFileName
-                {
-                    get { return _outputFileName; }
-                }
+                public string OutputFileName => _outputFileName;
 
-                public string OutputDirectory
-                {
-                    get { return _outputDirectory; }
-                }
+                public string OutputDirectory => _outputDirectory;
 
-                public string ProjectDirectory
-                {
-                    get { return _projectDirectory; }
-                }
+                public string ProjectDirectory => _projectDirectory;
 
                 public void BeginInitialization()
                 {

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/ApplyChangesOperation.cs
@@ -36,10 +36,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             _changedSolution = changedSolution;
         }
 
-        public Solution ChangedSolution
-        {
-            get { return _changedSolution; }
-        }
+        public Solution ChangedSolution => _changedSolution;
 
         public override void Apply(Workspace workspace, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/CodeActions/Operations/OpenDocumentOperation.cs
+++ b/src/Workspaces/Core/Portable/CodeActions/Operations/OpenDocumentOperation.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CodeAnalysis.CodeActions
             _activate = activateIfAlreadyOpen;
         }
 
-        public DocumentId DocumentId
-        {
-            get { return _documentId; }
-        }
+        public DocumentId DocumentId => _documentId;
 
         public override void Apply(Workspace workspace, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/FormatCodeCleanupProvider.cs
@@ -10,10 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
 {
     internal class FormatCodeCleanupProvider : ICodeCleanupProvider
     {
-        public string Name
-        {
-            get { return PredefinedCodeCleanupProviderNames.Format; }
-        }
+        public string Name => PredefinedCodeCleanupProviderNames.Format;
 
         public async Task<Document> CleanupAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimplificationCodeCleanupProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeCleanup/Providers/SimplificationCodeCleanupProvider.cs
@@ -10,10 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeCleanup.Providers
 {
     internal class SimplificationCodeCleanupProvider : ICodeCleanupProvider
     {
-        public string Name
-        {
-            get { return PredefinedCodeCleanupProviderNames.Simplification; }
-        }
+        public string Name => PredefinedCodeCleanupProviderNames.Simplification;
 
         public Task<Document> CleanupAsync(Document document, IEnumerable<TextSpan> spans, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/CodeFixContext.cs
@@ -26,28 +26,28 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// Document corresponding to the <see cref="CodeFixContext.Span"/> to fix.
         /// </summary>
-        public Document Document { get { return _document; } }
+        public Document Document => _document;
 
         /// <summary>
         /// Project corresponding to the diagnostics to fix.
         /// </summary>
-        internal Project Project { get { return _project; } }
+        internal Project Project => _project;
 
         /// <summary>
         /// Text span within the <see cref="CodeFixContext.Document"/> to fix.
         /// </summary>
-        public TextSpan Span { get { return _span; } }
+        public TextSpan Span => _span;
 
         /// <summary>
         /// Diagnostics to fix.
         /// NOTE: All the diagnostics in this collection have the same <see cref="CodeFixContext.Span"/>.
         /// </summary>
-        public ImmutableArray<Diagnostic> Diagnostics { get { return _diagnostics; } }
+        public ImmutableArray<Diagnostic> Diagnostics => _diagnostics;
 
         /// <summary>
         /// CancellationToken.
         /// </summary>
-        public CancellationToken CancellationToken { get { return _cancellationToken; } }
+        public CancellationToken CancellationToken => _cancellationToken;
 
         /// <summary>
         /// Creates a code fix context to be passed into <see cref="CodeFixProvider.RegisterCodeFixesAsync(CodeFixContext)"/> method.

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/FixAllContext.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// Solution to fix all occurrences.
         /// </summary>
-        public Solution Solution { get { return this.Project.Solution; } }
+        public Solution Solution => this.Project.Solution;
 
         /// <summary>
         /// Project within which fix all occurrences was triggered.

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractMethodSymbol.cs
@@ -46,13 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public abstract IMethodSymbol PartialDefinitionPart { get; }
         public abstract IMethodSymbol PartialImplementationPart { get; }
 
-        public virtual ITypeSymbol ReceiverType
-        {
-            get
-            {
-                return this.ContainingType;
-            }
-        }
+        public virtual ITypeSymbol ReceiverType => this.ContainingType;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -64,21 +58,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return visitor.VisitMethod(this);
         }
 
-        public virtual MethodKind MethodKind
-        {
-            get
-            {
-                return MethodKind.Ordinary;
-            }
-        }
+        public virtual MethodKind MethodKind => MethodKind.Ordinary;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Method;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Method;
 
         public virtual bool IsGenericMethod
         {
@@ -96,13 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public virtual bool IsAsync
-        {
-            get
-            {
-                return this.Modifiers.IsAsync;
-            }
-        }
+        public virtual bool IsAsync => this.Modifiers.IsAsync;
 
         public virtual bool IsVararg
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAbstractNamedTypeSymbol.cs
@@ -32,13 +32,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.NamedType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.NamedType;
 
         public override void Accept(SymbolVisitor visitor)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationArrayTypeSymbol.cs
@@ -26,21 +26,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return new CodeGenerationArrayTypeSymbol(this.ElementType, this.Rank);
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Array;
-            }
-        }
+        public override TypeKind TypeKind => TypeKind.Array;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.ArrayType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.ArrayType;
 
         public override void Accept(SymbolVisitor visitor)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAttributeData.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationAttributeData.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         private readonly ImmutableArray<TypedConstant> _constructorArguments;
         private readonly ImmutableArray<KeyValuePair<string, TypedConstant>> _namedArguments;
 
-        protected override INamedTypeSymbol CommonAttributeClass { get { return _attributeClass; } }
+        protected override INamedTypeSymbol CommonAttributeClass => _attributeClass;
         protected override IMethodSymbol CommonAttributeConstructor { get { return null; } }
-        protected override ImmutableArray<TypedConstant> CommonConstructorArguments { get { return _constructorArguments; } }
-        protected override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments { get { return _namedArguments; } }
+        protected override ImmutableArray<TypedConstant> CommonConstructorArguments => _constructorArguments;
+        protected override ImmutableArray<KeyValuePair<string, TypedConstant>> CommonNamedArguments => _namedArguments;
         protected override SyntaxReference CommonApplicationSyntaxReference { get { return null; } }
 
         public CodeGenerationAttributeData(

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedMethodSymbol.cs
@@ -26,21 +26,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             _typeArguments = typeArguments;
         }
 
-        public override int Arity
-        {
-            get
-            {
-                return _constructedFrom.Arity;
-            }
-        }
+        public override int Arity => _constructedFrom.Arity;
 
-        public override bool ReturnsVoid
-        {
-            get
-            {
-                return _constructedFrom.ReturnsVoid;
-            }
-        }
+        public override bool ReturnsVoid => _constructedFrom.ReturnsVoid;
 
         public override ITypeSymbol ReturnType
         {
@@ -59,13 +47,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override ImmutableArray<ITypeParameterSymbol> TypeParameters
-        {
-            get
-            {
-                return _constructedFrom.TypeParameters;
-            }
-        }
+        public override ImmutableArray<ITypeParameterSymbol> TypeParameters => _constructedFrom.TypeParameters;
 
         public override ImmutableArray<IParameterSymbol> Parameters
         {
@@ -76,13 +58,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override IMethodSymbol ConstructedFrom
-        {
-            get
-            {
-                return _constructedFrom;
-            }
-        }
+        public override IMethodSymbol ConstructedFrom => _constructedFrom;
 
         public override IMethodSymbol OverriddenMethod
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructedNamedTypeSymbol.cs
@@ -34,21 +34,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override int Arity
-        {
-            get
-            {
-                return _constructedFrom.Arity;
-            }
-        }
+        public override int Arity => _constructedFrom.Arity;
 
-        public override bool IsGenericType
-        {
-            get
-            {
-                return _constructedFrom.IsGenericType;
-            }
-        }
+        public override bool IsGenericType => _constructedFrom.IsGenericType;
 
         public override bool IsUnboundGenericType
         {
@@ -58,29 +46,11 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override bool IsScriptClass
-        {
-            get
-            {
-                return _constructedFrom.IsScriptClass;
-            }
-        }
+        public override bool IsScriptClass => _constructedFrom.IsScriptClass;
 
-        public override bool IsImplicitClass
-        {
-            get
-            {
-                return _constructedFrom.IsImplicitClass;
-            }
-        }
+        public override bool IsImplicitClass => _constructedFrom.IsImplicitClass;
 
-        public override IEnumerable<string> MemberNames
-        {
-            get
-            {
-                return _constructedFrom.MemberNames;
-            }
-        }
+        public override IEnumerable<string> MemberNames => _constructedFrom.MemberNames;
 
         public override IMethodSymbol DelegateInvokeMethod
         {
@@ -100,13 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override INamedTypeSymbol ConstructedFrom
-        {
-            get
-            {
-                return _constructedFrom;
-            }
-        }
+        public override INamedTypeSymbol ConstructedFrom => _constructedFrom;
 
         public override INamedTypeSymbol ConstructUnboundGenericType()
         {
@@ -146,25 +110,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return ImmutableArray.CreateRange(_constructedFrom.TypeMembers.Cast<INamedTypeSymbol>());
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return _constructedFrom.TypeKind;
-            }
-        }
+        public override TypeKind TypeKind => _constructedFrom.TypeKind;
 
         protected override CodeGenerationSymbol Clone()
         {
             return new CodeGenerationConstructedNamedTypeSymbol(_constructedFrom, _typeArguments, this.TypeMembers);
         }
 
-        public override ImmutableArray<ITypeParameterSymbol> TypeParameters
-        {
-            get
-            {
-                return _constructedFrom.TypeParameters;
-            }
-        }
+        public override ImmutableArray<ITypeParameterSymbol> TypeParameters => _constructedFrom.TypeParameters;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConstructorSymbol.cs
@@ -28,13 +28,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
         }
 
-        public override MethodKind MethodKind
-        {
-            get
-            {
-                return MethodKind.Constructor;
-            }
-        }
+        public override MethodKind MethodKind => MethodKind.Constructor;
 
         protected override CodeGenerationSymbol Clone()
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationConversionSymbol.cs
@@ -36,12 +36,6 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
         }
 
-        public override MethodKind MethodKind
-        {
-            get
-            {
-                return MethodKind.Conversion;
-            }
-        }
+        public override MethodKind MethodKind => MethodKind.Conversion;
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationDestructorSymbol.cs
@@ -25,13 +25,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
         }
 
-        public override MethodKind MethodKind
-        {
-            get
-            {
-                return MethodKind.Destructor;
-            }
-        }
+        public override MethodKind MethodKind => MethodKind.Destructor;
 
         protected override CodeGenerationSymbol Clone()
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -60,13 +60,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 this.Name, this.AddMethod, this.RemoveMethod, this.RaiseMethod, this.ParameterList);
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Event;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Event;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -78,13 +72,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return visitor.VisitEvent(this);
         }
 
-        public new IEventSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new IEventSymbol OriginalDefinition => this;
 
         public IEventSymbol OverriddenEvent
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationFieldSymbol.cs
@@ -37,21 +37,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 this.Modifiers, this.Type, this.Name, this.HasConstantValue, this.ConstantValue);
         }
 
-        public new IFieldSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new IFieldSymbol OriginalDefinition => this;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Field;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Field;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -63,21 +51,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return visitor.VisitField(this);
         }
 
-        public bool IsConst
-        {
-            get
-            {
-                return this.Modifiers.IsConst;
-            }
-        }
+        public bool IsConst => this.Modifiers.IsConst;
 
-        public bool IsReadOnly
-        {
-            get
-            {
-                return this.Modifiers.IsReadOnly;
-            }
-        }
+        public bool IsReadOnly => this.Modifiers.IsReadOnly;
 
         public bool IsVolatile
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationMethodSymbol.cs
@@ -44,37 +44,13 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             _methodKind = methodKind;
         }
 
-        public override ITypeSymbol ReturnType
-        {
-            get
-            {
-                return _returnType;
-            }
-        }
+        public override ITypeSymbol ReturnType => _returnType;
 
-        public override ImmutableArray<ITypeParameterSymbol> TypeParameters
-        {
-            get
-            {
-                return _typeParameters;
-            }
-        }
+        public override ImmutableArray<ITypeParameterSymbol> TypeParameters => _typeParameters;
 
-        public override ImmutableArray<IParameterSymbol> Parameters
-        {
-            get
-            {
-                return _parameters;
-            }
-        }
+        public override ImmutableArray<IParameterSymbol> Parameters => _parameters;
 
-        public override ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations
-        {
-            get
-            {
-                return _explicitInterfaceImplementations;
-            }
-        }
+        public override ImmutableArray<IMethodSymbol> ExplicitInterfaceImplementations => _explicitInterfaceImplementations;
 
         protected override CodeGenerationSymbol Clone()
         {
@@ -94,13 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return result;
         }
 
-        public override int Arity
-        {
-            get
-            {
-                return this.TypeParameters.Length;
-            }
-        }
+        public override int Arity => this.TypeParameters.Length;
 
         public override bool ReturnsVoid
         {
@@ -118,13 +88,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override IMethodSymbol ConstructedFrom
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public override IMethodSymbol ConstructedFrom => this;
 
         public override IMethodSymbol OverriddenMethod
         {
@@ -142,13 +106,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override MethodKind MethodKind
-        {
-            get
-            {
-                return _methodKind;
-            }
-        }
+        public override MethodKind MethodKind => _methodKind;
 
         public override ITypeSymbol GetTypeInferredDuringReduction(ITypeParameterSymbol reducedFromTypeParameter)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
@@ -54,13 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 this.EnumUnderlyingType);
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return _typeKind;
-            }
-        }
+        public override TypeKind TypeKind => _typeKind;
 
         public override SymbolKind Kind
         {
@@ -128,21 +122,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override INamedTypeSymbol EnumUnderlyingType
-        {
-            get
-            {
-                return _enumUnderlyingType;
-            }
-        }
+        public override INamedTypeSymbol EnumUnderlyingType => _enumUnderlyingType;
 
-        public override INamedTypeSymbol ConstructedFrom
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public override INamedTypeSymbol ConstructedFrom => this;
 
         public override INamedTypeSymbol ConstructUnboundGenericType()
         {
@@ -173,13 +155,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override INamedTypeSymbol BaseType
-        {
-            get
-            {
-                return _baseType;
-            }
-        }
+        public override INamedTypeSymbol BaseType => _baseType;
 
         public override ImmutableArray<INamedTypeSymbol> Interfaces
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamedTypeSymbol.cs
@@ -56,21 +56,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
 
         public override TypeKind TypeKind => _typeKind;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.NamedType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.NamedType;
 
-        public override int Arity
-        {
-            get
-            {
-                return this.TypeParameters.Length;
-            }
-        }
+        public override int Arity => this.TypeParameters.Length;
 
         public override bool IsGenericType
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationNamespaceSymbol.cs
@@ -41,13 +41,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return new CodeGenerationNamespaceSymbol(this.Name, _members);
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Namespace;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Namespace;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -82,10 +76,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public NamespaceKind NamespaceKind
-        {
-            get { return NamespaceKind.Module; }
-        }
+        public NamespaceKind NamespaceKind => NamespaceKind.Module;
 
         public Compilation ContainingCompilation
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationOperatorSymbol.cs
@@ -35,13 +35,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         {
         }
 
-        public override MethodKind MethodKind
-        {
-            get
-            {
-                return MethodKind.UserDefinedOperator;
-            }
-        }
+        public override MethodKind MethodKind => MethodKind.UserDefinedOperator;
 
         public static int GetParameterCount(CodeGenerationOperatorKind operatorKind)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
@@ -47,21 +47,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 this.ExplicitDefaultValue);
         }
 
-        public new IParameterSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new IParameterSymbol OriginalDefinition => this;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Parameter;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Parameter;
 
         public override void Accept(SymbolVisitor visitor)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPointerTypeSymbol.cs
@@ -22,21 +22,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return new CodeGenerationPointerTypeSymbol(this.PointedAtType);
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.Pointer;
-            }
-        }
+        public override TypeKind TypeKind => TypeKind.Pointer;
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.PointerType;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.PointerType;
 
         public override void Accept(SymbolVisitor visitor)
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationPropertySymbol.cs
@@ -59,13 +59,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return result;
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Property;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Property;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -93,13 +87,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public new IPropertySymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new IPropertySymbol OriginalDefinition => this;
 
         public IPropertySymbol OverriddenProperty
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationSymbol.cs
@@ -125,45 +125,15 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public bool IsStatic
-        {
-            get
-            {
-                return this.Modifiers.IsStatic;
-            }
-        }
+        public bool IsStatic => this.Modifiers.IsStatic;
 
-        public bool IsVirtual
-        {
-            get
-            {
-                return this.Modifiers.IsVirtual;
-            }
-        }
+        public bool IsVirtual => this.Modifiers.IsVirtual;
 
-        public bool IsOverride
-        {
-            get
-            {
-                return this.Modifiers.IsOverride;
-            }
-        }
+        public bool IsOverride => this.Modifiers.IsOverride;
 
-        public bool IsAbstract
-        {
-            get
-            {
-                return this.Modifiers.IsAbstract;
-            }
-        }
+        public bool IsAbstract => this.Modifiers.IsAbstract;
 
-        public bool IsSealed
-        {
-            get
-            {
-                return this.Modifiers.IsSealed;
-            }
-        }
+        public bool IsSealed => this.Modifiers.IsSealed;
 
         public bool IsExtern
         {
@@ -228,13 +198,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return GetAttributes().WhereAsArray(a => a.AttributeConstructor.Equals(attributeConstructor));
         }
 
-        public ISymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public ISymbol OriginalDefinition => this;
 
         public abstract void Accept(SymbolVisitor visitor);
 
@@ -278,13 +242,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return null;
         }
 
-        public virtual string MetadataName
-        {
-            get
-            {
-                return this.Name;
-            }
-        }
+        public virtual string MetadataName => this.Name;
 
         public bool HasUnsupportedMetadata
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeParameterSymbol.cs
@@ -45,13 +45,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
                 this.HasValueTypeConstraint, this.Ordinal);
         }
 
-        public new ITypeParameterSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new ITypeParameterSymbol OriginalDefinition => this;
 
         public ITypeParameterSymbol ReducedFrom
         {
@@ -61,13 +55,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.TypeParameter;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.TypeParameter;
 
         public override void Accept(SymbolVisitor visitor)
         {
@@ -79,13 +67,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return visitor.VisitTypeParameter(this);
         }
 
-        public override TypeKind TypeKind
-        {
-            get
-            {
-                return TypeKind.TypeParameter;
-            }
-        }
+        public override TypeKind TypeKind => TypeKind.TypeParameter;
 
         public TypeParameterKind TypeParameterKind
         {

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -74,13 +74,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
-        public new ITypeSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new ITypeSymbol OriginalDefinition => this;
 
         public ISymbol FindImplementationForInterfaceMember(ISymbol interfaceMember)
         {

--- a/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
+++ b/src/Workspaces/Core/Portable/CodeRefactorings/CodeRefactoringContext.cs
@@ -19,19 +19,19 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings
         /// <summary>
         /// Document corresponding to the <see cref="CodeRefactoringContext.Span"/> to refactor.
         /// </summary>
-        public Document Document { get { return _document; } }
+        public Document Document => _document;
 
         /// <summary>
         /// Text span within the <see cref="CodeRefactoringContext.Document"/> to refactor.
         /// </summary>
-        public TextSpan Span { get { return _span; } }
+        public TextSpan Span => _span;
 
         private readonly Action<CodeAction> _registerRefactoring;
 
         /// <summary>
         /// CancellationToken.
         /// </summary>
-        public CancellationToken CancellationToken { get { return _cancellationToken; } }
+        public CancellationToken CancellationToken => _cancellationToken;
 
         /// <summary>
         /// Creates a code refactoring context to be passed into <see cref="CodeRefactoringProvider.ComputeRefactoringsAsync(CodeRefactoringContext)"/> method.

--- a/src/Workspaces/Core/Portable/Differencing/Edit.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Edit.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Differencing
             _newNode = newNode;
         }
 
-        public EditKind Kind { get { return _kind; } }
+        public EditKind Kind => _kind;
 
         /// <summary>
         /// Insert: 
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         /// Move, Update: 
         /// Node in the old tree/sequence.
         /// </summary>
-        public TNode OldNode { get { return _oldNode; } }
+        public TNode OldNode => _oldNode;
 
         /// <summary>
         /// Insert: 
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Differencing
         /// Move, Update:
         /// Node in the new tree/sequence.
         /// </summary>
-        public TNode NewNode { get { return _newNode; } }
+        public TNode NewNode => _newNode;
 
         public override bool Equals(object obj)
         {

--- a/src/Workspaces/Core/Portable/Differencing/EditScript.cs
+++ b/src/Workspaces/Core/Portable/Differencing/EditScript.cs
@@ -27,30 +27,15 @@ namespace Microsoft.CodeAnalysis.Differencing
             _edits = edits.AsImmutable();
         }
 
-        public ImmutableArray<Edit<TNode>> Edits
-        {
-            get { return _edits; }
-        }
+        public ImmutableArray<Edit<TNode>> Edits => _edits;
 
-        public Match<TNode> Match
-        {
-            get { return _match; }
-        }
+        public Match<TNode> Match => _match;
 
-        private TreeComparer<TNode> Comparer
-        {
-            get { return _match.Comparer; }
-        }
+        private TreeComparer<TNode> Comparer => _match.Comparer;
 
-        private TNode Root1
-        {
-            get { return _match.OldRoot; }
-        }
+        private TNode Root1 => _match.OldRoot;
 
-        private TNode Root2
-        {
-            get { return _match.NewRoot; }
-        }
+        private TNode Root2 => _match.NewRoot;
 
         private void AddUpdatesInsertsMoves(List<Edit<TNode>> edits)
         {

--- a/src/Workspaces/Core/Portable/Differencing/Match.cs
+++ b/src/Workspaces/Core/Portable/Differencing/Match.cs
@@ -319,29 +319,11 @@ namespace Microsoft.CodeAnalysis.Differencing
             return TryGetPartnerInTree2(node1, out partner2) && node2.Equals(partner2);
         }
 
-        public TreeComparer<TNode> Comparer
-        {
-            get
-            {
-                return _comparer;
-            }
-        }
+        public TreeComparer<TNode> Comparer => _comparer;
 
-        public TNode OldRoot
-        {
-            get
-            {
-                return _root1;
-            }
-        }
+        public TNode OldRoot => _root1;
 
-        public TNode NewRoot
-        {
-            get
-            {
-                return _root2;
-            }
-        }
+        public TNode NewRoot => _root2;
 
         public IReadOnlyDictionary<TNode, TNode> Matches
         {

--- a/src/Workspaces/Core/Portable/Differencing/SequenceEdit.cs
+++ b/src/Workspaces/Core/Portable/Differencing/SequenceEdit.cs
@@ -49,24 +49,12 @@ namespace Microsoft.CodeAnalysis.Differencing
         /// <summary>
         /// Index in the old sequence, or -1 if the edit is insert.
         /// </summary>
-        public int OldIndex
-        {
-            get
-            {
-                return _oldIndex;
-            }
-        }
+        public int OldIndex => _oldIndex;
 
         /// <summary>
         /// Index in the new sequence, or -1 if the edit is delete.
         /// </summary>
-        public int NewIndex
-        {
-            get
-            {
-                return _newIndex;
-            }
-        }
+        public int NewIndex => _newIndex;
 
         public bool Equals(SequenceEdit other)
         {

--- a/src/Workspaces/Core/Portable/Editing/DocumentEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/DocumentEditor.cs
@@ -42,18 +42,12 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// The <see cref="Document"/> specified when the editor was first created.
         /// </summary>
-        public Document OriginalDocument
-        {
-            get { return _document; }
-        }
+        public Document OriginalDocument => _document;
 
         /// <summary>
         /// The <see cref="CodeAnalysis.SemanticModel"/> of the original document.
         /// </summary>
-        public SemanticModel SemanticModel
-        {
-            get { return _model; }
-        }
+        public SemanticModel SemanticModel => _model;
 
         /// <summary>
         /// Returns the changed <see cref="Document"/>.

--- a/src/Workspaces/Core/Portable/Editing/SolutionEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SolutionEditor.cs
@@ -26,10 +26,7 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// The <see cref="Solution"/> that was specified when the <see cref="SolutionEditor"/> was constructed.
         /// </summary>
-        public Solution OriginalSolution
-        {
-            get { return _solution; }
-        }
+        public Solution OriginalSolution => _solution;
 
         /// <summary>
         /// Gets the <see cref="DocumentEditor"/> for the corresponding <see cref="DocumentId"/>.

--- a/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SymbolEditor.cs
@@ -54,18 +54,12 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// The original solution.
         /// </summary>
-        public Solution OriginalSolution
-        {
-            get { return _originalSolution; }
-        }
+        public Solution OriginalSolution => _originalSolution;
 
         /// <summary>
         /// The solution with the edits applied.
         /// </summary>
-        public Solution ChangedSolution
-        {
-            get { return _currentSolution; }
-        }
+        public Solution ChangedSolution => _currentSolution;
 
         /// <summary>
         /// The documents changed since the <see cref="SymbolEditor"/> was constructed.

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditor.cs
@@ -41,18 +41,12 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// The <see cref="SyntaxNode"/> that was specified when the <see cref="SyntaxEditor"/> was constructed.
         /// </summary>
-        public SyntaxNode OriginalRoot
-        {
-            get { return _root; }
-        }
+        public SyntaxNode OriginalRoot => _root;
 
         /// <summary>
         /// A <see cref="SyntaxGenerator"/> to use to create and change <see cref="SyntaxNode"/>'s.
         /// </summary>
-        public SyntaxGenerator Generator
-        {
-            get { return _generator; }
-        }
+        public SyntaxGenerator Generator => _generator;
 
         /// <summary>
         /// Returns the changed root node.

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolTree/SymbolTreeInfo.Node.cs
@@ -24,15 +24,9 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                 _parentIndex = parentIndex;
             }
 
-            public string Name
-            {
-                get { return _name; }
-            }
+            public string Name => _name;
 
-            public int ParentIndex
-            {
-                get { return _parentIndex; }
-            }
+            public int ParentIndex => _parentIndex;
 
             public bool IsRoot
             {

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.AnchorData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.AnchorData.cs
@@ -22,37 +22,13 @@ namespace Microsoft.CodeAnalysis.Formatting
                 this.OriginalColumn = originalColumn;
             }
 
-            public TextSpan TextSpan
-            {
-                get
-                {
-                    return _operation.TextSpan;
-                }
-            }
+            public TextSpan TextSpan => _operation.TextSpan;
 
-            public SyntaxToken AnchorToken
-            {
-                get
-                {
-                    return _operation.AnchorToken;
-                }
-            }
+            public SyntaxToken AnchorToken => _operation.AnchorToken;
 
-            public SyntaxToken StartToken
-            {
-                get
-                {
-                    return _operation.StartToken;
-                }
-            }
+            public SyntaxToken StartToken => _operation.StartToken;
 
-            public SyntaxToken EndToken
-            {
-                get
-                {
-                    return _operation.EndToken;
-                }
-            }
+            public SyntaxToken EndToken => _operation.EndToken;
 
             public int OriginalColumn { get; }
         }

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.IndentationData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.IndentationData.cs
@@ -45,10 +45,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 _indentation = indentation;
             }
 
-            public override int Indentation
-            {
-                get { return _indentation; }
-            }
+            public override int Indentation => _indentation;
         }
 
         private class LazyIndentationData : IndentationData
@@ -60,10 +57,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 _indentationGetter = indentationGetter;
             }
 
-            public override int Indentation
-            {
-                get { return _indentationGetter.Value; }
-            }
+            public override int Indentation => _indentationGetter.Value;
         }
 
         private class RelativeIndentationData : LazyIndentationData
@@ -78,10 +72,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             public TextSpan InseparableRegionSpan { get; }
             public IndentBlockOperation Operation { get; }
 
-            public SyntaxToken EndToken
-            {
-                get { return this.Operation.EndToken; }
-            }
+            public SyntaxToken EndToken => this.Operation.EndToken;
         }
 
         int IIntervalIntrospector<IndentationData>.GetStart(IndentationData value)

--- a/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Context/FormattingContext.cs
@@ -605,19 +605,10 @@ namespace Microsoft.CodeAnalysis.Formatting
             return IsSpacingSuppressed(spanBetweenTwoTokens);
         }
 
-        public OptionSet OptionSet
-        {
-            get { return _engine.OptionSet; }
-        }
+        public OptionSet OptionSet => _engine.OptionSet;
 
-        public TreeData TreeData
-        {
-            get { return _engine.TreeData; }
-        }
+        public TreeData TreeData => _engine.TreeData;
 
-        public TokenStream TokenStream
-        {
-            get { return _tokenStream; }
-        }
+        public TokenStream TokenStream => _tokenStream;
     }
 }

--- a/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/AbstractTriviaDataFactory.Whitespace.cs
@@ -37,10 +37,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 this.Spaces = indentation;
             }
 
-            public override bool TreatAsElastic
-            {
-                get { return _elastic; }
-            }
+            public override bool TreatAsElastic => _elastic;
 
             public override bool IsWhitespaceOnlyTrivia
             {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.Iterator.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.Iterator.cs
@@ -70,13 +70,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                     return false;
                 }
 
-                public ValueTuple<int, SyntaxToken, SyntaxToken> Current
-                {
-                    get
-                    {
-                        return _current;
-                    }
-                }
+                public ValueTuple<int, SyntaxToken, SyntaxToken> Current => _current;
 
                 object System.Collections.IEnumerator.Current
                 {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TokenStream.cs
@@ -137,13 +137,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
         }
 
-        public int TokenCount
-        {
-            get
-            {
-                return _tokens.Count;
-            }
-        }
+        public int TokenCount => _tokens.Count;
 
         public SyntaxToken GetToken(int index)
         {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TreeData.cs
@@ -51,10 +51,7 @@ namespace Microsoft.CodeAnalysis.Formatting
         public abstract string GetTextBetween(SyntaxToken token1, SyntaxToken token2);
         public abstract int GetOriginalColumn(int tabSize, SyntaxToken token);
 
-        public SyntaxNode Root
-        {
-            get { return _root; }
-        }
+        public SyntaxNode Root => _root;
 
         public bool IsFirstToken(SyntaxToken token)
         {
@@ -66,15 +63,9 @@ namespace Microsoft.CodeAnalysis.Formatting
             return _lastToken == token;
         }
 
-        public int StartPosition
-        {
-            get { return this.Root.FullSpan.Start; }
-        }
+        public int StartPosition => this.Root.FullSpan.Start;
 
-        public int EndPosition
-        {
-            get { return this.Root.FullSpan.End; }
-        }
+        public int EndPosition => this.Root.FullSpan.End;
 
         public IEnumerable<SyntaxToken> GetApplicableTokens(TextSpan textSpan)
         {

--- a/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Engine/TriviaData.cs
@@ -27,8 +27,8 @@ namespace Microsoft.CodeAnalysis.Formatting
             _language = language;
         }
 
-        protected OptionSet OptionSet { get { return _optionSet; } }
-        protected string Language { get { return _language; } }
+        protected OptionSet OptionSet => _optionSet;
+        protected string Language => _language;
 
         public int LineBreaks { get; protected set; }
         public int Spaces { get; protected set; }

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/AbstractTriviaFormatter.cs
@@ -215,25 +215,13 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
         }
 
-        protected TreeData TreeInfo
-        {
-            get { return this.Context.TreeData; }
-        }
+        protected TreeData TreeInfo => this.Context.TreeData;
 
-        protected OptionSet OptionSet
-        {
-            get { return this.Context.OptionSet; }
-        }
+        protected OptionSet OptionSet => this.Context.OptionSet;
 
-        protected string Language
-        {
-            get { return _language; }
-        }
+        protected string Language => _language;
 
-        protected TokenStream TokenStream
-        {
-            get { return this.Context.TokenStream; }
-        }
+        protected TokenStream TokenStream => this.Context.TokenStream;
 
         public List<SyntaxTrivia> FormatToSyntaxTrivia(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Formatting/TriviaEngine/TriviaList.cs
+++ b/src/Workspaces/Core/Portable/Formatting/TriviaEngine/TriviaList.cs
@@ -70,10 +70,7 @@ namespace Microsoft.CodeAnalysis.Formatting
                 return _enumerator.MoveNext();
             }
 
-            public SyntaxTrivia Current
-            {
-                get { return _enumerator.Current; }
-            }
+            public SyntaxTrivia Current => _enumerator.Current;
 
             void IDisposable.Dispose()
             {
@@ -83,10 +80,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             {
             }
 
-            object IEnumerator.Current
-            {
-                get { return this.Current; }
-            }
+            object IEnumerator.Current => this.Current;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
+++ b/src/Workspaces/Core/Portable/LinkedFileDiffMerging/LinkedFileMergeSessionResult.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis
         public Solution MergedSolution { get; }
 
         private readonly Dictionary<DocumentId, IEnumerable<TextSpan>> _mergeConflictCommentSpans = new Dictionary<DocumentId, IEnumerable<TextSpan>>();
-        public Dictionary<DocumentId, IEnumerable<TextSpan>> MergeConflictCommentSpans { get { return _mergeConflictCommentSpans; } }
+        public Dictionary<DocumentId, IEnumerable<TextSpan>> MergeConflictCommentSpans => _mergeConflictCommentSpans;
 
         public LinkedFileMergeSessionResult(Solution mergedSolution, IEnumerable<LinkedFileMergeResult> fileMergeResults)
         {

--- a/src/Workspaces/Core/Portable/Log/InteractionClass.cs
+++ b/src/Workspaces/Core/Portable/Log/InteractionClass.cs
@@ -34,9 +34,6 @@ namespace Microsoft.CodeAnalysis.Internal.Log
             _interactionClass = interactionClass;
         }
 
-        public InteractionClass InteractionClass
-        {
-            get { return _interactionClass; }
-        }
+        public InteractionClass InteractionClass => _interactionClass;
     }
 }

--- a/src/Workspaces/Core/Portable/Options/OptionChangedEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionChangedEventArgs.cs
@@ -15,8 +15,8 @@ namespace Microsoft.CodeAnalysis.Options
             _value = value;
         }
 
-        public IOption Option { get { return _optionKey.Option; } }
-        public string Language { get { return _optionKey.Language; } }
-        public object Value { get { return _value; } }
+        public IOption Option => _optionKey.Option;
+        public string Language => _optionKey.Language;
+        public object Value => _value;
     }
 }

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -54,10 +54,7 @@ namespace Microsoft.CodeAnalysis.Options
             get { return typeof(T); }
         }
 
-        object IOption.DefaultValue
-        {
-            get { return this.DefaultValue; }
-        }
+        object IOption.DefaultValue => this.DefaultValue;
 
         bool IOption.IsPerLanguage
         {

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -55,10 +55,7 @@ namespace Microsoft.CodeAnalysis.Options
             get { return typeof(T); }
         }
 
-        object IOption.DefaultValue
-        {
-            get { return this.DefaultValue; }
-        }
+        object IOption.DefaultValue => this.DefaultValue;
 
         bool IOption.IsPerLanguage
         {

--- a/src/Workspaces/Core/Portable/OrderableMetadata.cs
+++ b/src/Workspaces/Core/Portable/OrderableMetadata.cs
@@ -19,21 +19,9 @@ namespace Microsoft.CodeAnalysis
 
         public string Name { get; }
 
-        IEnumerable<string> IOrderableMetadata.After
-        {
-            get
-            {
-                return AfterTyped;
-            }
-        }
+        IEnumerable<string> IOrderableMetadata.After => AfterTyped;
 
-        IEnumerable<string> IOrderableMetadata.Before
-        {
-            get
-            {
-                return BeforeTyped;
-            }
-        }
+        IEnumerable<string> IOrderableMetadata.Before => BeforeTyped;
 
         public OrderableMetadata(IDictionary<string, object> data)
         {

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictResolution.cs
@@ -98,13 +98,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             }
         }
 
-        public RenamedSpansTracker RenamedSpansTracker
-        {
-            get
-            {
-                return _renamedSpansTracker;
-            }
-        }
+        public RenamedSpansTracker RenamedSpansTracker => _renamedSpansTracker;
 
         public int GetAdjustedTokenStartingPosition(
             int startingPosition,
@@ -124,13 +118,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         /// <summary>
         /// The list of all document ids of documents that have been touched for this rename operation.
         /// </summary>
-        public IEnumerable<DocumentId> DocumentIds
-        {
-            get
-            {
-                return _renamedSpansTracker.DocumentIds;
-            }
-        }
+        public IEnumerable<DocumentId> DocumentIds => _renamedSpansTracker.DocumentIds;
 
         public IEnumerable<RelatedLocation> GetRelatedLocationsForDocument(DocumentId documentId)
         {
@@ -168,24 +156,12 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
         /// <summary>
         /// The new workspace snapshot
         /// </summary>
-        public Solution NewSolution
-        {
-            get
-            {
-                return _newSolution;
-            }
-        }
+        public Solution NewSolution => _newSolution;
 
         /// <summary>
         /// The base workspace snapshot
         /// </summary>
-        public Solution OldSolution
-        {
-            get
-            {
-                return _oldSolution;
-            }
-        }
+        public Solution OldSolution => _oldSolution;
 
         /// <summary>
         /// Whether the text that was resolved with was even valid. This may be false if the

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/ConflictingIdentifierTracker.cs
@@ -22,13 +22,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
             _tokenBeingRenamed = tokenBeingRenamed;
         }
 
-        public IEnumerable<SyntaxToken> ConflictingTokens
-        {
-            get
-            {
-                return _conflictingTokensToReport;
-            }
-        }
+        public IEnumerable<SyntaxToken> ConflictingTokens => _conflictingTokensToReport;
 
         public void AddIdentifier(SyntaxToken token)
         {

--- a/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameLocations.cs
@@ -92,11 +92,11 @@ namespace Microsoft.CodeAnalysis.Rename
             _mergedResult = new SearchResult(mergedLocations, mergedImplicitLocations, mergedReferencedSymbols);
         }
 
-        public ISet<RenameLocation> Locations { get { return _mergedResult.Locations; } }
-        public ISymbol Symbol { get { return _symbol; } }
-        public Solution Solution { get { return _solution; } }
-        public IEnumerable<ISymbol> ReferencedSymbols { get { return _mergedResult.ReferencedSymbols; } }
-        public IEnumerable<ReferenceLocation> ImplicitLocations { get { return _mergedResult.ImplicitLocations; } }
+        public ISet<RenameLocation> Locations => _mergedResult.Locations;
+        public ISymbol Symbol => _symbol;
+        public Solution Solution => _solution;
+        public IEnumerable<ISymbol> ReferencedSymbols => _mergedResult.ReferencedSymbols;
+        public IEnumerable<ReferenceLocation> ImplicitLocations => _mergedResult.ImplicitLocations;
 
         /// <summary>
         /// Find the locations that need to be renamed.

--- a/src/Workspaces/Core/Portable/Shared/Collections/SimpleIntervalTree`1.cs
+++ b/src/Workspaces/Core/Portable/Shared/Collections/SimpleIntervalTree`1.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CodeAnalysis.Shared.Collections
             }
         }
 
-        protected IIntervalIntrospector<T> Introspector
-        {
-            get { return _introspector; }
-        }
+        protected IIntervalIntrospector<T> Introspector => _introspector;
 
         public IEnumerable<T> GetOverlappingIntervals(int start, int length)
         {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/ProgressTracker.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/ProgressTracker.cs
@@ -26,21 +26,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             _updateActionOpt = updateActionOpt;
         }
 
-        public int CompletedItems
-        {
-            get
-            {
-                return _completedItems;
-            }
-        }
+        public int CompletedItems => _completedItems;
 
-        public int TotalItems
-        {
-            get
-            {
-                return _totalItems;
-            }
-        }
+        public int TotalItems => _totalItems;
 
         public void AddItems(int count)
         {

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SignatureComparer.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SignatureComparer.cs
@@ -22,21 +22,9 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             _symbolEquivalenceComparer = symbolEquivalenceComparer;
         }
 
-        private IEqualityComparer<IParameterSymbol> ParameterEquivalenceComparer
-        {
-            get
-            {
-                return _symbolEquivalenceComparer.ParameterEquivalenceComparer;
-            }
-        }
+        private IEqualityComparer<IParameterSymbol> ParameterEquivalenceComparer => _symbolEquivalenceComparer.ParameterEquivalenceComparer;
 
-        private IEqualityComparer<ITypeSymbol> SignatureTypeEquivalenceComparer
-        {
-            get
-            {
-                return _symbolEquivalenceComparer.SignatureTypeEquivalenceComparer;
-            }
-        }
+        private IEqualityComparer<ITypeSymbol> SignatureTypeEquivalenceComparer => _symbolEquivalenceComparer.SignatureTypeEquivalenceComparer;
 
         public bool HaveSameSignature(ISymbol symbol1, ISymbol symbol2, bool caseSensitive)
         {

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKeyResolution.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKeyResolution.cs
@@ -24,19 +24,13 @@ namespace Microsoft.CodeAnalysis
             _candidateReason = candidateReason;
         }
 
-        public ISymbol Symbol
-        {
-            get { return _symbol; }
-        }
+        public ISymbol Symbol => _symbol;
 
         public ImmutableArray<ISymbol> CandidateSymbols
         {
             get { return _candidateSymbols.NullToEmpty(); }
         }
 
-        public CandidateReason CandidateReason
-        {
-            get { return _candidateReason; }
-        }
+        public CandidateReason CandidateReason => _candidateReason;
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -82,10 +82,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// Original expression to be replaced.
         /// </summary>
-        public TExpressionSyntax OriginalExpression
-        {
-            get { return _expression; }
-        }
+        public TExpressionSyntax OriginalExpression => _expression;
 
         /// <summary>
         /// First ancestor of <see cref="OriginalExpression"/> which is either a statement, attribute, constructor initializer,
@@ -109,10 +106,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
         /// <summary>
         /// Semantic model for the syntax tree corresponding to <see cref="OriginalExpression"/>
         /// </summary>
-        public TSemanticModel OriginalSemanticModel
-        {
-            get { return _semanticModel; }
-        }
+        public TSemanticModel OriginalSemanticModel => _semanticModel;
 
         /// <summary>
         /// Node which replaces the <see cref="OriginalExpression"/>.
@@ -154,13 +148,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             }
         }
 
-        public CancellationToken CancellationToken
-        {
-            get
-            {
-                return _cancellationToken;
-            }
-        }
+        public CancellationToken CancellationToken => _cancellationToken;
 
         protected abstract TSyntaxNode GetSemanticRootForSpeculation(TExpressionSyntax expression);
 

--- a/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
@@ -534,13 +534,7 @@ namespace Roslyn.Utilities
                 var ignored = _taskBuilder.Task;
             }
 
-            public Task<T> Task
-            {
-                get
-                {
-                    return _taskBuilder.Task;
-                }
-            }
+            public Task<T> Task => _taskBuilder.Task;
 
             public void RegisterForCancellation(Action<object> callback, CancellationToken cancellationToken)
             {

--- a/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/BidirectionalMap.cs
@@ -79,21 +79,9 @@ namespace Roslyn.Utilities
                 _backwardMap.Add(value, key));
         }
 
-        public IEnumerable<TKey> Keys
-        {
-            get
-            {
-                return _forwardMap.Keys;
-            }
-        }
+        public IEnumerable<TKey> Keys => _forwardMap.Keys;
 
-        public IEnumerable<TValue> Values
-        {
-            get
-            {
-                return _backwardMap.Keys;
-            }
-        }
+        public IEnumerable<TValue> Values => _backwardMap.Keys;
 
         public bool IsEmpty
         {

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableHashMap.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/ImmutableHashMap.cs
@@ -71,10 +71,7 @@ namespace Roslyn.Collections.Immutable
         /// <summary>
         /// Gets an empty map with default equality comparers.
         /// </summary>
-        public static ImmutableHashMap<TKey, TValue> Empty
-        {
-            get { return s_emptySingleton; }
-        }
+        public static ImmutableHashMap<TKey, TValue> Empty => s_emptySingleton;
 
         /// <summary>
         /// See the <see cref="IImmutableDictionary&lt;TKey, TValue&gt;"/> interface.
@@ -728,10 +725,7 @@ namespace Roslyn.Collections.Immutable
                 _buckets = buckets;
             }
 
-            internal override int Count
-            {
-                get { return _buckets.Length; }
-            }
+            internal override int Count => _buckets.Length;
 
             internal override Bucket Add(int suggestedHashRoll, ValueBucket bucket, IEqualityComparer<TKey> comparer, IEqualityComparer<TValue> valueComparer, bool overwriteExistingValue)
             {
@@ -887,10 +881,7 @@ namespace Roslyn.Collections.Immutable
                 throw new InvalidOperationException();
             }
 
-            internal override int Count
-            {
-                get { return _count; }
-            }
+            internal override int Count => _count;
 
             internal override Bucket Add(int suggestedHashRoll, ValueBucket bucket, IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer, bool overwriteExistingValue)
             {
@@ -1169,13 +1160,7 @@ namespace Roslyn.Collections.Immutable
 
         private static class Strings
         {
-            public static string DuplicateKey
-            {
-                get
-                {
-                    return Microsoft.CodeAnalysis.WorkspacesResources.DuplicateKey;
-                }
-            }
+            public static string DuplicateKey => Microsoft.CodeAnalysis.WorkspacesResources.DuplicateKey;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
+++ b/src/Workspaces/Core/Portable/Utilities/CompilerUtilities/linkedhashqueue.cs
@@ -30,13 +30,7 @@ namespace Roslyn.Utilities
             _map = new Dictionary<T, LinkedListNode<T>>(comparer);
         }
 
-        public int Count
-        {
-            get
-            {
-                return _list.Count;
-            }
-        }
+        public int Count => _list.Count;
 
         public void Clear()
         {
@@ -45,13 +39,7 @@ namespace Roslyn.Utilities
             _insertionIndex = 0;
         }
 
-        public T First
-        {
-            get
-            {
-                return _list.First.Value;
-            }
-        }
+        public T First => _list.First.Value;
 
         /// <summary>
         /// Adds this item (or moves it if it's already in the queue) to the end.  If the item is not

--- a/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ObjectPools/PooledObject.cs
@@ -22,13 +22,7 @@ namespace Roslyn.Utilities
             _releaser = releaser;
         }
 
-        public T Object
-        {
-            get
-            {
-                return _pooledObject;
-            }
-        }
+        public T Object => _pooledObject;
 
         public void Dispose()
         {

--- a/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SerializableBytes.cs
@@ -168,13 +168,7 @@ namespace Roslyn.Utilities
                 this.chunks = new List<byte[]>();
             }
 
-            public override long Length
-            {
-                get
-                {
-                    return this.length;
-                }
-            }
+            public override long Length => this.length;
 
             public override bool CanRead
             {

--- a/src/Workspaces/Core/Portable/Utilities/SimpleTaskQueue.cs
+++ b/src/Workspaces/Core/Portable/Utilities/SimpleTaskQueue.cs
@@ -73,12 +73,6 @@ namespace Roslyn.Utilities
                 cancellationToken);
         }
 
-        public Task LastScheduledTask
-        {
-            get
-            {
-                return _latestTask;
-            }
-        }
+        public Task LastScheduledTask => _latestTask;
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefLanguageServices.cs
@@ -31,15 +31,9 @@ namespace Microsoft.CodeAnalysis.Host.Mef
                     .Where(lz => lz.Metadata.Language == language).ToImmutableArray();
         }
 
-        public override HostWorkspaceServices WorkspaceServices
-        {
-            get { return _workspaceServices; }
-        }
+        public override HostWorkspaceServices WorkspaceServices => _workspaceServices;
 
-        public override string Language
-        {
-            get { return _language; }
-        }
+        public override string Language => _language;
 
         public bool HasServices
         {

--- a/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Host/Mef/MefWorkspaceServices.cs
@@ -40,15 +40,9 @@ namespace Microsoft.CodeAnalysis.Host.Mef
             get { return (HostServices)_exportProvider; }
         }
 
-        internal IMefHostExportProvider HostExportProvider
-        {
-            get { return _exportProvider; }
-        }
+        internal IMefHostExportProvider HostExportProvider => _exportProvider;
 
-        public override Workspace Workspace
-        {
-            get { return _workspace; }
-        }
+        public override Workspace Workspace => _workspace;
 
         public override TWorkspaceService GetService<TWorkspaceService>()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -35,13 +35,7 @@ namespace Microsoft.CodeAnalysis
             _state = state;
         }
 
-        internal DocumentState State
-        {
-            get
-            {
-                return _state;
-            }
-        }
+        internal DocumentState State => _state;
 
         internal override TextDocumentState GetDocumentState()
         {
@@ -51,13 +45,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The kind of source code this document contains.
         /// </summary>
-        public SourceCodeKind SourceCodeKind
-        {
-            get
-            {
-                return _state.SourceCodeKind;
-            }
-        }
+        public SourceCodeKind SourceCodeKind => _state.SourceCodeKind;
 
         /// <summary>
         /// Get the current syntax tree for the document if the text is already loaded and the tree is already parsed.
@@ -132,13 +120,7 @@ namespace Microsoft.CodeAnalysis
         /// 
         /// If <code>false</code> then these methods will return <code>null</code> instead.
         /// </summary>
-        public bool SupportsSyntaxTree
-        {
-            get
-            {
-                return this.State.SupportsSyntaxTree;
-            }
-        }
+        public bool SupportsSyntaxTree => this.State.SupportsSyntaxTree;
 
         /// <summary>
         /// <code>true</code> if this Document supports providing data through the

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis
             return string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, _debugName);
         }
 
-        internal string DebugName { get { return _debugName; } }
+        internal string DebugName => _debugName;
 
         public override string ToString()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_SimpleProperties.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState_SimpleProperties.cs
@@ -7,15 +7,9 @@ namespace Microsoft.CodeAnalysis
 {
     internal partial class DocumentState
     {
-        public HostLanguageServices LanguageServices
-        {
-            get { return _languageServices; }
-        }
+        public HostLanguageServices LanguageServices => _languageServices;
 
-        public ParseOptions ParseOptions
-        {
-            get { return _options; }
-        }
+        public ParseOptions ParseOptions => _options;
 
         public SourceCodeKind SourceCodeKind
         {
@@ -25,9 +19,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        public bool IsGenerated
-        {
-            get { return this.info.IsGenerated; }
-        }
+        public bool IsGenerated => this.info.IsGenerated;
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/MetadataOnlyReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/MetadataOnlyReference.cs
@@ -155,13 +155,7 @@ namespace Microsoft.CodeAnalysis
                 _image = image;
             }
 
-            public VersionStamp Version
-            {
-                get
-                {
-                    return _version;
-                }
-            }
+            public VersionStamp Version => _version;
 
             public MetadataReference GetMetadataReference(Compilation compilation, ImmutableArray<string> aliases, bool embedInteropTypes)
             {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -35,55 +35,28 @@ namespace Microsoft.CodeAnalysis
             _projectState = projectState;
         }
 
-        internal ProjectState State
-        {
-            get { return _projectState; }
-        }
+        internal ProjectState State => _projectState;
 
         /// <summary>
         /// The solution this project is part of.
         /// </summary>
-        public Solution Solution
-        {
-            get
-            {
-                return _solution;
-            }
-        }
+        public Solution Solution => _solution;
 
         /// <summary>
         /// The ID of the project. Multiple <see cref="Project"/> instances may share the same ID. However, only
         /// one project may have this ID in any given solution.
         /// </summary>
-        public ProjectId Id
-        {
-            get
-            {
-                return _projectState.Id;
-            }
-        }
+        public ProjectId Id => _projectState.Id;
 
         /// <summary>
         /// The path to the project file or null if there is no project file.
         /// </summary>
-        public string FilePath
-        {
-            get
-            {
-                return _projectState.FilePath;
-            }
-        }
+        public string FilePath => _projectState.FilePath;
 
         /// <summary>
         /// The path to the output file, or null if it is not known.
         /// </summary>
-        public string OutputFilePath
-        {
-            get
-            {
-                return _projectState.OutputFilePath;
-            }
-        }
+        public string OutputFilePath => _projectState.OutputFilePath;
 
         /// <summary>
         /// <code>true</code> if this <see cref="Project"/> supports providing data through the
@@ -102,54 +75,27 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The language services from the host environment associated with this project's language.
         /// </summary>
-        public HostLanguageServices LanguageServices
-        {
-            get { return _projectState.LanguageServices; }
-        }
+        public HostLanguageServices LanguageServices => _projectState.LanguageServices;
 
         /// <summary>
         /// The language associated with the project.
         /// </summary>
-        public string Language
-        {
-            get
-            {
-                return _projectState.LanguageServices.Language;
-            }
-        }
+        public string Language => _projectState.LanguageServices.Language;
 
         /// <summary>
         /// The name of the assembly this project represents.
         /// </summary>
-        public string AssemblyName
-        {
-            get
-            {
-                return _projectState.AssemblyName;
-            }
-        }
+        public string AssemblyName => _projectState.AssemblyName;
 
         /// <summary>
         /// The name of the project. This may be different than the assembly name.
         /// </summary>
-        public string Name
-        {
-            get
-            {
-                return _projectState.Name;
-            }
-        }
+        public string Name => _projectState.Name;
 
         /// <summary>
         /// The list of all other metadata sources (assemblies) that this project references.
         /// </summary>
-        public IReadOnlyList<MetadataReference> MetadataReferences
-        {
-            get
-            {
-                return _projectState.MetadataReferences;
-            }
-        }
+        public IReadOnlyList<MetadataReference> MetadataReferences => _projectState.MetadataReferences;
 
         /// <summary>
         /// The list of all other projects within the same solution that this project references.
@@ -166,101 +112,47 @@ namespace Microsoft.CodeAnalysis
         /// The list of all other projects that this project references, including projects that 
         /// are not part of the solution.
         /// </summary>
-        public IReadOnlyList<ProjectReference> AllProjectReferences
-        {
-            get
-            {
-                return _projectState.ProjectReferences;
-            }
-        }
+        public IReadOnlyList<ProjectReference> AllProjectReferences => _projectState.ProjectReferences;
 
         /// <summary>
         /// The list of all the diagnostic analyzer references for this project.
         /// </summary>
-        public IReadOnlyList<AnalyzerReference> AnalyzerReferences
-        {
-            get
-            {
-                return _projectState.AnalyzerReferences;
-            }
-        }
+        public IReadOnlyList<AnalyzerReference> AnalyzerReferences => _projectState.AnalyzerReferences;
 
         /// <summary>
         /// The options used by analyzers for this project.
         /// </summary>
-        public AnalyzerOptions AnalyzerOptions
-        {
-            get
-            {
-                return _projectState.AnalyzerOptions;
-            }
-        }
+        public AnalyzerOptions AnalyzerOptions => _projectState.AnalyzerOptions;
 
         /// <summary>
         /// The options used when building the compilation for this project.
         /// </summary>
-        public CompilationOptions CompilationOptions
-        {
-            get
-            {
-                return _projectState.CompilationOptions;
-            }
-        }
+        public CompilationOptions CompilationOptions => _projectState.CompilationOptions;
 
         /// <summary>
         /// The options used when parsing documents for this project.
         /// </summary>
-        public ParseOptions ParseOptions
-        {
-            get
-            {
-                return _projectState.ParseOptions;
-            }
-        }
+        public ParseOptions ParseOptions => _projectState.ParseOptions;
 
         /// <summary>
         /// Returns true if this is a submission project.
         /// </summary>
-        public bool IsSubmission
-        {
-            get
-            {
-                return _projectState.IsSubmission;
-            }
-        }
+        public bool IsSubmission => _projectState.IsSubmission;
 
         /// <summary>
         /// True if the project has any documents.
         /// </summary>
-        public bool HasDocuments
-        {
-            get
-            {
-                return _projectState.HasDocuments;
-            }
-        }
+        public bool HasDocuments => _projectState.HasDocuments;
 
         /// <summary>
         /// All the document IDs associated with this project.
         /// </summary>
-        public IReadOnlyList<DocumentId> DocumentIds
-        {
-            get
-            {
-                return _projectState.DocumentIds;
-            }
-        }
+        public IReadOnlyList<DocumentId> DocumentIds => _projectState.DocumentIds;
 
         /// <summary>
         /// All the additional document IDs associated with this project.
         /// </summary>
-        public IReadOnlyList<DocumentId> AdditionalDocumentIds
-        {
-            get
-            {
-                return _projectState.AdditionalDocumentIds;
-            }
-        }
+        public IReadOnlyList<DocumentId> AdditionalDocumentIds => _projectState.AdditionalDocumentIds;
 
         /// <summary>
         /// All the documents associated with this project.
@@ -422,13 +314,7 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// The project version. This equates to the version of the project file.
         /// </summary>
-        public VersionStamp Version
-        {
-            get
-            {
-                return _projectState.Version;
-            }
-        }
+        public VersionStamp Version => _projectState.Version;
 
         /// <summary>
         /// The version of the most recently modified document.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectChanges.cs
@@ -18,20 +18,11 @@ namespace Microsoft.CodeAnalysis
             _oldProject = oldProject;
         }
 
-        public ProjectId ProjectId
-        {
-            get { return _newProject.Id; }
-        }
+        public ProjectId ProjectId => _newProject.Id;
 
-        public Project OldProject
-        {
-            get { return _oldProject; }
-        }
+        public Project OldProject => _oldProject;
 
-        public Project NewProject
-        {
-            get { return _newProject; }
-        }
+        public Project NewProject => _newProject;
 
         public IEnumerable<ProjectReference> GetAddedProjectReferences()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -58,10 +58,7 @@ namespace Microsoft.CodeAnalysis
             return string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, _debugName);
         }
 
-        internal string DebugName
-        {
-            get { return _debugName; }
-        }
+        internal string DebugName => _debugName;
 
         public override string ToString()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectReference.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectReference.cs
@@ -25,17 +25,17 @@ namespace Microsoft.CodeAnalysis
             _embedInteropTypes = embedInteropTypes;
         }
 
-        public ProjectId ProjectId { get { return _projectId; } }
+        public ProjectId ProjectId => _projectId;
 
         /// <summary>
         /// Aliases for the reference. Empty if the reference has no aliases.
         /// </summary>
-        public ImmutableArray<string> Aliases { get { return _aliases; } }
+        public ImmutableArray<string> Aliases => _aliases;
 
         /// <summary>
         /// True if interop types defined in the referenced project should be embedded into the referencing project.
         /// </summary>
-        public bool EmbedInteropTypes { get { return _embedInteropTypes; } }
+        public bool EmbedInteropTypes => _embedInteropTypes;
 
         public override bool Equals(object obj)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectState.cs
@@ -186,46 +186,22 @@ namespace Microsoft.CodeAnalysis
             return doc;
         }
 
-        public ProjectId Id
-        {
-            get { return this.ProjectInfo.Id; }
-        }
+        public ProjectId Id => this.ProjectInfo.Id;
 
-        public string FilePath
-        {
-            get { return this.ProjectInfo.FilePath; }
-        }
+        public string FilePath => this.ProjectInfo.FilePath;
 
-        public string OutputFilePath
-        {
-            get { return this.ProjectInfo.OutputFilePath; }
-        }
+        public string OutputFilePath => this.ProjectInfo.OutputFilePath;
 
-        public HostLanguageServices LanguageServices
-        {
-            get { return _languageServices; }
-        }
+        public HostLanguageServices LanguageServices => _languageServices;
 
-        public string Name
-        {
-            get { return this.ProjectInfo.Name; }
-        }
+        public string Name => this.ProjectInfo.Name;
 
-        public bool IsSubmission
-        {
-            get { return this.ProjectInfo.IsSubmission; }
-        }
+        public bool IsSubmission => this.ProjectInfo.IsSubmission;
 
-        public Type HostObjectType
-        {
-            get { return this.ProjectInfo.HostObjectType; }
-        }
+        public Type HostObjectType => this.ProjectInfo.HostObjectType;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public VersionStamp Version
-        {
-            get { return this.ProjectInfo.Version; }
-        }
+        public VersionStamp Version => this.ProjectInfo.Version;
 
         public AnalyzerOptions AnalyzerOptions
         {
@@ -262,46 +238,25 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public ProjectInfo ProjectInfo
-        {
-            get { return _projectInfo; }
-        }
+        public ProjectInfo ProjectInfo => _projectInfo;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public string AssemblyName
-        {
-            get { return this.ProjectInfo.AssemblyName; }
-        }
+        public string AssemblyName => this.ProjectInfo.AssemblyName;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public CompilationOptions CompilationOptions
-        {
-            get { return this.ProjectInfo.CompilationOptions; }
-        }
+        public CompilationOptions CompilationOptions => this.ProjectInfo.CompilationOptions;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public ParseOptions ParseOptions
-        {
-            get { return this.ProjectInfo.ParseOptions; }
-        }
+        public ParseOptions ParseOptions => this.ProjectInfo.ParseOptions;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<MetadataReference> MetadataReferences
-        {
-            get { return this.ProjectInfo.MetadataReferences; }
-        }
+        public IReadOnlyList<MetadataReference> MetadataReferences => this.ProjectInfo.MetadataReferences;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<AnalyzerReference> AnalyzerReferences
-        {
-            get { return this.ProjectInfo.AnalyzerReferences; }
-        }
+        public IReadOnlyList<AnalyzerReference> AnalyzerReferences => this.ProjectInfo.AnalyzerReferences;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<ProjectReference> ProjectReferences
-        {
-            get { return this.ProjectInfo.ProjectReferences; }
-        }
+        public IReadOnlyList<ProjectReference> ProjectReferences => this.ProjectInfo.ProjectReferences;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
         public bool HasDocuments
@@ -316,28 +271,16 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<DocumentId> DocumentIds
-        {
-            get { return _documentIds; }
-        }
+        public IReadOnlyList<DocumentId> DocumentIds => _documentIds;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        public IReadOnlyList<DocumentId> AdditionalDocumentIds
-        {
-            get { return _additionalDocumentIds; }
-        }
+        public IReadOnlyList<DocumentId> AdditionalDocumentIds => _additionalDocumentIds;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        private ImmutableDictionary<DocumentId, DocumentState> DocumentStates
-        {
-            get { return _documentStates; }
-        }
+        private ImmutableDictionary<DocumentId, DocumentState> DocumentStates => _documentStates;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Collapsed)]
-        private ImmutableDictionary<DocumentId, TextDocumentState> AdditionalDocumentStates
-        {
-            get { return _additionalDocumentStates; }
-        }
+        private ImmutableDictionary<DocumentId, TextDocumentState> AdditionalDocumentStates => _additionalDocumentStates;
 
         public bool ContainsDocument(DocumentId documentId)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.State.cs
@@ -137,10 +137,7 @@ namespace Microsoft.CodeAnalysis
             {
                 private readonly bool _hasCompleteReferences;
 
-                public override ValueSource<Compilation> FinalCompilation
-                {
-                    get { return this.Compilation; }
-                }
+                public override ValueSource<Compilation> FinalCompilation => this.Compilation;
 
                 public override bool? HasCompleteReferences => _hasCompleteReferences;
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTranslationAction.Actions.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTranslationAction.Actions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis
                     return UpdateDocumentInCompilationAsync(oldCompilation, _oldState, _newState, cancellationToken);
                 }
 
-                public DocumentId DocumentId { get { return _newState.Info.Id; } }
+                public DocumentId DocumentId => _newState.Info.Id;
             }
 
             private class RemoveAllDocumentsAction : CompilationTranslationAction

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -117,15 +117,9 @@ namespace Microsoft.CodeAnalysis
             return latestVersion;
         }
 
-        internal int WorkspaceVersion
-        {
-            get { return _workspaceVersion; }
-        }
+        internal int WorkspaceVersion => _workspaceVersion;
 
-        internal SolutionServices Services
-        {
-            get { return _solutionServices; }
-        }
+        internal SolutionServices Services => _solutionServices;
 
         /// <summary>
         /// branch id of this solution
@@ -138,50 +132,32 @@ namespace Microsoft.CodeAnalysis
         /// 
         /// version only has a meaning between primary solution and branched one or between solutions from same branch.
         /// </summary>
-        internal BranchId BranchId
-        {
-            get { return _branchId; }
-        }
+        internal BranchId BranchId => _branchId;
 
         /// <summary>
         /// The Workspace this solution is associated with.
         /// </summary>
-        public Workspace Workspace
-        {
-            get { return _solutionServices.Workspace; }
-        }
+        public Workspace Workspace => _solutionServices.Workspace;
 
         /// <summary>
         /// The Id of the solution. Multiple solution instances may share the same Id.
         /// </summary>
-        public SolutionId Id
-        {
-            get { return _id; }
-        }
+        public SolutionId Id => _id;
 
         /// <summary>
         /// The path to the solution file or null if there is no solution file.
         /// </summary>
-        public string FilePath
-        {
-            get { return _filePath; }
-        }
+        public string FilePath => _filePath;
 
         /// <summary>
         /// The solution version. This equates to the solution file's version.
         /// </summary>
-        public VersionStamp Version
-        {
-            get { return _version; }
-        }
+        public VersionStamp Version => _version;
 
         /// <summary>
         /// A list of all the ids for all the projects contained by the solution.
         /// </summary>
-        public IReadOnlyList<ProjectId> ProjectIds
-        {
-            get { return _projectIds; }
-        }
+        public IReadOnlyList<ProjectId> ProjectIds => _projectIds;
 
         /// <summary>
         /// A list of all the projects contained by the solution.

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SyntacticDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SyntacticDocument.cs
@@ -24,10 +24,7 @@ namespace Microsoft.CodeAnalysis
             this.Root = root;
         }
 
-        public Project Project
-        {
-            get { return this.Document.Project; }
-        }
+        public Project Project => this.Document.Project;
 
         public static async Task<SyntacticDocument> CreateAsync(Document document, CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocumentState.cs
@@ -45,30 +45,15 @@ namespace Microsoft.CodeAnalysis
             this.textAndVersionSource = textAndVersionSource;
         }
 
-        public DocumentId Id
-        {
-            get { return this.info.Id; }
-        }
+        public DocumentId Id => this.info.Id;
 
-        public string FilePath
-        {
-            get { return this.info.FilePath; }
-        }
+        public string FilePath => this.info.FilePath;
 
-        public DocumentInfo Info
-        {
-            get { return this.info; }
-        }
+        public DocumentInfo Info => this.info;
 
-        public IReadOnlyList<string> Folders
-        {
-            get { return this.info.Folders; }
-        }
+        public IReadOnlyList<string> Folders => this.info.Folders;
 
-        public string Name
-        {
-            get { return this.info.Name; }
-        }
+        public string Name => this.info.Name;
 
         public static TextDocumentState Create(DocumentInfo info, SolutionServices services)
         {

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -69,18 +69,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Services provider by the host for implementing workspace features.
         /// </summary>
-        public HostWorkspaceServices Services
-        {
-            get { return _services; }
-        }
+        public HostWorkspaceServices Services => _services;
 
         /// <summary>
         /// primary branch id that current solution has
         /// </summary>
-        internal BranchId PrimaryBranchId
-        {
-            get { return _primaryBranchId; }
-        }
+        internal BranchId PrimaryBranchId => _primaryBranchId;
 
         /// <summary>
         /// Override this property if the workspace supports partial semantics for documents.
@@ -95,10 +89,7 @@ namespace Microsoft.CodeAnalysis
         /// This is generally <see cref="WorkspaceKind.Host"/> if originating from the host environment, but may be 
         /// any other name used for a specific kind of workspace.
         /// </summary>
-        public string Kind
-        {
-            get { return _workspaceKind; }
-        }
+        public string Kind => _workspaceKind;
 
         /// <summary>
         /// Create a new empty solution instance associated with this workspace.

--- a/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
+++ b/src/Workspaces/Core/Portable/Workspace/WorkspaceRegistration.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis
         {
         }
 
-        public Workspace Workspace { get { return _registeredWorkspace; } }
+        public Workspace Workspace => _registeredWorkspace;
         public event EventHandler WorkspaceChanged;
 
         internal void SetWorkspaceAndRaiseEvents(Workspace workspace)

--- a/src/Workspaces/CoreTest/ReferencedSymbolTests.cs
+++ b/src/Workspaces/CoreTest/ReferencedSymbolTests.cs
@@ -229,13 +229,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
                 }
             }
 
-            public string Name
-            {
-                get
-                {
-                    return _name;
-                }
-            }
+            public string Name => _name;
 
             public ISymbol OriginalDefinition
             {


### PR DESCRIPTION
This updates the LS to move all properties of the form:

```
Type Property
{
    get
    {
        return simpleExpression;
    }
}
```

Into the form: ```Type Property => simpleExpression;```.

Certain things had to be true to make this change.

1. The accessor list could not contain any form of trivia in it (beyond whitespace).  One exception to this is trivia on the semicolon of the return statement.  Because we use this same semicolon in the final property declaration, it's fine for it to have trivia.
2. The accessor could not have attributes on it.
3. The simple expression could only be an expression comprised of this/base/identifiers/dots.

In other words, these were actually really simple properties that read far better in their new form.   I did not change any properties that were more complex as i wasn't sure if the new form would be desirable.