### PR TITLE
Use var codestyle updates

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -212,8 +212,10 @@
     <Compile Include="Completion\CompletionProviders\XmlDocumentationCommentCompletionProviderTests.cs" />
     <Compile Include="Completion\LoadDirectiveCompletionProviderTests.cs" />
     <Compile Include="Completion\ReferenceDirectiveCompletionProviderTests.cs" />
-    <Compile Include="Diagnostics\UseImplicitTyping\UseExplicitTypingTests.cs" />
-    <Compile Include="Diagnostics\UseImplicitTyping\UseImplicitTypingTests.cs" />
+    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseExplicitTypeTests.cs" />
+    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseExplicitTypeTests_FixAllTests.cs" />
+    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseImplicitTypeTests_FixAllTests.cs" />
+    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseImplicitTypeTests.cs" />
     <Compile Include="GoToAdjacentMember\CSharpGoToAdjacentMemberTests.cs" />
     <Compile Include="Diagnostics\AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -15,7 +15,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitTyping
 {
-    public class UseExplicitTypingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public partial class UseExplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace) =>
             new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
@@ -34,6 +34,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
         private IDictionary<OptionKey, object> ExplicitTypingEverywhere() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
+
+        private IDictionary<OptionKey, object> ExplicitTypingExceptWhereApparent() =>
+            Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
         private IDictionary<OptionKey, object> ExplicitTypingEnforcements() =>

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
@@ -1,0 +1,412 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitTyping
+{
+    public partial class UseExplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        #region "Fix all occurrences tests"
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInDocumentScope_PreferExplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseExplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInDocument:var|} i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInProject_PreferExplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseExplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInProject:var|} i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i2 = 0;
+        var p2 = new Program2();
+        var tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i2 = 0;
+        Program2 p2 = new Program2();
+        Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInSolution_PreferExplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseExplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInSolution:var|} i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i2 = 0;
+        var p2 = new Program2();
+        var tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i3 = 0;
+        var p3 = new Program2();
+        var tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i2 = 0;
+        Program2 p2 = new Program2();
+        Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInDocumentScope_PreferExplicitTypeExceptWhereApparent()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseExplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInDocument:var|} p = this;
+        var i1 = 0;
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        Program p = this;
+        int i1 = 0;
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ExplicitTypingExceptWhereApparent(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        #endregion
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1147,6 +1147,28 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        public async Task SuggestVar_BuiltInTypesRulePrecedesOverTypeIsApparentRule()
+        {
+            // The option settings here say 
+            // "use explicit type for built-in types" and
+            // "use implicit type where apparent".
+            // The rationale for preferring explicit type for built-in types is 
+            // they have short names and using var doesn't gain anything.
+            // Accordingly, the `built-in type` rule precedes over the `where apparent` rule
+            // and we do not suggest `use var` here.
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    public void Process()
+    {
+        object o = int.MaxValue;
+        [|int|] i = (Int32)o;
+    }
+}", options: ImplicitTypingWhereApparent());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
         public async Task SuggestVarWhereTypingIsEvident_IsExpression()
         {
             await TestAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitTyping
 {
-    public class UseImplicitTypingTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    public partial class UseImplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace) =>
             new Tuple<DiagnosticAnalyzer, CodeFixProvider>(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1132,7 +1132,7 @@ class C
     public void Process()
     {
         object o = int.MaxValue;
-        [|int|] i = (int)o;
+        [|Int32|] i = (Int32)o;
     }
 }",
 @"using System;
@@ -1141,7 +1141,7 @@ class C
     public void Process()
     {
         object o = int.MaxValue;
-        var i = (int)o;
+        var i = (Int32)o;
     }
 }", options: ImplicitTypingWhereApparent());
         }
@@ -1156,7 +1156,7 @@ class C
     public void Process()
     {
         A a = new A();
-        [|bool|] s = a is IInterface;
+        [|Boolean|] s = a is IInterface;
     }
 }
 class A : IInterface
@@ -1235,7 +1235,7 @@ class C
 {
     public void Process()
     {
-        [|int|] a = int.Parse(""1"");
+        [|Int32|] a = int.Parse(""1"");
     }
 }",
 @"using System;
@@ -1308,7 +1308,7 @@ class C
     public void Process()
     {
         int integralValue = 12534;
-        [|decimal|] decimalValue = Convert.ToDecimal(integralValue);
+        [|Decimal|] decimalValue = Convert.ToDecimal(integralValue);
     }
 }",
 @"using System;
@@ -1333,7 +1333,7 @@ class C
     {
         int codePoint = 1067;
         IConvertible iConv = codePoint;
-        [|char|] ch = iConv.ToChar(null);
+        [|Char|] ch = iConv.ToChar(null);
     }
 }",
 @"using System;

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -987,7 +987,7 @@ class C
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task DoNotSuggestVarOnIntrinsicTypeWithOption()
+        public async Task DoNotSuggestVarOnBuiltInType_Literal_WithOption()
         {
             await TestMissingAsync(
 @"using System;
@@ -996,6 +996,48 @@ class C
     static void M()
     {
         [|int|] s = 5;
+    }
+}", options: ImplicitTypingButKeepIntrinsics());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        public async Task DoNotSuggestVarOnBuiltInType_WithOption()
+        {
+            await TestMissingAsync(
+@"using System;
+class C
+{
+    private const int maxValue = int.MaxValue;
+
+    static void M()
+    {
+        [|int|] s = (unchecked(maxValue + 10));
+    }
+}", options: ImplicitTypingButKeepIntrinsics());
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        public async Task SuggestVarOnFrameworkTypeEquivalentToBuiltInType()
+        {
+            await TestAsync(
+@"using System;
+class C
+{
+    private const int maxValue = int.MaxValue;
+
+    static void M()
+    {
+        [|Int32|] s = (unchecked(maxValue + 10));
+    }
+}",
+@"using System;
+class C
+{
+    private const int maxValue = int.MaxValue;
+
+    static void M()
+    {
+        var s = (unchecked(maxValue + 10));
     }
 }", options: ImplicitTypingButKeepIntrinsics());
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
@@ -1,0 +1,412 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitTyping
+{
+    public partial class UseImplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        #region "Fix all occurrences tests"
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInDocumentScope_PreferImplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseImplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInDocument:int|} i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        var i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i1 = 0;
+        Program2 p = new Program2();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInProject_PreferImplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseImplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInProject:int|} i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i2 = 0;
+        Program2 p2 = new Program2();
+        Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        var i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i2 = 0;
+        var p2 = new Program2();
+        var tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInSolution_PreferImplicitTypeEverywhere()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseImplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInSolution:int|} i1 = 0;
+        Program p = new Program();
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i2 = 0;
+        Program2 p2 = new Program2();
+        Tuple&lt;bool, int&gt; tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        int i3 = 0;
+        Program2 p3 = new Program2();
+        Tuple&lt;bool, int&gt; tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        var i1 = 0;
+        var p = new Program();
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i2 = 0;
+        var p2 = new Program2();
+        var tuple2 = Tuple.Create(true, 1);
+
+        return i2;
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program2
+{
+    static int F(int x, int y)
+    {
+        var i3 = 0;
+        var p3 = new Program2();
+        var tuple3 = Tuple.Create(true, 1);
+
+        return i3;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInDocumentScope_PreferBuiltInTypes()
+        {
+            var fixAllActionId = CSharpFeaturesResources.UseImplicitType;
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        {|FixAllInDocument:Program|} p = new Program();
+        int i1 = 0;
+        Tuple&lt;bool, int&gt; tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+using System;
+
+class Program
+{
+    static int F(int x, int y)
+    {
+        var p = new Program();
+        int i1 = 0;
+        var tuple = Tuple.Create(true, 1);
+
+        return i1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, options: ImplicitTypingButKeepIntrinsics(), fixAllActionEquivalenceKey: fixAllActionId);
+        }
+
+        #endregion
+    }
+}

--- a/src/Features/CSharp/Portable/CodeFixes/UseImplicitTyping/UseExplicitTypingCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/UseImplicitTyping/UseExplicitTypingCodeFixProvider.cs
@@ -24,6 +24,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping
         public override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(IDEDiagnosticIds.UseExplicitTypingDiagnosticId);
 
+        public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
+
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var document = context.Document;

--- a/src/Features/CSharp/Portable/CodeFixes/UseImplicitTyping/UseImplicitTypingCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/UseImplicitTyping/UseImplicitTypingCodeFixProvider.cs
@@ -20,6 +20,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping
         public override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(IDEDiagnosticIds.UseImplicitTypingDiagnosticId);
 
+        public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
+
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var document = context.Document;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.State.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
                         IsInVariableDeclarationContext
                      && IsTypeApparentInDeclaration((VariableDeclarationSyntax)declaration, semanticModel, TypeStyle, cancellationToken);
 
-                IsInIntrinsicTypeContext = IsIntrinsicType(declaration);
+                IsInIntrinsicTypeContext = IsIntrinsicTypeInDeclaration(declaration);
             }
 
             /// <summary>
@@ -155,8 +155,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
                 return node;
             }
 
-            private bool IsIntrinsicType(SyntaxNode declarationStatement) =>
-                (declarationStatement as VariableDeclarationSyntax)?.Variables.Single().Initializer.Value.IsAnyLiteralExpression() == true;
+            private bool IsIntrinsicTypeInDeclaration(SyntaxNode declarationStatement)
+            {
+                PredefinedTypeSyntax predefinedType = null;
+                if (declarationStatement is VariableDeclarationSyntax)
+                {
+                    predefinedType = ((VariableDeclarationSyntax)declarationStatement).Type as PredefinedTypeSyntax;
+                }
+                else if (declarationStatement is ForEachStatementSyntax)
+                {
+                    predefinedType = ((ForEachStatementSyntax)declarationStatement).Type as PredefinedTypeSyntax;
+                }
+
+                return predefinedType != null ? SyntaxFacts.IsPredefinedType(predefinedType.Keyword.Kind()) : false;
+            }
 
             private bool IsPossibleCreationOrConversionMethod(IMethodSymbol methodSymbol, ITypeSymbol declaredType, SemanticModel semanticModel, ExpressionSyntax typeName, CancellationToken cancellationToken)
             {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.State.cs
@@ -65,8 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
                      && IsTypeApparentInDeclaration((VariableDeclarationSyntax)declaration, semanticModel, TypeStyle, cancellationToken);
 
                 IsInIntrinsicTypeContext =
-                        IsIntrinsicTypeInDeclaration(declaration)
-                     || IsInferredIntrinsicType(declaration, semanticModel, cancellationToken);
+                        IsPredefinedTypeInDeclaration(declaration)
+                     || IsInferredPredefinedType(declaration, semanticModel, cancellationToken);
             }
 
             /// <summary>
@@ -166,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             /// to var. <see cref="SyntaxFacts.IsPredefinedType(SyntaxKind)"/> considers string
             /// and object but the compiler's implementation of IsIntrinsicType does not.
             /// </remarks>
-            private bool IsIntrinsicTypeInDeclaration(SyntaxNode declarationStatement)
+            private bool IsPredefinedTypeInDeclaration(SyntaxNode declarationStatement)
             {
                 var predefinedType = GetTypeSyntaxFromDeclaration(declarationStatement) as PredefinedTypeSyntax;
 
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
                     : false;
             }
 
-            private bool IsInferredIntrinsicType(SyntaxNode declarationStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
+            private bool IsInferredPredefinedType(SyntaxNode declarationStatement, SemanticModel semanticModel, CancellationToken cancellationToken)
             {
                 TypeSyntax typeSyntax = GetTypeSyntaxFromDeclaration(declarationStatement);
 


### PR DESCRIPTION
Part of #9155

_**Change summary:**_

1. Implements a fix all provider for the codestyle, and adds corresponding tests. (modulo: see footnote<sup>1</sup>)
2. Fixes an oversight with detection of built-in types. 

---

<sup>1</sup>still not the perfect fix-all provider, because the underlying implementation uses 2 separate diagnostics and fixers, 
which means there can be 2 distinct kinds of infractions.

(a) using var instead of explicit type when it is not the preferred choice
(b) using explicit type instead of var when it is not the preferred choice.

the fix-all provider will fix all infractions of the same kind but not all infractions of both kinds. 
For some reason, I preferred having these separate diagnostics and fixers in my initial implementation. It feels like merging them into one makes it better. 