### PR TITLE
[AskMode] Replace exception with value `Invalid` when an unexpected value is en…

### DIFF
--- a/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/Expression.vb
@@ -770,7 +770,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Case BinaryOperatorKind.GreaterThan
                         Return BinaryOperationKind.OperatorMethodGreaterThan
                     Case Else
-                        Throw ExceptionUtilities.UnexpectedValue(OperatorKind And BinaryOperatorKind.OpMask)
+                        Return BinaryOperationKind.Invalid
                 End Select
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/OperationAnalyzerTests.vb
@@ -1644,15 +1644,15 @@ Module Module1
         r = x / y      
         r = x \ y      
         r = x Mod y    
-        ' r = x ^ y  TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        r = x ^ y      ' TODO: Bug https://github.com/dotnet/roslyn/issues/9174
         r = x = y      
         r = x <> y     
         r = x < y      
         r = x > y      
         r = x <= y     
         r = x >= y     
-        ' r = x Like y   TODO: Bug https://github.com/dotnet/roslyn/issues/9174
-        ' r = x & y      TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        r = x Like y   ' TODO: Bug https://github.com/dotnet/roslyn/issues/9174
+        r = x & y      ' TODO: Bug https://github.com/dotnet/roslyn/issues/9174
         r = x And y    
         r = x Or y     
         r = x Xor y    


### PR DESCRIPTION
…countered in `BoundUserDefinedBinaryOperator.get_IBinaryOperatorExpression_BinaryOperationKind()` in VB. This only fixes the crash in #9174, the actual support for those operations will be added in 1.3.

@JohnHamby @dotnet/roslyn-interactive @AlekseyTs @MattGertz 