### PR TITLE
Consume new use var options from CodeGen features

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.IntroduceVariable;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
@@ -15,6 +16,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
         protected override object CreateCodeRefactoringProvider(Workspace workspace)
         {
             return new IntroduceVariableCodeRefactoringProvider();
+        }
+
+        private readonly SimpleCodeStyleOption onWithInfo = new SimpleCodeStyleOption(true, NotificationOption.Info);
+
+        // specify all options explicitly to override defaults.
+        private IDictionary<OptionKey, object> ImplicitTypingEverywhere() =>
+            OptionSet(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
+
+        internal IDictionary<OptionKey, object> OptionSet(OptionKey option, object value)
+        {
+            var options = new Dictionary<OptionKey, object>();
+            options.Add(option, value);
+            return options;
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -261,7 +277,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             await TestAsync(
                 @"class C { static int Baz; void Foo() { Bar([|C.Baz|]); Bar(1 + 1); } }",
                 @"class C { static int Baz; void Foo() { var {|Rename:baz|} = C.Baz; Bar(baz); Bar(1 + 1); } }",
-                index: 0);
+                index: 0,
+                options: ImplicitTypingEverywhere());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -289,7 +306,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Introd
             await TestAsync(
 @"using System ; class Program { private static int v = 5 ; static void Main ( string [ ] args ) { Func < int , int > d = ( x ) => { return [|x * v|] ; } ; d . Invoke ( v ) ; } } ",
 @"using System ; class Program { private static int v = 5 ; static void Main ( string [ ] args ) { Func < int , int > d = ( x ) => { var {|Rename:v1|} = x * v; return v1 ; } ; d . Invoke ( v ) ; } } ",
-index: 0);
+index: 0,
+options: ImplicitTypingEverywhere());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -308,7 +326,8 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
             await TestAsync(
 @"static class G<T> { public class @class { } public static void Add(object t) { } } class Program { static void Main() { G<int>.Add([|new G<int>.@class()|]); } }",
 @"static class G<T> { public class @class { } public static void Add(object t) { } } class Program { static void Main() { var {|Rename:@class|} = new G<int>.@class(); G<int>.Add(@class); } }",
-index: 0);
+index: 0,
+options: ImplicitTypingEverywhere());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -326,7 +345,8 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         {
             await TestAsync(
 @"static class G<T> { public class @class { } public static void Add(object t) { } static void Main() { G<int>.Add([|new G<int>.@class()|]); } }",
-@"static class G<T> { public class @class { } public static void Add(object t) { } static void Main() { var {|Rename:class1|} = new G<int>.@class(); G<int>.Add(class1); } }");
+@"static class G<T> { public class @class { } public static void Add(object t) { } static void Main() { var {|Rename:class1|} = new G<int>.@class(); G<int>.Add(class1); } }",
+options: ImplicitTypingEverywhere());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -377,7 +397,8 @@ compareTokens: false);
         {
             await TestAsync(
 @"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main < T > ( string [ ] args ) { Foo ( [|( T ) 2 . ToString ( )|] ) ; } } ",
-@"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main < T > ( string [ ] args ) { var {|Rename:t|} = ( T ) 2 . ToString ( ) ; Foo ( t ) ; } } ");
+@"using System ; using System . Collections . Generic ; using System . Linq ; class Program { static void Main < T > ( string [ ] args ) { var {|Rename:t|} = ( T ) 2 . ToString ( ) ; Foo ( t ) ; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(540468, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540468")]
@@ -554,7 +575,8 @@ index: 1);
         {
             await TestAsync(
 @"class Program { static void Main ( string [ ] args ) { int [ ] a = null ; int [ ] temp = checked ( [|a = new [ ] { 1 , 2 , 3 }|] ) ; } } ",
-@"class Program { static void Main ( string [ ] args ) { int [ ] a = null ; var {|Rename:v|} = a = new [ ] { 1 , 2 , 3 } ; int [ ] temp = checked ( v ) ; } } ");
+@"class Program { static void Main ( string [ ] args ) { int [ ] a = null ; var {|Rename:v|} = a = new [ ] { 1 , 2 , 3 } ; int [ ] temp = checked ( v ) ; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(543832, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543832")]
@@ -1084,7 +1106,7 @@ static class C
     }
 }",
 
-compareTokens: false);
+compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(606347, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/606347")]
@@ -1186,7 +1208,8 @@ index: 2);
         {
             await TestAsync(
 @"using System ; class Program { static void Main ( string [ ] args ) { Func < int , int > f = x => [|x + 1|] ; } } ",
-@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , int > f = x => { var {|Rename:v|} = x + 1 ; return v; }; } } ");
+@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , int > f = x => { var {|Rename:v|} = x + 1 ; return v; }; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(530480, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530480")]
@@ -1195,7 +1218,8 @@ index: 2);
         {
             await TestAsync(
 @"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => y => [|x + 1|] ; } } ",
-@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => { var {|Rename:v|} = x + 1 ; return y => v; }; } } ");
+@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => { var {|Rename:v|} = x + 1 ; return y => v; }; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(530480, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530480")]
@@ -1204,7 +1228,8 @@ index: 2);
         {
             await TestAsync(
 @"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => y => [|y + 1|] ; } } ",
-@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => y =>{ var {|Rename:v|} =  y + 1 ; return v; }; } } ");
+@"using System ; class Program { static void Main ( string [ ] args ) { Func < int , Func < int , int > > f = x => y =>{ var {|Rename:v|} =  y + 1 ; return v; }; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(530480, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530480")]
@@ -1240,7 +1265,8 @@ index: 2);
         {
             await TestAsync(
 @"using System ; class Program { static void Main ( ) { [|new Nullable < int * > ( )|] . GetValueOrDefault ( ) ; } } ",
-@"using System ; class Program { static void Main ( ) { var {|Rename:v|} = new Nullable < int * > ( ) ; v . GetValueOrDefault ( ) ; } } ");
+@"using System ; class Program { static void Main ( ) { var {|Rename:v|} = new Nullable < int * > ( ) ; v . GetValueOrDefault ( ) ; } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(530919, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530919")]
@@ -1259,7 +1285,8 @@ options: new Dictionary<OptionKey, object> { { new OptionKey(CSharpCodeStyleOpti
         {
             await TestAsync(
 @"using System.Collections.Generic; class C { static void Main(string[] args) { var set = new HashSet<string>(); set.Add([|set.ToString()|]); } } ",
-@"using System.Collections.Generic; class C { static void Main(string[] args) { var set = new HashSet<string>(); var {|Rename:v|} = set.ToString(); set.Add(v); } } ");
+@"using System.Collections.Generic; class C { static void Main(string[] args) { var set = new HashSet<string>(); var {|Rename:v|} = set.ToString(); set.Add(v); } } ",
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(655498, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/655498")]
@@ -1357,7 +1384,7 @@ class Program
         d.Add(""a"", exception);
     }
 }",
-compareTokens: false);
+compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(884961, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/884961")]
@@ -1384,7 +1411,7 @@ class C
         var l = new List<int>() { tickCount };
     }
 }",
-compareTokens: false);
+compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(884961, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/884961")]
@@ -1443,7 +1470,7 @@ class C
         return new Program { A = { { v, 0 } } }.A.Count;
     }
 }",
-compareTokens: false);
+compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(884961, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/884961")]
@@ -1470,7 +1497,7 @@ class C
         var a = new int[] { tickCount };
     }
 }",
-compareTokens: false);
+compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(884961, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/884961")]
@@ -1534,7 +1561,8 @@ class C
     }
 }",
 index: 1,
-compareTokens: false);
+compareTokens: false,
+options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(939259, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/939259")]
@@ -1620,7 +1648,7 @@ compareTokens: false);
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1037057, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1037057")]
@@ -1650,7 +1678,7 @@ class C
         int y = v * (x + 5);
     }
 }
-", index: 0, compareTokens: false);
+", index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1065661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1065661")]
@@ -1697,7 +1725,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1097147, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1097147")]
@@ -1725,7 +1753,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1097147, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1097147")]
@@ -1771,7 +1799,7 @@ class B
     public int Length { get; set; }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1097147, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1097147")]
@@ -1819,7 +1847,7 @@ class B
     public int GetAge() { return age; }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
@@ -1907,7 +1935,7 @@ class Complex
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
@@ -2084,7 +2112,7 @@ class SampleCollection<T>
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(528, "http://github.com/dotnet/roslyn/issues/528")]
@@ -2385,7 +2413,7 @@ class TestClass
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(976, "https://github.com/dotnet/roslyn/issues/976")]
@@ -2415,7 +2443,7 @@ class TestClass
     }
 }";
 
-            await TestAsync(code, expected, index: 1, compareTokens: false);
+            await TestAsync(code, expected, index: 1, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(909152, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/909152")]
@@ -2463,7 +2491,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1130990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1130990")]
@@ -2493,7 +2521,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0, compareTokens: false, options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(1130990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1130990")]

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -19,6 +20,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateVar
         {
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
                 null, new GenerateVariableCodeFixProvider());
+        }
+
+        private readonly SimpleCodeStyleOption onWithInfo = new SimpleCodeStyleOption(true, NotificationOption.Info);
+
+        // specify all options explicitly to override defaults.
+        private IDictionary<OptionKey, object> ImplicitTypingEverywhere() =>
+            OptionSet(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
+            .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
+
+        internal IDictionary<OptionKey, object> OptionSet(OptionKey option, object value)
+        {
+            var options = new Dictionary<OptionKey, object>();
+            options.Add(option, value);
+            return options;
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -1771,7 +1787,7 @@ index: 3);
             await TestAsync(
 @"class Program { void Main ( ) { [|undefined|] = 1 ; } } ",
 @"class Program { void Main ( ) { var undefined = 1 ; } } ",
-index: 2);
+index: 2, options: ImplicitTypingEverywhere());
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
@@ -1853,7 +1869,7 @@ class C
 #line default
 #line hidden
 }
-");
+", options: ImplicitTypingEverywhere());
         }
 
         [WorkItem(546027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546027")]

--- a/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Interactive/CodeActions/InteractiveIntroduceVariableTests.cs
@@ -123,7 +123,7 @@ class C
     {
         for (int i = 0; i < 10; i++)
         {
-            var {|Rename:v|} = i + 1;
+            int {|Rename:v|} = i + 1;
             Console.WriteLine(v);
         }
     }

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -108,6 +108,8 @@
     <Compile Include="CodeRefactorings\MoveDeclarationNearReference\MoveDeclarationNearReferenceCodeRefactoringProvider.State.cs" />
     <Compile Include="CodeStyle\CSharpCodeStyleOptions.cs" />
     <Compile Include="CodeStyle\CSharpCodeStyleOptionsProvider.cs" />
+    <Compile Include="CodeStyle\TypeStyle\TypeStyle.cs" />
+    <Compile Include="CodeStyle\TypeStyle\TypeStyleHelper.cs" />
     <Compile Include="Completion\CompletionProviders\AttributeNamedParameterCompletionProvider.ItemRules.cs" />
     <Compile Include="Completion\CompletionProviders\AttributeNamedParameterCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\CompletionUtilities.cs" />

--- a/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyle.cs
+++ b/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyle.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
+{
+    [Flags]
+    internal enum TypeStyle
+    {
+        None = 0,
+        ImplicitTypeForIntrinsicTypes = 1 << 0,
+        ImplicitTypeWhereApparent = 1 << 1,
+        ImplicitTypeWherePossible = 1 << 2,
+    }
+}

--- a/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -1,0 +1,255 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
+{
+    internal static class TypeStyleHelper
+    {
+        /// <summary>
+        /// Given an expression of assignment, answers whether the declaration
+        /// can use var keyword, by looking at the user's style preferences 
+        /// obtained from options and the context obtained from the expression.
+        /// </summary>
+        public static bool IsImplicitTypePreferred(
+            ExpressionSyntax initializerExpression,
+            SemanticModel semanticModel,
+            OptionSet optionSet,
+            CancellationToken cancellationToken)
+        {
+            var stylePreferences = GetCurrentTypeStylePreferences(optionSet);
+
+            var isBuiltInTypeContext = IsBuiltInType(initializerExpression, semanticModel, cancellationToken);
+
+            var isTypeApparentContext = IsTypeApparentInAssignmentExpression(stylePreferences,
+                                            initializerExpression,
+                                            semanticModel,
+                                            cancellationToken);
+
+            return IsImplicitStylePreferred(stylePreferences, isBuiltInTypeContext, isTypeApparentContext);
+        }
+
+        /// <summary>
+        /// Given an expression of assignment, answers if its type is
+        /// considered an intrinsic predefined type.
+        /// </summary>
+        private static bool IsBuiltInType(
+            ExpressionSyntax initializerExpression,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken) =>
+                semanticModel.GetTypeInfo(initializerExpression, cancellationToken).Type?.IsSpecialType() == true;
+
+        private static bool IsImplicitStylePreferred(TypeStyle stylePreferences,
+            bool isBuiltInTypeContext,
+            bool isTypeApparentContext)
+        {
+
+            return isBuiltInTypeContext
+                    ? stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes)
+                    : isTypeApparentContext
+                        ? stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent)
+                        : stylePreferences.HasFlag(TypeStyle.ImplicitTypeWherePossible);
+        }
+
+        /// <summary>
+        /// Analyzes if type information is obvious to the reader by simply looking at the assignment expression.
+        /// </summary>
+        /// <remarks>
+        /// <paramref name="typeInDeclaration"/> accepts null, to be able to cater to codegen features
+        /// that are about to generate a local declaration and do not have this information to pass in.
+        /// Things (like analyzers) that do have a local declaration already, should pass this in.
+        /// </remarks>
+        public static bool IsTypeApparentInAssignmentExpression(
+            TypeStyle stylePreferences,
+            ExpressionSyntax initializerExpression,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken,
+            ITypeSymbol typeInDeclaration = null)
+        {
+            // default(type)
+            if (initializerExpression.IsKind(SyntaxKind.DefaultExpression))
+            {
+                return true;
+            }
+
+            // literals, use var if options allow usage here.
+            if (initializerExpression.IsAnyLiteralExpression())
+            {
+                return stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
+            }
+
+            // constructor invocations cases:
+            //      = new type();
+            if (initializerExpression.IsKind(SyntaxKind.ObjectCreationExpression) &&
+                !initializerExpression.IsKind(SyntaxKind.AnonymousObjectCreationExpression))
+            {
+                return true;
+            }
+
+            // explicit conversion cases: 
+            //      (type)expr, expr is type, expr as type
+            if (initializerExpression.IsKind(SyntaxKind.CastExpression) ||
+                initializerExpression.IsKind(SyntaxKind.IsExpression) ||
+                initializerExpression.IsKind(SyntaxKind.AsExpression))
+            {
+                return true;
+            }
+
+            // other Conversion cases:
+            //      a. conversion with helpers like: int.Parse methods
+            //      b. types that implement IConvertible and then invoking .ToType()
+            //      c. System.Convert.Totype()
+            var memberName = GetRightmostInvocationExpression(initializerExpression).GetRightmostName();
+            if (memberName == null)
+            {
+                return false;
+            }
+
+            var methodSymbol = semanticModel.GetSymbolInfo(memberName, cancellationToken).Symbol as IMethodSymbol;
+            if (methodSymbol == null)
+            {
+                return false;
+            }
+
+            if (memberName.IsRightSideOfDot())
+            {
+                var containingTypeName = memberName.GetLeftSideOfDot();
+                return IsPossibleCreationOrConversionMethod(methodSymbol, typeInDeclaration, semanticModel, containingTypeName, cancellationToken);
+            }
+
+            return false;
+        }
+
+        private static bool IsPossibleCreationOrConversionMethod(IMethodSymbol methodSymbol,
+            ITypeSymbol typeInDeclaration,
+            SemanticModel semanticModel,
+            ExpressionSyntax containingTypeName,
+            CancellationToken cancellationToken)
+        {
+            if (methodSymbol.ReturnsVoid)
+            {
+                return false;
+            }
+
+            var containingType = semanticModel.GetTypeInfo(containingTypeName, cancellationToken).Type;
+
+            return IsPossibleCreationMethod(methodSymbol, typeInDeclaration, containingType)
+                || IsPossibleConversionMethod(methodSymbol, typeInDeclaration, containingType, semanticModel, cancellationToken);
+        }
+
+        /// <summary>
+        /// Looks for types that have static methods that return the same type as the container.
+        /// e.g: int.Parse, XElement.Load, Tuple.Create etc.
+        /// </summary>
+        private static bool IsPossibleCreationMethod(IMethodSymbol methodSymbol, 
+            ITypeSymbol typeInDeclaration, 
+            ITypeSymbol containingType)
+        {
+            if (!methodSymbol.IsStatic)
+            {
+                return false;
+            }
+
+            return IsContainerTypeEqualToReturnType(methodSymbol, typeInDeclaration, containingType);
+        }
+
+        /// <summary>
+        /// If we have a method ToXXX and its return type is also XXX, then type name is apparent
+        /// e.g: Convert.ToString.
+        /// </summary>
+        private static bool IsPossibleConversionMethod(IMethodSymbol methodSymbol, 
+            ITypeSymbol typeInDeclaration, 
+            ITypeSymbol containingType, 
+            SemanticModel semanticModel, 
+            CancellationToken cancellationToken)
+        {
+            var returnType = methodSymbol.ReturnType;
+            var returnTypeName = returnType.IsNullable()
+                ? returnType.GetTypeArguments().First().Name
+                : returnType.Name;
+
+            return methodSymbol.Name.Equals("To" + returnTypeName, StringComparison.Ordinal);
+        }
+
+        /// <remarks>
+        /// If there are type arguments on either side of assignment, we match type names instead of type equality 
+        /// to account for inferred generic type arguments.
+        /// e.g: Tuple.Create(0, true) returns Tuple&lt;X,y&gt; which isn't the same as type Tuple.
+        /// otherwise, we match for type equivalence
+        /// </remarks>
+        private static bool IsContainerTypeEqualToReturnType(IMethodSymbol methodSymbol, 
+            ITypeSymbol typeInDeclaration, 
+            ITypeSymbol containingType)
+        {
+            var returnType = methodSymbol.ReturnType;
+
+            if (typeInDeclaration?.GetTypeArguments().Length > 0 ||
+                containingType.GetTypeArguments().Length > 0)
+            {
+                return containingType.Name.Equals(returnType.Name);
+            }
+            else
+            {
+                return containingType.Equals(returnType);
+            }
+        }
+
+        private static ExpressionSyntax GetRightmostInvocationExpression(ExpressionSyntax node)
+        {
+            var awaitExpression = node as AwaitExpressionSyntax;
+            if (awaitExpression != null && awaitExpression.Expression != null)
+            {
+                return GetRightmostInvocationExpression(awaitExpression.Expression);
+            }
+
+            var invocationExpression = node as InvocationExpressionSyntax;
+            if (invocationExpression != null && invocationExpression.Expression != null)
+            {
+                return GetRightmostInvocationExpression(invocationExpression.Expression);
+            }
+
+            var conditional = node as ConditionalAccessExpressionSyntax;
+            if (conditional != null)
+            {
+                return GetRightmostInvocationExpression(conditional.WhenNotNull);
+            }
+
+            return node;
+        }
+
+        private static TypeStyle GetCurrentTypeStylePreferences(OptionSet optionSet)
+        {
+            var stylePreferences = TypeStyle.None;
+
+            var styleForIntrinsicTypes = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
+            var styleForApparent = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
+            var styleForElsewhere = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible);
+
+            if (styleForIntrinsicTypes.IsChecked)
+            {
+                stylePreferences |= TypeStyle.ImplicitTypeForIntrinsicTypes;
+            }
+
+            if (styleForApparent.IsChecked)
+            {
+                stylePreferences |= TypeStyle.ImplicitTypeWhereApparent;
+            }
+
+            if (styleForElsewhere.IsChecked)
+            {
+                stylePreferences |= TypeStyle.ImplicitTypeWherePossible;
+            }
+
+            return stylePreferences;
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypingStyleDiagnosticAnalyzerBase.cs
@@ -16,15 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
 {
     internal abstract partial class CSharpTypingStyleDiagnosticAnalyzerBase : DiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        [Flags]
-        internal enum TypeStyle
-        {
-            None = 0,
-            ImplicitTypeForIntrinsicTypes = 1 << 0,
-            ImplicitTypeWhereApparent = 1 << 1,
-            ImplicitTypeWherePossible = 1 << 2,
-        }
-
         private readonly string _diagnosticId;
         private readonly LocalizableString _title;
         private readonly LocalizableString _message;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypingDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypingDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypingDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypingDiagnosticAnalyzer.cs
@@ -3,6 +3,7 @@
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
@@ -127,7 +128,9 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
                 return SyntaxFactory.IdentifierName("var");
             }
 
-            if (!isConstant && options.GetOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals) && CanUseVar(typeSymbol))
+            if (!isConstant && 
+                CanUseVar(typeSymbol) && 
+                TypeStyleHelper.IsImplicitTypePreferred(expression, document.SemanticModel, options, cancellationToken))
             {
                 return SyntaxFactory.IdentifierName("var");
             }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
@@ -39,18 +39,21 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 }
             }
 
-            protected override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            protected async override Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
             {
-                var newRoot = GetNewRoot(cancellationToken);
+                var newRoot = await GetNewRoot(cancellationToken).ConfigureAwait(false);
                 var newDocument = _document.WithSyntaxRoot(newRoot);
 
-                return Task.FromResult(newDocument);
+                return newDocument;
             }
 
-            private SyntaxNode GetNewRoot(CancellationToken cancellationToken)
+            private async Task<SyntaxNode> GetNewRoot(CancellationToken cancellationToken)
             {
                 SyntaxNode newRoot;
-                if (_service.TryConvertToLocalDeclaration(_state.LocalType, _state.IdentifierToken, _document.Project.Solution.Workspace.Options, out newRoot))
+
+                var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                if (_service.TryConvertToLocalDeclaration(_state.LocalType, _state.IdentifierToken, _document.Project.Solution.Workspace.Options, semanticModel, cancellationToken, out newRoot))
                 {
                     return newRoot;
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
         protected abstract bool TryInitializeExplicitInterfaceState(SemanticDocument document, SyntaxNode node, CancellationToken cancellationToken, out SyntaxToken identifierToken, out IPropertySymbol propertySymbol, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeIdentifierNameState(SemanticDocument document, TSimpleNameSyntax identifierName, CancellationToken cancellationToken, out SyntaxToken identifierToken, out TExpressionSyntax simpleNameOrMemberAccessExpression, out bool isInExecutableBlock, out bool isinConditionalAccessExpression);
 
-        protected abstract bool TryConvertToLocalDeclaration(ITypeSymbol type, SyntaxToken identifierToken, OptionSet options, out SyntaxNode newRoot);
+        protected abstract bool TryConvertToLocalDeclaration(ITypeSymbol type, SyntaxToken identifierToken, OptionSet options, SemanticModel semanticModel, CancellationToken cancellationToken,  out SyntaxNode newRoot);
 
         public async Task<IEnumerable<CodeAction>> GenerateVariableAsync(
             Document document,

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateVariable/VisualBasicGenerateVariableService.vb
@@ -112,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateVariable
             Return expression.CanReplaceWithLValue(semanticModel, cancellationToken)
         End Function
 
-        Protected Overrides Function TryConvertToLocalDeclaration(type As ITypeSymbol, identifierToken As SyntaxToken, options As OptionSet, ByRef newRoot As SyntaxNode) As Boolean
+        Protected Overrides Function TryConvertToLocalDeclaration(type As ITypeSymbol, identifierToken As SyntaxToken, options As OptionSet, semanticModel As SemanticModel, cancellationToken As CancellationToken, ByRef newRoot As SyntaxNode) As Boolean
             Return False
         End Function
     End Class


### PR DESCRIPTION
This is part of #9155

Since, we replaced an existing user option about using var in local declarations with 3 new codestyle options, we need to update code generation features that were directly consuming these affected options.

![image](https://cloud.githubusercontent.com/assets/4213867/13414091/b07b7d90-df04-11e5-9bee-bab2ad110924.png)

This PR, selectively handles updating the consumers of the obsolete option and moving them over to use the new options.

The changes are fairly straight forward, I extract existing logic from the 'use var' analyzers into a static class that can now be called from both the analyzer and the codegen features.

The changes are deliberately as minimal as possible, because the long term vision for this would be as follows:

1. Move the logic to determine whether one should use var into language agnostic workspace layer (with language specific impl at CSharp and Basic workspaces)

2. Make it work with the simplifier to simplify or expand from explicit type name to var or vice-versa.

3. CodeGen features should just tack on a simplifier annotation and move on.