### PR TITLE
Check file checksums to ensure no corruption occurred.

### DIFF
--- a/src/VisualStudio/Core/Def/Packaging/IPackageSearchDelayService.cs
+++ b/src/VisualStudio/Core/Def/Packaging/IPackageSearchDelayService.cs
@@ -19,9 +19,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         TimeSpan UpdateSucceededDelay { get; }
 
         /// <summary>
-        /// They time to wait after a failed update (default = 1 minute).
+        /// They time to wait after a simple expected sort of failure (i.e. IO exceptions, 
+        /// network exceptions, etc).  Things we can recover from and would expect would 
+        /// be transient.
         /// </summary>
-        TimeSpan UpdateFailedDelay { get; }
+        TimeSpan ExpectedFailureDelay { get; }
+
+        /// <summary>
+        /// They time to wait after a catastrophic failed update (default = 1 day).  For
+        /// example, if we download the full DB xml from the server and we cannot parse
+        /// it.  Retrying soon after will not help.  We'll just have to wait until proper
+        /// data is on the server for us to query.
+        /// </summary>
+        TimeSpan CatastrophicFailureDelay { get; }
 
         /// <summary>
         /// They time to wait after writing to disk fails (default = 10 seconds).

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchService.DelayService.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchService.DelayService.cs
@@ -10,7 +10,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
         {
             public TimeSpan CachePollDelay { get; } = TimeSpan.FromMinutes(1);
             public TimeSpan FileWriteDelay { get; } = TimeSpan.FromSeconds(10);
-            public TimeSpan UpdateFailedDelay { get; } = TimeSpan.FromMinutes(1);
+            public TimeSpan ExpectedFailureDelay { get; } = TimeSpan.FromMinutes(1);
+            public TimeSpan CatastrophicFailureDelay { get; } = TimeSpan.FromDays(1);
             public TimeSpan UpdateSucceededDelay { get; } = TimeSpan.FromDays(1);
         }
     }

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
@@ -632,7 +632,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                     if (expectedChecksum != actualChecksum)
                     {
                         _service._reportAndSwallowException(
-                            new FormatException($"Expected checksum {expectedChecksum} not equal to actual checksum {actualChecksum}"));
+                            new FormatException($"Checksum mismatch: expected != actual. {expectedChecksum} != {actualChecksum}"));
 
                         bytes = null;
                         return false;

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 }
                 catch (Exception e) when (_service._reportAndSwallowException(e))
                 {
-                    // We retrieved bytes from teh server, but we couldn't make a DB
+                    // We retrieved bytes from the server, but we couldn't make a DB
                     // out of it.  That's very bad.  Just trying again one minute later
                     // isn't going to help.  We need to wait until there is good data
                     // on the server for us to download.
@@ -625,9 +625,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 {
                     var expectedChecksum64 = checksumAttribute.Value;
                     var expectedChecksum = Convert.FromBase64String(expectedChecksum64);
-                    using (var md5 = MD5.Create())
+                    using (var sha256 = SHA256.Create())
                     {
-                        var actualChecksum = md5.ComputeHash(contentBytes);
+                        var actualChecksum = sha256.ComputeHash(contentBytes);
                         if (!expectedChecksum.SequenceEqual(actualChecksum))
                         {
                             _service._reportAndSwallowException(

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
@@ -5,7 +5,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -623,19 +622,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 var checksumAttribute = element.Attribute(ChecksumAttributeName);
                 if (checksumAttribute != null)
                 {
-                    var expectedChecksum64 = checksumAttribute.Value;
-                    var expectedChecksum = Convert.FromBase64String(expectedChecksum64);
+                    var expectedChecksum = checksumAttribute.Value;
+                    string actualChecksum;
                     using (var sha256 = SHA256.Create())
                     {
-                        var actualChecksum = sha256.ComputeHash(contentBytes);
-                        if (!expectedChecksum.SequenceEqual(actualChecksum))
-                        {
-                            _service._reportAndSwallowException(
-                                new FormatException($"Expected checksum {expectedChecksum64} not equal to actual checksum {Convert.ToBase64String(actualChecksum)}"));
+                        actualChecksum = Convert.ToBase64String(sha256.ComputeHash(contentBytes));
+                    }
 
-                            bytes = null;
-                            return false;
-                        }
+                    if (expectedChecksum != actualChecksum)
+                    {
+                        _service._reportAndSwallowException(
+                            new FormatException($"Expected checksum {expectedChecksum} not equal to actual checksum {actualChecksum}"));
+
+                        bytes = null;
+                        return false;
                     }
                 }
 

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchService.Update.cs
@@ -629,7 +629,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                         actualChecksum = Convert.ToBase64String(sha256.ComputeHash(contentBytes));
                     }
 
-                    if (expectedChecksum != actualChecksum)
+                    if (!StringComparer.Ordinal.Equals(expectedChecksum, actualChecksum))
                     {
                         _service._reportAndSwallowException(
                             new FormatException($"Checksum mismatch: expected != actual. {expectedChecksum} != {actualChecksum}"));


### PR DESCRIPTION
We encountered an issue on the server producing the DB files for add-nuget-reference.  That server occasionally produced truncated DB files that it would send down to the client.  The client would read this file in, successfully convert it to a DB, and go on its merry way.  The next day it would then encounter a crash when it downloaded the patch for that DB as MSDelta was not able to properly apply things.

This crash was handled properly on the client.  Because of the inability to patch, we would then try to download the full DB.  This would work, but could again cause the client to end up with a truncated DB.  

We fixed the issue on the server, and we've marked all existing previous versions as "out of date".  This "out of date" flag essentially acts as a kill-bit, telling the client they should download the full DB.  By doing this, any client with those versions will now try to download the full DB instead of trying to patch themselves.  I verified this working locally.  

We've also added more information to the XML that we send to the client.  Specifically, we create an MD5 checksum of the original DB contents that we send down along with the payload.  This checksum allows the client to verify that what it unpacks matches what is expected.  

If the contents don't match what is expected, we generate a Non fatal watson (so we can get notifications about the issue), and we have the client back off for a day.  The idea here is that just trying to update over and over agian will cause nothing but repeated failures.  However, once we notice this and address whatever server problem is causing us to generate bad data, then the client will get a proper db.

--

The bad: we had a server bug.
The good: the client behaved decently well in the presence of this (no crashing or otherwise bad behavior).  Though it would end up watson'ing once a minute as it hit the same issue again and again.

