### PR TITLE
Fix devenv /build and devenv /upgrade

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -23,9 +23,14 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             Kind = kind;
         }
 
-        internal static ForegroundThreadData CreateDefault()
+        /// <summary>
+        /// Creates the default ForegroundThreadData assuming that the current thread is the UI thread.
+        /// </summary>
+        /// <param name="defaultKind">The ForegroundThreadDataKind to fall back to if a UI thread cannot be found</param>
+        /// <returns>default ForegroundThreadData values</returns>
+        internal static ForegroundThreadData CreateDefault(ForegroundThreadDataKind? defaultKind = null)
         {
-            var kind = ForegroundThreadDataInfo.CreateDefault();
+            var kind = ForegroundThreadDataInfo.CreateDefault(defaultKind);
 
             // None of the work posted to the foregroundTaskScheduler should block pending keyboard/mouse input from the user.
             // So instead of using the default priority which is above user input, we use Background priority which is 1 level

--- a/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/ForegroundThreadAffinitizedObject.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
+using static Microsoft.CodeAnalysis.Utilities.ForegroundThreadDataKind;
 
 namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 {
@@ -28,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         /// </summary>
         /// <param name="defaultKind">The ForegroundThreadDataKind to fall back to if a UI thread cannot be found</param>
         /// <returns>default ForegroundThreadData values</returns>
-        internal static ForegroundThreadData CreateDefault(ForegroundThreadDataKind? defaultKind = null)
+        internal static ForegroundThreadData CreateDefault(ForegroundThreadDataKind defaultKind)
         {
             var kind = ForegroundThreadDataInfo.CreateDefault(defaultKind);
 
@@ -86,7 +87,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         // they believe to be the foreground. 
         static ForegroundThreadAffinitizedObject()
         {
-            s_fallbackForegroundThreadData = ForegroundThreadData.CreateDefault();
+            s_fallbackForegroundThreadData = ForegroundThreadData.CreateDefault(Unknown);
         }
 
         public ForegroundThreadAffinitizedObject(ForegroundThreadData foregroundThreadData = null, bool assertIsForeground = false)
@@ -115,7 +116,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
         /// <returns></returns>
         public bool IsValid()
         {
-            return _foregroundThreadData.Kind != ForegroundThreadDataKind.Unknown;
+            return _foregroundThreadData.Kind != Unknown;
         }
 
         public void AssertIsForeground()

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -8,6 +8,7 @@ using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
+using static Microsoft.CodeAnalysis.Utilities.ForegroundThreadDataKind;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 {
@@ -28,8 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         protected override void Initialize()
         {
             base.Initialize();
-
-            var defaultForegroundThreadData = ForegroundThreadData.CreateDefault();
+            var defaultForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: CommandLineMode);
             ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = defaultForegroundThreadData;
             _foregroundObject = new ForegroundThreadAffinitizedObject(defaultForegroundThreadData);
 

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
         protected override void Initialize()
         {
             base.Initialize();
-            var defaultForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: CommandLineMode);
+            var defaultForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: ForcedByPackageInitialize);
             ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = defaultForegroundThreadData;
             _foregroundObject = new ForegroundThreadAffinitizedObject(defaultForegroundThreadData);
 

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Utilities;
 using Microsoft.CodeAnalysis.Versions;
 using Microsoft.VisualStudio.ComponentModelHost;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
@@ -24,6 +23,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Task = System.Threading.Tasks.Task;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interactive;
+using static Microsoft.CodeAnalysis.Utilities.ForegroundThreadDataKind;
 
 namespace Microsoft.VisualStudio.LanguageServices.Setup
 {
@@ -44,10 +44,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
         {
             base.Initialize();
 
-            ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = ForegroundThreadData.CreateDefault();
+            ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: CommandLineMode);
             Debug.Assert(
-                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == ForegroundThreadDataKind.Wpf ||
-                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == ForegroundThreadDataKind.JoinableTask);
+                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == Wpf ||
+                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == JoinableTask);
 
             FatalError.Handler = FailFast.OnFatalException;
             FatalError.NonFatalHandler = WatsonReporter.Report;

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -44,10 +44,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
         {
             base.Initialize();
 
-            ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: CommandLineMode);
-            Debug.Assert(
-                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == Wpf ||
-                ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind == JoinableTask);
+            ForegroundThreadAffinitizedObject.CurrentForegroundThreadData = ForegroundThreadData.CreateDefault(defaultKind: ForcedByPackageInitialize);
+            Debug.Assert(ForegroundThreadAffinitizedObject.CurrentForegroundThreadData.Kind != Unknown);
 
             FatalError.Handler = FailFast.OnFatalException;
             FatalError.NonFatalHandler = WatsonReporter.Report;

--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Utilities
         Wpf,
         StaUnitTest,
         JoinableTask,
-        CommandLineMode,
+        ForcedByPackageInitialize,
         Unknown
     }
 

--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Utilities
         Wpf,
         StaUnitTest,
         JoinableTask,
+        CommandLineMode,
         Unknown
     }
 
@@ -27,7 +28,7 @@ namespace Microsoft.CodeAnalysis.Utilities
             s_fallbackForegroundThreadDataKind = CreateDefault();
         }
 
-        internal static ForegroundThreadDataKind CreateDefault()
+        internal static ForegroundThreadDataKind CreateDefault(ForegroundThreadDataKind? defaultKind = null)
         {
             var syncConextTypeName = SynchronizationContext.Current?.GetType().FullName;
 
@@ -43,7 +44,14 @@ namespace Microsoft.CodeAnalysis.Utilities
 
                 default:
 
-                    return ForegroundThreadDataKind.Unknown;
+                    if (defaultKind != null)
+                    {
+                        return defaultKind.Value;
+                    }
+                    else
+                    {
+                        return ForegroundThreadDataKind.Unknown;
+                    }
             }
         }
 

--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using static Microsoft.CodeAnalysis.Utilities.ForegroundThreadDataKind;
 
 namespace Microsoft.CodeAnalysis.Utilities
 {
@@ -36,22 +37,15 @@ namespace Microsoft.CodeAnalysis.Utilities
             {
                 case "System.Windows.Threading.DispatcherSynchronizationContext":
 
-                    return ForegroundThreadDataKind.Wpf;
+                    return Wpf;
 
                 case "Microsoft.VisualStudio.Threading.JoinableTask+JoinableTaskSynchronizationContext":
 
-                    return ForegroundThreadDataKind.JoinableTask;
+                    return JoinableTask;
 
                 default:
 
-                    if (defaultKind != null)
-                    {
-                        return defaultKind.Value;
-                    }
-                    else
-                    {
-                        return ForegroundThreadDataKind.Unknown;
-                    }
+                    return defaultKind ?? Unknown;
             }
         }
 


### PR DESCRIPTION
When we set the default ForegroundThreadDataKind assume that we are on an STA thread if no SynchronizationContext is present.

fixes internal bugs 183778 and 195024