### PR TITLE
Correct build order dependency for VB result provider

### DIFF
--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/NetFX20/BasicResultProvider.NetFX20.vbproj
@@ -39,6 +39,11 @@
       <Project>{BEDC5A4A-809E-4017-9CFD-6C8D4E1847F0}</Project>
       <Name>ResultProvider.NetFX20</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Tools\Source\CompilerGeneratorTools\Source\VisualBasicSyntaxGenerator\VisualBasicSyntaxGenerator.vbproj">
+      <Project>{6AA96934-D6B7-4CC8-990D-DB6B9DD56E34}</Project>
+      <Name>VisualBasicSyntaxGenerator</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Include="..\..\..\..\..\Compilers\VisualBasic\Portable\Scanner\CharacterInfo.vb">

--- a/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ResultProvider/Portable/BasicResultProvider.Portable.vbproj
@@ -37,6 +37,11 @@
       <Project>{fa0e905d-ec46-466d-b7b2-3b5557f9428c}</Project>
       <Name>ResultProvider.Portable</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Tools\Source\CompilerGeneratorTools\Source\VisualBasicSyntaxGenerator\VisualBasicSyntaxGenerator.vbproj">
+      <Project>{6AA96934-D6B7-4CC8-990D-DB6B9DD56E34}</Project>
+      <Name>VisualBasicSyntaxGenerator</Name>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Label="Linked Files">
     <Compile Include="..\..\..\..\..\Compilers\VisualBasic\Portable\Scanner\CharacterInfo.vb">


### PR DESCRIPTION
This project uses the VB syntax generator hence needs a reference to the project in order to guarantee it's built first.

closes #7869