### PR TITLE
Fix for #9463: iterator rewriter to report missing types gracefully

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -990,7 +990,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal NamedTypeSymbol GetSpecialType(SpecialType typeId, DiagnosticBag diagnostics, CSharpSyntaxNode node)
         {
-            NamedTypeSymbol typeSymbol = this.Compilation.GetSpecialType(typeId);
+            return GetSpecialType(this.Compilation, typeId, node, diagnostics);
+        }
+
+        internal static NamedTypeSymbol GetSpecialType(CSharpCompilation compilation, SpecialType typeId, CSharpSyntaxNode node, DiagnosticBag diagnostics)
+        {
+            NamedTypeSymbol typeSymbol = compilation.GetSpecialType(typeId);
             Debug.Assert((object)typeSymbol != null, "Expect an error type if special type isn't found");
             ReportUseSiteDiagnostics(typeSymbol, diagnostics, node);
             return typeSymbol;

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -414,11 +414,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <param name="node">Where to report the error, if any.</param>
         Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag) As NamedTypeSymbol
             Dim reportedAnError As Boolean = False
-            Return GetSpecialType(typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
+            Return GetSpecialType(SourceModule.ContainingAssembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
+        End Function
+
+        Public Shared Function GetSpecialType(assembly As AssemblySymbol, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag) As NamedTypeSymbol
+            Dim reportedAnError As Boolean = False
+            Return GetSpecialType(assembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError:=False)
         End Function
 
         Public Function GetSpecialType(typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
-            Dim symbol As NamedTypeSymbol = SourceModule.ContainingAssembly.GetSpecialType(typeId)
+            Return GetSpecialType(SourceModule.ContainingAssembly, typeId, node, diagBag, reportedAnError, suppressUseSiteError)
+        End Function
+
+        Public Shared Function GetSpecialType(assembly As AssemblySymbol, typeId As SpecialType, node As SyntaxNodeOrToken, diagBag As DiagnosticBag, ByRef reportedAnError As Boolean, suppressUseSiteError As Boolean) As NamedTypeSymbol
+            Dim symbol As NamedTypeSymbol = assembly.GetSpecialType(typeId)
 
             If diagBag IsNot Nothing Then
                 Dim info = GetUseSiteErrorForSpecialType(symbol, suppressUseSiteError)
@@ -526,8 +535,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' member isn't found.
         ''' </summary>
         Friend Function GetSpecialTypeMember(member As SpecialMember, syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag) As Symbol
+            Return GetSpecialTypeMember(Me.ContainingMember.ContainingAssembly, member, syntax, diagnostics)
+        End Function
+
+        Friend Shared Function GetSpecialTypeMember(assembly As AssemblySymbol, member As SpecialMember, syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag) As Symbol
             Dim useSiteError As DiagnosticInfo = Nothing
-            Dim specialMemberSymbol As Symbol = GetSpecialTypeMember(Me.ContainingMember.ContainingAssembly, member, useSiteError)
+            Dim specialMemberSymbol As Symbol = GetSpecialTypeMember(assembly, member, useSiteError)
 
             If useSiteError IsNot Nothing Then
                 ReportDiagnostic(diagnostics, syntax, useSiteError)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenIterators.vb
@@ -1,5 +1,6 @@
-﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
@@ -1688,5 +1689,146 @@ End Class
             Dim verifier = CompileAndVerify(compilation, verify:=False)
             verifier.VerifyDiagnostics()
         End Sub
+
+        <Fact, WorkItem(9463, "https://github.com/dotnet/roslyn/issues/9463")>
+        Public Sub IEnumerableIteratorReportsDiagnosticsWhenCoreTypesAreMissing()
+            ' Note that IDisposable.Dispose, IEnumerator.Current and other types are missing
+            ' Also, IEnumerator(Of T) doesn't have a get accessor
+            Dim source = "
+Namespace System
+    Public Class [Object]
+    End Class
+    Public Class [Int32]
+    End Class
+    Public Class [Boolean]
+    End Class
+    Public Class [String]
+    End Class
+    Public Class Exception
+    End Class
+    Public Class ValueType
+    End Class
+    Public Class [Enum]
+    End Class
+    Public Class Void
+    End Class
+    Public Interface IDisposable
+    End Interface
+End Namespace
+
+Namespace System.Collections
+    Public Interface IEnumerable
+    End Interface
+    Public Interface IEnumerator
+    End Interface
+End Namespace
+
+Namespace System.Collections.Generic
+    Public Interface IEnumerator(Of T)
+        WriteOnly Property Current As T
+    End Interface
+End Namespace
+
+Class C
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+        Yield Nothing
+    End Function
+End Class
+"
+            Dim compilation = CreateCompilation({Parse(source)})
+
+            compilation.AssertTheseEmitDiagnostics(<expected>
+BC30002: Type 'System.Collections.Generic.IEnumerable' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30524: Property 'System.Collections.Generic.IEnumerator(Of T).Current' is 'WriteOnly'.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.Generic.IEnumerable`1.GetEnumerator' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerable.GetEnumerator' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerator.Current' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerator.MoveNext' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerator.Reset' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.IDisposable.Dispose' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerable
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                </expected>)
+        End Sub
+
+        <Fact, WorkItem(9463, "https://github.com/dotnet/roslyn/issues/9463")>
+        Public Sub IEnumeratorIteratorReportsDiagnosticsWhenCoreTypesAreMissing()
+            ' Note that IDisposable.Dispose and other types are missing
+            ' Also IEnumerator.Current lacks a get accessor
+            Dim source = "
+Namespace System
+    Public Class [Object]
+    End Class
+    Public Class [Int32]
+    End Class
+    Public Class [Boolean]
+    End Class
+    Public Class [String]
+    End Class
+    Public Class Exception
+    End Class
+    Public Class ValueType
+    End Class
+    Public Class [Enum]
+    End Class
+    Public Class Void
+    End Class
+    Public Interface IDisposable
+    End Interface
+End Namespace
+
+Namespace System.Collections
+    Public Interface IEnumerable
+    End Interface
+    Public Interface IEnumerator
+        WriteOnly Property Current As Object
+    End Interface
+End Namespace
+
+Class C
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+        Yield Nothing
+    End Function
+End Class
+"
+            Dim compilation = CreateCompilation({Parse(source)})
+
+            ' No error about IEnumerable
+            compilation.AssertTheseEmitDiagnostics(<expected>
+BC30002: Type 'System.Collections.Generic.IEnumerator' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC30524: Property 'System.Collections.IEnumerator.Current' is 'WriteOnly'.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.Generic.IEnumerator`1.Current' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerator.MoveNext' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.Collections.IEnumerator.Reset' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC35000: Requested operation is not available because the runtime library function 'System.IDisposable.Dispose' is not defined.
+    Public Iterator Function SomeNumbers() As System.Collections.IEnumerator
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                </expected>)
+        End Sub
+
     End Class
 End Namespace

--- a/src/Test/Utilities/Shared/Assert/AssertEx.cs
+++ b/src/Test/Utilities/Shared/Assert/AssertEx.cs
@@ -441,10 +441,13 @@ namespace Roslyn.Test.Utilities
                 }
             }
 
+            var expectedString = string.Join(itemSeparator, expected.Select(itemInspector));
             var actualString = string.Join(itemSeparator, actual.Select(itemInspector));
 
             var message = new StringBuilder();
             message.AppendLine();
+            message.AppendLine("Expected:");
+            message.AppendLine(expectedString);
             message.AppendLine("Actual:");
             message.AppendLine(actualString);
             message.AppendLine("Differences:");


### PR DESCRIPTION
Two changes here:  

- Adding type checks before iterator rewrite starts
- Refactoring a large VB method in the iterator rewriter to align to C# implementation, which has a side-effect of re-ordering some methods that are generated

A few notes:

- I ended opting for reporting multiple diagnostics (not just the first one)
- I didn't end up storing the types between the place they are checked and the place they are used
- if this approach is acceptable, I will implement a similar change for async rewriter as next step
- some files had a unicode signature character at the start, which I removed

CC @dotnet/roslyn-compiler 