### PR TITLE
Non-Fatal Watson if ReiteratedVersionNumber matches when text does not.

### DIFF
--- a/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
+++ b/src/EditorFeatures/Text/Extensions.SnapshotSourceText.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
+using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
@@ -88,7 +89,27 @@ namespace Microsoft.CodeAnalysis.Text
                 var text = strongBox.Value;
                 if (text != null && text._reiteratedVersion == editorSnapshot.Version.ReiteratedVersionNumber)
                 {
-                    return text;
+                    if (text.Length == editorSnapshot.Length)
+                    {
+                        return text;
+                    }
+                    else
+                    {
+                        // In editors with non-compliant Undo/Redo implementations, you can end up
+                        // with two Versions with the same ReiteratedVersionNumber but with very
+                        // different text. We've never provably seen this problem occur in Visual 
+                        // Studio, but we have seen crashes that look like they could have been
+                        // caused by incorrect results being returned from this cache. 
+                        try
+                        {
+                            throw new InvalidOperationException(
+                                $"The matching cached SnapshotSourceText with <Reiterated Version, Length> = <{text._reiteratedVersion}, {text.Length}> " +
+                                $"does not match the given editorSnapshot with <{editorSnapshot.Version.ReiteratedVersionNumber}, {editorSnapshot.Length}>");
+                        }
+                        catch (Exception e) when (FatalError.ReportWithoutCrash(e))
+                        {
+                        }
+                    }
                 }
 
                 text = new SnapshotSourceText(editorSnapshot, editorSnapshot.TextBuffer.GetEncodingOrUTF8());


### PR DESCRIPTION
This incorrect caching behavior can be triggered in editors with
misbehaving undo/redo implementations, and it has been observed in ETA.
The errors that follow from this look very much like several Watsons we
have from Visual Studio, even though we've never been able to prove this
caching failure in Visual Studio. This should let us know if there's
something in Visual Studio violating the ReiteratedVersionNumber
contract, which we would then track down to fix or potentially use as
evidence to remove this secondary cache.

Bugs that show symptoms consistent with this type of failure include https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=112211&_a=edit and https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workItems?id=94620&_a=edit