### PR TITLE
[Ask Mode] Add `OperatorMethodIntegerDivide` to `BinaryOperationKind`

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/OperationTestAnalyzer.cs
@@ -1524,6 +1524,37 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         }
     }
 
+    public class BinaryOperatorVBTestAnalyzer : DiagnosticAnalyzer
+    {
+        public static readonly DiagnosticDescriptor BinaryUserDefinedOperatorDescriptor = new DiagnosticDescriptor(
+            "BinaryUserDefinedOperator",
+            "Binary user defined operator found",
+            "A Binary user defined operator {0} is found",
+            "Testing",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics 
+            => ImmutableArray.Create(BinaryUserDefinedOperatorDescriptor);
+
+        public sealed override void Initialize(AnalysisContext context)
+        {
+            context.RegisterOperationAction(
+                (operationContext) =>
+                {
+                    var binary = (IBinaryOperatorExpression)operationContext.Operation;
+                    if (binary.GetBinaryOperandsKind() == BinaryOperandsKind.OperatorMethod)
+                    {
+                        operationContext.ReportDiagnostic(
+                            Diagnostic.Create(BinaryUserDefinedOperatorDescriptor, 
+                                binary.Syntax.GetLocation(),
+                                binary.BinaryOperationKind.ToString()));
+                    }
+                },
+                OperationKind.BinaryOperatorExpression);
+        }
+    }
+
     public class NullOperationSyntaxTestAnalyzer : DiagnosticAnalyzer
     {
         private const string ReliabilityCategory = "Reliability";

--- a/src/Compilers/Core/Portable/Compilation/IExpression.cs
+++ b/src/Compilers/Core/Portable/Compilation/IExpression.cs
@@ -570,6 +570,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         OperatorMethodSubtract = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.Subtract,
         OperatorMethodMultiply = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.Multiply,
         OperatorMethodDivide = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.Divide,
+        OperatorMethodIntegerDivide = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.IntegerDivide,
         OperatorMethodRemainder = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.Remainder,
         OperatorMethodLeftShift = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.LeftShift,
         OperatorMethodRightShift = BinaryOperandsKind.OperatorMethod | SimpleBinaryOperationKind.RightShift,

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -281,6 +281,7 @@ Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodEquals = 272 
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodExclusiveOr = 268 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodGreaterThan = 279 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodGreaterThanOrEqual = 278 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
+Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodIntegerDivide = 261 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodLeftShift = 264 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodLessThan = 276 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind
 Microsoft.CodeAnalysis.Semantics.BinaryOperationKind.OperatorMethodLessThanOrEqual = 277 -> Microsoft.CodeAnalysis.Semantics.BinaryOperationKind

--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -739,6 +739,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Return BinaryOperationKind.OperatorMethodMultiply
                     Case BinaryOperatorKind.Divide
                         Return BinaryOperationKind.OperatorMethodDivide
+                    Case BinaryOperatorKind.IntegerDivide
+                        Return BinaryOperationKind.OperatorMethodIntegerDivide
                     Case BinaryOperatorKind.Modulo
                         Return BinaryOperationKind.OperatorMethodRemainder
                     Case BinaryOperatorKind.And

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -1526,6 +1526,167 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub BinaryOperatorsVisualBasic()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Public Class B2
+
+    Public Shared Operator +(x As B2, y As B2) As B2 
+        System.Console.WriteLine("+")
+        Return x
+    End Operator
+
+    Public Shared Operator -(x As B2, y As B2) As B2 
+        System.Console.WriteLine("-")
+        Return x
+    End Operator
+
+    Public Shared Operator *(x As B2, y As B2) As B2 
+        System.Console.WriteLine("*")
+        Return x
+    End Operator
+
+    Public Shared Operator /(x As B2, y As B2) As B2 
+        System.Console.WriteLine("/")
+        Return x
+    End Operator
+
+    Public Shared Operator \(x As B2, y As B2) As B2 
+        System.Console.WriteLine("\")
+        Return x
+    End Operator
+
+    Public Shared Operator Mod(x As B2, y As B2) As B2 
+        System.Console.WriteLine("Mod")
+        Return x
+    End Operator
+
+    Public Shared Operator ^(x As B2, y As B2) As B2 
+        System.Console.WriteLine("^")
+        Return x
+    End Operator
+
+    Public Shared Operator =(x As B2, y As B2) As B2 
+        System.Console.WriteLine("=")
+        Return x
+    End Operator
+
+    Public Shared Operator <>(x As B2, y As B2) As B2
+        System.Console.WriteLine("<>")
+        Return x
+    End Operator
+
+    Public Shared Operator <(x As B2, y As B2) As B2 
+        System.Console.WriteLine("<")
+        Return x
+    End Operator
+
+    Public Shared Operator >(x As B2, y As B2) As B2 
+        System.Console.WriteLine(">")
+        Return x
+    End Operator
+
+    Public Shared Operator <=(x As B2, y As B2) As B2
+        System.Console.WriteLine("<=")
+        Return x
+    End Operator
+
+    Public Shared Operator >=(x As B2, y As B2) As B2
+        System.Console.WriteLine(">=")
+        Return x
+    End Operator
+
+    Public Shared Operator Like(x As B2, y As B2) As B2
+        System.Console.WriteLine("Like")
+        Return x
+    End Operator
+
+    Public Shared Operator &(x As B2, y As B2) As B2 
+        System.Console.WriteLine("&")
+        Return x
+    End Operator
+
+    Public Shared Operator And(x As B2, y As B2) As B2
+        System.Console.WriteLine("And")
+        Return x
+    End Operator
+
+    Public Shared Operator Or(x As B2, y As B2) As B2 
+        System.Console.WriteLine("Or")
+        Return x
+    End Operator
+
+    Public Shared Operator Xor(x As B2, y As B2) As B2
+        System.Console.WriteLine("Xor")
+        Return x
+    End Operator
+
+    Public Shared Operator <<(x As B2, y As Integer) As B2
+        System.Console.WriteLine("<<")
+        Return x
+    End Operator
+
+    Public Shared Operator >>(x As B2, y As Integer) As B2
+        System.Console.WriteLine(">>")
+        Return x
+    End Operator
+End Class
+
+Module Module1
+
+    Sub Main() 
+        Dim x, y As New B2()
+        Dim r As B2
+        r = x + y      
+        r = x - y      
+        r = x * y      
+        r = x / y      
+        r = x \ y      
+        r = x Mod y    
+        ' r = x ^ y  TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        r = x = y      
+        r = x <> y     
+        r = x < y      
+        r = x > y      
+        r = x <= y     
+        r = x >= y     
+        ' r = x Like y   TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        ' r = x & y      TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        r = x And y    
+        r = x Or y     
+        r = x Xor y    
+        r = x << 2     
+        r = x >> 3       
+    End Sub
+End Module
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New BinaryOperatorVBTestAnalyzer}, Nothing, Nothing, False,
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x + y").WithArguments("OperatorMethodAdd").WithLocation(109, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x - y").WithArguments("OperatorMethodSubtract").WithLocation(110, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x * y").WithArguments("OperatorMethodMultiply").WithLocation(111, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x / y").WithArguments("OperatorMethodDivide").WithLocation(112, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x \ y").WithArguments("OperatorMethodIntegerDivide").WithLocation(113, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x Mod y").WithArguments("OperatorMethodRemainder").WithLocation(114, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x = y").WithArguments("OperatorMethodEquals").WithLocation(116, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x <> y").WithArguments("OperatorMethodNotEquals").WithLocation(117, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x < y").WithArguments("OperatorMethodLessThan").WithLocation(118, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x > y").WithArguments("OperatorMethodGreaterThan").WithLocation(119, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x <= y").WithArguments("OperatorMethodLessThanOrEqual").WithLocation(120, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x >= y").WithArguments("OperatorMethodGreaterThanOrEqual").WithLocation(121, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x And y").WithArguments("OperatorMethodAnd").WithLocation(124, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x Or y").WithArguments("OperatorMethodOr").WithLocation(125, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x Xor y").WithArguments("OperatorMethodExclusiveOr").WithLocation(126, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x << 2").WithArguments("OperatorMethodLeftShift").WithLocation(127, 13),
+                Diagnostic(BinaryOperatorVBTestAnalyzer.BinaryUserDefinedOperatorDescriptor.Id, "x >> 3").WithArguments("OperatorMethodRightShift").WithLocation(128, 13))
+        End Sub
+
+        <Fact>
         Public Sub NullOperationSyntaxVisualBasic()
             Dim source = <compilation>
                              <file name="c.vb">


### PR DESCRIPTION
Add `BinaryOperationKind.OperatorMethodIntegerDivide` to represent `\` in VB.
This fixes crash in #9129. But there are several other binary opertors from VB are still not in IOperation (see #9174)

@JohnHamby @AlekseyTs @dotnet/roslyn-interactive 