### PR TITLE
Convert MSBuild warnings to errors

### DIFF
--- a/build/scripts/check-msbuild.ps1
+++ b/build/scripts/check-msbuild.ps1
@@ -1,0 +1,30 @@
+# Examine an MSBuild log and issue an error if any MSBulid warnings are discovered.
+
+param ([string]$logFile = $(throw "Need a build log file"))
+$ErrorActionPreference="Stop"
+
+try
+{
+    $exitCode = 0
+    $pattern = "\bwarning\b\s+\bMSB(\d+):(.*)"
+    foreach ($line in gc $logFile) {
+        $m = [regex]::match($line, $pattern, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        if ($m.Success) {
+            $num = $m.Groups[1].Value
+            $text = $m.Groups[2].Value
+            $location = $line.Substring(0, $m.Index)
+            write-host ("error MSB{0}: {1} -> {2}" -f $num, $text, $location)
+            write-host "Original MSB warning line below"
+            write-host $line
+            $exitCode = 1
+        }
+    }
+
+    exit $exitCode
+}
+catch
+{
+    write-host "Error: $($_.Exception.Message)"
+    exit 1
+}
+

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -44,6 +44,7 @@ REM Set the build version only so the assembly version is set to the semantic ve
 REM which allows analyzers to load because the compiler has binding redirects to the
 REM semantic version
 msbuild %MSBuildAdditionalCommandLineArgs% /p:BuildVersion=0.0.0.0 "%RoslynRoot%build\Toolset.sln" /p:NuGetRestorePackages=false /p:Configuration=%BuildConfiguration% /fileloggerparameters:LogFile="%bindir%\Bootstrap.log" || goto :BuildFailed
+powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\check-msbuild.ps1" "%bindir%\Bootstrap.log" || goto :BuildFailed
 
 if not exist "%bindir%\Bootstrap" mkdir "%bindir%\Bootstrap" || goto :BuildFailed
 move "Binaries\%BuildConfiguration%\*" "%bindir%\Bootstrap" || goto :BuildFailed
@@ -61,6 +62,7 @@ if defined TestDeterminism (
 )
 
 msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath="%bindir%\Bootstrap" BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /fileloggerparameters:LogFile="%bindir%\Build.log";verbosity=diagnostic || goto :BuildFailed
+powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\check-msbuild.ps1" "%bindir%\Build.log" || goto :BuildFailed
 
 call :TerminateBuildProcesses
 


### PR DESCRIPTION
Our build should be warning and error free.  Unfortunately there is no way to enforce this in MSBuild because warnings cannot be promoted to errors.  Given that we're already logging all builds to disk I added a script that looks through the logs and issues an error if any warnings are discovered.