### PR TITLE
Fix issue where we weren't properly inferring a delegate type in a signature.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2835,6 +2835,50 @@ public class Test
 }");
         }
 
+        [WorkItem(8230, "https://github.com/dotnet/roslyn/issues/8230")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateMethodForOverloadedSignatureWithDelegateType()
+        {
+            await TestAsync(
+@"
+using System;
+
+class PropertyMetadata
+{
+    public PropertyMetadata(object defaultValue) { }
+    public PropertyMetadata(EventHandler changedHandler) { }
+}
+
+class Program
+{
+    static void Main()
+    {
+        new PropertyMetadata([|OnChanged|]);
+    }
+}
+",
+@"using System;
+
+class PropertyMetadata
+{
+    public PropertyMetadata(object defaultValue) { }
+    public PropertyMetadata(EventHandler changedHandler) { }
+}
+
+class Program
+{
+    static void Main()
+    {
+        new PropertyMetadata(OnChanged);
+    }
+
+    private static void OnChanged(object sender, EventArgs e)
+    {
+        throw new NotImplementedException();
+    }
+}");
+        }
+
         public class GenerateConversionTest : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeInferenceServiceExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeInferenceServiceExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             CancellationToken cancellationToken)
         {
             var types = typeInferenceService.InferTypes(semanticModel, expression, cancellationToken);
-            var delegateTypes = types.Select(t => t?.GetDelegateType(semanticModel.Compilation));
+            var delegateTypes = types.Select(t => t.GetDelegateType(semanticModel.Compilation));
             return delegateTypes.WhereNotNull().FirstOrDefault();
         }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeInferenceServiceExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeInferenceServiceExtensions.cs
@@ -16,8 +16,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             SyntaxNode expression,
             CancellationToken cancellationToken)
         {
-            var type = typeInferenceService.InferType(semanticModel, expression, objectAsDefault: false, cancellationToken: cancellationToken);
-            return type.GetDelegateType(semanticModel.Compilation);
+            var types = typeInferenceService.InferTypes(semanticModel, expression, cancellationToken);
+            var delegateTypes = types.Select(t => t?.GetDelegateType(semanticModel.Compilation));
+            return delegateTypes.WhereNotNull().FirstOrDefault();
         }
 
         public static ITypeSymbol InferType(this ITypeInferenceService typeInferenceService,


### PR DESCRIPTION
This was causing generate-method to not offer a proper fix when it should have been.

Fixes https://github.com/dotnet/roslyn/issues/8230