### PR TITLE
Generate unique job names

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -174,16 +174,21 @@ static void addStandardJob(def myJob, String jobName, String branchName, String 
   }
 }
 
+def branchNames = []
 ['master', 'future', 'stabilization', 'future-stabilization', 'hotfixes', 'prtest'].each { branchName ->
-  // folder("${branchName.substring(0, 6)}")
+  def shortBranchName = branchName.substring(0, 6)
+  def jobBranchName = shortBranchName in branchNames ? branchName : shortBranchName
+  branchNames << jobBranchName
+
+  // folder("${jobBranchName}")
   ['win', 'linux', 'mac'].each { opsys ->
-    // folder("${branchName.substring(0, 6)}/${opsys.substring(0, 3)}")
+    // folder("${jobBranchName}/${opsys.substring(0, 3)}")
     ['dbg', 'rel'].each { configuration ->
       if ((configuration == 'dbg') || ((branchName != 'prtest') && (opsys == 'win'))) {
-        // folder("${branchName.substring(0, 6)}/${opsys.substring(0, 3)}/${configuration}")
+        // folder("${jobBranchName}/${opsys.substring(0, 3)}/${configuration}")
         ['unit32', 'unit64'].each { buildTarget ->
           if ((opsys == 'win') || (buildTarget == 'unit32')) {
-            def jobName = "roslyn_${branchName.substring(0, 6)}_${opsys.substring(0, 3)}_${configuration}_${buildTarget}"
+            def jobName = "roslyn_${jobBranchName}_${opsys.substring(0, 3)}_${configuration}_${buildTarget}"
             def myJob = job(jobName) {
               description('')
             }
@@ -231,7 +236,7 @@ set TMP=%TEMP%
   }
 
   if (branchName != 'prtest') {
-    def determinismJobName = "roslyn_${branchName.substring(0, 6)}_determinism"
+    def determinismJobName = "roslyn_${jobBranchName}_determinism"
     def determinismJob = job(determinismJobName) {
       description('')
     }


### PR DESCRIPTION
This change ensures that job names for 'future' and 'future-stabilization' are different.
The job names for existing branches will not change.