### PR TITLE
Fixes unintended move of banner text, as reported in issue #8797.

### DIFF
--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1202,50 +1202,29 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNamespaceImports(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
-            var usings = AsUsingDirectives(imports);
+            SyntaxList<UsingDirectiveSyntax> usingsToInsert = AsUsingDirectives(imports);
 
             switch (declaration.Kind())
             {
                 case SyntaxKind.CompilationUnit:
-                    var cu = ((CompilationUnitSyntax)declaration);
-
-                    if (index == 0 && usings.Count > 0)
-                    {
-                        // First. Copy any pp directives or banners from the compilation unit.  They have to
-                        // move to the first using node.
-                        usings = CopyBanner(cu, usings);
-
-                        // Now, we need to fix up the compilation unit.  We need to strip it of its banner, 
-                        // and we need to add additional whitespace to match the user's style.
-                        var blankLines = usings[0].GetLeadingBlankLines();
-                        cu = cu.GetNodeWithoutLeadingBannerAndPreprocessorDirectives()
-                            .WithPrependedLeadingTrivia(blankLines);
-                    }
-
-                    return cu.WithUsings(cu.Usings.InsertRange(index, usings));
+                    var cu = (CompilationUnitSyntax)declaration;
+                    return PreserveBanner(cu, usingsToInsert, index);
                 case SyntaxKind.NamespaceDeclaration:
-                    var nd = ((NamespaceDeclarationSyntax)declaration);
-                    return nd.WithUsings(nd.Usings.InsertRange(index, usings));
+                    var nd = (NamespaceDeclarationSyntax)declaration;
+                    return nd.WithUsings(nd.Usings.InsertRange(index, usingsToInsert));
                 default:
                     return declaration;
             }
         }
 
-        private static SyntaxList<UsingDirectiveSyntax> CopyBanner(CompilationUnitSyntax cu, SyntaxList<UsingDirectiveSyntax> usingsToInsert)
+        private static CompilationUnitSyntax PreserveBanner(CompilationUnitSyntax compilationUnit,
+            SyntaxList<UsingDirectiveSyntax> usingsToInsert, int insertAtOffset)
         {
-            // First. Strip any pp directives or banners on the compilation unit.  They
-            // have to stay at the top of the list.
-            IEnumerable<SyntaxTrivia> banner = cu.GetLeadingBannerAndPreprocessorDirectives();
-
-            // Now, we want to remove any blank lines from the new first node and then reattach the banner. 
-            var finalFirstNode = usingsToInsert[0];
-            finalFirstNode = finalFirstNode.GetNodeWithoutLeadingBlankLines();
-            finalFirstNode = finalFirstNode.WithLeadingTrivia(banner.Concat(finalFirstNode.GetLeadingTrivia()));
-
-            // Place the updated first node back in the result list.
-            List<UsingDirectiveSyntax> resultList = usingsToInsert.ToList();
-            resultList[0] = finalFirstNode;
-            return resultList.ToSyntaxList();
+            return (CompilationUnitSyntax) PreserveTrivia(compilationUnit, cu =>
+            {
+                var newUsings = cu.Usings.InsertRange(insertAtOffset, usingsToInsert);
+                return cu.WithUsings(newUsings);
+            });
         }
 
         public override IReadOnlyList<SyntaxNode> GetMembers(SyntaxNode declaration)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -1202,29 +1202,24 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
         public override SyntaxNode InsertNamespaceImports(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
         {
+            return PreserveTrivia(declaration, d => InsertNamespaceImportsInternal(d, index, imports));
+        }
+
+        private SyntaxNode InsertNamespaceImportsInternal(SyntaxNode declaration, int index, IEnumerable<SyntaxNode> imports)
+        {
             SyntaxList<UsingDirectiveSyntax> usingsToInsert = AsUsingDirectives(imports);
 
             switch (declaration.Kind())
             {
                 case SyntaxKind.CompilationUnit:
                     var cu = (CompilationUnitSyntax)declaration;
-                    return PreserveBanner(cu, usingsToInsert, index);
+                    return cu.WithUsings(cu.Usings.InsertRange(index, usingsToInsert));
                 case SyntaxKind.NamespaceDeclaration:
                     var nd = (NamespaceDeclarationSyntax)declaration;
                     return nd.WithUsings(nd.Usings.InsertRange(index, usingsToInsert));
                 default:
                     return declaration;
             }
-        }
-
-        private static CompilationUnitSyntax PreserveBanner(CompilationUnitSyntax compilationUnit,
-            SyntaxList<UsingDirectiveSyntax> usingsToInsert, int insertAtOffset)
-        {
-            return (CompilationUnitSyntax) PreserveTrivia(compilationUnit, cu =>
-            {
-                var newUsings = cu.Usings.InsertRange(insertAtOffset, usingsToInsert);
-                return cu.WithUsings(newUsings);
-            });
         }
 
         public override IReadOnlyList<SyntaxNode> GetMembers(SyntaxNode declaration)

--- a/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
+++ b/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
@@ -70,15 +70,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Editing
                     : UsingsAndExternAliasesDirectiveComparer.NormalInstance;
 
             // find insertion point
-            int existingIndex = 0;
             foreach (var existingImport in gen.GetNamespaceImports(root))
             {
                 if (comparer.Compare(import, existingImport) < 0)
                 {
-                    return gen.InsertNamespaceImports(root, existingIndex, import);
+                    return gen.InsertNodesBefore(root, existingImport, new[] { import });
                 }
-
-                existingIndex++;
             }
 
             return gen.AddNamespaceImports(root, import);

--- a/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
+++ b/src/Workspaces/CSharp/Portable/Editing/CSharpImportAdder.cs
@@ -70,12 +70,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Editing
                     : UsingsAndExternAliasesDirectiveComparer.NormalInstance;
 
             // find insertion point
+            int existingIndex = 0;
             foreach (var existingImport in gen.GetNamespaceImports(root))
             {
                 if (comparer.Compare(import, existingImport) < 0)
                 {
-                    return gen.InsertNodesBefore(root, existingImport, new[] { import });
+                    return gen.InsertNamespaceImports(root, existingIndex, import);
                 }
+
+                existingIndex++;
             }
 
             return gen.AddNamespaceImports(root, import);

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -364,7 +364,7 @@ class C
 
         [Fact]
         [WorkItem(8797, "https://github.com/dotnet/roslyn/issues/8797")]
-        public async Task TestBannerTextRemainsAtTopOfDocument()
+        public async Task TestBannerTextRemainsAtTopOfDocumentWithoutExistingImports()
         {
             await TestAsync(
 @"// --------------------------------------------------------------------------------------------------------------------
@@ -395,6 +395,50 @@ class C
 // </copyright>
 // --------------------------------------------------------------------------------------------------------------------
 using System.Collections.Generic;
+
+class C 
+{
+   public List<int> F;
+}");
+        }
+
+        [Fact]
+        [WorkItem(8797, "https://github.com/dotnet/roslyn/issues/8797")]
+        public async Task TestBannerTextRemainsAtTopOfDocumentWithExistingImports()
+        {
+            await TestAsync(
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using ZZZ;
+
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+using ZZZ;
+
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+using ZZZ;
 
 class C 
 {

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Editing;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Simplification;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
@@ -337,7 +338,15 @@ namespace N
             // to Simplifier not reducing the namespace reference because it would 
             // become ambiguous, thus leaving an unused using directive
             await TestAsync(
-    @"
+@"namespace N { class C { } }
+
+class C 
+{
+   public N.C F;
+}",
+
+@"using N;
+
 namespace N { class C { } }
 
 class C 
@@ -345,23 +354,52 @@ class C
    public N.C F;
 }",
 
-    @"using N;
-
-namespace N { class C { } }
-
-class C 
-{
-   public N.C F;
-}",
-
-    @"
-namespace N { class C { } }
+@"namespace N { class C { } }
 
 class C 
 {
    public N.C F;
 }");
         }
+
+        [Fact]
+        [WorkItem(8797, "https://github.com/dotnet/roslyn/issues/8797")]
+        public async Task TestBannerTextRemainsAtTopOfDocument()
+        {
+            await TestAsync(
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""File.cs"" company=""MyOrgnaization"">
+// Copyright (C) MyOrgnaization 2016
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+
+class C 
+{
+   public List<int> F;
+}");
+        }
     }
 }
-

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -401,5 +401,36 @@ class C
    public List<int> F;
 }");
         }
+
+        [Fact]
+        [WorkItem(8797, "https://github.com/dotnet/roslyn/issues/8797")]
+        public async Task TestLeadingWhitespaceLinesArePreserved()
+        {
+            await TestAsync(
+@"
+
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"
+
+using System.Collections.Generic;
+
+class C 
+{
+   public System.Collections.Generic.List<int> F;
+}",
+
+@"
+
+using System.Collections.Generic;
+
+class C 
+{
+   public List<int> F;
+}");
+        }
     }
 }


### PR DESCRIPTION
My implementation was inspired by the logic in http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp.Features/Organizing/Organizers/MemberDeclarationsOrganizer.cs.

Additionally I had to correct an existing broken test, which succeeded because some whitespace got stripped before.

Fixes #8797.