### PR TITLE
Prefix assembly name with project name

### DIFF
--- a/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
+++ b/src/Test/DeployCoreClrTestRuntime/DeployCoreClrTestRuntime.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{59BABFC3-C19B-4472-A93D-3DD3835BC219}</ProjectGuid>
     <OutputType>Exe</OutputType>
-    <AssemblyName>DoNotUse</AssemblyName>
+    <AssemblyName>DeployCoreClrTestRuntime_DoNotUse</AssemblyName>
     <Prefer32Bit>false</Prefer32Bit>
     <LargeAddressAware>true</LargeAddressAware>
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\..\</SolutionDir>

--- a/src/Test/DeployDesktopTestRuntime/DeployDesktopTestRuntime.csproj
+++ b/src/Test/DeployDesktopTestRuntime/DeployDesktopTestRuntime.csproj
@@ -10,7 +10,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ProjectGuid>{23683607-168A-4189-955E-908F0E80E60D}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>Roslyn.TestRuntime.FX46</AssemblyName>
+    <AssemblyName>DeplyDesktopTestRuntime_DoNotUse</AssemblyName>
     <Nonshipping>true</Nonshipping>
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/src/Tools/CommonNetCoreReferences/CommonNetCoreReferences.csproj
+++ b/src/Tools/CommonNetCoreReferences/CommonNetCoreReferences.csproj
@@ -7,7 +7,7 @@
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{B5A6057A-EB4C-49FB-987D-943137E72E47}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AssemblyName>DoNotUse</AssemblyName>
+    <AssemblyName>CommonNetCoreReferences_DoNotUse</AssemblyName>
     <Prefer32Bit>false</Prefer32Bit>
     <LargeAddressAware>true</LargeAddressAware>
     <SolutionDir Condition="'$(SolutionDir)' == '' OR '$(SolutionDir)' == '*Undefined*'">..\..\..\..\</SolutionDir>


### PR DESCRIPTION
I just realized that the name `DoNotUse` could be confusing and hard to associate with a project. This PR prefixes our project names with the assembly name so you know which project is building that assembly.

/cc @jaredpar @jasonmalinowski @davkean @dotnet/roslyn-infrastructure 