### PR TITLE
Fix issue where we weren't offering 'generate variable'

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -2886,5 +2886,37 @@ class Outer
 }
 ");
         }
+
+        [WorkItem(8358, "https://github.com/dotnet/roslyn/issues/8358")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestNotOnStaticWithExistingInstance1()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    int _field;
+    void M()
+    {
+        C.[|_field|] = 42;
+    }
+}");
+        }
+
+        [WorkItem(8358, "https://github.com/dotnet/roslyn/issues/8358")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestNotOnStaticWithExistingInstance2()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    int _field;
+    static C()
+    {
+        [|_field|] = 42;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -2850,5 +2850,41 @@ index: 2);
 @"using System ; public class Test { public static int Property1 { get { int _field = 0 ; return _field ; } } } ",
 index: 3);
         }
+
+        [WorkItem(8358, "https://github.com/dotnet/roslyn/issues/8358")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TestSameNameAsInstanceVariableInContainingType()
+        {
+            await TestAsync(
+@"
+class Outer
+{
+    int _field;
+
+    class Inner
+    {
+        public Inner(int field)
+        {
+            [|_field|] = field;
+        }
+    }
+}",
+@"
+class Outer
+{
+    int _field;
+
+    class Inner
+    {
+        private int _field;
+
+        public Inner(int field)
+        {
+            _field = field;
+        }
+    }
+}
+");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
@@ -24,11 +24,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable
         private const string CS0117 = nameof(CS0117); // error CS0117: 'TestNs.Program' does not contain a definition for 'blah'
         private const string CS0539 = nameof(CS0539); // error CS0539: 'Class.SomeProp' in explicit interface declaration is not a member of interface
         private const string CS0246 = nameof(CS0246); // error CS0246: The type or namespace name 'Version' could not be found
+        private const string CS0120 = nameof(CS0120); // error CS0120: An object reference is required for the non-static field, method, or property 'A'
 
-        public override ImmutableArray<string> FixableDiagnosticIds
-        {
-            get { return ImmutableArray.Create(CS1061, CS0103, CS0117, CS0539, CS0246); }
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds =>
+            ImmutableArray.Create(CS1061, CS0103, CS0117, CS0539, CS0246, CS0120);
 
         protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {


### PR DESCRIPTION
when there was an existing variable with the same name in an outer type.

Fixes https://github.com/dotnet/roslyn/issues/8358