### PR TITLE
Rename Engine: Handle type parameters of partial types

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3526,5 +3526,39 @@ class Program
                 result.AssertLabeledSpansAre("Conflict", replacement:="Program.nameof(Program.field);", type:=RelatedLocationType.ResolvedNonReferenceConflict)
             End Using
         End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
+        Public Sub RenameTypeParameterInPartialClass()
+            Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+partial class C&lt;[|$$T|]&gt; {}
+partial class C&lt;[|T|]&gt; {}
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="T2")
+            End Using
+        End Sub
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
+        Public Sub RenameMethodToConflictWithTypeParameter()
+            Using result = RenameEngineResult.Create(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true">
+                            <Document>
+partial class C&lt;{|Conflict:T|}&gt; { void [|$$M|]() { } }
+partial class C&lt;{|Conflict:T|}&gt; {}
+                            </Document>
+                        </Project>
+                    </Workspace>, renameTo:="T2")
+
+                result.AssertLabeledSpansAre("Conflict", type:=RelatedLocationType.UnresolvedConflict)
+            End Using
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -3059,6 +3059,50 @@ End Class
                     result.AssertLabeledSpansAre("conflict", renameTo, RelatedLocationType.UnresolvedConflict)
                 End Using
             End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
+            Public Sub RenameTypeParameterInPartialClass()
+                Using result = RenameEngineResult.Create(
+                        <Workspace>
+                            <Project Language="Visual Basic" CommonReferences="true">
+                                <Document><![CDATA[
+Partial Class C(Of [|$$T|])
+End Class
+
+Partial Class C(Of [|T|])
+End Class
+]]>
+                                </Document>
+                            </Project>
+                        </Workspace>, renameTo:="T2")
+                End Using
+            End Sub
+
+            <Fact>
+            <Trait(Traits.Feature, Traits.Features.Rename)>
+            <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
+            Public Sub RenameMethodToConflictWithTypeParameter()
+                Using result = RenameEngineResult.Create(
+                        <Workspace>
+                            <Project Language="Visual Basic" CommonReferences="true">
+                                <Document><![CDATA[
+Partial Class C(Of {|Conflict:T|})
+    Sub [|$$M|]()
+    End Sub
+End Class
+
+Partial Class C(Of {|Conflict:T|})
+End Class
+]]>
+                                </Document>
+                            </Project>
+                        </Workspace>, renameTo:="T")
+
+                    result.AssertLabeledSpansAre("Conflict", type:=RelatedLocationType.UnresolvedConflict)
+                End Using
+            End Sub
         End Class
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #7440. We previously assumed that TypeParameters would only have one locations, which is not true in partial types.