### PR TITLE
Fix bugs in TrueFalseKeywordRecommender.ShouldPreselect

### DIFF
--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
@@ -24,12 +24,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
         End Function
 
         Private Function ShouldPreselect(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As Boolean
-            Dim documentId = context?.Workspace?.CurrentSolution.GetDocumentIdsWithFilePath(context.SyntaxTree.FilePath).FirstOrDefault()
-            If documentId Is Nothing Then
+            ' The Workspace might be null in the keyword recommender tests, since we don't create one for those.
+            ' This function still gets test coverage through the all-up completion tests.
+            Dim document = context.Workspace?.CurrentSolution.GetDocument(context.SyntaxTree)
+
+            If document Is Nothing Then
                 Return False
             End If
 
-            Dim document = context.Workspace.CurrentSolution.GetDocument(documentId)
             Dim typeInferenceService = document.Project.LanguageServices.GetService(Of ITypeInferenceService)()
             Dim types = typeInferenceService.InferTypes(context.SemanticModel, context.Position, cancellationToken)
 


### PR DESCRIPTION
We shouldn't access CurrentSolution more than once if the workspace would change underneath us, and we can ensure we get the right document directly if we don't go through file path.

I noticed this while investigating a MEF corruption issue which happened to result in a null ref. My first guess was this was the bug, even though it wasn't.

Review: @dotnet/roslyn-ide. @Pilchie, this might be low enough risk it's worth putting in stabilization under the bar of "why not?".