### PR TITLE
Only log formatting events in telemetry when they are enacted by the …

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/FormatCommandHandler.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting
         {
             var formattingService = document.GetLanguageService<IEditorFormattingService>();
 
+            using (Logger.LogBlock(FunctionId.CommandHandler_FormatCommand, cancellationToken))
             using (var transaction = new CaretPreservingEditTransaction(EditorFeaturesResources.Formatting, textView, _undoHistoryRegistry, _editorOperationsFactoryService))
             {
                 var changes = formattingService.GetFormattingChangesAsync(document, selectionOpt, cancellationToken).WaitAndGetResult(cancellationToken);

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -60,6 +60,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
 
         CommandHandler_GetCommandState,
         CommandHandler_ExecuteHandlers,
+        CommandHandler_FormatCommand,
 
         Workspace_SourceText_GetChangeRanges,
         Workspace_Recoverable_RecoverRootAsync,


### PR DESCRIPTION
…user

Fixes internal bug [178050](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=178050&triage=true&fullScreen=true&_a=edit) 

Closed changes are in PR https://github.com/dotnet/roslyn-internal/pull/634