### PR TITLE
Log commit information before we start a CI build

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -25,6 +25,10 @@ call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd
 
 powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\check-branch.ps1" || goto :BuildFailed
 
+REM Output the commit that we're building, for reference in Jenkins logs
+echo Building this commit:
+git show --no-patch --pretty=raw HEAD
+
 REM Restore the NuGet packages 
 call "%RoslynRoot%\Restore.cmd" || goto :BuildFailed
 

--- a/cibuild.sh
+++ b/cibuild.sh
@@ -88,6 +88,9 @@ if [ "$USE_CACHE" == "false" ]; then
     make clean_toolset
 fi
 
+echo Building this commit:
+git show --no-patch --pretty=raw HEAD
+
 echo Building Bootstrap
 run_make bootstrap
 


### PR DESCRIPTION
By passing --pretty=raw we get the full SHA1s of all parent commits,
as well as the tree SHA1 so we can confirm content as well.

*Review:* @dotnet/roslyn-infrastructure, @jaredpar