### PR TITLE
Add null check for compilation before attempting to run analyzers in …

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     }
                 }
 
-                if (!_document.SupportsSyntaxTree)
+                if (!_document.SupportsSyntaxTree || compilation == null)
                 {
                     return ImmutableArray<Diagnostic>.Empty;
                 }
@@ -245,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     }
                 }
 
-                if (!_document.SupportsSyntaxTree)
+                if (!_document.SupportsSyntaxTree || compilation == null)
                 {
                     return ImmutableArray<Diagnostic>.Empty;
                 }


### PR DESCRIPTION
…the IDE DiagnosticAnalyzerDriver.

Note that we will still continue to run the non-compilation based DocumentAnalyzers and ProjectAnalyzers, which are IDE-only analyzers, for languages such as TypeScript.

This change fixes the NRE reported in VSO Watson bug [192709](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=192709)