### PR TITLE
Only collect archives in the case of aborted or failed runs.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -60,16 +60,19 @@ static void addArtifactArchiving(def myJob, String patternString, String exclude
     publishers {
       flexiblePublish {
         conditionalAction {
-          status('ABORTED', 'FAILURE')
-        }
-        publishers {
-          archiveArtifacts {
-            allowEmpty(true)
-            defaultExcludes(false)
-            exclude(excludeString)
-            fingerprint(false)
-            onlyIfSuccessful(false)
-            pattern(patternString)
+          condition {
+            status('ABORTED', 'FAILURE')
+          }
+
+          publishers {
+            archiveArtifacts {
+              allowEmpty(true)
+              defaultExcludes(false)
+              exclude(excludeString)
+              fingerprint(false)
+              onlyIfSuccessful(false)
+              pattern(patternString)
+            }
           }
         }
       }

--- a/netci.groovy
+++ b/netci.groovy
@@ -58,13 +58,20 @@ static void addWrappers(def myJob) {
 static void addArtifactArchiving(def myJob, String patternString, String excludeString) {
   myJob.with {
     publishers {
-      archiveArtifacts {
-        allowEmpty(true)
-        defaultExcludes(false)
-        exclude(excludeString)
-        fingerprint(false)
-        onlyIfSuccessful(false)
-        pattern(patternString)
+      flexiblePublish {
+        conditionalAction {
+          status('ABORTED', 'FAILURE')
+        }
+        publishers {
+          archiveArtifacts {
+            allowEmpty(true)
+            defaultExcludes(false)
+            exclude(excludeString)
+            fingerprint(false)
+            onlyIfSuccessful(false)
+            pattern(patternString)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Our archives are currently quite large (though we are working to reduce their size).  We can save a lot of machine space if we only collect archives for when things actually go wrong.  No one needs them for when things go right :)