### PR TITLE
Add skeleton assembly logging

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7046,6 +7046,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to An error occurred while writing the output file: {0}.
+        /// </summary>
+        internal static string ERR_PeWritingFailure {
+            get {
+                return ResourceManager.GetString("ERR_PeWritingFailure", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Neither &apos;is&apos; nor &apos;as&apos; is valid on pointer types.
         /// </summary>
         internal static string ERR_PointerInAsOrIs {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4676,6 +4676,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string literals.</value>
   </data>
   <data name="ERR_PeWritingFailure" xml:space="preserve">
-    <value>An error occurred while writing the output file.</value>
+    <value>An error occurred while writing the output file: {0}</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
@@ -16,6 +16,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private class StrongNameProviderWithBadInputStream : StrongNameProvider
         {
             private StrongNameProvider _underlyingProvider;
+
+            public Exception ThrownException;
+
             public StrongNameProviderWithBadInputStream(StrongNameProvider underlyingProvider)
             {
                 _underlyingProvider = underlyingProvider;
@@ -27,7 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             internal override Stream CreateInputStream()
             {
-                throw new IOException("This is a test IOException");
+                ThrownException = new IOException("This is a test IOException");
+                throw ThrownException;
             }
 
             internal override StrongNameKeys CreateKeys(string keyFilePath, string keyContainerName, CommonMessageProvider messageProvider) =>
@@ -53,9 +57,9 @@ class C
             var comp = CreateCompilationWithMscorlib(src,
                 options: options);
 
-            comp.VerifyEmitDiagnostics(
+            comp.Emit(new MemoryStream()).Diagnostics.Verify(
                 // error CS8104: An error occurred while writing the Portable Executable file.
-                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments("This is a test IOException").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments(testProvider.ThrownException.ToString()).WithLocation(1, 1));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/CompilationEmitTests.cs
@@ -2701,13 +2701,13 @@ class C
             var result = compilation.Emit(output);
             result.Diagnostics.Verify(
                 // error CS8104: An error occurred while writing the Portable Executable file.
-                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments("I/O error occurred.").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments(output.ThrownException.ToString()).WithLocation(1, 1));
 
-            output.BreakHow = 1;
+            output.BreakHow = BrokenStream.BreakHowType.ThrowOnSetPosition;
             result = compilation.Emit(output);
             result.Diagnostics.Verify(    
                 // error CS8104: An error occurred while writing the Portable Executable file.
-                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments("Specified method is not supported.").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments(output.ThrownException.ToString()).WithLocation(1, 1));
 
             // disposed stream is not writable
             var outReal = new MemoryStream();
@@ -2723,7 +2723,7 @@ class C
 
             var output = new MemoryStream();
             var pdb = new BrokenStream();
-            pdb.BreakHow = 2;
+            pdb.BreakHow = BrokenStream.BreakHowType.ThrowOnSetLength;
             var result = compilation.Emit(output, pdb);
 
             // error CS0041: Unexpected error writing debug information -- 'Exception from HRESULT: 0x806D0004'
@@ -2969,12 +2969,12 @@ public class X
 }";
             var compilation = CreateCompilationWithMscorlib(source);
             var broken = new BrokenStream();
-            broken.BreakHow = 0;
+            broken.BreakHow = BrokenStream.BreakHowType.ThrowOnWrite;
             var result = compilation.Emit(broken);
             Assert.False(result.Success);
             result.Diagnostics.Verify(
                 // error CS8104: An error occurred while writing the Portable Executable file.
-                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments("I/O error occurred.").WithLocation(1, 1));
+                Diagnostic(ErrorCode.ERR_PeWritingFailure).WithArguments(broken.ThrownException.ToString()).WithLocation(1, 1));
         }
     }
 }

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1908,7 +1908,7 @@ namespace Microsoft.CodeAnalysis
                 }
                 catch (Cci.PeWritingException e)
                 {
-                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.Message));
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(MessageProvider.ERR_PeWritingFailure, Location.None, e.InnerException.ToString()));
                     return false;
                 }
                 catch (ResourceException e)

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -9010,6 +9010,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to An error occurred while writing the output file: {0}.
+        '''</summary>
+        Friend ReadOnly Property ERR_PeWritingFailure() As String
+            Get
+                Return ResourceManager.GetString("ERR_PeWritingFailure", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Cannot embed interop types from assembly &apos;{0}&apos; because it is missing the &apos;{1}&apos; attribute..
         '''</summary>
         Friend ReadOnly Property ERR_PIAHasNoAssemblyGuid1() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5348,6 +5348,6 @@
     <value>Combined length of user strings used by the program exceeds allowed limit. Try to decrease use of string or XML literals.</value>
   </data>
   <data name="ERR_PeWritingFailure" xml:space="preserve">
-    <value>An error occurred while writing the output file.</value>
+    <value>An error occurred while writing the output file: {0}</value>
   </data>
 </root>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/EmitTestStrongNameProvider.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/EmitTestStrongNameProvider.vb
@@ -11,6 +11,8 @@ Partial Public Class InternalsVisibleToAndStrongNameTests
     Private Class StrongNameProviderWithBadInputStream
         Inherits StrongNameProvider
         Private _underlyingProvider As StrongNameProvider
+        Public Property ThrownException As Exception
+
         Public Sub New(underlyingProvider As StrongNameProvider)
             _underlyingProvider = underlyingProvider
         End Sub
@@ -25,7 +27,8 @@ Partial Public Class InternalsVisibleToAndStrongNameTests
         End Function
 
         Friend Overrides Function CreateInputStream() As Stream
-            Throw New IOException("This is a test IOException")
+            ThrownException = New IOException("This is a test IOException")
+            Throw ThrownException
         End Function
 
         Friend Overrides Function CreateKeys(keyFilePath As String, keyContainerName As String, messageProvider As CommonMessageProvider) As StrongNameKeys
@@ -53,8 +56,8 @@ End Class
                 </file>
             </compilation>, options:=options)
 
-        comp.VerifyEmitDiagnostics(
-            Diagnostic(ERRID.ERR_PeWritingFailure).WithArguments("This is a test IOException").WithLocation(1, 1))
+        comp.Emit(New MemoryStream()).Diagnostics.Verify(
+            Diagnostic(ERRID.ERR_PeWritingFailure).WithArguments(testProvider.ThrownException.ToString()).WithLocation(1, 1))
 
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/CompilationEmitTests.vb
@@ -2939,14 +2939,14 @@ End Module
             Dim emitResult As EmitResult
 
             Using output = New BrokenStream()
-                output.BreakHow = 0
+                output.BreakHow = BrokenStream.BreakHowType.ThrowOnWrite
                 emitResult = compilation.Emit(output, Nothing, Nothing, Nothing)
-            End Using
 
-            CompilationUtils.AssertTheseDiagnostics(emitResult.Diagnostics,
+                CompilationUtils.AssertTheseDiagnostics(emitResult.Diagnostics,
 <expected>
-BC37256: An error occurred while writing the output file.
+BC37256: An error occurred while writing the output file: <%= output.ThrownException.ToString() %>
 </expected>)
+            End Using
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateMethodCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateMethodCrossLanguageTests.vb
@@ -3,10 +3,17 @@
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateMethod
     Partial Public Class GenerateMethodCrossLanguageTests
         Inherits AbstractCrossLanguageUserDiagnosticTest
+
+        Private ReadOnly _outputHelper As ITestOutputHelper
+
+        Public Sub New(outputHelper As ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, language As String) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
             If language = LanguageNames.CSharp Then
@@ -56,7 +63,7 @@ public class VBClass
 end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -93,7 +100,7 @@ public class VBClass
 end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -135,7 +142,7 @@ public class VBClass
 end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -169,7 +176,7 @@ end class
                     end interface
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -211,7 +218,7 @@ end class
                     end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -286,7 +293,7 @@ end class
                     }
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -327,7 +334,7 @@ end class
                     end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -368,7 +375,7 @@ end class
     end class
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -413,7 +420,7 @@ end class
                     }
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
@@ -458,7 +465,7 @@ end class
                     }]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -513,7 +520,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -583,7 +590,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -653,7 +660,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -733,7 +740,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         Public Async Function GenerateMethodUsingTypeConstraint_3BaseTypeConstraints_CommonDerived() As Task
@@ -821,7 +828,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -906,7 +913,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -998,7 +1005,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
         <WorkItem(608827, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608827")>
@@ -1071,7 +1078,7 @@ Module Program
 End Module]]>
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
 
 #Region "Normal tests"

--- a/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateVariableCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateVariableCrossLanguageTests.vb
@@ -3,10 +3,17 @@
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateVariable
     Partial Public Class GenerateVariableCrossLanguageTests
         Inherits AbstractCrossLanguageUserDiagnosticTest
+
+        Private ReadOnly _outputHelper As ITestOutputHelper
+
+        Public Sub New(outputHelper As ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace, language As String) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
             If language = LanguageNames.CSharp Then
@@ -52,7 +59,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics.GenerateVariable
                     }
                 </text>.Value.Trim()
 
-            Await TestAsync(input, expected)
+            Await TestAsync(input, expected, onAfterWorkspaceCreated:=Sub(w) w.SetTestLogger(AddressOf _outputHelper.WriteLine))
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.vb
@@ -7,12 +7,21 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Roslyn.Utilities
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.FindReferences
     Partial Public Class FindReferencesTests
+        Private ReadOnly _outputHelper As ITestOutputHelper
+
+        Public Sub New(outputHelper As ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         Private Async Function TestAsync(definition As XElement, Optional searchSingleFileOnly As Boolean = False, Optional uiVisibleOnly As Boolean = False) As Task
 
             Using workspace = Await TestWorkspace.CreateAsync(definition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
+
                 For Each cursorDocument In workspace.Documents.Where(Function(d) d.CursorPosition.HasValue)
                     Dim cursorPosition = cursorDocument.CursorPosition.Value
 

--- a/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/AliasTests.vb
@@ -1,13 +1,20 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class AliasTests
+        Private ReadOnly _outputHelper As ITestOutputHelper
+
+        Sub New(outputHelper As ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <WorkItem(543759, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543759")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -27,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceAndAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -48,7 +55,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceButNotDifferentlyNamedAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -70,7 +77,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructedTypeAliasFromUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -94,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructedTypeAliasFromDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -116,7 +123,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructedTypeAliasFromDeclaration2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -138,7 +145,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasFromUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -160,7 +167,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasFromDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -182,7 +189,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleSpecialTypeAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -204,7 +211,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleSpecialTypeDoubleAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -227,7 +234,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -249,7 +256,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -282,7 +289,7 @@ public class C3
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToSameNameNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -310,7 +317,7 @@ public class C3
         <WorkItem(586743, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586743")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameOneDuplicateAliasToNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -339,7 +346,7 @@ public class C3
         <WorkItem(542693, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542693")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameOuterAliasWithNestedAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -365,7 +372,7 @@ namespace N
         <WorkItem(10028, "DevDiv_Projects/Roslyn")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConflictWithAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -395,7 +402,7 @@ class C1
         <WorkItem(579200, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/579200")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug579200_RenameNestedAliasTarget()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -423,7 +430,7 @@ namespace N
         <WorkItem(579214, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/579214")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug579214_RenameAttributeNamedDynamic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -440,7 +447,7 @@ class C : [|$$dynamic|]::Object { }
         <WorkItem(629695, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/629695")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug629695_DetectConflictWithAliasInSameBlockCompUnit()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -485,7 +492,7 @@ class Program
         <WorkItem(629695, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/629695")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug629695_DetectConflictWithAliasInSameBlockNSDecl()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -533,7 +540,7 @@ namespace X
         <WorkItem(629695, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/629695")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug629695_DetectConflictWithAliasInSameBlockWithEscaping()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -581,7 +588,7 @@ namespace X
         <WorkItem(603365, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603365"), WorkItem(745833, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/745833")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug603365_RenameAliasToClassNameOnlyFixesAliasUsages_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -609,7 +616,7 @@ namespace N
         <WorkItem(603365, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603365")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug603365_RenameAliasToClassNameOnlyFixesAliasUsages_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -639,7 +646,7 @@ namespace N
         <WorkItem(632303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632303")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToAttributeAndEndingWithAttributeAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -674,7 +681,7 @@ class Program
         <WorkItem(632303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632303")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToAttributeAndEndingWithAttributeAttributeWithResolvedConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -711,7 +718,7 @@ class Program
         <WorkItem(529531, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529531")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToNullableWithResolvedConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/DeclarationConflictTests.vb
@@ -2,14 +2,20 @@
 
 Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
+
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class DeclarationConflictTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <WpfFact(Skip:="917043")>
         <WorkItem(917043, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/917043")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictForDelegate()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -31,7 +37,7 @@ class C
         <WorkItem(917043, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/917043")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictForIsolatedScopes()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -55,7 +61,7 @@ class C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenFields()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -75,7 +81,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenFieldAndMethodDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -95,7 +101,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenPropertyAndFieldDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -115,7 +121,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenMethodDeclarations()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -135,7 +141,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenParameterDeclarations()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -154,7 +160,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenMethodsOfDifferentSignature()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -173,7 +179,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenMemberDeclarationsWithOutOrRefDifferenceOnly()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -193,7 +199,7 @@ class Foo
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenMethodsDifferingByArity()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -213,7 +219,7 @@ class Foo
         <WorkItem(546429, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546429")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictWithNamespaceDefinedInMetadata()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -228,7 +234,7 @@ namespace [|$$Foo|] { }
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictWithEquallyNamedNamespaces()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -245,7 +251,7 @@ namespace N1 { }
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictInFieldInitializerOfFieldAndModuleNameResolvedThroughFullQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -276,7 +282,7 @@ class [|$$C|]
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_NoConflictBetweenLambdaParameterAndField()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -296,7 +302,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeParametersInTypeDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -317,7 +323,7 @@ class Program<{|declconflict:A|}, [|$$B|]>
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeParametersInMethodDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -340,7 +346,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeParametersInMethodDeclaration_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -363,7 +369,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeParameterAndMember_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -386,7 +392,7 @@ class Program<{|declconflict:@a|}>
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeParameterAndMember_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -408,7 +414,7 @@ class Program<{|declconflict:@a|}>
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_OverridingImplicitlyUsedMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -449,7 +455,7 @@ class C : A
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_OverridingImplicitlyUsedMethod_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -489,7 +495,7 @@ class C : A
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_OverridingImplicitlyUsedMethod_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -527,7 +533,7 @@ class C : A
         <WorkItem(851604, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/851604")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictInsideAttributeArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -550,7 +556,7 @@ class C
         <WorkItem(6306, "https://github.com/dotnet/roslyn/issues/6306")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ResolveConflictInAnonymousTypeProperty()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -574,7 +580,7 @@ class C
         <WorkItem(6308, "https://github.com/dotnet/roslyn/issues/6308")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ResolveConflictWhenAnonymousTypeIsUsedAsGenericArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/CSharp/EscapingTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/EscapingTests.vb
@@ -4,10 +4,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class EscapingTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingToEscapedKeyword1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -25,7 +31,7 @@ class [|$$Foo|]
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingToEscapedKeyword2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -44,7 +50,7 @@ class {|escaped:$$Foo|}
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub UseFullAttributeNameWhenShortNameIsKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -70,7 +76,7 @@ class [|$$MainAttribute|] : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeAttributeIfKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -97,7 +103,7 @@ class {|escaped:$$MainAttribute|} : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DoNotStickTokensTogetherForRefParameter_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -117,7 +123,7 @@ class {|escaped:$$MainAttribute|} : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DoNotStickTokensTogetherForRefParameter_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -136,7 +142,7 @@ class {|escaped:$$MainAttribute|} : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedIdentifierUnescapes()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -157,7 +163,7 @@ class {|escaped:$$MainAttribute|} : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedIdentifierUnescapes_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -179,7 +185,7 @@ class {|escaped:$$MainAttribute|} : System.Attribute
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedIdentifierUnescapes_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>

--- a/src/EditorFeatures/Test2/Rename/CSharp/GenericTypeParameterTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/GenericTypeParameterTests.vb
@@ -2,10 +2,16 @@
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class GenericTypeParameterTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <WorkItem(403671, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/403671")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CustomerReported_ErrorTolerance()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>

--- a/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/ImplicitReferenceConflictTests.vb
@@ -5,10 +5,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class ImplicitReferenceConflictTests
 
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextCausesConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -46,7 +52,7 @@ class C
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextInVBCausesConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
 
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -93,7 +99,7 @@ class D
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextInVBToUpperCaseOnlyCausesConflictInCSForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
 
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Rename/CSharp/InteractiveTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/InteractiveTests.vb
@@ -2,10 +2,16 @@
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class InteractiveTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingTopLevelMethodsSupported()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Submission Language="C#" CommonReferences="true">
 void [|$$Foo|]()

--- a/src/EditorFeatures/Test2/Rename/CSharp/InterfaceTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/InterfaceTests.vb
@@ -2,10 +2,16 @@
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class InterfaceTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <WorkItem(546205, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546205")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameExplicitlyImplementedInterfaceMemberFromDefinition()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -28,7 +34,7 @@ class C : I
         <WorkItem(546205, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546205")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameExplicitlyImplementedInterfaceMemberFromImplementation()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -51,7 +57,7 @@ class C : I
         <WorkItem(546205, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546205")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameExplicitlyImplementedInterfaceMemberWithInterfaceInNamespace()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -76,7 +82,7 @@ class C : N.I
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInterfaceForExplicitlyImplementedInterfaceMemberWithInterfaceInNamespace()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>

--- a/src/EditorFeatures/Test2/Rename/CSharp/LocalConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/CSharp/LocalConflictTests.vb
@@ -4,11 +4,17 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.CSharp
     Public Class LocalConflictTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(539939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539939")>
         Public Sub ConflictingLocalWithLocal()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -33,7 +39,7 @@ class Program
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(539939, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539939")>
         Public Sub ConflictingLocalWithParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -56,7 +62,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingLocalWithForEachRangeVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -81,7 +87,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingLocalWithForLoopVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -106,7 +112,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingLocalWithUsingBlockVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -131,7 +137,7 @@ class Program : IDisposable
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingLocalWithSimpleLambdaParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -157,7 +163,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingLocalWithParenthesizedLambdaParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -183,7 +189,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictingFromClauseWithLetClause()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -215,7 +221,7 @@ class C
         <WorkItem(543407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543407")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLabelsInSameMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -243,7 +249,7 @@ public class C
         <WorkItem(543407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543407")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLabelInMethodAndLambda()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -271,7 +277,7 @@ public class C
         <WorkItem(543407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543407")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLabelsInLambda()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -298,7 +304,7 @@ public class C
         <WorkItem(543407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543407")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenLabelsInTwoNonNestedLambdas()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -324,7 +330,7 @@ public class C
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(545468, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545468")>
         Public Sub NoConflictsWithCatchBlockWithoutExceptionVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -353,7 +359,7 @@ class Test
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(1081066, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1081066")>
         Public Sub NoConflictsBetweenCatchClauses()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -378,7 +384,7 @@ class Test
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(1081066, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1081066")>
         Public Sub ConflictsWithinCatchClause()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -404,7 +410,7 @@ class Test
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(546163, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546163")>
         Public Sub NoConflictsWithCatchExceptionWithoutDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -433,7 +439,7 @@ class Test
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(992721, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/992721")>
         Public Sub ConflictingLocalWithFieldWithExtensionMethodInvolved()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
             <Workspace>
                 <Project Language="C#" CommonReferences="true">
                     <Document>

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -16,6 +16,12 @@ Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Public Class InlineRenameTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <WpfFact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Async Function SimpleEditAndCommit() As Task
@@ -635,7 +641,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameWithInheritenceCascadingWithClass()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>

--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -10,6 +10,7 @@ Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.VisualStudio.Text
 Imports Xunit.Sdk
 Imports Microsoft.CodeAnalysis.Options
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     ''' <summary>
@@ -54,8 +55,9 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             _renameTo = renameTo
         End Sub
 
-        Public Shared Function Create(workspaceXml As XElement, renameTo As String, Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing) As RenameEngineResult
+        Public Shared Function Create(helper As ITestOutputHelper, workspaceXml As XElement, renameTo As String, Optional changedOptionSet As Dictionary(Of OptionKey, Object) = Nothing) As RenameEngineResult
             Dim workspace = TestWorkspace.CreateWorkspace(workspaceXml)
+            workspace.SetTestLogger(AddressOf helper.WriteLine)
 
             Dim engineResult As RenameEngineResult = Nothing
             Try

--- a/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineResult.vb
@@ -84,15 +84,10 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
                     Next
                 End If
 
-                AssertIsComplete(workspace.CurrentSolution)
-
                 Dim locations = RenameLocations.FindAsync(symbol, workspace.CurrentSolution, optionSet, CancellationToken.None).Result
                 Dim originalName = symbol.Name.Split("."c).Last()
 
                 Dim result = ConflictResolver.ResolveConflictsAsync(locations, originalName, renameTo, optionSet, hasConflict:=Nothing, cancellationToken:=CancellationToken.None).Result
-
-                AssertIsComplete(result.OldSolution)
-                AssertIsComplete(result.NewSolution)
 
                 engineResult = New RenameEngineResult(workspace, result, renameTo)
                 engineResult.AssertUnlabeledSpansRenamedAndHaveNoConflicts()
@@ -108,15 +103,6 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
 
             Return engineResult
         End Function
-
-        Private Shared Sub AssertIsComplete(currentSolution As Solution)
-            ' Ensure we don't have a partial solution. This is to detect for possible root causes of
-            ' https://github.com/dotnet/roslyn/issues/9298
-
-            If currentSolution.Projects.Any(Function(p) Not p.HasCompleteReferencesAsync().Result) Then
-                AssertEx.Fail("We have an incomplete project floating around which we should not.")
-            End If
-        End Sub
 
         Friend ReadOnly Property ConflictResolution As ConflictResolution
             Get

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.CSharpConflicts.vb
@@ -3,13 +3,19 @@
 Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
-    Partial Public Class RenameEngineTest
+    Partial Public Class RenameEngineTests
         Public Class CSharpConflicts
+            Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+            Sub New(outputHelper As Abstractions.ITestOutputHelper)
+                _outputHelper = outputHelper
+            End Sub
+
             <WpfFact(Skip:="799977")>
             <WorkItem(773543, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773543")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithRollBacksInsideLambdas_2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -37,7 +43,7 @@ class C
             <WorkItem(773534, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773534")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithRollBacksInsideLambdas_1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -69,7 +75,7 @@ class C
             <WorkItem(773435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773435")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithInvocationOnDelegateInstance()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -100,7 +106,7 @@ class C
             <WorkItem(782020, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/782020")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithSameClassInOneNamespace()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -128,7 +134,7 @@ namespace N
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameCrossAssembly()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true" AssemblyName="VBAssembly1">
                             <ProjectReference>CSAssembly1</ProjectReference>
@@ -160,7 +166,7 @@ public class [|C|]
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInsideLambdaBody()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -208,7 +214,7 @@ class Proaasgram
             <WorkItem(1069237, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1069237")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInsideExpressionBodiedLambda()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -234,7 +240,7 @@ public class B
             <WorkItem(1069237, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1069237")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInsideExpressionBodiedLambda2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -259,7 +265,7 @@ public class B
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInsideMethodBody()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -287,7 +293,7 @@ public class B
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInInvocationWithLambda_1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -337,7 +343,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInInvocationWithLambda_2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -387,7 +393,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInInvocationWithLambda_3()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -437,7 +443,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInInvocationWithLambda_4()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -487,7 +493,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionInInvocationWithLambda_5()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -537,7 +543,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceField1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -562,7 +568,7 @@ class Foo
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceField2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -589,7 +595,7 @@ class Foo
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceFieldRenamingToKeyword()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -616,7 +622,7 @@ class Foo
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithStaticField()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -643,7 +649,7 @@ class Foo
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithFieldFromAnotherLanguage()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <ProjectReference>VisualBasicAssembly</ProjectReference>
@@ -675,7 +681,7 @@ End Class
             <WorkItem(539745, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539745")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictingTypeDeclaration()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true" LanguageVersion="CSharp6">
                             <Document><![CDATA[
@@ -722,7 +728,7 @@ static class C<T>
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingToInvalidIdentifier()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -742,7 +748,7 @@ class {|Invalid:$$Foo|}
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingToInvalidIdentifier2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -764,7 +770,7 @@ class {|Invalid:$$Foo|}
             <WorkItem(539636, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539636")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingToConflictingMethodInvocation()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -794,7 +800,7 @@ class Program
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingToConflictingMethodInvocation2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -825,7 +831,7 @@ class Program
             Public Sub RenamingTypeToConflictingMemberAndParentTypeName()
                 ' It's important that we see conflicts for both simultaneously, so I do a single
                 ' test for both cases.
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -849,7 +855,7 @@ class {|Conflict:Foo|}
             <WorkItem(539733, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539733")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingMemberToNameConflictingWithParent()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -870,7 +876,7 @@ class {|Conflict:Foo|}
             <WorkItem(540199, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540199")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenamingMemberToInvalidIdentifierName()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -889,7 +895,7 @@ class {|Invalid:$$Foo|}
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MinimalQualificationOfBaseType1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -915,7 +921,7 @@ class Y : X
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MinimalQualificationOfBaseType2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -942,7 +948,7 @@ class Y : X
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
             Public Sub EscapeIfKeywordWhenDoingTypeNameQualification()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -969,7 +975,7 @@ static class Foo
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
             Public Sub EscapeUnboundGenericTypesInTypeOfContext()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1004,7 +1010,7 @@ class Program
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
             Public Sub EscapeUnboundGenericTypesInTypeOfContext2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1040,7 +1046,7 @@ class Program
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
             Public Sub EscapeUnboundGenericTypesInTypeOfContext3()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1083,7 +1089,7 @@ class Program
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542651, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542651")>
             Public Sub ReplaceAliasWithGenericTypeThatIncludesArrays()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1111,7 +1117,7 @@ class Program
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542651, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542651")>
             Public Sub ReplaceAliasWithGenericTypeThatIncludesPointers()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1139,7 +1145,7 @@ class Program
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542651, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542651")>
             Public Sub ReplaceAliasWithNestedGenericType()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1170,7 +1176,7 @@ class B
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542103")>
             Public Sub RewriteConflictingExtensionMethodCallSite()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -1201,7 +1207,7 @@ static class E
             <WorkItem(528902, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528902")>
             <WorkItem(645152, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/645152")>
             Public Sub RewriteConflictingExtensionMethodCallSiteWithReturnTypeChange()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -1231,7 +1237,7 @@ static class E
             <WorkItem(535068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535068")>
             <WorkItem(542821, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542821")>
             Public Sub RewriteConflictingExtensionMethodCallSiteRequiringTypeArguments()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1263,7 +1269,7 @@ static class E
             <WorkItem(535068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535068")>
             <WorkItem(542103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542103")>
             Public Sub RewriteConflictingExtensionMethodCallSiteInferredTypeArguments()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -1293,7 +1299,7 @@ static class E
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub DoNotDetectQueryContinuationNamedTheSame()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -1322,7 +1328,7 @@ class C
             <WorkItem(543027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543027")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameHandlesUsingWithoutDeclaration()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -1351,7 +1357,7 @@ class Program
             <WorkItem(543027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543027")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameHandlesForWithoutDeclaration()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -1378,7 +1384,7 @@ class Program
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeSuffix()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1403,7 +1409,7 @@ public class [|$$SomethingAttribute|] : Attribute
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAddAttributeSuffix()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1427,7 +1433,7 @@ public class [|$$SomethingAttribute|] : Attribute
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameKeepAttributeSuffixOnUsages()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1451,7 +1457,7 @@ public class [|$$SomethingAttribute|] : Attribute
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameToConflictWithValue()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1480,7 +1486,7 @@ class C
             <WorkItem(543482, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543482")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeWithConflictingUse()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1508,7 +1514,7 @@ class [|$$Main|] : System.Attribute
             <WorkItem(542649, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542649")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub QualifyTypeWithGlobalWhenConflicting()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test.cs">
@@ -1532,7 +1538,7 @@ class B
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSymbolConflictWithLocals()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1559,7 +1565,7 @@ class C
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(528738, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528738")>
         Public Sub RenameAliasToCatchConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1582,7 +1588,7 @@ namespace X
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAttributeToCreateConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1608,7 +1614,7 @@ class [|$$Main|] : Attribute // Rename 'Main' to 'Special'
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameUsingToKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1635,7 +1641,7 @@ class B
         <WorkItem(16809, "http://vstfdevdiv:8080/DevDiv_Projects/Roslyn/_workitems/edit/16809")>
         <WorkItem(535066, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535066")>
         Public Sub RenameInNestedClasses()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1672,7 +1678,7 @@ namespace N
         <WorkItem(531433, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531433")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAndEscapeContextualKeywordsInCSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1693,7 +1699,7 @@ class [|t$$o|] // Rename 'to' to 'from'
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(522774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/522774")>
         Public Sub RenameCrefWithConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1730,7 +1736,7 @@ class C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameClassContainingAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1757,7 +1763,7 @@ class [|$$B|]
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameFunctionWithOverloadConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1782,7 +1788,7 @@ class Bar
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameActionWithFunctionConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1811,7 +1817,7 @@ class Program
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(552522, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552522")>
         Public Sub RenameFunctionNameToDelegateTypeConflict1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1842,7 +1848,7 @@ class A
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(552520, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552520")>
         Public Sub RenameFunctionNameToDelegateTypeConflict2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1871,7 +1877,7 @@ class A
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameFunctionNameToDelegateTypeConflict3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1903,7 +1909,7 @@ class A
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(552520, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552520")>
         Public Sub RenameFunctionNameToDelegateTypeConflict4()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1936,7 +1942,7 @@ class A
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(552722, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552722")>
         Public Sub RenameActionTypeConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1965,7 +1971,7 @@ class A
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(552722, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/552722")>
         Public Sub RenameConflictAttribute1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -1987,7 +1993,7 @@ class [|$$FooAttribute|] : System.Attribute
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConflictAttribute2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2011,7 +2017,7 @@ class AAttributeAttribute : Attribute
         <WorkItem(576573, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/576573")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug576573_ConflictAttributeWithNamespace()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2042,7 +2048,7 @@ namespace X
         <WorkItem(579602, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/579602")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug579602_RenameFunctionWithDynamicParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2073,7 +2079,7 @@ class A
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub IdentifyConflictsWithVar()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2101,7 +2107,7 @@ class [|$$vor|]
         <WorkItem(633180, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633180")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_DetectOverLoadResolutionChangesInEnclosingInvocations()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2140,7 +2146,7 @@ static class E
         <WorkItem(635622, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/635622")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ExpandingDynamicAddsObjectCast()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2170,7 +2176,7 @@ class C
         <WorkItem(673562, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673562")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceConflictsAndResolves()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2205,7 +2211,7 @@ namespace N
         <WorkItem(673667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673667")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameUnnecessaryExpansion()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2237,7 +2243,7 @@ namespace N
         <WorkItem(768910, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/768910")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInCrefPreservesWhitespaceTrivia()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2276,7 +2282,7 @@ public class A
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2305,7 +2311,7 @@ class C
         <WorkItem(725934, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/725934")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_This()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2334,7 +2340,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_Nested()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2364,7 +2370,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_ReferenceType()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2391,7 +2397,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_ConstructedTypeArgumentNonGenericContainer()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2421,7 +2427,7 @@ class D<T>
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_SameTypeParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2449,7 +2455,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_ArrayTypeParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2476,7 +2482,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_MultiDArrayTypeParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2503,7 +2509,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_UsedAsArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2530,7 +2536,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_UsedInConstructorInitialization()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2557,7 +2563,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_CalledOnObject()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2584,7 +2590,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_UsedInGenericDelegate()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2611,7 +2617,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_UsedInNonGenericDelegate()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2638,7 +2644,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_MultipleTypeParameters()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2666,7 +2672,7 @@ class C
         <WorkItem(730781, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730781")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_ConflictInDerived()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2695,7 +2701,7 @@ class D : C
         <WorkItem(728653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/728653")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameGenericInvocationWithDynamicArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2722,7 +2728,7 @@ class C
         <WorkItem(728646, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/728646")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ExpandInvocationInStaticMemberAccess()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2756,7 +2762,7 @@ class D
         <WorkItem(728628, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/728628")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RecursiveTypeParameterExpansionFail()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2784,7 +2790,7 @@ class C<T>
         <WorkItem(728575, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/728575")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithProperBracesForTypeInferenceAdditionToMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2810,7 +2816,7 @@ class C
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_GenericBase()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2840,7 +2846,7 @@ class D : C<int>
         <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
         <WpfFact(Skip:="Story 736967"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub GenericNameTypeInferenceExpansion_InErrorCode()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2877,7 +2883,7 @@ class C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CS_ConflictBetweenTypeNamesInTypeConstraintSyntax()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -2907,7 +2913,7 @@ internal abstract partial class AbstractReferenceFinder<TSymbol> : IReferenceFin
         <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub MemberQualificationInNameOfUsesTypeName_StaticReferencingInstance()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2932,7 +2938,7 @@ class C
         <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingStatic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2957,7 +2963,7 @@ class C
         <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -2982,7 +2988,7 @@ class C
         <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub MemberQualificationInNameOfMethodInvocationUsesThisDot()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3009,7 +3015,7 @@ class C
         <WorkItem(1053, "https://github.com/dotnet/roslyn/issues/1053")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameComplexifiesInLambdaBodyExpression()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3031,7 +3037,7 @@ class C
         <WorkItem(1053, "https://github.com/dotnet/roslyn/issues/1053")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameComplexifiesInExpressionBodiedMembers()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3054,7 +3060,7 @@ class C
         <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestConflictBetweenClassAndInterface1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3072,7 +3078,7 @@ interface [|$$I|] { }
         <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestConflictBetweenClassAndInterface2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3090,7 +3096,7 @@ interface {|conflict:I|} { }
         <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestConflictBetweenClassAndNamespace1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3108,7 +3114,7 @@ namespace N { }
         <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestConflictBetweenClassAndNamespace2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3126,7 +3132,7 @@ namespace [|$$N|] { }
         <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestNoConflictBetweenTwoNamespaces()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3142,7 +3148,7 @@ namespace N2 { }
         <WorkItem(1729, "https://github.com/dotnet/roslyn/issues/1729")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestNoConflictWithParametersOrLocalsOfDelegateType()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3175,7 +3181,7 @@ class C
         <WorkItem(1729, "https://github.com/dotnet/roslyn/issues/1729")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub TestConflictWithLocalsOfDelegateTypeWhenBindingChangesToNonDelegateLocal()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document FilePath="Test.cs"><![CDATA[
@@ -3202,7 +3208,7 @@ class C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoCrashOrConflictOnRenameWithNameOfInAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3223,7 +3229,7 @@ class C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictWhenNameOfReferenceDoesNotBindToAnyOriginalSymbols()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3247,7 +3253,7 @@ class C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictWhenNameOfReferenceDoesNotBindToSomeOriginalSymbols()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3266,7 +3272,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictWhenNameOfReferenceBindsToSymbolForFirstTime()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3285,7 +3291,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictWhenNameOfReferenceChangesBindingFromMetadataToSource()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3311,7 +3317,7 @@ class Program
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub InvalidNamesDoNotCauseCrash_IntroduceQualifiedName()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3331,7 +3337,7 @@ class {|conflict:C$$|} { }
         Public Sub InvalidNamesDoNotCauseCrash_AccidentallyPasteLotsOfCode()
             Dim renameTo = "class C { public void M() { for (int i = 0; i < 10; i++) { System.Console.Writeline(""This is a test""); } } }"
 
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -3349,7 +3355,7 @@ class {|conflict:C$$|} { }
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DeclarationConflictInFileWithoutReferences_SameProject()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document FilePath="Test1.cs">
@@ -3381,7 +3387,7 @@ class Program2
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DeclarationConflictInFileWithoutReferences_DifferentProjects()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true" AssemblyName="CSAssembly1">
                            <Document FilePath="Test1.cs">
@@ -3417,7 +3423,7 @@ class Program2
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DeclarationConflictInFileWithoutReferences_PartialTypes()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document FilePath="Test1.cs">
@@ -3447,7 +3453,7 @@ partial class C
         <WorkItem(1439, "https://github.com/dotnet/roslyn/issues/1439")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInsideNameOf1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -3474,7 +3480,7 @@ class Program
         <WorkItem(1439, "https://github.com/dotnet/roslyn/issues/1439")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInsideNameOf2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -3501,7 +3507,7 @@ class Program
         <WorkItem(1439, "https://github.com/dotnet/roslyn/issues/1439")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInsideNameOf3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -3531,7 +3537,7 @@ class Program
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
         Public Sub RenameTypeParameterInPartialClass()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -3547,7 +3553,7 @@ partial class C&lt;[|T|]&gt; {}
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
         Public Sub RenameMethodToConflictWithTypeParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.VisualBasicConflicts.vb
@@ -4,13 +4,20 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Partial Public Class RenameEngineTests
+
         Public Class VisualBasicConflicts
+            Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+            Sub New(outputHelper As Abstractions.ITestOutputHelper)
+                _outputHelper = outputHelper
+            End Sub
+
             <WpfFact(Skip:="798375, 799977")>
             <WorkItem(798375, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/798375")>
             <WorkItem(773543, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773543")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithRollBacksInsideLambdas_2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -38,7 +45,7 @@ End Class
             <WorkItem(773534, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773534")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithRollBacksInsideLambdas()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -68,7 +75,7 @@ End Class
             <WorkItem(857937, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/857937")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub HandleInvocationExpressions()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -88,7 +95,7 @@ End Module
             <WorkItem(773435, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773435")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithInvocationOnDelegateInstance()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -114,7 +121,7 @@ End Class
             <WorkItem(782020, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/782020")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub BreakingRenameWithSameClassInOneNamespace()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -139,7 +146,7 @@ End Namespace
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub OverloadResolutionConflictResolve_1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -195,7 +202,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub OverloadResolutionConflictResolve_2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -256,7 +263,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub OverloadResolutionConflictResolve_3()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -322,7 +329,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub OverloadResolutionConflictResolve_4()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -388,7 +395,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameStatementWithResolvingAndUnresolvingConflictInSameStatement_VB()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -427,7 +434,7 @@ End Module
             <WorkItem(729401, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/729401")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub IntroduceWhitespaceTriviaToInvocationIfCallKeywordIsIntroduced()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document FilePath="Test.vb">
@@ -459,7 +466,7 @@ End Class
             <WorkItem(728646, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/728646")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ExpandInvocationInStaticMemberAccess()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document FilePath="Test.vb">
@@ -497,7 +504,7 @@ End Class
             <Fact()>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_Me()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -531,7 +538,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -564,7 +571,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_Nested()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -599,7 +606,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_ReferenceType()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -627,7 +634,7 @@ End Module
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136"), WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103"), WorkItem(755801, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755801")>
             <WpfFact(Skip:="755801"), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_Cref()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -655,7 +662,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_DifferentScope1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -690,7 +697,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_ConstructedTypeArgumentGenericContainer()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -718,7 +725,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_ConstructedTypeArgumentNonGenericContainer()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -748,7 +755,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_ObjectType()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -776,7 +783,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_SameTypeParameter()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -805,7 +812,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_MultiDArrayTypeParameter()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -834,7 +841,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_UsedAsArgument()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -864,7 +871,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_UsedInConstructorInitialization()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -894,7 +901,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_CalledOnObject()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -922,7 +929,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_UsedInGenericDelegate()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -950,7 +957,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_UsedInNonGenericDelegate()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -978,7 +985,7 @@ End Class
             <WorkItem(639136, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/639136")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_MultipleTypeParameters()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1007,7 +1014,7 @@ End Class
             <WorkItem(730781, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/730781")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ConflictResolutionWithTypeInference_ConflictInDerived()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1044,7 +1051,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceField()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1068,7 +1075,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceFieldRenamingToKeyword()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1094,7 +1101,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithInstanceFieldRenamingToKeyword2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1117,7 +1124,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithSharedField()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1141,7 +1148,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ParameterConflictingWithFieldInModule()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1165,7 +1172,7 @@ End Module
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MinimalQualificationOfBaseType1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1196,7 +1203,7 @@ End Module
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MinimalQualificationOfBaseType2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1227,7 +1234,7 @@ End Module
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub PreserveTypeCharactersForKeywordsAsIdentifiers()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1256,7 +1263,7 @@ End Class
             <WorkItem(543016, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543016")>
             <WpfFact(Skip:="529695"), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameDoesNotBreakQuery()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                         <Workspace>
                             <Project Language="Visual Basic" CommonReferences="true">
                                 <Document>
@@ -1289,7 +1296,7 @@ End Class
             <WorkItem(566460, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/566460")>
             <WorkItem(542349, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542349")>
             Public Sub ProperlyEscapeNewKeywordWithTypeCharacters()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1316,7 +1323,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub AvoidDoubleEscapeAttempt()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1336,7 +1343,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ReplaceAliasWithNestedGenericType()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1370,7 +1377,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(540440, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540440")>
             Public Sub RenamingFunctionWithFunctionVariableFromFunction()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1392,7 +1399,7 @@ End Module
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(540440, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540440")>
             Public Sub RenamingFunctionWithFunctionVariableFromFunctionVariable()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1415,7 +1422,7 @@ End Module
             <WorkItem(542999, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542999")>
             <WorkItem(566542, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/566542")>
             Public Sub ResolveConflictingTypeIncludedThroughModule1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -1446,7 +1453,7 @@ End Namespace
             <WorkItem(543068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543068")>
             <WorkItem(566542, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/566542")>
             Public Sub ResolveConflictingTypeIncludedThroughModule2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -1477,7 +1484,7 @@ End Namespace
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(543068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543068")>
             Public Sub ResolveConflictingTypeImportedFromMultipleTypes()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -1510,7 +1517,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542936, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542936")>
             Public Sub ConflictWithImplicitlyDeclaredLocal()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -1533,7 +1540,7 @@ End Module
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(542886, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542886")>
             Public Sub RenameForRangeVariableUsedInLambda()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -1558,7 +1565,7 @@ End Module
             <WorkItem(543021, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543021")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ShouldNotCascadeToExplicitlyImplementedInterfaceMethodOfDifferentName()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1584,7 +1591,7 @@ End Structure
             <WorkItem(543021, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543021")>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub ShouldNotCascadeToImplementingMethodOfDifferentName()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -1609,7 +1616,7 @@ End Structure
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeSuffix()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -1633,7 +1640,7 @@ End Class]]></Document>
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeFromUsage()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -1659,7 +1666,7 @@ End Class]]></Document>
                 ' This is a simple scenario but it has a somewhat strange tree in VB. The
                 ' BeginTerminator of the ElseBlockSyntax is missing, and just so happens to land at
                 ' the same location as the NewMethod invocation that follows the Else.
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1684,7 +1691,7 @@ End Module
             <WorkItem(11004, "DevDiv_Projects/Roslyn")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameImplicitlyDeclaredLocal()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1709,7 +1716,7 @@ End Module
             <WorkItem(11004, "DevDiv_Projects/Roslyn")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameFieldToConflictWithImplicitlyDeclaredLocal()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1738,7 +1745,7 @@ End Module
             <WorkItem(543420, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543420")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameParameterOfEvent()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1758,7 +1765,7 @@ End Class
             <WorkItem(543587, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543587")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameLocalInMethodMissingParameterList()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1780,7 +1787,7 @@ End Module
             <WorkItem(542649, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542649")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub QualifyTypeWithGlobalWhenConflicting()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1805,7 +1812,7 @@ End Class
             <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub QualifyFieldInReDimStatement()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1830,7 +1837,7 @@ End Module
             <WorkItem(545604, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545604")>
             <WpfFact(Skip:="566542"), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub QualifyTypeNameInImports()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1856,7 +1863,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameNewOverload()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1891,7 +1898,7 @@ End Class
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeRequiringReducedNameToResolveConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -1920,7 +1927,7 @@ End Class
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameEvent()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1955,7 +1962,7 @@ class C : I
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameInterfaceImplementation()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -1982,7 +1989,7 @@ End Class
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameAttributeConflictWithNamespace()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2011,7 +2018,7 @@ End Namespace
             Public Sub RenameREMToUnicodeREM()
                 Dim text = ChrW(82) & ChrW(69) & ChrW(77)
                 Dim compareText = "[" & text & "]"
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -2027,7 +2034,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameImports()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2057,7 +2064,7 @@ End Module
             <WorkItem(578105, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578105")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug578105_VBRenamingPartialMethodDifferentCasing()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2080,7 +2087,7 @@ End Class
             <WorkItem(588142, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/588142")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug588142_SimplifyAttributeUsageCanAlwaysEscapeInVB()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2103,7 +2110,7 @@ End Class
             <WorkItem(588038, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/588038")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug588142_RenameAttributeToAttribute()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2127,7 +2134,7 @@ End Class
             <WorkItem(576573, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/576573")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug576573_ConflictAttributeWithNamespace()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2156,7 +2163,7 @@ End Namespace
             <WorkItem(603368, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603368")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug603368_ConflictAttributeWithNamespaceCaseInsensitive()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2185,7 +2192,7 @@ End Namespace
             <WorkItem(603367, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603367")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug603367_ConflictAttributeWithNamespaceCaseInsensitive2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2213,7 +2220,7 @@ End Class
             <WorkItem(603276, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603276")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug603276_ConflictAttributeWithNamespaceCaseInsensitive3()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2236,7 +2243,7 @@ End Class
             <WorkItem(529712, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529712")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug529712_ConflictNamespaceWithModuleName_1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb"><![CDATA[
@@ -2267,7 +2274,7 @@ End Namespace
             <WorkItem(529837, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529837")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug529837_ResolveConflictByOmittingModuleName()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2301,7 +2308,7 @@ End Namespace
             <WorkItem(529989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529989")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub Bug529989_RenameCSharpIdentifierToInvalidVBIdentifier()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2329,7 +2336,7 @@ End Namespace
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameModuleBetweenAssembly()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <ProjectReference>Project2</ProjectReference>
@@ -2362,7 +2369,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameModuleClassConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2401,7 +2408,7 @@ End Namespace
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameModuleNamespaceNested()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2438,7 +2445,7 @@ End Module
 
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameModuleConflictWithInterface()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2470,7 +2477,7 @@ End Namespace                             </Document>
             <WorkItem(628700, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/628700")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameModuleConflictWithLocal()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2501,7 +2508,7 @@ End Namespace
             <WorkItem(633180, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633180")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub VB_DetectOverLoadResolutionChangesInEnclosingInvocations()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2552,7 +2559,7 @@ End Module
             <WorkItem(673562, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673562"), WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameNamespaceConflictsAndResolves()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -2581,7 +2588,7 @@ End Namespace
             <WorkItem(673667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673667")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameUnnecessaryExpansion()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2608,7 +2615,7 @@ End Namespace
             <WorkItem(645152, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/645152")>
             <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub AdjustTriviaForExtensionMethodRewrite()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -2638,7 +2645,7 @@ End Module
             <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameCrefWithConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document>
@@ -2673,7 +2680,7 @@ End Class
             <WorkItem(768910, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/768910")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub RenameInCrefPreservesWhitespaceTrivia()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -2706,7 +2713,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(1016652, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1016652")>
             Public Sub VB_ConflictBetweenTypeNamesInTypeConstraintSyntax()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -2739,7 +2746,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
             Public Sub RenamingCompilerGeneratedPropertyBackingField_InvokeFromProperty()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2762,7 +2769,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(905, "https://github.com/dotnet/roslyn/issues/905")>
             Public Sub RenamingCompilerGeneratedPropertyBackingField_IntroduceConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2809,7 +2816,7 @@ End Class
             <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MemberQualificationInNameOfUsesTypeName_StaticReferencingInstance()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2831,7 +2838,7 @@ End Class
             <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingStatic()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2853,7 +2860,7 @@ End Class
             <WorkItem(1193, "https://github.com/dotnet/roslyn/issues/1193")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub MemberQualificationInNameOfUsesTypeName_InstanceReferencingInstance()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document>
@@ -2875,7 +2882,7 @@ End Class
             <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub TestConflictBetweenClassAndInterface1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2895,7 +2902,7 @@ End Interface
             <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub TestConflictBetweenClassAndInterface2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2915,7 +2922,7 @@ End Interface
             <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub TestConflictBetweenClassAndNamespace1()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2935,7 +2942,7 @@ End Namespace
             <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub TestConflictBetweenClassAndNamespace2()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2955,7 +2962,7 @@ End Namespace
             <WorkItem(1027506, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1027506")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub TestNoConflictBetweenTwoNamespaces()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2973,7 +2980,7 @@ End Namespace
             <WorkItem(1195, "https://github.com/dotnet/roslyn/issues/1195")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub NameOfReferenceNoConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -2995,7 +3002,7 @@ End Class
             <WorkItem(1195, "https://github.com/dotnet/roslyn/issues/1195")>
             <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub NameOfReferenceWithConflict()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -3018,7 +3025,7 @@ End Class
             <Fact>
             <Trait(Traits.Feature, Traits.Features.Rename)>
             Public Sub InvalidNamesDoNotCauseCrash_IntroduceQualifiedName()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -3044,7 +3051,7 @@ Class C
         System.Console.WriteLine(""Hello, Test!"")
     End Sub
 End Class"
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document FilePath="Test.cs"><![CDATA[
@@ -3064,7 +3071,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
             Public Sub RenameTypeParameterInPartialClass()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                         <Workspace>
                             <Project Language="Visual Basic" CommonReferences="true">
                                 <Document><![CDATA[
@@ -3084,7 +3091,7 @@ End Class
             <Trait(Traits.Feature, Traits.Features.Rename)>
             <WorkItem(7440, "https://github.com/dotnet/roslyn/issues/7440")>
             Public Sub RenameMethodToConflictWithTypeParameter()
-                Using result = RenameEngineResult.Create(
+                Using result = RenameEngineResult.Create(_outputHelper,
                         <Workspace>
                             <Project Language="Visual Basic" CommonReferences="true">
                                 <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameEngineTests.vb
@@ -13,12 +13,17 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     ''' there is no fancy logic applied to it.
     ''' </summary>
     Partial Public Class RenameEngineTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <WorkItem(543661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543661")>
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CannotRenameNamespaceAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -39,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
         <WorkItem(813409, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/813409")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeDoesNotRenameGeneratedConstructorCalls()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                    <Workspace>
                        <Project Language="C#" CommonReferences="true">
                            <Document>
@@ -58,7 +63,7 @@ struct [|$$Type|]
         <WorkItem(856078, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/856078")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub UnmodifiedDocumentsAreNotCheckedOutBySourceControl()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document FilePath="Test1.cs">
@@ -86,7 +91,7 @@ class C2
         <WorkItem(773400, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773400")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ReferenceConflictInsideDelegateLocalNotRenamed()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -116,7 +121,7 @@ class C
         <WorkItem(773673, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/773673")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoreThanOneTokenInUnResolvedStatement()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -144,7 +149,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInvocationExpressionAcrossProjects()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test1.cs">
@@ -176,7 +181,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInvocationExpressionAcrossProjectsWithPartialClass()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test1.cs">
@@ -212,7 +217,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInvocationExpressionAcrossProjectsWithConflictResolve()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test1.cs">
@@ -256,7 +261,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RollBackExpandedConflicts_WithinInvocationExpression()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                             <Workspace>
                                 <Project Language="C#" CommonReferences="true">
                                     <Document>
@@ -285,7 +290,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RollBackExpandedConflicts_WithinQuery()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                             <Workspace>
                                 <Project Language="Visual Basic" CommonReferences="true">
                                     <Document>
@@ -307,7 +312,7 @@ class {|unresolve3:$$D|} // Rename to C
         Public Sub RenameOverloadCSharp()
             Dim changingOptions = New Dictionary(Of OptionKey, Object)()
             changingOptions.Add(RenameOptions.RenameOverloads, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                             <Workspace>
                                 <Project Language="C#" CommonReferences="true">
                                     <Document>
@@ -345,7 +350,7 @@ class {|unresolve3:$$D|} // Rename to C
         Public Sub RenameOverloadVisualBasic()
             Dim changingOptions = New Dictionary(Of OptionKey, Object)()
             changingOptions.Add(RenameOptions.RenameOverloads, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                             <Workspace>
                                 <Project Language="Visual Basic" CommonReferences="true">
                                     <Document>
@@ -384,7 +389,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, WorkItem(761929, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/761929"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictCheckInInvocationCSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -417,7 +422,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, WorkItem(761922, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/761922"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictCheckInInvocationVisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -443,7 +448,7 @@ class {|unresolve3:$$D|} // Rename to C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameType()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -468,7 +473,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeAcrossFiles()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#">
                         <Document>
@@ -501,7 +506,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeAcrossProjectsAndLanguages()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document>
@@ -539,7 +544,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpTypeFromConstructorDefinition()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -565,7 +570,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpTypeFromConstructorUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -591,7 +596,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpTypeFromDestructor()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -611,7 +616,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpTypeFromSynthesizedConstructorUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -633,7 +638,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpPredefinedTypeVariables1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -657,7 +662,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpPredefinedTypeVariables2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -681,7 +686,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpPredefinedTypeVariables3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -705,7 +710,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicPredefinedTypeVariables1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -725,7 +730,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicPredefinedTypeVariables2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -745,7 +750,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicPredefinedTypeVariables3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -765,7 +770,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(539801, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539801")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpEnumMemberToContainingEnumName()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -785,7 +790,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(5886, "https://github.com/dotnet/roslyn/pull/5886")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpEnumToEnumMemberName()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -804,7 +809,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicTypeFromConstructorUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -828,7 +833,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicTypeFromSynthesizedConstructorUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -848,7 +853,7 @@ class {|unresolve3:$$D|} // Rename to C
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespace()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -869,7 +874,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(6874, "http://vstfdevdiv:8080/DevDiv_Projects/Roslyn/_workitems/edit/6874")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicEnum()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -889,7 +894,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(6874, "http://vstfdevdiv:8080/DevDiv_Projects/Roslyn/_workitems/edit/6874")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicEnumMember()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -909,7 +914,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(539525, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539525")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DoNothingRename()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -931,7 +936,7 @@ class {|unresolve3:$$D|} // Rename to C
         <WorkItem(553631, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/553631")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpBugfix553631()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -959,7 +964,7 @@ class Program
         <WorkItem(553631, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/553631")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VisualBasicBugfix553631()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -991,7 +996,7 @@ End Class
         <WorkItem(541697, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541697")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameExtensionMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1020,7 +1025,7 @@ End Class
         <WorkItem(542202, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542202")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpIndexerNamedArgument1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1046,7 +1051,7 @@ End Class
         <WorkItem(542106, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542106")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCSharpIndexerNamedArgument2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1071,7 +1076,7 @@ End Class
         <WorkItem(541928, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541928")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameRangeVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1098,7 +1103,7 @@ End Class
         <WorkItem(542106, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542106")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicParameterizedPropertyNamedArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1128,7 +1133,7 @@ End Class
         <WorkItem(543340, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543340")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIndexerParameterFromDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1153,7 +1158,7 @@ class Program
         <WorkItem(543340, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543340")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIndexerParameterFromUseInsideGetAccessor()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1178,7 +1183,7 @@ class Program
         <WorkItem(543340, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543340")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIndexerParameterFromUseInsideSetAccessor()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1203,7 +1208,7 @@ class Program
         <WorkItem(542492, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542492")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialMethodParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1233,7 +1238,7 @@ partial class Test
         <WorkItem(528820, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528820")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVisualBasicAnonymousKey()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1258,7 +1263,7 @@ partial class Test
         <WorkItem(542543, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542543")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIncludesPreviouslyInvalidReference()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1285,7 +1290,7 @@ partial class Test
         <WorkItem(543027, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543027")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameVariableInQueryAsUsingStatement()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1322,7 +1327,7 @@ class MyManagedType : System.IDisposable
         <WorkItem(543169, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543169")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub LambdaWithOutParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1352,7 +1357,7 @@ class D
         <WorkItem(543567, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543567")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CascadeBetweenOverridingProperties()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document FilePath="Test.vb">
@@ -1390,7 +1395,7 @@ End Class
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(529799, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529799")>
         Public Sub CascadeBetweenImplementedInterfaceEvent()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document FilePath="Test.vb">
@@ -1415,7 +1420,7 @@ End Class
         <WorkItem(543567, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543567")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CascadeBetweenEventParameters()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -1442,7 +1447,7 @@ class Bar : IFoo
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(531260, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531260")>
         Public Sub DoNotCascadeToMetadataSymbols()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1463,7 +1468,7 @@ class Bar : IFoo
         <WorkItem(545473, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545473")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialTypeParameter_CSharp1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -1484,7 +1489,7 @@ partial class Class1
         <WorkItem(545473, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545473")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialTypeParameter_CSharp2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document><![CDATA[
@@ -1505,7 +1510,7 @@ partial class Class1
         <WorkItem(545472, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545472")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialTypeParameter_VB1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -1526,7 +1531,7 @@ End Module
         <WorkItem(545472, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545472")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialTypeParameter_VB2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -1548,7 +1553,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub AmbiguousBeforeRenameHandledCorrectly_Bug11516()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1571,7 +1576,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub AmbiguousBeforeRenameHandledCorrectly_Bug11516_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1595,7 +1600,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialMethods_1_CS()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1622,7 +1627,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialMethods_2_CS()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1649,7 +1654,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialMethods_1_VB()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1673,7 +1678,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamePartialMethods_2_VB()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1697,7 +1702,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug530740()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1736,7 +1741,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMethodThatImplementsInterfaceMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1769,7 +1774,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DoNotRemoveAttributeSuffixOn__Attribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1792,7 +1797,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEventParameterOnUsage()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1816,7 +1821,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCompilerGeneratedBackingFieldForNonCustomEvent()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1840,7 +1845,7 @@ End Module
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCompilerGeneratedEventHandlerForNonCustomEvent()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1866,7 +1871,7 @@ End Module
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpRenameParenthesizedFunctionName()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1890,7 +1895,7 @@ End Module
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VisualBasicAwaitAsIdentifierInAsyncShouldBeEscaped()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1915,7 +1920,7 @@ End Module
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpAwaitAsIdentifierInAsyncMethodShouldBeEscaped0()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1950,7 +1955,7 @@ class M
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpAwaitAsIdentifierInAsyncLambdaShouldBeEscaped()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -1984,7 +1989,7 @@ class s
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpAwaitAsIdentifierInAsyncLambdaShouldBeEscaped1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -2019,7 +2024,7 @@ class s
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharpAwaitAsIdentifierInAsyncLambdaShouldNotBeEscaped()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -2053,7 +2058,7 @@ class s
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VBRoundTripMissingModuleName_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -2084,7 +2089,7 @@ class s
         <Fact()>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VBRoundTripMissingModuleName_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -2115,7 +2120,7 @@ class s
         <WorkItem(603767, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603767")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug603767_RenamePartialAttributeDeclarationWithDifferentCasingAndCSharpUsage()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2147,7 +2152,7 @@ class s
         <WorkItem(603371, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603371")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug603371_VisualBasicRenameAttributeToGlobal()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2168,7 +2173,7 @@ class s
         <WorkItem(603371, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/603371")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug603371_VisualBasicRenameAttributeToGlobal_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2189,7 +2194,7 @@ class s
         <WorkItem(602494, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/602494")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug602494_RenameOverrideWithNoOverriddenMember()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2208,7 +2213,7 @@ class s
         <WorkItem(576607, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/576607")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug576607()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2233,7 +2238,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_VisualBasicOverrideImplicitPropertyAccessor()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2264,7 +2269,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_VisualBasicOverrideImplicitPropertyAccessor_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2295,7 +2300,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_VisualBasicOverrideImplicitPropertyAccessor_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2335,7 +2340,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_CrossLanguageOverrideImplicitPropertyAccessor_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2380,7 +2385,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_CrossLanguageOverrideImplicitPropertyAccessor_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2429,7 +2434,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_CrossLanguageOverrideImplicitPropertyAccessor_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2478,7 +2483,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_CrossLanguageOverrideImplicitPropertyAccessor_4()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2544,7 +2549,7 @@ End Class
         <WorkItem(529765, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529765")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug529765_CrossLanguageOverrideImplicitPropertyAccessor_5()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2603,7 +2608,7 @@ End Class
         <WorkItem(610120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/610120")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug610120_CrossLanguageOverrideImplicitPropertyAccessorConflictWithVBProperty()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2666,7 +2671,7 @@ End Class
         <WorkItem(612380, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/612380")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug612380_CrossLanguageOverrideImplicitPropertyAccessorCascadesToInterface()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2723,7 +2728,7 @@ End Class
         <WorkItem(866094, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/866094")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug866094()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2751,7 +2756,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameDynamicallyBoundFunction()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2781,7 +2786,7 @@ class A
         <WorkItem(529989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529989")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharp_RenameToIdentifierWithUnicodeEscaping()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2804,7 +2809,7 @@ public class A
         <WorkItem(576966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/576966")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharp_RenameParenthesizedMethodNames()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2827,7 +2832,7 @@ class C
         <WorkItem(632052, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632052")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CSharp_RenameParameterUsedInObjectInitializer()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2857,7 +2862,7 @@ class C
         <WorkItem(624092, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/624092")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub LocationsIssue()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -2896,7 +2901,7 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameParam1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -2923,7 +2928,7 @@ class Program
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameParam1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -2945,7 +2950,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameParam2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -2974,7 +2979,7 @@ End Class]]>
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameParam2_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -2996,7 +3001,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeParam1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -3025,7 +3030,7 @@ class B<[|T|]>
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeParam1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -3056,7 +3061,7 @@ End Class]]>
         <WorkItem(624310, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/624310")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug624310_VBCascadeLambdaParameterInFieldInitializer()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                         <Document>
@@ -3080,7 +3085,7 @@ End Class]]>
         <WorkItem(624310, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/624310")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug624310_CSNoCascadeLambdaParameterInFieldInitializer()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3101,7 +3106,7 @@ class Program
         <WorkItem(633582, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/633582")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug633582_CSDoNotAddParenthesesInExpansionForParenthesizedBinaryExpression()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3131,7 +3136,7 @@ class Program
         <Fact(Skip:="https://github.com/dotnet/roslyn/issues/9412")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameExplicitInterfaceImplementation()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3162,7 +3167,7 @@ namespace X
         <WorkItem(529803, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529803")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingEventCascadesToCSUsingEventHandlerDelegate()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3212,7 +3217,7 @@ class Program : IA
         <WorkItem(529803, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529803")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingCompilerGeneratedDelegateTypeForEventCascadesBackToEvent_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3262,7 +3267,7 @@ class Program : IA
         <WorkItem(529803, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529803")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingCompilerGeneratedDelegateTypeForEventCascadesBackToEvent_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3312,7 +3317,7 @@ class Program : IA
         <WorkItem(655621, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/655621")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingCompilerGeneratedDelegateTypeForEventCascadesBackToEvent_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3344,7 +3349,7 @@ class C
         <WorkItem(655621, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/655621")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingCompilerGeneratedDelegateTypeForEventCascadesBackToEvent_4()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3376,7 +3381,7 @@ class C
         <WorkItem(655621, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/655621"), WorkItem(762094, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/762094")>
         <WpfFact(Skip:="762094"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingCompilerGeneratedDelegateTypeForEventCascadesBackToEvent_5()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3408,7 +3413,7 @@ Class C
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameVarNotSupported()
             Assert.ThrowsAny(Of ArgumentException)(Sub()
-                                                       Dim result = RenameEngineResult.Create(
+                                                       Dim result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3434,7 +3439,7 @@ namespace X
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameCustomTypeNamedVarSupported()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3467,7 +3472,7 @@ namespace X
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameDynamicNotSupported()
             Assert.ThrowsAny(Of ArgumentException)(Sub()
-                                                       Dim result = RenameEngineResult.Create(
+                                                       Dim result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3493,7 +3498,7 @@ namespace X
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToVarSupported()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3517,7 +3522,7 @@ class [|Program|]
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToVarSupportedButConflictsWithOtherVar()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3543,7 +3548,7 @@ class [|Program|]
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToVarSupportedButDoesntConflictsWithOtherVarOfSameType()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3569,7 +3574,7 @@ class [|Program|]
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToDynamicSupported()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3593,7 +3598,7 @@ class [|Program|]
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToDynamicSupportedButConflictsWithOtherDynamic_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3619,7 +3624,7 @@ class [|Program|]
         <WorkItem(627297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/627297")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub Bug622086_CSRenameToDynamicSupportedButConflictsWithOtherDynamic_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                         <Document><![CDATA[
@@ -3647,7 +3652,7 @@ class [|Program|]
         <WorkItem(608989, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608989")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceInVbFromCSharReference()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
@@ -3676,7 +3681,7 @@ class Y : [|$$N|].X { }
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeFromCref()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3700,7 +3705,7 @@ class [|Program|]
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameTypeFromCref_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document>
@@ -3721,7 +3726,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMemberFromCref()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3745,7 +3750,7 @@ class Program
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMemberFromCref_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document>
@@ -3766,7 +3771,7 @@ End Class
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefFromMember()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3790,7 +3795,7 @@ class Program
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefFromMember_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document>
@@ -3812,7 +3817,7 @@ End Class
         <WorkItem(546952, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546952")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIncludingCrefContainingAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3840,7 +3845,7 @@ class {|yAttribute:F$$ooAttribute|} : Attribute
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIncludingCrefContainingAttribute_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document>
@@ -3865,7 +3870,7 @@ End Class
         <WorkItem(546952, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546952")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameFromCrefContainingAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3892,7 +3897,7 @@ class {|yAttribute:FooAttribute|} : Attribute
         <WorkItem(546952, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546952"), WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameFromCrefContainingAttribute_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" AssemblyName="VisualBasicAssembly" CommonReferences="true">
                         <Document FilePath="Test.vb">
@@ -3917,7 +3922,7 @@ End Class
         <WorkItem(531015, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531015")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefTypeParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" AssemblyName="CSharpAssembly" CommonReferences="true">
                         <Document FilePath="Test.cs">
@@ -3935,7 +3940,7 @@ class C<T> { }
         <WorkItem(640373, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/640373")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -3970,7 +3975,7 @@ class Tester
         <WorkItem(640373, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/640373")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4001,7 +4006,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4037,7 +4042,7 @@ class Tester
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref2_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4070,7 +4075,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4091,7 +4096,7 @@ class C<[|$$T|]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref3_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4113,7 +4118,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref4()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4136,7 +4141,7 @@ class C<T>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref4_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4161,7 +4166,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref5()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4183,7 +4188,7 @@ class {|Resolve:C|}<T>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref5_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4205,7 +4210,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref6()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4233,7 +4238,7 @@ class [|C|]
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref6_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4259,7 +4264,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref7()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4304,7 +4309,7 @@ namespace Test
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref7_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4342,7 +4347,7 @@ End Namespace]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref8()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4376,7 +4381,7 @@ class B : C, I
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref8_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4407,7 +4412,7 @@ End Class]]>
 
         <WpfFact(Skip:="640502"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref9()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4442,7 +4447,7 @@ class B : C, I
 
         <Fact(), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref9_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4474,7 +4479,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref10()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4508,7 +4513,7 @@ class C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref10_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4539,7 +4544,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref11()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4566,7 +4571,7 @@ class Test
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref11_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4589,7 +4594,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref12()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4624,7 +4629,7 @@ class Bar
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref12_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4655,7 +4660,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref13()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4690,7 +4695,7 @@ public class Bar
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref13_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4720,7 +4725,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref14()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4757,7 +4762,7 @@ public class A
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref14_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4786,7 +4791,7 @@ End Class]]>
         <WorkItem(673562, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673562")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref15()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4818,7 +4823,7 @@ namespace N
         <WorkItem(673562, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673562")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref15_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4847,7 +4852,7 @@ End Namespace]]>
         <WorkItem(673667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673667"), WorkItem(760850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/760850")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref17()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4880,7 +4885,7 @@ class P
         <WorkItem(673667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673667"), WorkItem(760850, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/760850")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref17_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -4911,7 +4916,7 @@ End Class]]>
         <WorkItem(673667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673667")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCref18()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4944,7 +4949,7 @@ namespace N
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithUsing1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -4978,7 +4983,7 @@ namespace N1
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithUsing1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5011,7 +5016,7 @@ End Namespace
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithUsing2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5050,7 +5055,7 @@ namespace N2
         <WorkItem(767163, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/767163")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithUsing2_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5086,7 +5091,7 @@ End Namespace
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithInterface()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5121,7 +5126,7 @@ namespace N
         <WorkItem(569103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/569103")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefWithInterface_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5151,7 +5156,7 @@ End Namespace]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefCrossAssembly()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <ProjectReference>VBAssembly</ProjectReference>
@@ -5197,7 +5202,7 @@ End Namespace
         <WorkItem(767163, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/767163")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameCrefCrossAssembly_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <ProjectReference>CSAssembly</ProjectReference>
@@ -5240,7 +5245,7 @@ namespace [|$$N|]
         <WorkItem(673809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673809")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameStaticConstructorInsideCref1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5269,7 +5274,7 @@ class [|P|]
         <WorkItem(673809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673809")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameStaticConstructorInsideCref1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5295,7 +5300,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameStaticConstructorInsideCref2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5324,7 +5329,7 @@ class [|P|]
         <WorkItem(673809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673809")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameStaticConstructorInsideCref2_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5350,7 +5355,7 @@ End Class]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInheritanceCref1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5378,7 +5383,7 @@ class Q : P
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameInheritanceCref1_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5405,7 +5410,7 @@ End Class]]>
         <WorkItem(673858, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673858"), WorkItem(666167, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/666167")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameGenericTypeCrefWithConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5446,7 +5451,7 @@ namespace N
         <WorkItem(673858, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673858"), WorkItem(666167, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/666167"), WorkItem(768000, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/768000")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameGenericTypeCrefWithConflict_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5483,7 +5488,7 @@ End Namespace]]>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNestedNamespaceToParent1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5505,7 +5510,7 @@ namespace N
         <WorkItem(673641, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673641")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNestedNamespaceToParent2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5535,7 +5540,7 @@ namespace N
         <WorkItem(673809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/673809")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameStaticConstructor()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5560,7 +5565,7 @@ class [|Simple|]
         <WorkItem(675882, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/675882")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub SingleOnlyLocalDeclarationInsideLambdaRecurseInfinitely()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5585,7 +5590,7 @@ End Module
         <WorkItem(641231, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/641231")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameDontReplaceBaseConstructorToken_CSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document><![CDATA[
@@ -5615,7 +5620,7 @@ class Program
         <WorkItem(641231, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/641231")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameDontReplaceBaseConstructorToken_VisualBasic()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" CommonReferences="true">
                             <Document><![CDATA[
@@ -5646,7 +5651,7 @@ End Class
         <WorkItem(674762, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/674762")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMergedNamespaceAcrossProjects()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5672,7 +5677,7 @@ namespace [|N|] { }
         <WorkItem(674764, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/674764")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMergedNamespaceAcrossProjects_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5698,7 +5703,7 @@ namespace [|N|] { }
         <WorkItem(716278, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/716278")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMainWithoutAssertFailureVB()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5722,7 +5727,7 @@ End Module
         <WorkItem(716278, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/716278")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMainWithoutAssertFailureCSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="C#" CommonReferences="true">
                         <Document>
@@ -5748,7 +5753,7 @@ class Program
         <WorkItem(719062, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719062")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedIdentifierToUnescapedIdentifier()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5772,7 +5777,7 @@ End Module
         <WorkItem(719062, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719062")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedIdentifierToUnescapedIdentifierKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5797,7 +5802,7 @@ End Module
         <WorkItem(767187, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/767187")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEscapedTypeNew()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5819,7 +5824,7 @@ End Class
         <WorkItem(767187, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/767187")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructorInCref()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5838,7 +5843,7 @@ class [|C|]
         <WorkItem(1009633, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1009633")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameWithTryCatchBlock1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5861,7 +5866,7 @@ End Class
         <WorkItem(1009633, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1009633")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameWithTryCatchBlock2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5889,7 +5894,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, False)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5919,7 +5924,7 @@ End Module
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, False)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5951,7 +5956,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -5983,7 +5988,7 @@ End Module
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6015,7 +6020,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6039,7 +6044,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, False)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6065,7 +6070,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6090,7 +6095,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, False)
             renamingOptions.Add(RenameOptions.RenameInComments, False)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6118,7 +6123,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6152,7 +6157,7 @@ End Module
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6185,7 +6190,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6218,7 +6223,7 @@ End Module
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6251,7 +6256,7 @@ public class [|$$Program|]
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6290,7 +6295,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6330,7 +6335,7 @@ public class AnotherFile
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6375,7 +6380,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6419,7 +6424,7 @@ public class AnotherFile
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6490,7 +6495,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6558,7 +6563,7 @@ public class NotReferencingProject
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6601,7 +6606,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6637,7 +6642,7 @@ End Class
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6669,7 +6674,7 @@ End Module
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameInStrings, True)
             renamingOptions.Add(RenameOptions.RenameInComments, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6699,7 +6704,7 @@ class {|Conflict:foo|}
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMethodWithNameof_NoOverloads_CSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6720,7 +6725,7 @@ class C
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMethodWithNameof_WithOverloads_CSharp()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[
@@ -6747,7 +6752,7 @@ class C
         Public Sub RenameMethodWithNameof_WithOverloads_WithRenameOverloadsOption_CSharp()
             Dim renamingOptions = New Dictionary(Of OptionKey, Object)()
             renamingOptions.Add(RenameOptions.RenameOverloads, True)
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
                             <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
@@ -7,11 +7,16 @@ Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
     Public Class RenameNonRenameableSymbols
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub CannotRenameInheritedMetadataButRenameCascade()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>
@@ -48,7 +53,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameEventWithInvalidNames()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="C#" CommonReferences="true">
                             <Document>

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/AliasTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/AliasTests.vb
@@ -4,11 +4,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class AliasTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleSpecialTypeAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -28,7 +33,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleSpecialTypeDoubleAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -49,7 +54,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -69,7 +74,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -98,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToSameNameNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -123,7 +128,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <WorkItem(586743, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586743")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameOneDuplicateAliasToNoConflict()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -146,7 +151,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <WorkItem(541393, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541393")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameNamespaceAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -169,7 +174,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
         <WorkItem(545614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545614")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructedTypeAliasFromUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -192,7 +197,7 @@ End Module
         <WorkItem(545614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545614")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameConstructedTypeAliasFromDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -216,7 +221,7 @@ End Module
         <WorkItem(545614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545614")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasFromUse()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -239,7 +244,7 @@ End Module
         <WorkItem(545614, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545614")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameSimpleTypeAliasFromDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -261,7 +266,7 @@ End Module
         <WorkItem(546084, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546084")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictWhenRenamingAliasToSameAsGlobalTypeName()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -289,7 +294,7 @@ End Class
         <WorkItem(632303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632303")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToAttributeAndEndingWithAttributeAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -324,7 +329,7 @@ end class
         <WorkItem(632303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632303")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToAttributeAndEndingWithAttributeAttributeNoConflict1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -360,7 +365,7 @@ end class
         <WorkItem(632303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/632303")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameAliasToAttributeAndEndingWithAttributeAttributeWithConflict1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/CallSiteConflictResolutionTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/CallSiteConflictResolutionTests.vb
@@ -4,12 +4,18 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class CallSiteConflictResolutionTests
-        <WpfFact(skip:="535068")>
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
+        <WpfFact(Skip:="535068")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(542103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542103")>
         <WorkItem(535068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535068")>
         Public Sub RewriteConflictingExtensionMethodCallSite()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -42,7 +48,7 @@ End Module
         <WorkItem(542821, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542821")>
         <WorkItem(535068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535068")>
         Public Sub RewriteConflictingExtensionMethodCallSiteRequiringTypeArguments()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -75,7 +81,7 @@ End Module
         <WorkItem(542821, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542821")>
         <WorkItem(535068, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/535068")>
         Public Sub RewriteConflictingExtensionMethodCallSiteInferredTypeArguments()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -107,7 +113,7 @@ End Module
         <WorkItem(539636, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539636")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub QualifyConflictingMethodInvocation()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/DeclarationConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/DeclarationConflictTests.vb
@@ -4,10 +4,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class DeclarationConflictTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenFields()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -27,7 +33,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenFieldAndMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -48,7 +54,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenTwoMethodsWithSameSignature()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -71,7 +77,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenTwoParameters()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -91,7 +97,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenMethodsWithDifferentSignatures()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -114,7 +120,7 @@ End Module
         <WorkItem(543245, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543245")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenTwoLocals()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -137,7 +143,7 @@ End Module
         <WorkItem(543245, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543245")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLocalAndParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -159,7 +165,7 @@ End Module
         <WorkItem(545859, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545859")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenQueryVariableAndParameter()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -181,7 +187,7 @@ End Module
         <WorkItem(545859, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545859")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenTwoQueryVariables()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -204,7 +210,7 @@ End Module
         <WorkItem(543654, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543654")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLambdaParametersInsideMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -228,7 +234,7 @@ End Module
         <WorkItem(543654, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543654")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLambdaParametersInFieldInitializer()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -250,7 +256,7 @@ End Module
         <WorkItem(543654, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543654")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenLambdaParameterAndField()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -271,7 +277,7 @@ End Module
         <WorkItem(543407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543407")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenLabels()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -298,7 +304,7 @@ End Class
         <WorkItem(543308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543308")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenMethodsDifferingByByRef()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -323,7 +329,7 @@ End Module
         <WorkItem(543308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543308")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenMethodsDifferingByOptional()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -348,7 +354,7 @@ End Module
         <WorkItem(543308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543308")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub NoConflictBetweenMethodsDifferingByArity()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -372,7 +378,7 @@ End Module
         <WorkItem(546902, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546902")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenImplicitlyDeclaredLocalAndNamespace()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -396,7 +402,7 @@ End Module
         <WorkItem(529556, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529556")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenImplicitlyDeclaredLocalAndAndGlobalFunction()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -425,7 +431,7 @@ End Module
         <WorkItem(542217, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542217")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenAliases()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -452,7 +458,7 @@ End Namespace
         <WorkItem(530125, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530125")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenImplicitVariableAndClass()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -480,7 +486,7 @@ End Module
         <WorkItem(530038, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530038")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenEquallyNamedAlias()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -512,7 +518,7 @@ End Class
         <WorkItem(610120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/610120")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenEquallyNamedPropertyAndItsParameter_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -539,7 +545,7 @@ End Class
         <WorkItem(610120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/610120")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenEquallyNamedPropertyAndItsParameter_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -592,7 +598,7 @@ End Class
         <WorkItem(610120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/610120")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictBetweenEquallyNamedPropertyAndItsParameter_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -619,7 +625,7 @@ End Class
         <WorkItem(608198, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/608198"), WorkItem(798375, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/798375")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictInFieldInitializerOfFieldAndModuleNameResolvedThroughFullQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -640,7 +646,7 @@ End Module
         <WorkItem(528706, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528706")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForForEachLoopVariableNotBindingToTypeAnyMore()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -672,7 +678,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForForEachLoopVariableAndRangeVariable_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -705,7 +711,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForForEachLoopVariableAndRangeVariable_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -738,7 +744,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForForEachLoopVariableAndRangeVariable_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -773,7 +779,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForForEachLoopVariableAndRangeVariable_4()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -807,7 +813,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForUsingVariableAndRangeVariable_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -840,7 +846,7 @@ End Namespace
         <WorkItem(530476, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530476")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForUsingVariableAndRangeVariable_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -871,7 +877,7 @@ End Namespace
         <WorkItem(653311, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/653311")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForUsingVariableAndRangeVariable_3()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -900,7 +906,7 @@ End Namespace
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictForCatchVariable_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -929,7 +935,7 @@ End Namespace
         <WorkItem(529986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529986")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenTypeParametersInTypeDeclaration()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -948,7 +954,7 @@ End Class
         <WorkItem(529986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529986")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenTypeParametersInMethodDeclaration_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -969,7 +975,7 @@ End Class
         <WorkItem(529986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529986")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenTypeParametersInMethodDeclaration_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -990,7 +996,7 @@ End Class
         <WorkItem(529986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529986")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenTypeParameterAndMember_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1011,7 +1017,7 @@ End Class
         <WorkItem(529986, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529986")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenTypeParameterAndMember_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1031,7 +1037,7 @@ End Class
         <WorkItem(658437, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/658437")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_ConflictBetweenEscapedForEachControlVariableAndQueryRangeVariable()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -1062,7 +1068,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_OverridingImplicitlyUsedMethod()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -1105,7 +1111,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_OverridingImplicitlyUsedMethod_1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -1148,7 +1154,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub VB_OverridingImplicitlyUsedMethod_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -1188,7 +1194,7 @@ End Class
         <WorkItem(851604, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/851604")>
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub ConflictInsideSimpleArgument()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/EscapingTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/EscapingTests.vb
@@ -4,10 +4,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class EscapingTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeTypeWhenRenamingToKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -28,7 +34,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub DoNotEscapeMethodAfterDotWhenRenamingToKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -50,7 +56,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeAttributeWhenRenamingToRegularKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -76,7 +82,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeAttributeUsageWhenRenamingToAssembly()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -103,7 +109,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeAttributeUsageWhenRenamingToModule()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -130,7 +136,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingMethodToNew()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -159,7 +165,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingMethodToRem()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -182,7 +188,7 @@ End Module
         <WorkItem(542104, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542104")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingPropertyToMid()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -209,7 +215,7 @@ End Module
         <WorkItem(542104, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542104")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingPropertyToStrangelyCasedMid()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -236,7 +242,7 @@ End Module
         <WorkItem(542166, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542166")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingToMidWithTypeCharacters1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -263,7 +269,7 @@ End Module
         <WorkItem(542166, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542166")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeWhenRenamingToMidWithTypeCharacters2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -289,7 +295,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapePreserveKeywordWhenRenamingWithRedim()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -312,7 +318,7 @@ End Module
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
         Public Sub EscapeRemKeywordWhenDoingTypeNameQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -338,7 +344,7 @@ End Module
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
         Public Sub EscapeNewKeywordWhenDoingTypeNameQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -364,7 +370,7 @@ End Module
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
         Public Sub EscapeRemKeywordWhenDoingMeQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -390,7 +396,7 @@ End Class
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(542322, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542322")>
         Public Sub DoNotEscapeIfKeywordWhenDoingMeQualification()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -416,7 +422,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeIdentifierWhenRenamingToRemKeyword()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -438,7 +444,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeIdentifierWhenRenamingToRemKeyword2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -461,7 +467,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingToEscapedIdentifierWithFullwidthSquareBracket()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -482,7 +488,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeContextualKeywordsInQuery1()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -522,7 +528,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub EscapeMidIfNeeded()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -546,7 +552,7 @@ End Module
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingToRemAndUsingTypeCharactersIsNotAllowed()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[
@@ -567,7 +573,7 @@ End Module
 
         <WpfFact(Skip:="668158"), Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameIdentifierBracketed()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -588,7 +594,7 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameToIdentifierBracketed()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">
@@ -609,7 +615,7 @@ End Module
 
         <Fact, Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameToIdentifierBracketed_2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                     <Workspace>
                         <Project Language="Visual Basic" AssemblyName="VBAssembly" CommonReferences="true">
                             <Document FilePath="Test.vb">

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/ImplicitReferenceConflictTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/ImplicitReferenceConflictTests.vb
@@ -4,12 +4,17 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class ImplicitReferenceConflictTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <Fact>
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextCausesConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -47,7 +52,7 @@ End Class
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextToChangeCasingDoesntCauseConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -84,7 +89,7 @@ End Class
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextToChangeCasingInCSDoesntCauseConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">
@@ -135,7 +140,7 @@ End Class
         <WorkItem(528966, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528966")>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenameMoveNextInCSCauseConflictInForEach()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
 
                     <Project Language="C#" AssemblyName="Project1" CommonReferences="true">

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/InvalidIdentifierTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/InvalidIdentifierTests.vb
@@ -4,10 +4,16 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class InvalidIdentifierTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingToInvalidIdentifier()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -26,7 +32,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         Public Sub RenamingToInvalidIdentifier2()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -45,7 +51,7 @@ End Class
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename), WorkItem(545164, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545164")>
         Public Sub RenamingToUnderscoreAttribute()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document><![CDATA[

--- a/src/EditorFeatures/Test2/Rename/VisualBasic/QualificationTests.vb
+++ b/src/EditorFeatures/Test2/Rename/VisualBasic/QualificationTests.vb
@@ -4,11 +4,17 @@ Imports Microsoft.CodeAnalysis.Rename.ConflictEngine
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename.VisualBasic
     Public Class QualificationTests
+        Private ReadOnly _outputHelper As Abstractions.ITestOutputHelper
+
+        Sub New(outputHelper As Abstractions.ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
+
         <Fact>
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(545576, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545576")>
         Public Sub QualifyBackingField()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
                 <Workspace>
                     <Project Language="Visual Basic" CommonReferences="true">
                         <Document>
@@ -34,7 +40,7 @@ End Class
         <Trait(Traits.Feature, Traits.Features.Rename)>
         <WorkItem(992721, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/992721")>
         Public Sub ConflictingLocalWithFieldWithExtensionMethodInvolved()
-            Using result = RenameEngineResult.Create(
+            Using result = RenameEngineResult.Create(_outputHelper,
             <Workspace>
                 <Project Language="Visual Basic" CommonReferences="true">
                     <Document>

--- a/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/Workspaces/TryFindSourceDefinitionTests.vb
@@ -7,12 +7,19 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.FindSymbols
 Imports Microsoft.CodeAnalysis.Text
 Imports Xunit
+Imports Xunit.Abstractions
 
 Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
     Public Class TryFindSourceDefinitionTests
+        Private ReadOnly _outputHelper As ITestOutputHelper
+
         Private Function GetProject(snapshot As Solution, assemblyName As String) As Project
             Return snapshot.Projects.Single(Function(p) p.AssemblyName = assemblyName)
         End Function
+
+        Public Sub New(outputHelper As ITestOutputHelper)
+            _outputHelper = outputHelper
+        End Sub
 
         <Fact>
         Public Async Function TestFindTypeInCSharpToVisualBasicProject() As Task
@@ -40,6 +47,8 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
+
                 Dim snapshot = workspace.CurrentSolution
                 Dim Type = (Await GetProject(snapshot, "CSharpAssembly").GetCompilationAsync()).GlobalNamespace.GetTypeMembers("CSClass").Single()
 
@@ -84,6 +93,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
                 Dim snapshot = workspace.CurrentSolution
                 Dim Type = (Await GetProject(snapshot, "VBAssembly").GetCompilationAsync()).GlobalNamespace.GetTypeMembers("VBClass").Single()
 
@@ -125,6 +135,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
                 Dim compilation = Await GetProject(workspace.CurrentSolution, "VBAssembly").GetCompilationAsync()
                 Dim member = compilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single().GetMembers("M").Single()
 
@@ -163,6 +174,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
                 Dim compilation = Await GetProject(workspace.CurrentSolution, "VBAssembly").GetCompilationAsync()
                 Dim member = compilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single().GetMembers("M").Single()
 
@@ -201,6 +213,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
                 Dim compilation = Await GetProject(workspace.CurrentSolution, "VBAssembly").GetCompilationAsync()
                 Dim member = compilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single().GetMembers("M").Single()
 
@@ -236,6 +249,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 </Workspace>
 
             Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition)
+                workspace.SetTestLogger(AddressOf _outputHelper.WriteLine)
                 Dim retargetedCompilation = Await GetProject(workspace.CurrentSolution, "CSharpAssembly").GetCompilationAsync()
                 Dim originalClass = retargetedCompilation.GlobalNamespace.GetMembers("N").Single().GetTypeMembers("CSClass").Single()
                 Dim retargetingCompilation = Await GetProject(workspace.CurrentSolution, "CSharpAssembly2").GetCompilationAsync()

--- a/src/Test/Utilities/Shared/Pe/BrokenStream.cs
+++ b/src/Test/Utilities/Shared/Pe/BrokenStream.cs
@@ -7,7 +7,15 @@ namespace Roslyn.Test.Utilities
 {
     internal class BrokenStream : Stream
     {
-        public int BreakHow;
+        public enum BreakHowType
+        {
+            ThrowOnSetPosition,
+            ThrowOnWrite,
+            ThrowOnSetLength
+        }
+
+        public BreakHowType BreakHow;
+        public Exception ThrownException { get; private set; }
 
         public override bool CanRead
         {
@@ -44,8 +52,11 @@ namespace Roslyn.Test.Utilities
             }
             set
             {
-                if (BreakHow == 1)
-                    throw new NotSupportedException();
+                if (BreakHow == BreakHowType.ThrowOnSetPosition)
+                {
+                    ThrownException = new NotSupportedException();
+                    throw ThrownException;
+                }
             }
         }
 
@@ -61,14 +72,20 @@ namespace Roslyn.Test.Utilities
 
         public override void SetLength(long value)
         {
-            if (BreakHow == 2)
-                throw new IOException();
+            if (BreakHow == BreakHowType.ThrowOnSetLength)
+            {
+                ThrownException = new IOException();
+                throw ThrownException;
+            }
         }
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            if (BreakHow == 0)
-                throw new IOException();
+            if (BreakHow == BreakHowType.ThrowOnWrite)
+            {
+                ThrownException = new IOException();
+                throw ThrownException;
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.CompilationTracker.cs
@@ -741,15 +741,24 @@ namespace Microsoft.CodeAnalysis
                         var declarationCompilation = await this.GetOrBuildDeclarationCompilationAsync(solution, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                         MetadataReference reference;
+
+                        solution.Workspace.LogTestMessage($"Looking for a cached skeleton assembly for {projectReference.ProjectId} before taking the lock...");
+
                         if (!MetadataOnlyReference.TryGetReference(solution, projectReference, declarationCompilation, version, out reference))
                         {
                             // using async build lock so we don't get multiple consumers attempting to build metadata-only images for the same compilation.
                             using (await _buildLock.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
                             {
+                                solution.Workspace.LogTestMessage($"Build lock taken for {ProjectState.Id}...");
+
                                 // okay, we still don't have one. bring the compilation to final state since we are going to use it to create skeleton assembly
                                 var compilationInfo = await this.GetOrBuildCompilationInfoAsync(solution, lockGate: false, cancellationToken: cancellationToken).ConfigureAwait(false);
                                 reference = MetadataOnlyReference.GetOrBuildReference(solution, projectReference, compilationInfo.Compilation, version, cancellationToken);
                             }
+                        }
+                        else
+                        {
+                            solution.Workspace.LogTestMessage($"Reusing the already cached skeleton assembly for {projectReference.ProjectId}");
                         }
 
                         return reference;

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -46,6 +46,8 @@ namespace Microsoft.CodeAnalysis
 
         internal bool TestHookPartialSolutionsDisabled { get; set; }
 
+        private Action<string> _testMessageLogger;
+
         /// <summary>
         /// Constructs a new workspace instance.
         /// </summary>
@@ -64,6 +66,20 @@ namespace Microsoft.CodeAnalysis
 
             // initialize with empty solution
             _latestSolution = CreateSolution(SolutionId.CreateNewId());
+        }
+
+        internal void LogTestMessage(string message)
+        {
+            _testMessageLogger?.Invoke(message);
+        }
+
+        /// <summary>
+        /// Sets an internal logger that will receive some messages.
+        /// </summary>
+        /// <param name="writeLineMessageLogger">An action called to write a single line to the log.</param>
+        internal void SetTestLogger(Action<string> writeLineMessageLogger)
+        {
+            _testMessageLogger = writeLineMessageLogger;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request is "clean" pull request which adds various bits of logging so we can better track down the skeleton assembly issue we're currently seeing. Unlike this previous PRs, this one is actually safe to check in and merge.

*Review:* @dotnet/roslyn-ide, @dotnet/roslyn-infrastructure