### PR TITLE
XmlThreadSafetyElement param names

### DIFF
--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -47,6 +47,6 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlTextLiteral(string value) 
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlTextNewLine(string text) -> Microsoft.CodeAnalysis.SyntaxToken
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlTextNewLine(string text, bool continueXmlDocumentationComment) -> Microsoft.CodeAnalysis.SyntaxToken
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlThreadSafetyElement() -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlEmptyElementSyntax
-static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlThreadSafetyElement(bool static, bool instance) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlEmptyElementSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlThreadSafetyElement(bool isStatic, bool isInstance) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlEmptyElementSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlValueElement(Microsoft.CodeAnalysis.SyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.XmlNodeSyntax> content) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlElementSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.XmlValueElement(params Microsoft.CodeAnalysis.CSharp.Syntax.XmlNodeSyntax[] content) -> Microsoft.CodeAnalysis.CSharp.Syntax.XmlElementSyntax

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -723,15 +723,15 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Creates a threadsafty element within an xml documentation comment.
+        /// Creates a threadsafety element within an xml documentation comment.
         /// </summary>
-        /// <param name="static">Indicates whether static member of this class are safe for multi-threaded operations.</param>
-        /// <param name="instance">Indicates whether members of instances of this type are safe for multi-threaded operations.</param>
-        public static XmlEmptyElementSyntax XmlThreadSafetyElement(bool @static, bool instance)
+        /// <param name="isStatic">Indicates whether static member of this type are safe for multi-threaded operations.</param>
+        /// <param name="isInstance">Indicates whether instance members of this type are safe for multi-threaded operations.</param>
+        public static XmlEmptyElementSyntax XmlThreadSafetyElement(bool isStatic, bool isInstance)
         {
             return XmlEmptyElement(DocumentationCommentXmlNames.ThreadSafetyElementName).AddAttributes(
-                XmlTextAttribute(DocumentationCommentXmlNames.StaticAttributeName, @static.ToString().ToLowerInvariant()),
-                XmlTextAttribute(DocumentationCommentXmlNames.InstanceAttributeName, instance.ToString().ToLowerInvariant()));
+                XmlTextAttribute(DocumentationCommentXmlNames.StaticAttributeName, isStatic.ToString().ToLowerInvariant()),
+                XmlTextAttribute(DocumentationCommentXmlNames.InstanceAttributeName, isInstance.ToString().ToLowerInvariant()));
         }
 
         /// <summary>

--- a/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
@@ -43,6 +43,6 @@ Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlTextNewLine(text As S
 Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlTextNewLine(text As String, continueXmlDocumentationComment As Boolean) -> Microsoft.CodeAnalysis.SyntaxToken
 Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlTextNewLine(text As String, value As String, leading As Microsoft.CodeAnalysis.SyntaxTriviaList, trailing As Microsoft.CodeAnalysis.SyntaxTriviaList) -> Microsoft.CodeAnalysis.SyntaxToken
 Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlThreadSafetyElement() -> Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlEmptyElementSyntax
-Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlThreadSafetyElement(static As Boolean, instance As Boolean) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlEmptyElementSyntax
+Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlThreadSafetyElement(isStatic As Boolean, isInstance As Boolean) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlEmptyElementSyntax
 Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlValueElement(ParamArray content As Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax()) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlElementSyntax
 Shared Microsoft.CodeAnalysis.VisualBasic.SyntaxFactory.XmlValueElement(content As Microsoft.CodeAnalysis.SyntaxList(Of Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlNodeSyntax)) -> Microsoft.CodeAnalysis.VisualBasic.Syntax.XmlElementSyntax

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFactory.vb
@@ -524,12 +524,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Creates a threadsafty element within an xml documentation comment.
         ''' </summary>
-        ''' <param name="static" static="sfd">Indicates whether static member of this class are safe for multi-threaded operations.</param>
-        ''' <param name="instance">Indicates whether members of instances of this type are safe for multi-threaded operations.</param>
+        ''' <param name="isStatic" static="sfd">Indicates whether static member of this type are safe for multi-threaded operations.</param>
+        ''' <param name="isInstance">Indicates whether instance members of this type are safe for multi-threaded operations.</param>
         ''' <threadsafety static="true" instance=""/>
-        Public Shared Function XmlThreadSafetyElement([static] As Boolean, instance As Boolean) As XmlEmptyElementSyntax
-            Dim staticValueString = [static].ToString().ToLowerInvariant()
-            Dim instanceValueString = instance.ToString().ToLowerInvariant()
+        Public Shared Function XmlThreadSafetyElement(isStatic As Boolean, isInstance As Boolean) As XmlEmptyElementSyntax
+            Dim staticValueString = isStatic.ToString().ToLowerInvariant()
+            Dim instanceValueString = isInstance.ToString().ToLowerInvariant()
 
             Return XmlEmptyElement(XmlName(Nothing, XmlNameToken(DocumentationCommentXmlNames.ThreadSafetyElementName, SyntaxKind.XmlNameToken)).WithTrailingTrivia(ElasticSpace)).AddAttributes(
                 XmlAttribute(


### PR DESCRIPTION
Changing the names of the parameters to `isStatic` and `isInstance` to be consistent with the naming guidelines of boolean parameters.