### PR TITLE
reduce more allocations

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/ConstructedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstructedNamedTypeSymbol.cs
@@ -64,17 +64,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                    originalDefinition: constructedFrom.OriginalDefinition,
                    constructedFrom: constructedFrom, unbound: unbound)
         {
-            bool hasTypeArgumentsCustomModifiers = false;
-            _typeArguments = typeArguments.SelectAsArray(a =>
-                                                            {
-                                                                if (!a.CustomModifiers.IsDefaultOrEmpty)
-                                                                {
-                                                                    hasTypeArgumentsCustomModifiers = true;
-                                                                }
-
-                                                                return a.Type;
-                                                            });
-            _hasTypeArgumentsCustomModifiers = hasTypeArgumentsCustomModifiers;
+            _typeArguments = typeArguments.ToTypes(out _hasTypeArgumentsCustomModifiers);
             _constructedFrom = constructedFrom;
 
             Debug.Assert(constructedFrom.Arity == typeArguments.Length);

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
@@ -604,18 +605,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             base((ErrorTypeSymbol)constructedFrom.OriginalDefinition)
         {
             _constructedFrom = constructedFrom;
-            bool hasTypeArgumentsCustomModifiers = false;
-            _typeArguments = typeArguments.SelectAsArray(a =>
-                                                            {
-                                                                if (!a.CustomModifiers.IsDefaultOrEmpty)
-                                                                {
-                                                                    hasTypeArgumentsCustomModifiers = true;
-                                                                }
-
-                                                                return a.Type;
-                                                            });
-
-            _hasTypeArgumentsCustomModifiers = hasTypeArgumentsCustomModifiers;
+            _typeArguments = typeArguments.ToTypes(out _hasTypeArgumentsCustomModifiers);
             _map = new TypeMap(constructedFrom.ContainingType, constructedFrom.OriginalDefinition.TypeParameters, typeArguments);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolExtensions.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -12,6 +11,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.Collections.Generic;
+
+using static System.Linq.ImmutableArrayExtensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -327,6 +328,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return csSymbol;
+        }
+
+        internal static ImmutableArray<TypeSymbol> ToTypes(this ImmutableArray<TypeWithModifiers> typesWithModifiers, out bool hasModifiers)
+        {
+            hasModifiers = typesWithModifiers.Any(a => !a.CustomModifiers.IsDefaultOrEmpty);
+            return typesWithModifiers.SelectAsArray(a => a.Type);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Emit/CustomDebugInfoTests.cs
@@ -300,7 +300,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Emit
                 new LambdaDebugInfo(-180, new DebugId(2, 0), LambdaDebugInfo.StaticClosureOrdinal));
 
             var debugInfo = new EditAndContinueMethodDebugInformation(1, slots, closures, lambdas);
-            var records = new ArrayBuilder<Cci.BlobBuilder>();
+            var records = new ArrayBuilder<Cci.PooledBlobBuilder>();
 
             Cci.CustomDebugInfoWriter.SerializeCustomDebugInformation(debugInfo, records);
             var cdi = Cci.CustomDebugInfoWriter.SerializeCustomDebugMetadata(records);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataHeapsBuilder.cs
@@ -173,9 +173,11 @@ namespace Microsoft.Cci
                 return this.GetBlobIndex(str);
             }
 
-            var writer = new BlobBuilder();
+            var writer = PooledBlobBuilder.GetInstance();
             writer.WriteConstant(value);
-            return this.GetBlobIndex(writer);
+            var result = this.GetBlobIndex(writer);
+            writer.Free();
+            return result;
         }
 
         public BlobIdx GetBlobIndex(string str)

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -655,25 +655,42 @@ namespace Microsoft.Cci
 
         private ImmutableArray<IParameterDefinition> GetParametersToEmitCore(IMethodDefinition methodDef)
         {
-            var builder = ArrayBuilder<IParameterDefinition>.GetInstance();
+            ArrayBuilder<IParameterDefinition> builder = null;
+            var parameters = methodDef.Parameters;
+
             if (methodDef.ReturnValueIsMarshalledExplicitly || IteratorHelper.EnumerableIsNotEmpty(methodDef.ReturnValueAttributes))
             {
+                builder = ArrayBuilder<IParameterDefinition>.GetInstance(parameters.Length + 1);
                 builder.Add(new ReturnValueParameter(methodDef));
             }
 
-            foreach (IParameterDefinition parDef in methodDef.Parameters)
+            for (int i = 0; i < parameters.Length; i++)
             {
+                IParameterDefinition parDef = parameters[i];
+
                 // No explicit param row is needed if param has no flags (other than optionally IN),
                 // no name and no references to the param row, such as CustomAttribute, Constant, or FieldMarshal
-                if (parDef.HasDefaultValue || parDef.IsOptional || parDef.IsOut || parDef.IsMarshalledExplicitly ||
-                    parDef.Name != String.Empty ||
+                if (parDef.Name != String.Empty || 
+                    parDef.HasDefaultValue || parDef.IsOptional || parDef.IsOut || parDef.IsMarshalledExplicitly ||                   
                     IteratorHelper.EnumerableIsNotEmpty(parDef.GetAttributes(Context)))
                 {
-                    builder.Add(parDef);
+                    if (builder != null)
+                    {
+                        builder.Add(parDef);
+                    }
+                }
+                else
+                {
+                    // we have a parameter that does not need to be emitted (not common)
+                    if (builder == null)
+                    {
+                        builder = ArrayBuilder<IParameterDefinition>.GetInstance(parameters.Length);
+                        builder.AddRange(parameters, i);
+                    }
                 }
             }
 
-            return builder.ToImmutableAndFree();
+            return builder?.ToImmutableAndFree() ?? parameters;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/PEWriter/TypeNameSerializer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/TypeNameSerializer.cs
@@ -69,9 +69,10 @@ namespace Microsoft.Cci
             INamespaceTypeReference namespaceType = typeReference.AsNamespaceTypeReference;
             if (namespaceType != null)
             {
-                if (namespaceType.NamespaceName.Length != 0)
+                var name = namespaceType.NamespaceName;
+                if (name.Length != 0)
                 {
-                    sb.Append(namespaceType.NamespaceName);
+                    sb.Append(name);
                     sb.Append('.');
                 }
 

--- a/src/Compilers/Core/Portable/Text/LargeText.cs
+++ b/src/Compilers/Core/Portable/Text/LargeText.cs
@@ -51,19 +51,33 @@ namespace Microsoft.CodeAnalysis.Text
                 return SourceText.From(string.Empty, encoding, checksumAlgorithm);
             }
 
+            var maxCharRemainingGuess = encoding.GetMaxCharCount(length);
+
             using (var reader = new StreamReader(stream, encoding, detectEncodingFromByteOrderMarks: true, bufferSize: Math.Min(length, 4096), leaveOpen: true))
             {
-                ArrayBuilder<char[]> chunks = ArrayBuilder<char[]>.GetInstance(1 + length / ChunkSize);
+                ArrayBuilder<char[]> chunks = ArrayBuilder<char[]>.GetInstance(1 + maxCharRemainingGuess / ChunkSize);
                 while (!reader.EndOfStream)
                 {
-                    char[] chunk = new char[ChunkSize];
-                    int charsRead = reader.ReadBlock(chunk, 0, ChunkSize);
+                    var nextChunkSize = ChunkSize;
+                    if (maxCharRemainingGuess < ChunkSize)
+                    {
+                        // maxCharRemainingGuess typically overestimates a little
+                        // so we will first fill a slightly smaller (maxCharRemainingGuess - 64) chunk
+                        // and then use 64 char tail, which is likley to be resized.
+                        nextChunkSize = Math.Max(maxCharRemainingGuess - 64, 64);
+                    }
+
+                    char[] chunk = new char[nextChunkSize];
+
+                    int charsRead = reader.ReadBlock(chunk, 0, chunk.Length);
                     if (charsRead == 0)
                     {
                         break;
                     }
 
-                    if (charsRead < ChunkSize)
+                    maxCharRemainingGuess -= charsRead;
+
+                    if (charsRead < chunk.Length)
                     {
                         Array.Resize(ref chunk, charsRead);
                     }

--- a/src/Compilers/Core/SharedCollections/ObjectPool`1.cs
+++ b/src/Compilers/Core/SharedCollections/ObjectPool`1.cs
@@ -261,6 +261,8 @@ namespace Roslyn.Utilities
         {
             Debug.Assert(obj != null, "freeing null?");
 
+            Debug.Assert(_firstItem != obj, "freeing twice?");
+
             var items = _items;
             for (int i = 0; i < items.Length; i++)
             {


### PR DESCRIPTION
The reduction is about 10% of total bytes allocated during a build of Microsoft.CodeAnalysis.CSharp

Before:  337530026 bytes
After:     305675192 bytes
