### PR TITLE
allow find-all-references to navigate across portable/desktop boundaries

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinder_Hierarchy.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
                         if (member != null &&
                             member.IsOverride &&
                             member.OverriddenMember() != null &&
-                           SymbolEquivalenceComparer.Instance.Equals(member.OverriddenMember().OriginalDefinition, symbol.OriginalDefinition))
+                            DependentTypeFinder.OriginalSymbolsMatch(member.OverriddenMember().OriginalDefinition, symbol.OriginalDefinition, solution, cancellationToken))
                         {
                             results = results ?? new List<ISymbol>();
                             results.Add(member);

--- a/src/Workspaces/CoreTest/DependentTypeFinderTests.cs
+++ b/src/Workspaces/CoreTest/DependentTypeFinderTests.cs
@@ -4,30 +4,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
-    public class DependentTypeFinderTests : TestBase
+    public class DependentTypeFinderTests : ServicesTestBase
     {
-        private Solution AddProject(Solution solution, string projectName, string languageName, string code, MetadataReference metadataReference, params ProjectId[] projectReferences)
-        {
-            var suffix = languageName == LanguageNames.CSharp ? "cs" : "vb";
-            var pid = ProjectId.CreateNewId();
-            var did = DocumentId.CreateNewId(pid);
-            var pi = ProjectInfo.Create(
-                pid,
-                VersionStamp.Default,
-                projectName,
-                projectName,
-                languageName,
-                metadataReferences: new[] { metadataReference },
-                projectReferences: projectReferences.Select(p => new ProjectReference(p)));
-            return solution.AddProject(pi).AddDocument(did, $"{projectName}.{suffix}", SourceText.From(code));
-        }
-
         [WorkItem(4973, "https://github.com/dotnet/roslyn/issues/4973")]
         [Fact]
         public async Task ImmediatelyDerivedTypes_CSharp()
@@ -35,7 +18,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an abstract base class
-            solution = AddProject(solution, "PortableProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.CSharp, @"
 namespace N
 {
     public abstract class BaseClass { }
@@ -43,7 +26,7 @@ namespace N
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type derived from the portable abstract base
-            solution = AddProject(solution, "NormalProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.CSharp, @"
 using N;
 namespace M
 {
@@ -74,7 +57,7 @@ namespace M
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an abstract base class
-            solution = AddProject(solution, "PortableProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.CSharp, @"
 namespace N
 {
     public abstract class BaseClass { }
@@ -82,7 +65,7 @@ namespace N
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type derived from the portable abstract base
-            solution = AddProject(solution, "NormalProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.CSharp, @"
 using N;
 namespace M
 {
@@ -113,7 +96,7 @@ namespace M
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an abstract base class
-            solution = AddProject(solution, "PortableProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.VisualBasic, @"
 Namespace N
     Public MustInherit Class BaseClass
     End Class
@@ -121,7 +104,7 @@ End Namespace
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type derived from the portable abstract base
-            solution = AddProject(solution, "NormalProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.VisualBasic, @"
 Imports N
 Namespace M
     Public Class DerivedClass
@@ -153,7 +136,7 @@ End Namespace
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an abstract base class
-            solution = AddProject(solution, "PortableProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.CSharp, @"
 namespace N
 {
     public abstract class BaseClass { }
@@ -161,7 +144,7 @@ namespace N
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type derived from the portable abstract base
-            solution = AddProject(solution, "NormalProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.VisualBasic, @"
 Imports N
 Namespace M
     Public Class DerivedClass
@@ -193,7 +176,7 @@ End Namespace
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an interface
-            solution = AddProject(solution, "PortableProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.CSharp, @"
 namespace N
 {
     public interface IBaseInterface { }
@@ -201,7 +184,7 @@ namespace N
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type implementing that interface
-            solution = AddProject(solution, "NormalProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.CSharp, @"
 using N;
 namespace M
 {
@@ -231,7 +214,7 @@ namespace M
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an interface
-            solution = AddProject(solution, "PortableProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.VisualBasic, @"
 Namespace N
     Public Interface IBaseInterface
     End Interface
@@ -239,7 +222,7 @@ End Namespace
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type implementing that interface
-            solution = AddProject(solution, "NormalProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.VisualBasic, @"
 Imports N
 Namespace M
     Public Class ImplementingClass
@@ -270,7 +253,7 @@ End Namespace
             var solution = new AdhocWorkspace().CurrentSolution;
 
             // create portable assembly with an interface
-            solution = AddProject(solution, "PortableProject", LanguageNames.VisualBasic, @"
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.VisualBasic, @"
 Namespace N
     Public Interface IBaseInterface
     End Interface
@@ -278,7 +261,7 @@ End Namespace
 ", MscorlibRefPortable);
 
             // create a normal assembly with a type implementing that interface
-            solution = AddProject(solution, "NormalProject", LanguageNames.CSharp, @"
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.CSharp, @"
 using N;
 namespace M
 {

--- a/src/Workspaces/CoreTest/FindReferencesTests.cs
+++ b/src/Workspaces/CoreTest/FindReferencesTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.UnitTests
 {
-    public partial class FindReferencesTests : TestBase
+    public partial class FindReferencesTests : ServicesTestBase
     {
         private Solution CreateSolution()
         {
@@ -266,6 +266,58 @@ class B : C, A
             result.ForEach((reference) => Verify(reference, expectedMatchedLines));
 
             Assert.Empty(expectedMatchedLines);
+        }
+
+        [WorkItem(4936, "https://github.com/dotnet/roslyn/issues/4936")]
+        [Fact]
+        public async Task OverriddenMethodsFromPortableToDesktop()
+        {
+            var solution = new AdhocWorkspace().CurrentSolution;
+
+            // create portable assembly with a virtual method
+            solution = AddProjectWithMetadataReferences(solution, "PortableProject", LanguageNames.CSharp, @"
+namespace N
+{
+    public class BaseClass
+    {
+        public virtual void SomeMethod() { }
+    }
+}
+", MscorlibRefPortable);
+
+            // create a normal assembly with a type derived from the portable base and overriding the method
+            solution = AddProjectWithMetadataReferences(solution, "NormalProject", LanguageNames.CSharp, @"
+using N;
+namespace M
+{
+    public class DerivedClass : BaseClass
+    {
+        public override void SomeMethod() { }
+    }
+}
+", MscorlibRef, solution.Projects.Single(pid => pid.Name == "PortableProject").Id);
+
+            // get symbols for methods
+            var portableCompilation = await solution.Projects.Single(p => p.Name == "PortableProject").GetCompilationAsync();
+            var baseType = portableCompilation.GetTypeByMetadataName("N.BaseClass");
+            var baseVirtualMethodSymbol = baseType.GetMembers("SomeMethod").Single();
+
+            var normalCompilation = await solution.Projects.Single(p => p.Name == "NormalProject").GetCompilationAsync();
+            var derivedType = normalCompilation.GetTypeByMetadataName("M.DerivedClass");
+            var overriddenMethodSymbol = derivedType.GetMembers("SomeMethod").Single();
+
+            // FAR from the virtual method should find both methods
+            var refsFromVirtual = await SymbolFinder.FindReferencesAsync(baseVirtualMethodSymbol, solution);
+            Assert.Equal(2, refsFromVirtual.Count());
+
+            // FAR from the overriden method should find both methods
+            var refsFromOverride = await SymbolFinder.FindReferencesAsync(overriddenMethodSymbol, solution);
+            Assert.Equal(2, refsFromOverride.Count());
+
+            // all methods returned should be equal
+            var refsFromVirtualSorted = refsFromVirtual.Select(r => r.Definition).OrderBy(r => r.ContainingType.Name).ToArray();
+            var refsFromOverrideSorted = refsFromOverride.Select(r => r.Definition).OrderBy(r => r.ContainingType.Name).ToArray();
+            Assert.Equal(refsFromVirtualSorted, refsFromOverrideSorted);
         }
 
         private static void Verify(ReferencedSymbol reference, HashSet<int> expectedMatchedLines)

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -74,6 +74,7 @@
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingTests.TextMerging.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingTests.Features.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingTests.cs" />
+    <Compile Include="ServicesTestBase.cs" />
     <Compile Include="UtilityTest\AsyncLazyTests.cs" />
     <Compile Include="CodeCleanup\AddMissingTokensTests.cs" />
     <Compile Include="CodeCleanup\CodeCleanupTests.cs" />

--- a/src/Workspaces/CoreTest/ServicesTestBase.cs
+++ b/src/Workspaces/CoreTest/ServicesTestBase.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public abstract class ServicesTestBase : TestBase
+    {
+        public static Solution AddProjectWithMetadataReferences(Solution solution, string projectName, string languageName, string code, MetadataReference metadataReference, params ProjectId[] projectReferences)
+        {
+            var suffix = languageName == LanguageNames.CSharp ? "cs" : "vb";
+            var pid = ProjectId.CreateNewId();
+            var did = DocumentId.CreateNewId(pid);
+            var pi = ProjectInfo.Create(
+                pid,
+                VersionStamp.Default,
+                projectName,
+                projectName,
+                languageName,
+                metadataReferences: new[] { metadataReference },
+                projectReferences: projectReferences.Select(p => new ProjectReference(p)));
+            return solution.AddProject(pi).AddDocument(did, $"{projectName}.{suffix}", SourceText.From(code));
+        }
+    }
+}


### PR DESCRIPTION
*Given that the current behavior is incorrect and that a similar PR (#9056) was approved for ask-mode, this one is up for consideration, too.*

Find All References didn't take into account assembly retargeting when comparing symbols so a method in a desktop assembly that overrides a method in a portable assembly wasn't detected.  This was a simple case of updating the comparison used in FAR.

I also manually tested the scenario in #4936 (`Workspace.ApplyDocumentTextChanged` and `MSBuildWorkspace.ApplyDocumentTextChanged`).

Thanks to @balajikris for finding the exact line that needed to be updated.

Tagging @dotnet/roslyn-ide for review.

Fixes #4936.