### PR TITLE
Allow null Compilation in SymbolDistinguisher.Description.GetHashCode

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/SymbolDistinguisher.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/SymbolDistinguisher.cs
@@ -222,9 +222,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             public override int GetHashCode()
             {
-                return Hash.Combine(
-                    _distinguisher._compilation.GetHashCode(),
-                    GetSymbol().GetHashCode());
+                int result = GetSymbol().GetHashCode();
+                var compilation = _distinguisher._compilation;
+                if (compilation != null)
+                {
+                    result = Hash.Combine(result, compilation.GetHashCode());
+                }
+                return result;
             }
 
             public override string ToString()

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolDistinguisherTests.cs
@@ -703,5 +703,51 @@ class C { }";
         {
             return a.First.Equals(b.First) && a.Second.Equals(b.Second);
         }
+
+        [WorkItem(8470, "https://github.com/dotnet/roslyn/issues/8470")]
+        [Fact]
+        public void DescriptionNoCompilation()
+        {
+            var source =
+@"class A { }
+class B { }";
+            var compilation = CreateCompilationWithMscorlib(source);
+            var typeA = compilation.GetMember<NamedTypeSymbol>("A");
+            var typeB = compilation.GetMember<NamedTypeSymbol>("B");
+            var distinguisher1 = new SymbolDistinguisher(compilation, typeA, typeB);
+            var distinguisher2 = new SymbolDistinguisher(null, typeA, typeB);
+            var arg1A = distinguisher1.First;
+            var arg2A = distinguisher2.First;
+            Assert.False(arg1A.Equals(arg2A));
+            Assert.False(arg2A.Equals(arg1A));
+            int hashCode1A = arg1A.GetHashCode();
+            int hashCode2A = arg2A.GetHashCode();
+        }
+
+        [WorkItem(8470, "https://github.com/dotnet/roslyn/issues/8470")]
+        [Fact]
+        public void CompareDiagnosticsNoCompilation()
+        {
+            var source1 =
+@"public class A { }
+public class B<T> where T : A { }";
+            var compilation1 = CreateCompilationWithMscorlib(source1);
+            compilation1.VerifyDiagnostics();
+            var ref1 = compilation1.EmitToImageReference();
+            var source2 =
+@"class C : B<object> { }";
+            var compilation2 = CreateCompilationWithMscorlib(source2, references: new[] { ref1 });
+            var diagnostics = compilation2.GetDiagnostics();
+            diagnostics.Verify(
+                // (1,7): error CS0311: The type 'object' cannot be used as type parameter 'T' in the generic type or method 'B<T>'. There is no implicit reference conversion from 'object' to 'A'.
+                // class C : B<object> { }
+                Diagnostic(ErrorCode.ERR_GenericConstraintNotSatisfiedRefType, "C").WithArguments("B<T>", "A", "T", "object").WithLocation(1, 7));
+            // Command-line compiler calls SymbolDistinguisher.Description.GetHashCode()
+            // when adding diagnostics to a set.
+            foreach (var diagnostic in diagnostics)
+            {
+                diagnostic.GetHashCode();
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #8470