### PR TITLE
Fix for #9167: async and iterator rewriters do not require optional attribute types

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.vb
@@ -295,11 +295,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Overrides Function EnsureAllSymbolsAndSignature() As Boolean
             Dim hasErrors As Boolean = MyBase.EnsureAllSymbolsAndSignature
 
-            ' NOTE: in current implementation these attributes must exist
-            ' TODO: change to "don't use if not found"
-            EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor, hasErrors)
-            EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor, hasErrors)
-
             EnsureSpecialType(SpecialType.System_Object, hasErrors)
             EnsureSpecialType(SpecialType.System_Void, hasErrors)
             EnsureSpecialType(SpecialType.System_ValueType, hasErrors)

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
@@ -86,11 +86,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 hasErrors = True
             End If
 
-            ' NOTE: in current implementation these attributes must exist
-            ' TODO: change to "don't use if not found"
-            EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor, hasErrors)
-            EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Diagnostics_DebuggerNonUserCodeAttribute__ctor, hasErrors)
-
             ' NOTE: We don't ensure DebuggerStepThroughAttribute, it is just not emitted if not found
             ' EnsureWellKnownMember(Of MethodSymbol)(WellKnownMember.System_Diagnostics_DebuggerStepThroughAttribute__ctor, hasErrors)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1618,5 +1618,75 @@ End Module
             CompileAndVerify(source, expectedOutput:="420420")
         End Sub
 
+        <Fact, WorkItem(9167, "https://github.com/dotnet/roslyn/issues/9167")>
+        Public Sub IteratorShouldCompileWithoutOptionalAttributes()
+
+#Region "IL For corlib without CompilerGeneratedAttribute Or DebuggerNonUserCodeAttribute"
+            Dim corlib = "
+Namespace System
+    Public Class [Object]
+    End Class
+    Public Class [Int32]
+    End Class
+    Public Class [Boolean]
+    End Class
+    Public Class [String]
+    End Class
+    Public Class Exception
+    End Class
+    Public Class NotSupportedException
+        Inherits Exception
+    End Class
+    Public Class ValueType
+    End Class
+    Public Class [Enum]
+    End Class
+    Public Class Void
+    End Class
+    Public Interface IDisposable
+        Sub Dispose()
+    End Interface
+End Namespace
+Namespace System.Collections
+    Public Interface IEnumerable
+        Function GetEnumerator() As IEnumerator
+    End Interface
+    Public Interface IEnumerator
+        Function MoveNext() As Boolean
+        Property Current As Object
+        Sub Reset()
+    End Interface
+    Namespace Generic
+        Public Interface IEnumerable(Of T)
+            Inherits IEnumerable
+            Overloads Function GetEnumerator() As IEnumerator(Of T)
+        End Interface
+        Public Interface IEnumerator(Of T)
+            Inherits IEnumerator
+            Overloads Property Current As T
+        End Interface
+    End Namespace
+End Namespace
+Namespace System.Threading
+    Public Class Thread
+        Shared Property CurrentThread As Thread
+        Property ManagedThreadId As Integer
+    End Class
+End Namespace
+"
+#End Region
+
+            Dim source = "
+Class C
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+        Yield Nothing
+    End Function
+End Class
+"
+            ' The compilation succeeds even though CompilerGeneratedAttribute and DebuggerNonUserCodeAttribute are not available.
+            Dim compilation = CompilationUtils.CreateCompilation({Parse(source), Parse(corlib)})
+            Dim verifier = CompileAndVerify(compilation, verify:=False)
+            verifier.VerifyDiagnostics()
+        End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4456,26 +4456,6 @@ End Class
 Imports System
 Imports System.Threading.Tasks
 
-' TODO: the attribute shouldn't be needed (https://github.com/dotnet/roslyn/issues/9167)
-Namespace System.Runtime.CompilerServices
-    <AttributeUsage(AttributeTargets.All)>
-    Public Class CompilerGeneratedAttribute
-        Inherits Attribute
-        Public Sub New()
-        End Sub
-    End Class
-End Namespace
-
-' TODO: the attribute shouldn't be needed  (https://github.com/dotnet/roslyn/issues/9167)
-Namespace System.Diagnostics
-    <AttributeUsage(AttributeTargets.All)>
-    Public Class DebuggerHiddenAttribute
-        Inherits Attribute
-        Public Sub New()
-        End Sub
-    End Class
-End Namespace
-
 Namespace Microsoft.VisualBasic.CompilerServices
     Class ProjectData
         Shared Sub  SetProjectError(e As Exception)


### PR DESCRIPTION
(CompilerGeneratedAttribute or DebuggerNonUserCodeAttribute or DebuggerHiddenAttribute)

The fix simply removes the explicit checks to ensure those [optional](http://source.roslyn.io/#Microsoft.CodeAnalysis/WellKnownMembers.cs,736940babfcfb1d2) attribute types are present.  
The code that synthesizes those attributes (`TrySynthesizeAttribute` in C# and VB) already handles the case when those types are missing.

In fixing the reported problem with async rewriters, I noticed a similar situation with iterator rewriters. Fixing that uncovered two problems: (1) mincorlib was missing many members that are expected, (2) the compiler doesn't handle well when those members are missing (tracked by #9463).

@dotnet/roslyn-compiler  @tmat 