### PR TITLE
Test/fix scoping rules for pattern locals declared within a switch statement.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -760,5 +760,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(Locals.Length == 0);
             return new PatternVariableBinder(scopeOpt, scopeOpt, this);
         }
+
+        internal BoundExpression WrapWithVariablesIfAny(BoundExpression expression)
+        {
+            return (Locals.Length == 0)
+                ? expression
+                : new BoundSequence(expression.Syntax, Locals, ImmutableArray<BoundExpression>.Empty, expression, expression.Type) { WasCompilerGenerated = true };
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -761,6 +761,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new PatternVariableBinder(scopeOpt, scopeOpt, this);
         }
 
+        internal Binder WithPatternVariablesIfAny(ArgumentListSyntax initializerArgumentListOpt)
+        {
+            Debug.Assert(Locals.Length == 0);
+
+            if (initializerArgumentListOpt == null || initializerArgumentListOpt.Arguments.Count == 0)
+            {
+                return this;
+            }
+
+            return new PatternVariableBinder(initializerArgumentListOpt, initializerArgumentListOpt.Arguments, this);
+        }
+
         internal BoundExpression WrapWithVariablesIfAny(BoundExpression expression)
         {
             return (Locals.Length == 0)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Attributes.cs
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal CSharpAttributeData GetAttribute(AttributeSyntax node, NamedTypeSymbol boundAttributeType, DiagnosticBag diagnostics)
         {
-            var boundAttribute = BindAttribute(node, boundAttributeType, diagnostics);
+            var boundAttribute = new PatternVariableBinder(node, this).BindAttribute(node, boundAttributeType, diagnostics);
 
             return GetAttribute(boundAttribute, diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -339,7 +339,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ParameterSymbol parameter,
             EqualsValueClauseSyntax defaultValueSyntax)
         {
-            return new LocalScopeBinder(this.WithContainingMemberOrLambda(parameter.ContainingSymbol).WithAdditionalFlags(BinderFlags.ParameterDefaultValue));
+            return new LocalScopeBinder(this.WithContainingMemberOrLambda(parameter.ContainingSymbol).WithAdditionalFlags(BinderFlags.ParameterDefaultValue)).
+                   WithPatternVariablesIfAny(defaultValueSyntax.Value);
         }
 
         internal BoundExpression BindParameterDefaultValue(
@@ -357,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Always generate the conversion, even if the expression is not convertible to the given type.
             // We want the erroneous conversion in the tree.
-            return GenerateConversionForAssignment(parameterType, valueBeforeConversion, diagnostics, isDefaultParameter: true);
+            return WrapWithVariablesIfAny(GenerateConversionForAssignment(parameterType, valueBeforeConversion, diagnostics, isDefaultParameter: true));
         }
 
         internal BoundExpression BindEnumConstantInitializer(
@@ -2649,7 +2650,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? new PatternVariableBinder(initializerArgumentListOpt, initializerArgumentListOpt.Arguments, this)
                 : null;
             var result = (patBinder ?? this).BindConstructorInitializerCore(initializerArgumentListOpt, constructor, diagnostics);
-            return patBinder?.WrapWithPatternVariables(result) ?? result;
+            return patBinder?.WrapWithVariablesIfAny(result) ?? result;
         }
 
         private BoundExpression BindConstructorInitializerCore(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2645,12 +2645,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol constructor,
             DiagnosticBag diagnostics)
         {
-            // Handle scoping for possible pattern variables declared in the initializer
-            PatternVariableBinder patBinder = (initializerArgumentListOpt != null)
-                ? new PatternVariableBinder(initializerArgumentListOpt, initializerArgumentListOpt.Arguments, this)
-                : null;
-            var result = (patBinder ?? this).BindConstructorInitializerCore(initializerArgumentListOpt, constructor, diagnostics);
-            return patBinder?.WrapWithVariablesIfAny(result) ?? result;
+            var result = BindConstructorInitializerCore(initializerArgumentListOpt, constructor, diagnostics);
+            return WrapWithVariablesIfAny(result);
         }
 
         private BoundExpression BindConstructorInitializerCore(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -270,7 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var collisionDetector = new LocalScopeBinder(binder);
             var patternBinder = new PatternVariableBinder(equalsValueClauseNode, equalsValueClauseNode.Value, collisionDetector);
             var boundInitValue = patternBinder.BindVariableOrAutoPropInitializer(equalsValueClauseNode, RefKind.None, fieldSymbol.GetFieldType(fieldsBeingBound), initializerDiagnostics);
-            boundInitValue = patternBinder.WrapWithPatternVariables(boundInitValue);
+            boundInitValue = patternBinder.WrapWithVariablesIfAny(boundInitValue);
 
             if (isImplicitlyTypedField)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3450,7 +3450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.WRN_FilterIsConstant, filter.FilterExpression);
             }
 
-            boundFilter = patternBinder.WrapWithPatternVariables(boundFilter);
+            boundFilter = patternBinder.WrapWithVariablesIfAny(boundFilter);
             boundFilter = new BoundSequencePointExpression(filter, boundFilter, boundFilter.Type);
             return boundFilter;
         }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (decl.Pattern != null)
                             {
                                 // Patterns from the let statement introduce bindings into the enclosing scope.
-                                var patterns = PatternVariableFinder.FindPatternVariables(patterns: ImmutableArray.Create(decl.Pattern));
+                                var patterns = PatternVariableFinder.FindPatternVariables(decl.Pattern);
                                 foreach (var pattern in patterns)
                                 {
                                     var localSymbol = SourceLocalSymbol.MakeLocal(this.ContainingMemberOrLambda, this, RefKind.None, pattern.Type, pattern.Identifier, LocalDeclarationKind.PatternVariable);

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
@@ -32,6 +32,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (subExpression != null) expressionsToVisit.Add(subExpression);
                 }
             }
+
+            expressionsToVisit.ReverseContents();
+
             finder.VisitExpressions();
 
             if (!patterns.IsDefaultOrEmpty)

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private BoundPatternSwitchStatement BindPatternSwitch(SwitchStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var boundSwitchExpression = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
+            // See BindSwitchExpression for an explanation why we should use Next binder here.
+            var boundSwitchExpression = this.Next.BindValue(node.Expression, diagnostics, BindValueKind.RValue);
             // TODO: any constraints on a switch expression must be enforced here. For example,
             // it must have a type (not be target-typed, lambda, null, etc)
 

--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static AttributeSemanticModel Create(CSharpCompilation compilation, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Binder rootBinder)
         {
             var executableBinder = new ExecutableCodeBinder(syntax, attributeType, rootBinder);
-            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, new LocalScopeBinder(executableBinder));
+            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, new PatternVariableBinder(syntax, executableBinder));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/InitializerSemanticModel.cs
@@ -194,6 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         }
                         if (result != null)
                         {
+                            result = binder.WrapWithVariablesIfAny(result);
                             return new BoundFieldEqualsValue(equalsValue, field, result);
                         }
                         break;
@@ -205,6 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         BoundExpression result = binder.BindVariableOrAutoPropInitializer(equalsValue, RefKind.None, property.Type, diagnostics);
                         if (result != null)
                         {
+                            result = binder.WrapWithVariablesIfAny(result);
                             return new BoundPropertyEqualsValue(equalsValue, property, result);
                         }
                         break;

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxTreeSemanticModel.cs
@@ -1042,7 +1042,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                             (ConstructorInitializerSyntax)node,
                             constructorSymbol,
                             //insert an extra binder to perform constructor initialization checks
-                            outer.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructorSymbol));
+                            // Handle scoping for possible pattern variables declared in the initializer
+                            outer.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructorSymbol).
+                                WithPatternVariablesIfAny(((ConstructorInitializerSyntax)node).ArgumentList));
                     }
 
                 case SyntaxKind.Attribute:

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1726,7 +1726,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // wrap in ConstructorInitializerBinder for appropriate errors
-            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor);
+            // Handle scoping for possible pattern variables declared in the initializer
+            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor).
+                                       WithPatternVariablesIfAny(initializerArgumentListOpt);
 
             return initializerBinder.BindConstructorInitializer(initializerArgumentListOpt, constructor, diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_MatchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_MatchStatement.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // copy the original switch expression into a temp
             BoundAssignmentOperator initialStore;
-            var switchExpressionTemp = _factory.StoreToTemp(node.Expression, out initialStore, syntaxOpt: node.Expression.Syntax);
+            var switchExpressionTemp = _factory.StoreToTemp(VisitExpression(node.Expression), out initialStore, syntaxOpt: node.Expression.Syntax);
             statements.Add(_factory.ExpressionStatement(initialStore));
 
             // save the default label, if and when we find it.

--- a/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
@@ -52,15 +52,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
         {
             var enumConstant = fieldSymbol as SourceEnumConstantSymbol;
-            var collisionDetector = new LocalScopeBinder(binder);
+            Binder collisionDetector = new LocalScopeBinder(binder);
+            collisionDetector = collisionDetector.WithPatternVariablesIfAny(initializer.Value);
+            BoundExpression result;
+
             if ((object)enumConstant != null)
             {
-                return collisionDetector.BindEnumConstantInitializer(enumConstant, initializer.Value, diagnostics);
+                result = collisionDetector.BindEnumConstantInitializer(enumConstant, initializer.Value, diagnostics);
             }
             else
             {
-                return collisionDetector.BindVariableOrAutoPropInitializer(initializer, RefKind.None, fieldSymbol.Type, diagnostics);
+                result = collisionDetector.BindVariableOrAutoPropInitializer(initializer, RefKind.None, fieldSymbol.Type, diagnostics);
             }
+
+            result = collisionDetector.WrapWithVariablesIfAny(result);
+            return result;
         }
 
         internal static ConstantValue GetAndValidateConstantValue(

--- a/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 case SyntaxKind.ReturnStatement:
                     return ((ReturnStatementSyntax)statement).ReturnKeyword;
                 case SyntaxKind.SwitchStatement:
-                    return ((SwitchStatementSyntax)statement).OpenBraceToken;
+                    return ((SwitchStatementSyntax)statement).Expression.GetFirstToken();
                 case SyntaxKind.ThrowStatement:
                     return ((ThrowStatementSyntax)statement).ThrowKeyword;
                 case SyntaxKind.TryStatement:


### PR DESCRIPTION
Also fix a bug in lowering of a switch statement where the target expression was not lowered.

Fixes #8815.
Related to #8817.

Note to reviewers:
Only the last commit needs the review, the two first commits were already signed-off  on (including Ask Mode sign-off, see https://github.com/dotnet/roslyn/pull/9442).

@gafter, @jaredpar, @dotnet/roslyn-compiler Please review.
CC @MattGertz For "Ask Mode". 