### PR TITLE
[Ask Mode] Fix bugs in OperationWalker

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/OperationVisitor.cs
+++ b/src/Compilers/Core/Portable/Compilation/OperationVisitor.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Semantics
             // no-op
         }
 
-        internal void VisitNoneOperation(IOperation operation)
+        internal virtual void VisitNoneOperation(IOperation operation)
         {
             // no-op
         }
@@ -415,7 +415,7 @@ namespace Microsoft.CodeAnalysis.Semantics
             return default(TResult);
         }
 
-        internal TResult VisitNoneOperation(IOperation operation, TArgument argument)
+        internal virtual TResult VisitNoneOperation(IOperation operation, TArgument argument)
         {
             return default(TResult);
         }

--- a/src/Compilers/Core/Portable/Compilation/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Compilation/OperationWalker.cs
@@ -165,6 +165,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         {
             Visit(operation.Declaration);
             Visit(operation.Value);
+            Visit(operation.Body);
         }
 
         public override void VisitFixedStatement(IFixedStatement operation)
@@ -257,8 +258,8 @@ namespace Microsoft.CodeAnalysis.Semantics
 
         public override void VisitConditionalAccessExpression(IConditionalAccessExpression operation)
         {
-            Visit(operation.ConditionalValue);
             Visit(operation.ConditionalInstance);
+            Visit(operation.ConditionalValue);
         }
 
         public override void VisitConditionalAccessInstanceExpression(IConditionalAccessInstanceExpression operation)


### PR DESCRIPTION
- IUsingStatement.Body was not visited in VisitUsingStatement.
- IConditionalAccessExpression.ConditionalValue was visited before ConditionalInstance.
- Make VisitNoneOperation virtual (this is not a bug, but it is a required change for testing) 

@JohnHamby @dotnet/roslyn-interactive 