### PR TITLE
Attempt to detect one possible cause for the rename test flakiness

### DIFF
--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -82,10 +82,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                     Next
                 End If
 
+                AssertIsComplete(workspace.CurrentSolution)
+
                 Dim locations = RenameLocations.FindAsync(symbol, workspace.CurrentSolution, optionSet, CancellationToken.None).Result
                 Dim originalName = symbol.Name.Split("."c).Last()
 
                 Dim result = ConflictResolver.ResolveConflictsAsync(locations, originalName, renameTo, optionSet, hasConflict:=Nothing, cancellationToken:=CancellationToken.None).Result
+
+                AssertIsComplete(result.OldSolution)
+                AssertIsComplete(result.NewSolution)
 
                 engineResult = New RenameEngineResult(workspace, result, renameTo)
                 engineResult.AssertUnlabeledSpansRenamedAndHaveNoConflicts()
@@ -101,6 +106,15 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
             Return engineResult
         End Function
+
+        Private Shared Sub AssertIsComplete(currentSolution As Solution)
+            ' Ensure we don't have a partial solution. This is to detect for possible root causes of
+            ' https://github.com/dotnet/roslyn/issues/9298
+
+            If currentSolution.Projects.Any(Function(p) Not p.HasCompleteReferencesAsync().Result) Then
+                AssertEx.Fail("We have an incomplete project floating around which we should not.")
+            End If
+        End Sub
 
         Friend ReadOnly Property ConflictResolution As ConflictResolution
             Get


### PR DESCRIPTION
I'm unable to understand the root cause of the current flakiness, but this might be one reason. Adding this to see it if fails on the build machines.

Review: @dotnet/roslyn-ide, @dotnet/roslyn-infrastructure. @davkean, should I be putting this in stabilization?