### PR TITLE
[Ask mode] Remove `IReferenceExpression` interface

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1231,7 +1231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundAddressOfOperator : IAddressOfExpression
     {
-        IReferenceExpression IAddressOfExpression.Reference => (IReferenceExpression)this.Operand;
+        IOperation IAddressOfExpression.Reference => this.Operand;
 
         protected override OperationKind ExpressionKind => OperationKind.AddressOfExpression;
 

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -959,7 +959,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundAssignmentOperator : IAssignmentExpression
     {
-        IReferenceExpression IAssignmentExpression.Target => this.Left as IReferenceExpression;
+        IOperation IAssignmentExpression.Target => this.Left;
 
         IOperation IAssignmentExpression.Value => this.Right;
 
@@ -980,7 +980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         BinaryOperationKind ICompoundAssignmentExpression.BinaryOperationKind => Expression.DeriveBinaryOperationKind(this.Operator.Kind);
 
-        IReferenceExpression IAssignmentExpression.Target => this.Left as IReferenceExpression;
+        IOperation IAssignmentExpression.Target => this.Left;
 
         IOperation IAssignmentExpression.Value => this.Right;
 
@@ -1007,7 +1007,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         BinaryOperationKind ICompoundAssignmentExpression.BinaryOperationKind => Expression.DeriveBinaryOperationKind(((IIncrementExpression)this).IncrementOperationKind);
 
-        IReferenceExpression IAssignmentExpression.Target => this.Operand as IReferenceExpression;
+        IOperation IAssignmentExpression.Target => this.Operand;
 
         private static readonly ConditionalWeakTable<BoundIncrementOperator, IOperation> s_incrementValueMappings = new ConditionalWeakTable<BoundIncrementOperator, IOperation>();
 

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
@@ -1180,6 +1180,46 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                  OperationKind.None);
         }
     }
+    
+    public class AddressOfTestAnalyzer : DiagnosticAnalyzer
+    {
+        private const string ReliabilityCategory = "Reliability";
+        
+        public static readonly DiagnosticDescriptor AddressOfDescriptor = new DiagnosticDescriptor(
+            "AddressOfOperation",
+            "AddressOf operation found",
+            "An AddressOf operation found",
+            ReliabilityCategory,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public static readonly DiagnosticDescriptor InvalidAddressOfReferenceDescriptor = new DiagnosticDescriptor(
+            "InvalidAddressOfReference",
+            "Invalid AddressOf reference found",
+            "An invalid AddressOf reference found",
+            ReliabilityCategory,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+            ImmutableArray.Create(AddressOfDescriptor, InvalidAddressOfReferenceDescriptor);
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.RegisterOperationAction(
+                 (operationContext) =>
+                 {
+                     var addressOfOperation = (IAddressOfExpression)operationContext.Operation;
+                     operationContext.ReportDiagnostic(Diagnostic.Create(AddressOfDescriptor, addressOfOperation.Syntax.GetLocation()));
+
+                     if (addressOfOperation.Reference.Kind == OperationKind.InvalidExpression && addressOfOperation.IsInvalid)
+                     {
+                         operationContext.ReportDiagnostic(Diagnostic.Create(InvalidAddressOfReferenceDescriptor, addressOfOperation.Reference.Syntax.GetLocation()));
+                     }
+                 },
+                 OperationKind.AddressOfExpression);
+        }
+    }
 
     /// <summary>Analyzer used to test LambdaExpression IOperations.</summary>
     public class LambdaTestAnalyzer : DiagnosticAnalyzer
@@ -1708,8 +1748,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
                 },
                 OperationKind.PlaceholderExpression);
         }
-    }
-    
+    }    
 
     public class ForLoopConditionCrashVBTestAnalyzer : DiagnosticAnalyzer
     {

--- a/src/Compilers/Core/Portable/Compilation/Expression.cs
+++ b/src/Compilers/Core/Portable/Compilation/Expression.cs
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     {
         private readonly AssignmentExpression _assignment;
 
-        public Assignment(IReferenceExpression target, IOperation value, SyntaxNode syntax)
+        public Assignment(IOperation target, IOperation value, SyntaxNode syntax)
         {
             _assignment = new AssignmentExpression(target, value, syntax);
             this.Syntax = syntax;
@@ -154,14 +154,14 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         private sealed class AssignmentExpression : IAssignmentExpression
         {
-            public AssignmentExpression(IReferenceExpression target, IOperation value, SyntaxNode syntax)
+            public AssignmentExpression(IOperation target, IOperation value, SyntaxNode syntax)
             {
                 this.Value = value;
                 this.Target = target;
                 this.Syntax = syntax;
             }
 
-            public IReferenceExpression Target { get; }
+            public IOperation Target { get; }
 
             public IOperation Value { get; }
 
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     {
         private readonly CompoundAssignmentExpression _compoundAssignment;
 
-        public CompoundAssignment(IReferenceExpression target, IOperation value, BinaryOperationKind binaryOperationKind, IMethodSymbol operatorMethod, SyntaxNode syntax)
+        public CompoundAssignment(IOperation target, IOperation value, BinaryOperationKind binaryOperationKind, IMethodSymbol operatorMethod, SyntaxNode syntax)
         {
             _compoundAssignment = new CompoundAssignmentExpression(target, value, binaryOperationKind, operatorMethod, syntax);
             this.Syntax = syntax;
@@ -221,7 +221,7 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         private sealed class CompoundAssignmentExpression : ICompoundAssignmentExpression
         {
-            public CompoundAssignmentExpression(IReferenceExpression target, IOperation value, BinaryOperationKind binaryOperationKind, IMethodSymbol operatorMethod, SyntaxNode syntax)
+            public CompoundAssignmentExpression(IOperation target, IOperation value, BinaryOperationKind binaryOperationKind, IMethodSymbol operatorMethod, SyntaxNode syntax)
             {
                 this.Target = target;
                 this.Value = value;
@@ -230,7 +230,7 @@ namespace Microsoft.CodeAnalysis.Semantics
                 this.Syntax = syntax;
             }
 
-            public IReferenceExpression Target { get; }
+            public IOperation Target { get; }
 
             public IOperation Value { get; }
 

--- a/src/Compilers/Core/Portable/Compilation/IExpression.cs
+++ b/src/Compilers/Core/Portable/Compilation/IExpression.cs
@@ -999,7 +999,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// <summary>
         /// Addressed reference.
         /// </summary>
-        IReferenceExpression Reference { get; }
+        IOperation Reference { get; }
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/IExpression.cs
+++ b/src/Compilers/Core/Portable/Compilation/IExpression.cs
@@ -98,16 +98,9 @@ namespace Microsoft.CodeAnalysis.Semantics
     }
 
     /// <summary>
-    /// Represents a reference, which refers to a symbol or an element of a collection.
-    /// </summary>
-    public interface IReferenceExpression : IOperation
-    {
-    }
-
-    /// <summary>
     /// Represents a reference to an array element.
     /// </summary>
-    public interface IArrayElementReferenceExpression : IReferenceExpression
+    public interface IArrayElementReferenceExpression : IOperation
     {
         /// <summary>
         /// Array to be indexed.
@@ -122,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference through a pointer.
     /// </summary>
-    public interface IPointerIndirectionReferenceExpression : IReferenceExpression
+    public interface IPointerIndirectionReferenceExpression : IOperation
     {
         /// <summary>
         /// Pointer to be dereferenced.
@@ -133,7 +126,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a declared local variable.
     /// </summary>
-    public interface ILocalReferenceExpression : IReferenceExpression
+    public interface ILocalReferenceExpression : IOperation
     {
         /// <summary>
         /// Referenced local variable.
@@ -144,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a parameter.
     /// </summary>
-    public interface IParameterReferenceExpression : IReferenceExpression
+    public interface IParameterReferenceExpression : IOperation
     {
         /// <summary>
         /// Referenced parameter.
@@ -155,7 +148,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a local variable synthesized by language analysis.
     /// </summary>
-    public interface ISyntheticLocalReferenceExpression : IReferenceExpression
+    public interface ISyntheticLocalReferenceExpression : IOperation
     {
         /// <summary>
         /// Kind of the synthetic local.
@@ -212,7 +205,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a member of a class, struct, or interface.
     /// </summary>
-    public interface IMemberReferenceExpression : IReferenceExpression
+    public interface IMemberReferenceExpression : IOperation
     {
         /// <summary>
         /// Instance of the type. Null if the reference is to a static/shared member.
@@ -1096,7 +1089,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// <summary>
         /// Target of the assignment.
         /// </summary>
-        IReferenceExpression Target { get; }
+        IOperation Target { get; }
         /// <summary>
         /// Value to be assigned to the target of the assignment.
         /// </summary>
@@ -1139,7 +1132,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a late-bound reference to a member of a class or struct.
     /// </summary>
-    public interface ILateBoundMemberReferenceExpression : IReferenceExpression
+    public interface ILateBoundMemberReferenceExpression : IOperation
     {
         /// <summary>
         /// Instance used to bind the member reference.

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -336,7 +336,7 @@ Microsoft.CodeAnalysis.Semantics.ConversionKind.None = 0 -> Microsoft.CodeAnalys
 Microsoft.CodeAnalysis.Semantics.ConversionKind.OperatorMethod = 5 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.ConversionKind.TryCast = 2 -> Microsoft.CodeAnalysis.Semantics.ConversionKind
 Microsoft.CodeAnalysis.Semantics.IAddressOfExpression
-Microsoft.CodeAnalysis.Semantics.IAddressOfExpression.Reference.get -> Microsoft.CodeAnalysis.Semantics.IReferenceExpression
+Microsoft.CodeAnalysis.Semantics.IAddressOfExpression.Reference.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IArgument
 Microsoft.CodeAnalysis.Semantics.IArgument.ArgumentKind.get -> Microsoft.CodeAnalysis.Semantics.ArgumentKind
 Microsoft.CodeAnalysis.Semantics.IArgument.InConversion.get -> Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -353,7 +353,7 @@ Microsoft.CodeAnalysis.Semantics.IArrayElementReferenceExpression.Indices.get ->
 Microsoft.CodeAnalysis.Semantics.IArrayInitializer
 Microsoft.CodeAnalysis.Semantics.IArrayInitializer.ElementValues.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IOperation>
 Microsoft.CodeAnalysis.Semantics.IAssignmentExpression
-Microsoft.CodeAnalysis.Semantics.IAssignmentExpression.Target.get -> Microsoft.CodeAnalysis.Semantics.IReferenceExpression
+Microsoft.CodeAnalysis.Semantics.IAssignmentExpression.Target.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IAssignmentExpression.Value.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IAwaitExpression
 Microsoft.CodeAnalysis.Semantics.IAwaitExpression.AwaitedValue.get -> Microsoft.CodeAnalysis.IOperation
@@ -489,7 +489,6 @@ Microsoft.CodeAnalysis.Semantics.IPropertyReferenceExpression.Property.get -> Mi
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause.MaximumValue.get -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.IRangeCaseClause.MinimumValue.get -> Microsoft.CodeAnalysis.IOperation
-Microsoft.CodeAnalysis.Semantics.IReferenceExpression
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause.Relation.get -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.IRelationalCaseClause.Value.get -> Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -54,9 +54,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Implements IAssignmentExpression
         Implements ICompoundAssignmentExpression
 
-        Private ReadOnly Property IAssignmentExpression_Target As IReferenceExpression Implements IAssignmentExpression.Target
+        Private ReadOnly Property IAssignmentExpression_Target As IOperation Implements IAssignmentExpression.Target
             Get
-                Return TryCast(Me.Left, IReferenceExpression)
+                Return Me.Left
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Statement.vb
@@ -556,7 +556,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         If operators IsNot Nothing Then
                             ' Use the operator methods. Figure out the precise rules first.
                         Else
-                            Dim controlReference As IReferenceExpression = TryCast(BoundFor.ControlVariable, IReferenceExpression)
+                            Dim controlReference As IOperation = BoundFor.ControlVariable
                             If controlReference IsNot Nothing Then
 
                                 ' ControlVariable += StepValue
@@ -590,7 +590,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Dim statements As ArrayBuilder(Of IOperation) = ArrayBuilder(Of IOperation).GetInstance()
 
                         ' ControlVariable = InitialValue
-                        Dim controlReference As IReferenceExpression = TryCast(BoundFor.ControlVariable, IReferenceExpression)
+                        Dim controlReference As IOperation = BoundFor.ControlVariable
                         If controlReference IsNot Nothing Then
                             statements.Add(New Assignment(controlReference, BoundFor.InitialValue, BoundFor.InitialValue.Syntax))
                         End If


### PR DESCRIPTION
Replaced all references of `IReferenceExpression` with `IOperation`. This also fix #9020.

@JohnHamby @dotnet/roslyn-interactive @mavasani 
