### PR TITLE
don't assume all reference spans in an inline rename session are projected into the current view

### DIFF
--- a/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Rules/BaseIndentationFormattingRule.cs
@@ -203,6 +203,17 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
                 }
             }
 
+            if (token1.Equals(token2) && end < start)
+            {
+                // This can happen if `token1.Span` is larger than `span` on each end (due to trivia) and occurs when
+                // only a single token is projected into a buffer and the projection is sandwiched between two other
+                // projections into the same backing buffer.  An example of this is during broken code scenarios when
+                // typing certain Razor `@` directives.
+                var temp = end;
+                end = start;
+                start = temp;
+            }
+
             return TextSpan.FromBounds(start, end);
         }
     }


### PR DESCRIPTION
_This is the same as #8646 but against `stabilization`._

The Razor directives `@model` and `@inherits` have reference spans in the underlying generated file that aren't projected to the current Razor view and inline rename makes an incorrect assumption that all reference spans are projected.

This removes that assumption.

Also included in this PR is a temporary workaround for `@model` projections getting out of sync with the backing buffer that disables live-preview in Razor files during inline rename.  Below is the out-of-sync behavior that can lead to a crash:

![model](https://cloud.githubusercontent.com/assets/926281/13019862/bc2e90a4-d186-11e5-968d-e353b37f8a8c.gif)

The new no-live-update behavior is previewed below.  In an offline discussion this behavior was considered acceptable as a workaround for the crash/out-of-sync-projections because the user only notices it if both .cs and .cshtml files are visible at the same time (Razor currently doesn't support invoking cross-file reference inline rename directly from the .cshtml editor anyways.)

![no-live-update](https://cloud.githubusercontent.com/assets/926281/13019779/3806f28a-d186-11e5-93ba-58d2d93e92f7.gif)

Partially fixes #6821 and internal bug 182787.

### Other fixes included here:

There was also an issue discovered while testing that could cause a crash regarding certain Razor directives when typing and that's addressed in commit 8b48c5b.  This issue doesn't repro in released builds of VS but does repro on the latest internal-only builds.  I was able to confirm the crash and subsequently the fix by building the latest bits locally.