### PR TITLE
Dont add IndentOperation for Broken BracketedArgumentList

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -116,7 +116,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 var argument = node as BaseArgumentListSyntax;
-                if (argument != null && argument.Parent.Kind() != SyntaxKind.ThisConstructorInitializer)
+                if (argument != null &&
+                    argument.Parent.Kind() != SyntaxKind.ThisConstructorInitializer &&
+                    !IsBracketedArgumentListMissingBrackets(argument as BracketedArgumentListSyntax))
                 {
                     AddIndentBlockOperations(list, argument);
                     return;
@@ -151,6 +153,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                         AddIndentBlockOperations(list, constructorInitializer.ArgumentList);
                     }
                 }
+            }
+
+            private bool IsBracketedArgumentListMissingBrackets(BracketedArgumentListSyntax node)
+            {
+                return node != null && node.OpenBracketToken.IsMissing && node.CloseBracketToken.IsMissing;
             }
 
             private void ReplaceCaseIndentationRules(List<IndentBlockOperation> list, SyntaxNode node)

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2570,6 +2570,26 @@ class C
                 expectedIndentation: 8);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task DontCreateIndentOperationForBrokenBracketedArgumentList()
+        {
+            var code = @"
+class Program
+{
+    static void M()
+    {
+        string (userInput == ""Y"")
+
+    }
+}
+";
+
+            await AssertSmartIndentAsync(
+                code,
+                indentationLine: 6,
+                expectedIndentation: 12);
+        }
+
         private static async Task AssertSmartIndentInProjectionAsync(string markup, int expectedIndentation, CSharpParseOptions options = null)
         {
             var optionsSet = options != null


### PR DESCRIPTION
Fixes internal bug 150343

On adding Indent Operation around a broken BracketedArgumentList syntax
breaks Formatting. This fix adds a check to skip the IndentOperation for
the broken code.

There might be other general cases which could trigger this Contract
Failure. But finding a repo with a broken code that triggers this
failure is difficult.

If in the future we see similar failures then we can try to generalize
these cases.