### PR TITLE
Last  \r in source should not be represented as if there is another line in the source.

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -83,5 +83,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
         {
             CSharpSyntaxTree.ParseText(new RandomizedSourceText());
         }
+
+        [WorkItem(8200, "https://github.com/dotnet/roslyn/issues/8200")]
+        [Fact]
+        public void EolParsing()
+        {
+            var code = "\n\r"; // Note, it's not "\r\n"
+            var tree = CSharpSyntaxTree.ParseText(code);
+            var lines1 = tree.GetText().Lines.Count; // 3
+
+            var textSpan = Text.TextSpan.FromBounds(0, tree.Length);
+            var fileLinePositionSpan = tree.GetLineSpan(textSpan);    // throws ArgumentOutOfRangeException
+            var endLinePosition = fileLinePositionSpan.EndLinePosition;
+            var line = endLinePosition.Line;
+            var lines2 = line + 1;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -801,7 +801,7 @@ namespace Microsoft.CodeAnalysis.Text
                 var index = 0;
                 if (lastWasCR)
                 {
-                    if (buffer.Length > 0 && buffer[0] == '\n')
+                    if (length > 0 && buffer[0] == '\n')
                     {
                         index++;
                     }


### PR DESCRIPTION
Last  \r in source should not be represented as if there is another line in the source.

Doing so will cause crashes if such line is obtained and is also a compat break.

Fixes #8200