### PR TITLE
Case insensitive OSTYPE comparison

### DIFF
--- a/cibuild.sh
+++ b/cibuild.sh
@@ -57,7 +57,7 @@ run_make()
     local is_good=false
  
     MAKE="make"
-    if [[ $OSTYPE == *bsd* ]]; then
+    if [[ $OSTYPE == *[Bb][Ss][Dd]* ]]; then
         MAKE="gmake"
     fi
 


### PR DESCRIPTION
In #8701, a comparison was added for `bsd`. It worked on NetBSD as bash
returns `netbsd` for `echo $OSTYPE`. However, today I discovered that
on FreeBSD, it returns `FreeBSD` with upper cased `BSD`. This change
adds the mixed casing to avoid such problems in future for other
BSD-like OSes.

cc @agocke 