### PR TITLE
Test/fix scoping rules for pattern locals declared within a switch statement.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (decl.Pattern != null)
                             {
                                 // Patterns from the let statement introduce bindings into the enclosing scope.
-                                var patterns = PatternVariableFinder.FindPatternVariables(patterns: ImmutableArray.Create(decl.Pattern));
+                                var patterns = PatternVariableFinder.FindPatternVariables(decl.Pattern);
                                 foreach (var pattern in patterns)
                                 {
                                     var localSymbol = SourceLocalSymbol.MakeLocal(this.ContainingMemberOrLambda, this, RefKind.None, pattern.Type, pattern.Identifier, LocalDeclarationKind.PatternVariable);

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
@@ -16,7 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         private BoundPatternSwitchStatement BindPatternSwitch(SwitchStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var boundSwitchExpression = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
+            // See BindSwitchExpression for an explanation why we should use Next binder here.
+            var boundSwitchExpression = this.Next.BindValue(node.Expression, diagnostics, BindValueKind.RValue);
             // TODO: any constraints on a switch expression must be enforced here. For example,
             // it must have a type (not be target-typed, lambda, null, etc)
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_MatchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_MatchStatement.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // copy the original switch expression into a temp
             BoundAssignmentOperator initialStore;
-            var switchExpressionTemp = _factory.StoreToTemp(node.Expression, out initialStore, syntaxOpt: node.Expression.Syntax);
+            var switchExpressionTemp = _factory.StoreToTemp(VisitExpression(node.Expression), out initialStore, syntaxOpt: node.Expression.Syntax);
             statements.Add(_factory.ExpressionStatement(initialStore));
 
             // save the default label, if and when we find it.

--- a/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
@@ -320,7 +320,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 case SyntaxKind.ReturnStatement:
                     return ((ReturnStatementSyntax)statement).ReturnKeyword;
                 case SyntaxKind.SwitchStatement:
-                    return ((SwitchStatementSyntax)statement).OpenBraceToken;
+                    return ((SwitchStatementSyntax)statement).Expression.GetFirstToken();
                 case SyntaxKind.ThrowStatement:
                     return ((ThrowStatementSyntax)statement).ThrowKeyword;
                 case SyntaxKind.TryStatement:


### PR DESCRIPTION
Also fix a bug in lowering of a switch statement where the target expression was not lowered.

Fixes #8815.
Related to #8817.

@gafter, @jaredpar, @dotnet/roslyn-compiler Please review.
CC @MattGertz For "Ask Mode".