### PR TITLE
[Stabilization, Crash] Rename: Don't restrict rename project search set for explicit interface implementations

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -3153,8 +3153,48 @@ namespace X
                         </Document>
                     </Project>
                 </Workspace>, renameTo:="IFooEx")
+            End Using
+        End Sub
 
+        <WorkItem(8139, "https://github.com/dotnet/roslyn/issues/8139")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
+        Public Sub RenameExplicitInterfaceImplementationFromDifferentProject()
+            Using result = RenameEngineResult.Create(
+                <Workspace>
 
+                    <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
+                        <ProjectReference>Project2</ProjectReference>
+                        <Document>
+class Program
+{
+    static void Main(string[] args)
+    {
+        Test(new Class1());
+    }
+
+    static void Test(IInterface i)
+    {
+        i.[|M|]();
+    }
+}
+                        </Document>
+                    </Project>
+
+                    <Project Language="C#" AssemblyName="Project2" CommonReferences="true">
+                        <Document>
+public class Class1 : IInterface
+{
+    void IInterface.[|$$M|]() { }  // Rename 'M' from here
+}
+
+public interface IInterface
+{
+    void [|M|]();
+}
+                        </Document>
+                    </Project>
+
+                </Workspace>, renameTo:="Foo")
             End Using
         End Sub
 


### PR DESCRIPTION
Fixes #8139
    
We were previously asserting that renaming a private member meant that the rename operation would occur entirely in that member's declaring project, but rename affect other projects if the private member is an explicit implementation of a public interface member.

Triage - **Fixes a crash** - We were crashing when you'd rename an explicit interface implementation of interface from a different project.