### PR TITLE
Always use an absolute path for keyfile with public sign

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpCompilationOptions.cs
@@ -520,6 +520,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override void ValidateOptions(ArrayBuilder<Diagnostic> builder)
         {
+            ValidateOptions(builder, MessageProvider.Instance);
+
             //  /main & /target:{library|netmodule|winmdobj}
             if (this.MainTypeName != null)
             {
@@ -581,24 +583,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // TODO: add check for 
             //          (kind == 'arm' || kind == 'appcontainer' || kind == 'winmdobj') &&
             //          (version >= "6.2")
-
-            if (!CryptoPublicKey.IsEmpty)
-            {
-                if (CryptoKeyFile != null)
-                {
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_MutuallyExclusiveOptions, nameof(CryptoPublicKey), nameof(CryptoKeyFile)));
-                }
-
-                if (CryptoKeyContainer != null)
-                {
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_MutuallyExclusiveOptions, nameof(CryptoPublicKey), nameof(CryptoKeyContainer)));
-                }
-            }
-
-            if (PublicSign && DelaySign == true)
-            {
-                builder.Add(Diagnostic.Create(MessageProvider.Instance, (int)ErrorCode.ERR_MutuallyExclusiveOptions, nameof(PublicSign), nameof(DelaySign)));
-            }
         }
 
         public bool Equals(CSharpCompilationOptions other)

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCommandLineParser.cs
@@ -1118,6 +1118,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 keyFileSearchPaths.Add(outputDirectory);
             }
 
+            // Public sign doesn't use the legacy search path settings
+            if (publicSign && !string.IsNullOrWhiteSpace(keyFileSetting))
+            {
+                keyFileSetting = ParseGenericPathToFile(keyFileSetting, diagnostics, baseDirectory);
+            }
+
             var parsedFeatures = CompilerOptionParseUtilities.ParseFeatures(features);
 
             string compilationName;

--- a/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageProvider.cs
@@ -143,6 +143,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // compilation options:
         public override int ERR_BadCompilationOptionValue { get { return (int)ErrorCode.ERR_BadCompilationOptionValue; } }
+        public override int ERR_MutuallyExclusiveOptions => (int)ErrorCode.ERR_MutuallyExclusiveOptions;
 
         // emit options:
         public override int ERR_InvalidDebugInformationFormat { get { return (int)ErrorCode.ERR_InvalidDebugInformationFormat; } }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -449,6 +449,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // when both attributes and command-line options specified, cmd line wins.
             string keyFile = _compilation.Options.CryptoKeyFile;
 
+            // Public sign requires a keyfile
+            if (DeclaringCompilation.Options.PublicSign)
+            {
+                // TODO(https://github.com/dotnet/roslyn/issues/9150):
+                // Provide better error message if keys are provided by
+                // the attributes. Right now we'll just fall through to the
+                // "no key available" error.
+
+                // If we're public signing, we don't need a strong name provider
+                return StrongNameKeys.Create(keyFile, MessageProvider.Instance);
+            }
+
             if (string.IsNullOrEmpty(keyFile))
             {
                 keyFile = this.AssemblyKeyFileAttributeSetting;
@@ -471,16 +483,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            // If we're public signing, we don't need a strong name provider, just 
-            // the file containing the public key
-            if (DeclaringCompilation.Options.PublicSign && keyFile != null)
-            {
-                return StrongNameKeys.Create(keyFile, MessageProvider.Instance);
-            }
-            else
-            {
-                return StrongNameKeys.Create(DeclaringCompilation.Options.StrongNameProvider, keyFile, keyContainer, MessageProvider.Instance);
-            }
+            return StrongNameKeys.Create(DeclaringCompilation.Options.StrongNameProvider, keyFile, keyContainer, MessageProvider.Instance);
         }
 
         // A collection of assemblies to which we were granted internals access by only checking matches for assembly name

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -457,6 +457,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // the attributes. Right now we'll just fall through to the
                 // "no key available" error.
 
+                if (!string.IsNullOrEmpty(keyFile) && !PathUtilities.IsAbsolute(keyFile))
+                {
+                    // If keyFile has a relative path then there should be a diagnostic
+                    // about it
+                    Debug.Assert(!DeclaringCompilation.Options.Errors.IsEmpty);
+                    return StrongNameKeys.None;
+                }
+
                 // If we're public signing, we don't need a strong name provider
                 return StrongNameKeys.Create(keyFile, MessageProvider.Instance);
             }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -3730,6 +3730,15 @@ C:\*.cs(100,7): error CS0103: The name 'Foo' does not exist in the current conte
             Assert.False(parsedArgs.CompilationOptions.PublicSign);
         }
 
+        [WorkItem(8360, "https://github.com/dotnet/roslyn/issues/8360")]
+        [Fact]
+        public void PublicSign_KeyFileRelativePath()
+        {
+            var parsedArgs = DefaultParse(new[] { "/publicsign", "/keyfile:test.snk", "a.cs" }, _baseDirectory);
+            parsedArgs.Errors.Verify();
+            Assert.Equal(Path.Combine(_baseDirectory, "test.snk"), parsedArgs.CompilationOptions.CryptoKeyFile);
+        }
+
         [WorkItem(546301, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546301")]
         [Fact]
         public void SubsystemVersionTests()

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -26,6 +26,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class CompilationAPITests : CSharpTestBase
     {
+        [WorkItem(8360, "https://github.com/dotnet/roslyn/issues/8360")]
+        [Fact]
+        public void PublicSignWithRelativeKeyPath()
+        {
+            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithPublicSign(true).WithCryptoKeyFile("test.snk");
+            var comp = CSharpCompilation.Create("test", options: options);
+            comp.VerifyDiagnostics(
+    // error CS7088: Invalid 'CryptoKeyFile' value: 'test.snk'.
+    Diagnostic(ErrorCode.ERR_BadCompilationOptionValue).WithArguments("CryptoKeyFile", "test.snk").WithLocation(1, 1),
+    // error CS8102: Public signing was specified and requires a public key, but no public key was specified.
+    Diagnostic(ErrorCode.ERR_PublicSignButNoKey).WithLocation(1, 1));
+        }
+
         [Fact]
         public void CompilationName()
         {

--- a/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/Diagnostic/CommonMessageProvider.cs
@@ -155,6 +155,7 @@ namespace Microsoft.CodeAnalysis
 
         // compilation options:
         public abstract int ERR_BadCompilationOptionValue { get; }
+        public abstract int ERR_MutuallyExclusiveOptions { get; }
 
         // emit options:
         public abstract int ERR_InvalidDebugInformationFormat { get; }

--- a/src/Compilers/Core/Portable/StrongName/StrongNameKeys.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameKeys.cs
@@ -88,13 +88,14 @@ namespace Microsoft.CodeAnalysis
 
         internal static StrongNameKeys Create(string keyFilePath, CommonMessageProvider messageProvider)
         {
-            if (string.IsNullOrEmpty(keyFilePath) || !PathUtilities.IsAbsolute(keyFilePath))
+            if (string.IsNullOrEmpty(keyFilePath))
             {
                 return None;
             }
 
             try
             {
+                Debug.Assert(PathUtilities.IsAbsolute(keyFilePath));
                 var fileContent = ImmutableArray.Create(PortableShim.File.ReadAllBytes(keyFilePath));
 
                 return CreateHelper(fileContent, keyFilePath);

--- a/src/Compilers/Core/Portable/StrongName/StrongNameKeys.cs
+++ b/src/Compilers/Core/Portable/StrongName/StrongNameKeys.cs
@@ -88,14 +88,13 @@ namespace Microsoft.CodeAnalysis
 
         internal static StrongNameKeys Create(string keyFilePath, CommonMessageProvider messageProvider)
         {
-            if (string.IsNullOrEmpty(keyFilePath))
+            if (string.IsNullOrEmpty(keyFilePath) || !PathUtilities.IsAbsolute(keyFilePath))
             {
                 return None;
             }
 
             try
             {
-                Debug.Assert(PathUtilities.IsAbsolute(keyFilePath));
                 var fileContent = ImmutableArray.Create(PortableShim.File.ReadAllBytes(keyFilePath));
 
                 return CreateHelper(fileContent, keyFilePath);

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1191,6 +1191,11 @@ lVbRuntimePlus:
             ' Build search path
             Dim searchPaths As ImmutableArray(Of String) = BuildSearchPaths(baseDirectory, sdkPaths, responsePaths, libPaths)
 
+            ' Public sign doesn't use legacy search path settings
+            If publicSign AndAlso Not String.IsNullOrWhiteSpace(keyFileSetting) Then
+                keyFileSetting = ParseGenericPathToFile(keyFileSetting, diagnostics, baseDirectory)
+            End If
+
             ValidateWin32Settings(noWin32Manifest, win32ResourceFile, win32IconFile, win32ManifestFile, outputKind, diagnostics)
 
             ' Validate root namespace if specified

--- a/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/MessageProvider.vb
@@ -236,6 +236,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
+        Public Overrides ReadOnly Property ERR_MutuallyExclusiveOptions As Integer
+            Get
+                Return ERRID.ERR_MutuallyExclusiveOptions
+            End Get
+        End Property
+
         ' emit options:
 
         Public Overrides ReadOnly Property ERR_InvalidDebugInformationFormat As Integer

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -878,6 +878,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Friend Overrides Sub ValidateOptions(builder As ArrayBuilder(Of Diagnostic))
+            ValidateOptions(builder, MessageProvider.Instance)
+
             If Me.EmbedVbCoreRuntime AndAlso Me.OutputKind.IsNetModule() Then
                 builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_VBCoreNetModuleConflict))
             End If
@@ -925,20 +927,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' TODO: add check for 
             '          (kind == 'arm' || kind == 'appcontainer' || kind == 'winmdobj') &&
             '          (version >= "6.2")
-
-            If Not CryptoPublicKey.IsEmpty Then
-                If CryptoKeyFile IsNot Nothing Then
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(CryptoPublicKey), NameOf(CryptoKeyFile)))
-                End If
-
-                If CryptoKeyContainer IsNot Nothing Then
-                    builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(CryptoPublicKey), NameOf(CryptoKeyContainer)))
-                End If
-            End If
-
-            If PublicSign AndAlso DelaySign = True Then
-                builder.Add(Diagnostic.Create(MessageProvider.Instance, ERRID.ERR_MutuallyExclusiveOptions, NameOf(PublicSign), NameOf(DelaySign)))
-            End If
         End Sub
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -7512,6 +7512,15 @@ End Class
             Assert.False(args.CompilationOptions.PublicSign)
         End Sub
 
+
+        <WorkItem(8360, "https://github.com/dotnet/roslyn/issues/8360")>
+        <Fact>
+        Public Sub PublicSign_KeyFileRelativePath()
+            Dim parsedArgs = FullParse("/publicsign /keyfile:test.snk a.cs", _baseDirectory)
+            Assert.Equal(Path.Combine(_baseDirectory, "test.snk"), parsedArgs.CompilationOptions.CryptoKeyFile)
+            parsedArgs.Errors.Verify()
+        End Sub
+
         <ConditionalFact(GetType(WindowsOnly))>
         Public Sub CommandLineMisc()
             Dim args As VisualBasicCommandLineArguments

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -1673,6 +1673,45 @@ BC37254: Public sign was specified and requires a public key, but no public key 
         Assert.True(comp.Assembly.PublicKey.IsDefaultOrEmpty)
     End Sub
 
+
+    <Fact>
+    Public Sub KeyFileFromAttributes_PublicSign()
+        Dim source = <compilation>
+                         <file name="a.vb"><![CDATA[
+<assembly: System.Reflection.AssemblyKeyFile("test.snk")>
+Public Class C
+End Class
+]]>
+                         </file>
+                     </compilation>
+        Dim c = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll.WithPublicSign(True))
+        AssertTheseDiagnostics(c,
+                               <errors>
+BC37254: Public sign was specified and requires a public key, but no public key was specified
+                               </errors>)
+
+        Assert.True(c.Options.PublicSign)
+    End Sub
+
+    <Fact>
+    Public Sub KeyContainerFromAttributes_PublicSign()
+        Dim source = <compilation>
+                         <file name="a.vb"><![CDATA[
+<assembly: System.Reflection.AssemblyKeyName("roslynTestContainer")>
+Public Class C
+End Class
+]]>
+                         </file>
+                     </compilation>
+        Dim c = CreateCompilationWithMscorlib(source, options:=TestOptions.ReleaseDll.WithPublicSign(True))
+        AssertTheseDiagnostics(c,
+                               <errors>
+BC37254: Public sign was specified and requires a public key, but no public key was specified
+                               </errors>)
+
+        Assert.True(c.Options.PublicSign)
+    End Sub
+
     <Fact>
     Public Sub PublicSign_FromKeyFileNoStrongNameProvider()
         Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey)
@@ -1699,6 +1738,24 @@ BC37254: Public sign was specified and requires a public key, but no public key 
         Dim snk = Temp.CreateFile().WriteAllBytes(TestResources.General.snPublicKey2)
         Dim options = TestOptions.ReleaseDll.WithCryptoKeyFile(snk.Path).WithPublicSign(True)
         PublicSignCore(options)
+    End Sub
+
+    <Fact>
+    Public Sub PublicSign_KeyContainerOnly()
+        Dim source =
+            <compilation>
+                <file name="a.vb"><![CDATA[
+Public Class C
+End Class
+]]>
+                </file>
+            </compilation>
+        Dim options = TestOptions.ReleaseDll.WithCryptoKeyContainer("testContainer").WithPublicSign(True)
+        Dim compilation = CreateCompilationWithMscorlib(source, options:=options)
+        AssertTheseDiagnostics(compilation, <errors>
+BC2046: Compilation options 'PublicSign' and 'CryptoKeyContainer' can't both be specified at the same time.
+BC37254: Public sign was specified and requires a public key, but no public key was specified
+                                            </errors>)
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/CompilationAPITests.vb
@@ -21,6 +21,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
     Public Class CompilationAPITests
         Inherits BasicTestBase
 
+        <WorkItem(8360, "https://github.com/dotnet/roslyn/issues/8360")>
+        <Fact>
+        Public Sub PublicSignWithRelativeKeyPath()
+            Dim options = New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary).
+                    WithPublicSign(True).WithCryptoKeyFile("test.snk")
+            AssertTheseDiagnostics(VisualBasicCompilation.Create("test", options:=options),
+<errors>
+BC2014: the value 'test.snk' is invalid for option 'CryptoKeyFile'
+BC37254: Public sign was specified and requires a public key, but no public key was specified
+</errors>)
+        End Sub
+
         <Fact>
         Public Sub LocalizableErrorArgumentToStringDoesntStackOverflow()
             ' Error ID is arbitrary

--- a/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
+++ b/src/Test/Utilities/Shared/Mocks/TestMessageProvider.cs
@@ -355,6 +355,14 @@ namespace Roslyn.Test.Utilities
             }
         }
 
+        public override int ERR_MutuallyExclusiveOptions
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
         public override int ERR_TooManyUserStrings
         {
             get


### PR DESCRIPTION
Right now there are two code paths for signing using a keyfile:

1) Full & delay signing implemented using a strong-name provider, which
   calls into the CLR when necessary to do signing.
2) Public signing, which extracts the key directly from the file and
   embeds it manually into the assembly using only portable code.

The tricky part is that (1) also implements a bunch of legacy semantics
on how to resolve the key file from various search paths, since the key
file can also be specified via an attribute.

This behavior is already deprecated, so rather than implement the
complicated file resolution for public sign as well, this PR changes the
command line compilers to always produce an absolute path for the key
file before passing it to CompilationOptions when using public signing. 
CreateCompilation now also has a check to enforce that CryptoKeyFile 
is an absolute path when PublicSign is set.

Fixes #8360