### PR TITLE
[Ask Mode] initialize to max value so that there is no conflict when finding old…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.SimpleMRUCache.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             public void Touch(object instance)
             {
                 var oldIndex = -1;
-                var oldTime = DateTime.UtcNow;
+                var oldTime = DateTime.MaxValue;
 
                 for (var i = 0; i < _nodes.Length; i++)
                 {


### PR DESCRIPTION
…est cache.

this fixes Watson crash due to IndexOutOfIndex exception.

https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?_a=edit&id=179939

since it is watson crash, I dont have exact repro or scenarios where this happens, but this fix should make such situation can't ever happen.