### PR TITLE
Take a dump when TestImplicitCacheMonitoring fails

### DIFF
--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -136,7 +136,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             }
             while (weak.IsAlive);
 
-            Assert.False(weak.IsAlive);
+            // FailFast (and thereby capture a dump) to investigate what's
+            // rooting the object.
+            if (weak.IsAlive)
+            {
+                CodeAnalysis.Test.Utilities.ExceptionUtilities.FailFast(new Exception("Please investigate why the object wasn't collected!"));
+            }
+
             GC.KeepAlive(cacheService);
         }
 


### PR DESCRIPTION
This will allow the use of a memory profiler to determine what (if
anything) was still rooting objects in the cache.