### PR TITLE
Watch xUnit processes for dumps in RunTests

### DIFF
--- a/src/Tools/Source/RunTests/CrashDumps.cs
+++ b/src/Tools/Source/RunTests/CrashDumps.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RunTests
+{
+    public static class CrashDumps
+    {
+        public static bool TryMonitorProcess(Process processToMonitor, string outputPath)
+        {
+            var procDumpPath = TryGetProcDumpPath();
+
+            // Make sure everything is fully qualified as we are passing this to other processes
+            outputPath = Path.GetFullPath(outputPath);
+
+            if (procDumpPath == null)
+            {
+                return false;
+            }
+
+            var processStart = new ProcessStartInfo();
+
+            processStart.Arguments = GetProcDumpArgumentsForMonitoring(processToMonitor.Id, outputPath);
+            processStart.CreateNoWindow = true;
+            processStart.FileName = procDumpPath;
+            processStart.UseShellExecute = false;
+
+            var process = Process.Start(processStart);
+
+            return true;
+        }
+
+        private static string GetProcDumpArgumentsForMonitoring(int pid, string outputPath)
+        {
+            // Here's what these arguments mean:
+            //
+            // -g:  run as a native debugger in a managed process (no interop).
+            // -e:  dump when an unhandled exception happens
+            // -b:  dump when a breakpoint (__int 3 / Debugger.Break()) is encountered
+            // -ma: create a full memory dump
+            //
+            // without -g, procdump will not catch unhandled managed exception since CLR will always
+            // handle unhandled exception. for procdump point of view, there is no such thing as unhandled
+            // exception for managed app.
+
+            return $"-accepteula -g -e -b -ma {pid} {outputPath}";
+        }
+
+        private const string DotNetContinuousIntegrationProcDumpLocation = @"C:\Sysinternals\Procdump.exe";
+
+        private static string TryGetProcDumpPath()
+        {
+            if (File.Exists(DotNetContinuousIntegrationProcDumpLocation))
+            {
+                return DotNetContinuousIntegrationProcDumpLocation;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Tools/Source/RunTests/ProcessRunner.cs
+++ b/src/Tools/Source/RunTests/ProcessRunner.cs
@@ -56,7 +56,8 @@ namespace RunTests
             string workingDirectory = null,
             bool captureOutput = false,
             bool displayWindow = true,
-            Dictionary<string, string> environmentVariables = null)
+            Dictionary<string, string> environmentVariables = null,
+            Action<Process> processMonitor = null)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -69,6 +70,8 @@ namespace RunTests
             var task = CreateTask(process, taskCompletionSource, cancellationToken);
 
             process.Start();
+
+            processMonitor?.Invoke(process);
 
             if (lowPriority)
             {

--- a/src/Tools/Source/RunTests/ProcessTestExecutor.cs
+++ b/src/Tools/Source/RunTests/ProcessTestExecutor.cs
@@ -78,6 +78,8 @@ namespace RunTests
                 // an empty log just in case, so our runner will still fail.
                 File.Create(resultsFilePath).Close();
 
+                var dumpOutputFilePath = Path.Combine(resultsDir, Path.GetFileNameWithoutExtension(assemblyPath) + ".dmp");
+
                 var start = DateTime.UtcNow;
                 var xunitPath = _options.XunitPath;
                 var processOutput = await ProcessRunner.RunProcessAsync(
@@ -86,7 +88,8 @@ namespace RunTests
                     lowPriority: false,
                     displayWindow: false,
                     captureOutput: true,
-                    cancellationToken: cancellationToken).ConfigureAwait(false);
+                    cancellationToken: cancellationToken,
+                    processMonitor: p => CrashDumps.TryMonitorProcess(p, dumpOutputFilePath)).ConfigureAwait(false);
                 var span = DateTime.UtcNow - start;
 
                 if (processOutput.ExitCode != 0)

--- a/src/Tools/Source/RunTests/RunTests.csproj
+++ b/src/Tools/Source/RunTests/RunTests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="Cache\CachingTestExecutor.cs" />
     <Compile Include="Cache\ConentFile.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="CrashDumps.cs" />
     <Compile Include="FileUtil.cs" />
     <Compile Include="Cache\IDataStorage.cs" />
     <Compile Include="ITestExecutor.cs" />

--- a/src/Workspaces/CoreTest/AssemblyAttributes.cs
+++ b/src/Workspaces/CoreTest/AssemblyAttributes.cs
@@ -1,4 +1,0 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
-using Xunit;
-


### PR DESCRIPTION
We will launch ProcDump to monitor the existing xUnit processes. The dump files are written out to the same directory as results themselves.

*Note:* this currently has a commit that will intentionally break tests. That's to verify this actually works on the Jenkins machines end-to-end.

*Review:* @dotnet/roslyn-infrastructure, @dotnet/roslyn-ide, @rchande 