### PR TITLE
Fix casing on some resource strings

### DIFF
--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -181,7 +181,7 @@
     <value>Name can be simplified</value>
   </data>
   <data name="CantDetermineValidRangeOfStatements" xml:space="preserve">
-    <value>can't determine valid range of statements to extract out</value>
+    <value>Can't determine valid range of statements to extract</value>
   </data>
   <data name="NotAllCodePathReturns" xml:space="preserve">
     <value>Not all code paths return</value>
@@ -205,7 +205,7 @@
     <value>Contains invalid selection.</value>
   </data>
   <data name="TheSelectionContainsSyntacticErrors" xml:space="preserve">
-    <value>the selection contains syntactic errors</value>
+    <value>The selection contains syntactic errors</value>
   </data>
   <data name="SelectionCanNotCrossOverPreprocessorDirectives" xml:space="preserve">
     <value>Selection can not cross over preprocessor directives.</value>
@@ -223,7 +223,7 @@
     <value>The selected code is inside an unsafe context.</value>
   </data>
   <data name="NoValidStatementRangeToExtractOut" xml:space="preserve">
-    <value>no valid statement range to extract out</value>
+    <value>No valid statement range to extract</value>
   </data>
   <data name="Deprecated" xml:space="preserve">
     <value>deprecated</value>


### PR DESCRIPTION
While making a change I noticed several of our resource strings started (apparent) sentences with a lower case character.  Corrected.