### PR TITLE
Revert "Improve the Generate-Variable code-actions menu experience."

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
@@ -20,11 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateVar
         {
             return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
                 null, new GenerateVariableCodeFixProvider());
-        }
-
-        protected override IList<CodeAction> MassageActions(IList<CodeAction> actions)
-        {
-            return FlattenActions(actions);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -3,7 +3,6 @@
 Option Strict Off
 
 Imports System.Threading.Tasks
-Imports Microsoft.CodeAnalysis.CodeActions
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateVariable
@@ -14,10 +13,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.Genera
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
             Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(Nothing, New GenerateVariableCodeFixProvider())
-        End Function
-
-        Protected Overrides Function MassageActions(actions As IList(Of CodeAction)) As IList(Of CodeAction)
-            Return FlattenActions(actions)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -881,15 +881,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Generate variable.
-        /// </summary>
-        internal static string Generate_variable {
-            get {
-                return ResourceManager.GetString("Generate_variable", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Generate abstract method &apos;{0}&apos; in &apos;{1}&apos;.
         /// </summary>
         internal static string GenerateAbstractMethod {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -885,7 +885,4 @@ Do you want to continue?</value>
   <data name="Make_method_synchronous" xml:space="preserve">
     <value>Make method synchronous.</value>
   </data>
-  <data name="Generate_variable" xml:space="preserve">
-    <value>Generate variable</value>
-  </data>
 </root>

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,7 +45,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                     return SpecializedCollections.EmptyEnumerable<CodeAction>();
                 }
 
-                var actions = new List<CodeAction>();
+                var result = new List<CodeAction>();
 
                 var canGenerateMember = CodeGenerator.CanAdd(document.Project.Solution, state.TypeToGenerateIn, cancellationToken);
 
@@ -57,32 +56,24 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
                 {
                     if (canGenerateMember)
                     {
-                        AddPropertyCodeActions(actions, document, state);
-                        AddFieldCodeActions(actions, document, state);
+                        AddPropertyCodeActions(result, document, state);
+                        AddFieldCodeActions(result, document, state);
                     }
 
-                    AddLocalCodeActions(actions, document, state);
+                    AddLocalCodeActions(result, document, state);
                 }
                 else
                 {
                     if (canGenerateMember)
                     {
-                        AddFieldCodeActions(actions, document, state);
-                        AddPropertyCodeActions(actions, document, state);
+                        AddFieldCodeActions(result, document, state);
+                        AddPropertyCodeActions(result, document, state);
                     }
 
-                    AddLocalCodeActions(actions, document, state);
+                    AddLocalCodeActions(result, document, state);
                 }
 
-                if (actions.Count > 1)
-                {
-                    // Wrap the generate variable actions into a single top level suggestion
-                    // so as to not clutter the list.
-                    return SpecializedCollections.SingletonEnumerable(
-                        new MyCodeAction(FeaturesResources.Generate_variable, actions.AsImmutable()));
-                }
-
-                return actions;
+                return result;
             }
         }
 
@@ -143,14 +134,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
             if (state.CanGenerateLocal())
             {
                 result.Add(new GenerateLocalCodeAction((TService)this, document, state));
-            }
-        }
-
-        private class MyCodeAction : CodeAction.SimpleCodeAction
-        {
-            public MyCodeAction(string title, ImmutableArray<CodeAction> nestedActions)
-                : base(title, nestedActions)
-            {
             }
         }
     }


### PR DESCRIPTION
This reverts commit 0bef82b3b4d4acd3a3062dcaa0e3bde9bfdb4ecd.

This seems to have introduced a failure in `Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateVariable.GenerateVariableCrossLanguageTests.TestSimpleInstanceProperty_VisualBasicToCSharp`