### PR TITLE
Test/fix scoping rules for pattern locals in field/property initializers, parameter default values and attributes.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -760,5 +760,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(Locals.Length == 0);
             return new PatternVariableBinder(scopeOpt, scopeOpt, this);
         }
+
+        internal BoundExpression WrapWithVariablesIfAny(BoundExpression expression)
+        {
+            return (Locals.Length == 0)
+                ? expression
+                : new BoundSequence(expression.Syntax, Locals, ImmutableArray<BoundExpression>.Empty, expression, expression.Type) { WasCompilerGenerated = true };
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal CSharpAttributeData GetAttribute(AttributeSyntax node, NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics)
         {
-            var boundAttribute = BindAttribute(node, boundAttributeType, diagnostics);
+            var boundAttribute = new PatternVariableBinder(node, this).BindAttribute(node, boundAttributeType, diagnostics);
 
             return GetAttribute(boundAttribute, diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -339,7 +339,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ParameterSymbol parameter,
             EqualsValueClauseSyntax defaultValueSyntax)
         {
-            return new LocalScopeBinder(this.WithContainingMemberOrLambda(parameter.ContainingSymbol).WithAdditionalFlags(BinderFlags.ParameterDefaultValue));
+            return new LocalScopeBinder(this.WithContainingMemberOrLambda(parameter.ContainingSymbol).WithAdditionalFlags(BinderFlags.ParameterDefaultValue)).
+                   WithPatternVariablesIfAny(defaultValueSyntax.Value);
         }
 
         internal BoundExpression BindParameterDefaultValue(
@@ -357,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Always generate the conversion, even if the expression is not convertible to the given type.
             // We want the erroneous conversion in the tree.
-            return GenerateConversionForAssignment(parameterType, valueBeforeConversion, diagnostics, isDefaultParameter: true);
+            return WrapWithVariablesIfAny(GenerateConversionForAssignment(parameterType, valueBeforeConversion, diagnostics, isDefaultParameter: true));
         }
 
         internal BoundExpression BindEnumConstantInitializer(
@@ -2649,7 +2650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? new PatternVariableBinder(initializerArgumentListOpt, initializerArgumentListOpt.Arguments, this)
                 : null;
             var result = (patBinder ?? this).BindConstructorInitializerCore(initializerArgumentListOpt, constructor, diagnostics);
-            return patBinder?.WrapWithPatternVariables(result) ?? result;
+            return patBinder?.WrapWithVariablesIfAny(result) ?? result;
         }
 
         private BoundExpression BindConstructorInitializerCore(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var collisionDetector = new LocalScopeBinder(binder);
             var patternBinder = new PatternVariableBinder(equalsValueClauseNode, equalsValueClauseNode.Value, collisionDetector);
             var boundInitValue = patternBinder.BindVariableOrAutoPropInitializer(equalsValueClauseNode, RefKind.None, fieldSymbol.GetFieldType(fieldsBeingBound), initializerDiagnostics);
-            boundInitValue = patternBinder.WrapWithPatternVariables(boundInitValue);
+            boundInitValue = patternBinder.WrapWithVariablesIfAny(boundInitValue);
 
             if (isImplicitlyTypedField)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3450,7 +3450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.WRN_FilterIsConstant, filter.FilterExpression);
             }
 
-            boundFilter = patternBinder.WrapWithPatternVariables(boundFilter);
+            boundFilter = patternBinder.WrapWithVariablesIfAny(boundFilter);
             boundFilter = new BoundSequencePointExpression(filter, boundFilter, boundFilter.Type);
             return boundFilter;
         }

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
@@ -32,6 +32,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (subExpression != null) expressionsToVisit.Add(subExpression);
                 }
             }
+
+            expressionsToVisit.ReverseContents();
+
             finder.VisitExpressions();
 
             if (!patterns.IsDefaultOrEmpty)

--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static AttributeSemanticModel Create(CSharpCompilation compilation, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Binder rootBinder)
         {
             var executableBinder = new ExecutableCodeBinder(syntax, attributeType, rootBinder);
-            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, new LocalScopeBinder(executableBinder));
+            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, new PatternVariableBinder(syntax, executableBinder));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
@@ -194,6 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         if (result != null)
                         {
+                            result = binder.WrapWithVariablesIfAny(result);
                             return new BoundFieldEqualsValue(equalsValue, field, result);
                         }
                         break;
@@ -205,6 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         BoundExpression result = binder.BindVariableOrAutoPropInitializer(equalsValue, RefKind.None, property.Type, diagnostics);
                         if (result != null)
                         {
+                            result = binder.WrapWithVariablesIfAny(result);
                             return new BoundPropertyEqualsValue(equalsValue, property, result);
                         }
                         break;

--- a/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
@@ -52,15 +52,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
         {
             var enumConstant = fieldSymbol as SourceEnumConstantSymbol;
-            var collisionDetector = new LocalScopeBinder(binder);
+            Binder collisionDetector = new LocalScopeBinder(binder);
+            collisionDetector = collisionDetector.WithPatternVariablesIfAny(initializer.Value);
+            BoundExpression result;
+
             if ((object)enumConstant != null)
             {
-                return collisionDetector.BindEnumConstantInitializer(enumConstant, initializer.Value, diagnostics);
+                result = collisionDetector.BindEnumConstantInitializer(enumConstant, initializer.Value, diagnostics);
             }
             else
             {
-                return collisionDetector.BindVariableOrAutoPropInitializer(initializer, RefKind.None, fieldSymbol.Type, diagnostics);
+                result = collisionDetector.BindVariableOrAutoPropInitializer(initializer, RefKind.None, fieldSymbol.Type, diagnostics);
             }
+
+            result = collisionDetector.WrapWithVariablesIfAny(result);
+            return result;
         }
 
         internal static ConstantValue GetAndValidateConstantValue(


### PR DESCRIPTION
Fixes #8816.

@gafter, @jaredpar, @dotnet/roslyn-compiler Please review.