### PR TITLE
Pattern format and indentation work

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1299,6 +1299,49 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task IndentPatternPropertyFirst()
+        {
+            var code = @"
+class C
+{
+    void Main(object o)
+    {
+        var y = o is Point
+        {
+
+        }
+    }
+}";
+            await AssertIndentNotUsingSmartTokenFormatterButUsingIndenterAsync(
+                code,
+                indentationLine: 7,
+                expectedIndentation: 12);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task IndentPatternPropertySecond()
+        {
+            var code = @"
+class C
+{
+    void Main(object o)
+    {
+        var y = o is Point
+        {
+            X is 13,
+
+        }
+    }
+}";
+            await AssertIndentNotUsingSmartTokenFormatterButUsingIndenterAsync(
+                code,
+                indentationLine: 8,
+                expectedIndentation: 12);
+        }
+
         private async Task AssertIndentUsingSmartTokenFormatterAsync(
             string code,
             char ch,

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2590,6 +2590,99 @@ class Program
                 expectedIndentation: 12);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task PatternPropertyIndentFirst()
+        {
+            var code = @"
+class C
+{
+    void M(object o)
+    {
+        var y = o is Point
+        {
+
+        }
+    }
+}";
+
+            await AssertSmartIndentAsync(
+                code,
+                indentationLine: 7,
+                expectedIndentation: 12);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task PatternPropertyIndentSecond()
+        {
+            var code = @"
+class C
+{
+    void M(object o)
+    {
+        var y = o is Point
+        {
+            X is 4,
+
+        }
+    }
+}";
+
+            await AssertSmartIndentAsync(
+                code,
+                indentationLine: 8,
+                expectedIndentation: 12);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task PatternPropertyIndentNestedFirst()
+        {
+            var code = @"
+class C
+{
+    void M(object o)
+    {
+        var y = o is Point
+        {
+            X is Widget 
+            {
+
+            },
+
+        }
+    }
+}";
+
+            await AssertSmartIndentAsync(
+                code,
+                indentationLine: 9,
+                expectedIndentation: 16);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        public async Task PatternPropertyIndentNestedSecond()
+        {
+            var code = @"
+class C
+{
+    void M(object o)
+    {
+        var y = o is Point
+        {
+            X is Widget 
+            {
+                Y is 42,
+
+            },
+        }
+    }
+}";
+
+            await AssertSmartIndentAsync(
+                code,
+                indentationLine: 10,
+                expectedIndentation: 16);
+        }
+
         private static async Task AssertSmartIndentInProjectionAsync(string markup, int expectedIndentation, CSharpParseOptions options = null)
         {
             var optionsSet = options != null

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -855,6 +855,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return ValueTuple.Create(initializeExpressionNode.OpenBraceToken, initializeExpressionNode.CloseBraceToken);
             }
 
+            var propertyList = node as SubPropertyPatternListSyntax;
+            if (propertyList != null)
+            {
+                return ValueTuple.Create(propertyList.OpenBraceToken, propertyList.CloseBraceToken);
+            }
+
             return new ValueTuple<SyntaxToken, SyntaxToken>();
         }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -75,6 +75,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5;
         }
 
+        public static bool IsKind(this SyntaxNode node, SyntaxKind kind1, SyntaxKind kind2, SyntaxKind kind3, SyntaxKind kind4, SyntaxKind kind5, SyntaxKind kind6)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            var csharpKind = node.Kind();
+            return csharpKind == kind1 || csharpKind == kind2 || csharpKind == kind3 || csharpKind == kind4 || csharpKind == kind5 || csharpKind == kind6;
+        }
+
         /// <summary>
         /// Returns the list of using directives that affect <paramref name="node"/>. The list will be returned in
         /// top down order.  

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -154,6 +154,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 SetAlignmentBlockOperation(list, implicitArrayCreation.NewKeyword, implicitArrayCreation.Initializer.OpenBraceToken, implicitArrayCreation.Initializer.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
                 return;
             }
+
+            var propertyPattern = node as PropertyPatternSyntax;
+            if (propertyPattern?.PatternList != null)
+            {
+                SetAlignmentBlockOperation(list, propertyPattern.Type.GetFirstToken(), propertyPattern.PatternList.OpenBraceToken, propertyPattern.PatternList.CloseBraceToken, IndentBlockOption.RelativeToFirstTokenOnBaseTokenLine);
+                return;
+            }
         }
 
         private void SetAlignmentBlockOperation(List<IndentBlockOperation> list, SyntaxNode baseNode, SyntaxNode body)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -157,6 +157,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     AddSuppressWrappingIfOnSingleLineOperation(list, finallyClause.FinallyKeyword, finallyClause.Block.CloseBraceToken);
                 }
             }
+
+            var propertyPattern = node as PropertyPatternSyntax;
+            if (propertyPattern?.PatternList != null)
+            {
+                AddSuppressWrappingIfOnSingleLineOperation(list, propertyPattern.Type.GetFirstToken(), propertyPattern.PatternList.CloseBraceToken);
+            }
         }
 
         private void AddStatementExceptBlockSuppressOperations(List<SuppressOperation> list, SyntaxNode node)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/SuppressFormattingRule.cs
@@ -163,6 +163,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             {
                 AddSuppressWrappingIfOnSingleLineOperation(list, propertyPattern.Type.GetFirstToken(), propertyPattern.PatternList.CloseBraceToken);
             }
+
+            var casePatternLabel = node as CasePatternSwitchLabelSyntax;
+            if (casePatternLabel != null)
+            {
+                // Need to suppress the addition of a newline between }: in the pattern property case.
+                // case Point { X is 42 }:
+                propertyPattern = casePatternLabel.Pattern as PropertyPatternSyntax;
+                if (propertyPattern != null)
+                {
+                    AddSuppressOperation(list, propertyPattern.PatternList.CloseBraceToken, casePatternLabel.ColonToken, SuppressOption.NoWrapping);
+                }
+            }
         }
 
         private void AddStatementExceptBlockSuppressOperations(List<SuppressOperation> list, SyntaxNode node)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -264,6 +264,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             if (currentToken.IsKind(SyntaxKind.ColonToken))
             {
                 if (currentToken.Parent.IsKind(SyntaxKind.CaseSwitchLabel,
+                                               SyntaxKind.CasePatternSwitchLabel,
                                                SyntaxKind.DefaultSwitchLabel,
                                                SyntaxKind.LabeledStatement,
                                                SyntaxKind.AttributeTargetSpecifier,

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7377,10 +7377,10 @@ Point {x is             42};");
             var pattern = @"
 class C
 {{
-void M()
-{{
+    void M()
+    {{
 {0}
-}}
+    }}
 }}";
 
             expected = string.Format(pattern, transform(expected));

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7272,126 +7272,120 @@ class C
 }");
         }
 
-        public abstract class PatternFormattingEngineTests : FormattingEngineTests
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyDeclarationSimple()
         {
-            private Task AssertFormatBodyAsync(string expected, string input)
-            {
-                Func<string, string> transform = s => 
-                {
-                    var lines = s.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
-                    for (int i = 0; i < lines.Length; i++)
-                    {
-                        if (!string.IsNullOrEmpty(lines[i]))
-                        {
-                            lines[i] = new string(' ', count: 8) + lines[i];
-                        }
-                    }
-                    return string.Join(Environment.NewLine, lines);
-                };
+            var expected = @"if (o is Point p)";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"if (o is Point   p)");
+            await AssertFormatBodyAsync(expected, @"if (o is Point p  )");
+        }
 
-                var pattern = @"
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyPatternBodyEmpty()
+        {
+            var expected = @"if (o is Point { })";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"if (o is Point {})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point {      })");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyPatternValueSingle()
+        {
+            var expected = @"if (o is Point { x is 3 })";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{    x is 3})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{    x is 3    })");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{    x is   3    })");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyPatternValueMultiple()
+        {
+            var expected = @"if (o is Point { x is 3, y is 42 })";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3,y is 42})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,y is 42})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,y is   42})");
+            await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,  y is   42})");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyPatternNestedSingle()
+        {
+            var expected = @"if (o is Point { x is var y }";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"if (o is Point {x is var y}");
+            await AssertFormatBodyAsync(expected, @"if (o is Point {   x is var y}");
+            await AssertFormatBodyAsync(expected, @"if (o is Point {   x is var y    }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyDeclarationTypeOnNewLine()
+        {
+            var expected = @"
+var y = o is
+Point p;";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+var y = o is
+Point p;    ");
+
+            await AssertFormatBodyAsync(expected, @"
+var y = o   is
+Point p    ;");
+
+            await AssertFormatBodyAsync(expected, @"
+var y = o   is
+Point     p    ;");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task PropertyPatternTypeAndPatternOnNewLine()
+        {
+            var expected = @"
+var y = o is
+Point { x is 42 };";
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+var y = o is
+Point {x is 42};");
+
+            await AssertFormatBodyAsync(expected, @"
+var y = o is
+Point {x is             42};");
+
+        }
+
+        private Task AssertFormatBodyAsync(string expected, string input)
+        {
+            Func<string, string> transform = s => 
+            {
+                var lines = s.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+                for (int i = 0; i < lines.Length; i++)
+                {
+                    if (!string.IsNullOrEmpty(lines[i]))
+                    {
+                        lines[i] = new string(' ', count: 8) + lines[i];
+                    }
+                }
+                return string.Join(Environment.NewLine, lines);
+            };
+
+            var pattern = @"
 class C
 {{
-    void M()
-    {{
+void M()
+{{
 {0}
-    }}
+}}
 }}";
 
-                expected = string.Format(pattern, transform(expected));
-                input = string.Format(pattern, transform(input));
-                return AssertFormatAsync(expected, input);
-            }
-
-            public sealed class SameLinePatternFormattingEngineTests : PatternFormattingEngineTests
-            {
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task Declaration()
-                {
-                    var expected = @"if (o is Point p)";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"if (o is Point   p)");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point p  )");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task PropertyPatternEmpty()
-                {
-                    var expected = @"if (o is Point { })";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"if (o is Point {})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point {      })");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task PropertyPatternIsSingle()
-                {
-                    var expected = @"if (o is Point { x is 3 })";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{    x is 3})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{    x is 3    })");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{    x is   3    })");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task PropertyPatternIsMulitple()
-                {
-                    var expected = @"if (o is Point { x is 3, y is 42 })";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3,y is 42})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,y is 42})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,y is   42})");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point{x is 3   ,  y is   42})");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task PropertyPatternIsVar()
-                {
-                    var expected = @"if (o is Point { x is var y }";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"if (o is Point {x is var y}");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point {   x is var y}");
-                    await AssertFormatBodyAsync(expected, @"if (o is Point {   x is var y    }");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task DeclarationTypeOnNewLine()
-                {
-                    var expected = @"
-var y = o is
-    Point p;";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"
-var y = o is
-    Point p;    ");
-
-                    await AssertFormatBodyAsync(expected, @"
-var y = o   is
-    Point p    ;");
-
-                    await AssertFormatBodyAsync(expected, @"
-var y = o   is
-    Point     p    ;");
-                }
-
-                [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
-                public async Task PropertyTypeAndPatternOnNewLine()
-                {
-                    var expected = @"
-var y = o is
-    Point { x is 42 };";
-                    await AssertFormatBodyAsync(expected, expected);
-                    await AssertFormatBodyAsync(expected, @"
-var y = o is
-    Point {x is 42};");
-
-                    await AssertFormatBodyAsync(expected, @"
-var y = o is
-    Point {x is             42};");
-
-                }
-            }
+            expected = string.Format(pattern, transform(expected));
+            input = string.Format(pattern, transform(input));
+            return AssertFormatAsync(expected, input);
         }
     }
 }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -7359,6 +7359,133 @@ Point {x is             42};");
 
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task CasePatternDeclarationSimple()
+        {
+            var expected = @"
+switch (o)
+{
+    case Point p:
+}";
+
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point p   :
+}");
+
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point    p   :
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task CasePatternPropertyEmpty()
+        {
+            var expected = @"
+switch (o)
+{
+    case Point { }:
+}";
+
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point {}   :
+}");
+
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point    {    }   :
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task CasePatternPropertySingle()
+        {
+            var expected = @"
+switch (o)
+{
+    case Point { X is 42 }:
+}";
+
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point {X is 42}   :
+}");
+
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point    {  X   is 42  }   :
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task CasePatternPropertySingleFollowedByBreak()
+        {
+            var expected = @"
+switch (o)
+{
+    case Point { X is 42 }:
+        break;
+}";
+
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point {X is 42}   :
+        break;
+}");
+
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point    {  X   is 42  }   :
+        break;
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task CasePatternPropertySingleFollowedByBlock()
+        {
+            var expected = @"
+switch (o)
+{
+    case Point { X is 42 }:
+        {
+            M();
+        }
+}";
+
+            await AssertFormatBodyAsync(expected, expected);
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point {X is 42}   :
+        {
+            M();
+        }
+}");
+
+            await AssertFormatBodyAsync(expected, @"
+switch (o)
+{
+    case Point    {  X   is 42  }   :
+        {
+            M();
+        }
+}");
+        }
+
         private Task AssertFormatBodyAsync(string expected, string input)
         {
             Func<string, string> transform = s => 

--- a/src/Workspaces/CoreTest/FormattingTests.cs
+++ b/src/Workspaces/CoreTest/FormattingTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -7,6 +8,7 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
+using System;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {

--- a/src/Workspaces/CoreTest/FormattingTests.cs
+++ b/src/Workspaces/CoreTest/FormattingTests.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Test.Utilities;
@@ -8,7 +7,6 @@ using Roslyn.Test.Utilities;
 using Xunit;
 using CS = Microsoft.CodeAnalysis.CSharp;
 using VB = Microsoft.CodeAnalysis.VisualBasic;
-using System;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {


### PR DESCRIPTION
This updates the workspace layer to understand the basic formatting and indentation logic for patterns.  In particular the work surrounds property patterns:

```
object o = null;
if (o is Point { X is 42, Y is var y })
```

I patterned the expected behavior off of collection initializers / anonymous object creation.  They are the closest features syntactically to this.  

After this change I'm able to type patterns quite comfortably in the editor.  Probably some more advanced scenarios i'm missing so please do point those out. 