### PR TITLE
Fix up indentation where it got messed up in previous merges.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -714,10 +714,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         protected bool IsInitializerRefKindValid(
-            EqualsValueClauseSyntax initializer, 
-            CSharpSyntaxNode node, 
-            RefKind variableRefKind, 
-            DiagnosticBag diagnostics, 
+            EqualsValueClauseSyntax initializer,
+            CSharpSyntaxNode node,
+            RefKind variableRefKind,
+            DiagnosticBag diagnostics,
             out BindValueKind valueKind)
         {
             if (variableRefKind == RefKind.None)
@@ -1219,7 +1219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 ErrorCode.ERR_RefReadonlyLocalCause,
                 // impossible since readonly locals are never byref, but would be a reasonable error otherwise
-                ErrorCode.ERR_RefReadonlyLocalCause, 
+                ErrorCode.ERR_RefReadonlyLocalCause,
                 ErrorCode.ERR_AssgReadonlyLocalCause,
 
                 ErrorCode.ERR_RefReadonlyLocal2Cause,
@@ -1236,7 +1236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private bool CheckIsCallVariable(BoundCall call, CSharpSyntaxNode node, BindValueKind kind, bool checkingReceiver, DiagnosticBag diagnostics)
-            {
+        {
             // A call can only be a variable if it returns by reference. If this is the case,
             // whether or not it is a valid variable depends on whether or not the call is the
             // RHS of a return or an assign by reference:
@@ -1261,7 +1261,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 var parameterName = methodSymbol.Parameters[parameterIndex].Name;
                                 Error(diagnostics, errorCode, call.Syntax, methodSymbol, parameterName);
                                 return false;
-            }
+                            }
                         }
                     }
                 }
@@ -1650,7 +1650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return false;
                 }
 
-                if (fieldSymbol.ContainingType.IsValueType && 
+                if (fieldSymbol.ContainingType.IsValueType &&
                     !fieldIsStatic &&
                     !CheckIsValidReceiverForVariable(node, fieldAccess.ReceiverOpt, kind, diagnostics))
                 {
@@ -2046,8 +2046,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             }
                             else if (!CheckIsValidReceiverForVariable(eventSyntax, receiver, BindValueKind.Assignment, diagnostics))
                             {
-                            return false;
-                        }
+                                return false;
+                            }
                         }
                         else if (RequiresSettingValue(valueKind))
                         {
@@ -2155,11 +2155,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ReportDiagnosticsIfObsolete(diagnostics, setMethod, node, receiver?.Kind == BoundKind.BaseReference);
 
                     if (RequiresVariableReceiver(receiver, setMethod) && !CheckIsValidReceiverForVariable(node, receiver, BindValueKind.Assignment, diagnostics))
-                        {
-                            return false;
-                        }
+                    {
+                        return false;
                     }
                 }
+            }
 
             var isIndirectSet = RequiresSettingValue(valueKind) && propertySymbol.RefKind != RefKind.None;
             if (RequiresGettingValue(valueKind) || isIndirectSet)
@@ -2394,7 +2394,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (refKind != RefKind.None)
             {
                 if (conversion.Kind != ConversionKind.Identity)
-                {   
+                {
                     Error(diagnostics, ErrorCode.ERR_RefAssignmentMustHaveIdentityConversion, expression.Syntax, targetType);
                 }
             }
@@ -3106,7 +3106,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var symbol = this.ContainingMemberOrLambda as MethodSymbol;
             if ((object)symbol != null)
-        {
+            {
                 refKind = symbol.RefKind;
                 return symbol.ReturnType;
             }
@@ -3278,30 +3278,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (returnRefKind != RefKind.None)
                 {
                     if (conversion.Kind != ConversionKind.Identity)
-                    {   
+                    {
                         Error(diagnostics, ErrorCode.ERR_RefReturnMustHaveIdentityConversion, argument.Syntax, returnType);
                     }
                 }
                 else if (!conversion.IsImplicit || !conversion.IsValid)
-            {
-                if (!badAsyncReturnAlreadyReported)
                 {
+                    if (!badAsyncReturnAlreadyReported)
+                    {
                         RefKind unusedRefKind;
                         if (IsGenericTaskReturningAsyncMethod() && argument.Type == this.GetCurrentReturnType(out unusedRefKind))
-                    {
-                        // Since this is an async method, the return expression must be of type '{0}' rather than 'Task<{0}>'
-                        Error(diagnostics, ErrorCode.ERR_BadAsyncReturnExpression, argument.Syntax, returnType);
-                    }
-                    else
-                    {
-                        GenerateImplicitConversionError(diagnostics, argument.Syntax, conversion, argument, returnType);
-                        if (this.ContainingMemberOrLambda is LambdaSymbol)
                         {
-                            ReportCantConvertLambdaReturn(argument.Syntax, diagnostics);
+                            // Since this is an async method, the return expression must be of type '{0}' rather than 'Task<{0}>'
+                            Error(diagnostics, ErrorCode.ERR_BadAsyncReturnExpression, argument.Syntax, returnType);
+                        }
+                        else
+                        {
+                            GenerateImplicitConversionError(diagnostics, argument.Syntax, conversion, argument, returnType);
+                            if (this.ContainingMemberOrLambda is LambdaSymbol)
+                            {
+                                ReportCantConvertLambdaReturn(argument.Syntax, diagnostics);
+                            }
                         }
                     }
                 }
-            }
             }
 
             return CreateConversion(argument.Syntax, argument, conversion, false, returnType, diagnostics);
@@ -3522,7 +3522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if ((object)returnType != null)
             {
                 if ((refKind != RefKind.None) != (returnRefKind != RefKind.None))
-            {
+                {
                     var errorCode = refKind != RefKind.None
                         ? ErrorCode.ERR_MustNotHaveRefReturn
                         : ErrorCode.ERR_MustHaveRefReturn;

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -2760,12 +2760,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            return default(TResult);
+            return visitor.VisitNoneOperation(this, argument);
         }
 
         protected override OperationKind ExpressionKind
@@ -2773,7 +2774,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                return OperationKind.IsTypeExpression;
+                return OperationKind.None;
             }
         }
     }
@@ -2783,12 +2784,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            return default(TResult);
+            return visitor.VisitNoneOperation(this, argument);
         }
 
         protected override OperationKind ExpressionKind
@@ -2796,7 +2798,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                return OperationKind.IsTypeExpression;
+                return OperationKind.None;
             }
         }
     }
@@ -2806,12 +2808,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            return default(TResult);
+            return visitor.VisitNoneOperation(this, argument);
         }
 
         protected override OperationKind ExpressionKind
@@ -2819,7 +2822,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                return OperationKind.ThrowStatement;
+                return OperationKind.None;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -2760,13 +2760,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            return default(TResult);
         }
 
         protected override OperationKind ExpressionKind
@@ -2774,7 +2773,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                throw new NotImplementedException();
+                return OperationKind.IsTypeExpression;
             }
         }
     }
@@ -2784,13 +2783,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            return default(TResult);
         }
 
         protected override OperationKind ExpressionKind
@@ -2798,7 +2796,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                throw new NotImplementedException();
+                return OperationKind.IsTypeExpression;
             }
         }
     }
@@ -2808,13 +2806,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            return default(TResult);
         }
 
         protected override OperationKind ExpressionKind
@@ -2822,7 +2819,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             get
             {
                 // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-                throw new NotImplementedException();
+                return OperationKind.ThrowStatement;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
@@ -50,10 +50,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitBlockStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitBlockStatement(this, argument);
         }
     }
@@ -69,10 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitBranchStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitBranchStatement(this, argument);
         }
     }
@@ -88,10 +88,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitBranchStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitBranchStatement(this, argument);
         }
     }
@@ -105,10 +105,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitYieldBreakStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitYieldBreakStatement(this, argument);
         }
     }
@@ -124,10 +124,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitBranchStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitBranchStatement(this, argument);
         }
     }
@@ -139,10 +139,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitEmptyStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitEmptyStatement(this, argument);
         }
     }
@@ -160,10 +160,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitIfStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitIfStatement(this, argument);
         }
     }
@@ -185,10 +185,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitWhileUntilLoopStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitWhileUntilLoopStatement(this, argument);
         }
     }
@@ -210,10 +210,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitWhileUntilLoopStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitWhileUntilLoopStatement(this, argument);
         }
     }
@@ -252,10 +252,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitForLoopStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitForLoopStatement(this, argument);
         }
     }
@@ -275,10 +275,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitForEachLoopStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitForEachLoopStatement(this, argument);
         }
     }
@@ -341,12 +341,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             void IOperation.Accept(OperationVisitor visitor)
             {
                 visitor.VisitSwitchCase(this);
-        }
+            }
 
             TResult IOperation.Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+            {
                 return visitor.VisitSwitchCase(this, argument);
-    }
+            }
         }
     }
 
@@ -408,10 +408,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         void IOperation.Accept(OperationVisitor visitor)
         {
             visitor.VisitSingleValueCaseClause(this);
-    }
+        }
 
         TResult IOperation.Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitSingleValueCaseClause(this, argument);
         }
     }
@@ -429,10 +429,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void Accept(OperationVisitor visitor)
         {
             visitor.VisitTryStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitTryStatement(this, argument);
         }
     }
@@ -568,12 +568,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override OperationKind StatementKind => OperationKind.LockStatement;
 
         public override void Accept(OperationVisitor visitor)
-    {
+        {
             visitor.VisitLockStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitLockStatement(this, argument);
         }
     }
@@ -583,14 +583,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override OperationKind StatementKind => OperationKind.InvalidStatement;
 
         public override void Accept(OperationVisitor visitor)
-    {
+        {
             visitor.VisitInvalidStatement(this);
-    }
+        }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
-    {
+        {
             return visitor.VisitInvalidStatement(this, argument);
-    }
+        }
     }
 
     internal partial class BoundLocalDeclaration : IVariableDeclarationStatement

--- a/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Statement.cs
@@ -813,36 +813,36 @@ namespace Microsoft.CodeAnalysis.CSharp
     partial class BoundPatternSwitchStatement
     {
         // TODO: this may need its own OperationKind.
-        protected override OperationKind StatementKind => OperationKind.SwitchStatement;
+        protected override OperationKind StatementKind => OperationKind.None;
 
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            return visitor.VisitNoneOperation(this, argument);
         }
     }
 
     partial class BoundLetStatement
     {
         // TODO: this may need its own OperationKind.
-        protected override OperationKind StatementKind => OperationKind.IfStatement;
+        protected override OperationKind StatementKind => OperationKind.None;
 
         public override void Accept(OperationVisitor visitor)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            visitor.VisitNoneOperation(this);
         }
 
         public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
         {
             // TODO: implement IOperation for pattern-matching constructs (https://github.com/dotnet/roslyn/issues/8699)
-            throw new NotImplementedException();
+            return visitor.VisitNoneOperation(this, argument);
         }
     }
 }


### PR DESCRIPTION
Stub IOperation for pattern-matching operations (to avoid crashes).

Please review. @jaredpar @AlekseyTs 