### PR TITLE
Reference VS MEF Via NuGet

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -8,11 +8,6 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>

--- a/src/EditorFeatures/CSharpTest/project.lock.json
+++ b/src/EditorFeatures/CSharpTest/project.lock.json
@@ -63,6 +63,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -442,6 +465,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -950,6 +996,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {

--- a/src/EditorFeatures/CSharpTest2/CSharpEditorServicesTest2.csproj
+++ b/src/EditorFeatures/CSharpTest2/CSharpEditorServicesTest2.csproj
@@ -8,11 +8,6 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>

--- a/src/EditorFeatures/CSharpTest2/project.lock.json
+++ b/src/EditorFeatures/CSharpTest2/project.lock.json
@@ -63,6 +63,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -442,6 +465,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -950,6 +996,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {

--- a/src/EditorFeatures/Test/EditorServicesTest.csproj
+++ b/src/EditorFeatures/Test/EditorServicesTest.csproj
@@ -19,14 +19,6 @@
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-      <CopyLocal>True</CopyLocal>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Composition.Configuration, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
-      <CopyLocal>True</CopyLocal>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor.Interop.dll">
       <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Platform.VSEditor.Interop.dll</HintPath>
     </Reference>

--- a/src/EditorFeatures/Test/project.json
+++ b/src/EditorFeatures/Test/project.json
@@ -10,7 +10,8 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading": "4.0.10",
     "xunit": "2.1.0",
-    "xunit.runner.console": "2.1.0"
+    "xunit.runner.console": "2.1.0",
+    "Microsoft.VisualStudio.Composition": "14.0.50715-pre"
   },
   "frameworks": {
     "net46": {}

--- a/src/EditorFeatures/Test/project.lock.json
+++ b/src/EditorFeatures/Test/project.lock.json
@@ -63,6 +63,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -411,6 +434,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -757,6 +803,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -1232,6 +1301,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {
@@ -2153,6 +2250,7 @@
     "": [
       "BasicUndo >= 0.9.3",
       "Microsoft.Composition >= 1.0.27",
+      "Microsoft.VisualStudio.Composition >= 14.0.50715-pre",
       "Moq >= 4.2.1402.2112",
       "System.Collections >= 4.0.10",
       "System.Diagnostics.Debug >= 4.0.10",

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -15,9 +15,6 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Imaging.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/src/EditorFeatures/Test2/project.lock.json
+++ b/src/EditorFeatures/Test2/project.lock.json
@@ -63,6 +63,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -409,6 +432,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -884,6 +930,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -15,11 +15,6 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>

--- a/src/EditorFeatures/VisualBasicTest/project.lock.json
+++ b/src/EditorFeatures/VisualBasicTest/project.lock.json
@@ -63,6 +63,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -409,6 +432,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -884,6 +930,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {

--- a/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
+++ b/src/VisualStudio/CSharp/Test/CSharpVisualStudioTest.csproj
@@ -16,9 +16,6 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Language.StandardClassification, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Platform.VSEditor, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/VisualStudio/CSharp/Test/project.lock.json
+++ b/src/VisualStudio/CSharp/Test/project.lock.json
@@ -79,6 +79,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -441,6 +464,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -942,6 +988,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -15,13 +15,6 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <Reference Include="Microsoft.VisualStudio.Composition, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Composition.Configuration, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>$(DevEnvDir)\PrivateAssemblies\Microsoft.VisualStudio.Composition.Configuration.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.14.0.DesignTime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/src/VisualStudio/Core/Test/project.lock.json
+++ b/src/VisualStudio/Core/Test/project.lock.json
@@ -79,6 +79,29 @@
           "lib/net45/_._": {}
         }
       },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        }
+      },
       "Moq/4.2.1402.2112": {
         "compile": {
           "lib/net40/Moq.dll": {}
@@ -441,6 +464,29 @@
         },
         "runtime": {
           "lib/net45/_._": {}
+        }
+      },
+      "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+        "dependencies": {
+          "Microsoft.Composition": "[1.0.27, )",
+          "Microsoft.VisualStudio.Validation": "[14.0.50702, )",
+          "System.Collections.Immutable": "[1.1.36, )"
+        },
+        "compile": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        },
+        "runtime": {
+          "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll": {},
+          "lib/net451/Microsoft.VisualStudio.Composition.dll": {}
+        }
+      },
+      "Microsoft.VisualStudio.Validation/14.0.50702": {
+        "compile": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
+        },
+        "runtime": {
+          "lib/net45/Microsoft.VisualStudio.Validation.dll": {}
         }
       },
       "Moq/4.2.1402.2112": {
@@ -942,6 +988,34 @@
         "ref/netcore50/Microsoft.VisualBasic.xml",
         "ref/win8/_._",
         "ref/wpa81/_._"
+      ]
+    },
+    "Microsoft.VisualStudio.Composition/14.0.50715-pre": {
+      "sha512": "iW0ZItSqec+q0wmUHbFCDb/kxdKqa5LaoLYRso7sbnnx8DZst/WGc86ooxBg+P6imWVV69a5ABUAE14EIkDzHw==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Composition.dll",
+        "lib/net45/Microsoft.VisualStudio.Composition.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.Configuration.xml",
+        "lib/net451/Microsoft.VisualStudio.Composition.dll",
+        "lib/net451/Microsoft.VisualStudio.Composition.xml",
+        "Microsoft.VisualStudio.Composition.nuspec",
+        "package/services/metadata/core-properties/49476b50df234fd0aa965545b1ff4537.psmdcp"
+      ]
+    },
+    "Microsoft.VisualStudio.Validation/14.0.50702": {
+      "sha512": "+fqBUMqpfk8b1BwegIalBHoNzfnJUWFI/qrOGD6xEfhEH+732zZGlzO3Kuci+wiVX1NCD6HW5jZDEePVejGHcg==",
+      "type": "Package",
+      "files": [
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "lib/net45/Microsoft.VisualStudio.Validation.dll",
+        "lib/net45/Microsoft.VisualStudio.Validation.xml",
+        "Microsoft.VisualStudio.Validation.nuspec",
+        "package/services/metadata/core-properties/bc0320ca467749b1ac7a79765ec3e8cb.psmdcp"
       ]
     },
     "Moq/4.2.1402.2112": {


### PR DESCRIPTION
This is a cherry-pick of the commits from #9081 to `stabilization` so that you can build Roslyn with Update 2 installed.