### PR TITLE
Put the CoreCLR test results in a xUnitResults directory

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -72,6 +72,8 @@
           SkipUnchangedFiles="true"
           UseHardlinksIfPossible="true" />
 
+    <MakeDir Directories="$(CoreClrTestDirectory)\xUnitResults" />
+
     <ItemGroup>
 
       <!-- MakeConst unit tests tracked by https://github.com/dotnet/roslyn/issues/5918 -->
@@ -92,7 +94,7 @@
         Text="Found test assemblies outside a well-known test directory: 
 @(MisplacedTestAssemblies, '%0a')" />
 
-    <Exec Command="$(CoreClrTestDirectory)\CoreRun.exe $(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\TestResults.xml" />
+    <Exec Command="$(CoreClrTestDirectory)\CoreRun.exe $(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\xUnitResults\TestResults.xml" />
 
     <Exec Command="Binaries\$(Configuration)\RunTests.exe $(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')" />
 

--- a/build/scripts/tests.sh
+++ b/build/scripts/tests.sh
@@ -9,9 +9,9 @@ cd Binaries/$BUILD_CONFIGURATION/CoreClrTest
 
 chmod +x ./corerun
 
-mkdir -p ../xUnitResults/
+mkdir -p xUnitResults
 
-./corerun ./xunit.console.netcore.exe *.UnitTests.dll -parallel all -xml ../xUnitResults/CoreClrUnitTestResults.xml
+./corerun ./xunit.console.netcore.exe *.UnitTests.dll -parallel all -xml xUnitResults/TestResults.xml
 
 if [ $? -ne 0 ]; then
     echo Unit test failed


### PR DESCRIPTION
/cc @jaredpar @dotnet/roslyn-infrastructure 

Previously they were just going to a TestResults file that wouldn't necessarily be picked up by jenkins.