### PR TITLE
Update NuGet versions in stabilization branch

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -70,8 +70,9 @@
     <!-- Only set when building RTM with no dependencies on pre-release packages
     <NuGetReleaseVersion>$(RoslynSemanticVersion)</NuGetReleaseVersion>
     -->
-    <NuGetPreReleaseVersion>$(RoslynSemanticVersion)-beta1</NuGetPreReleaseVersion>
-    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
+    <NuGetPreReleaseBase>$(RoslynSemanticVersion)-rc1</NuGetPreReleaseBase>
+    <NuGetPreReleaseVersion>$(RoslynPreReleaseBase)-final</NuGetPreReleaseVersion>
+    <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseBase)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
Our previous NuGet prereleases were -beta1 -- we should start making -rc1 packages as we lock down.

In addition, `-rc1` does not take precedence over `-rc1-$stuff` in prerelease versions. This is fixed by appending a `-final` to the final prerelease package for a prerelease set.

/cc @davkean @jaredpar @Pilchie @natidea @dotnet/roslyn-infrastructure 