### PR TITLE
Dedup import scopes based on value equality instead of reference equality

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -263,7 +263,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// The Imports for all containing namespace declarations (innermost-to-outermost, including global).
+        /// The imports for all containing namespace declarations (innermost-to-outermost, including global),
+        /// or null if there are none.
         /// </summary>
         internal virtual ImportChain ImportChain
         {

--- a/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ImportChain.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal sealed class ImportChain : Cci.IImportScope
     {
         public readonly Imports Imports;
@@ -20,6 +21,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Imports = imports;
             ParentOpt = parentOpt;
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return $"{Imports.GetDebuggerDisplay()} ^ {ParentOpt?.GetHashCode() ?? 0}";
         }
 
         ImmutableArray<Cci.UsedNamespaceOrType> Cci.IImportScope.GetUsedNamespaces()

--- a/src/Compilers/CSharp/Portable/Binder/Imports.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Imports.cs
@@ -16,6 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// <summary>
     /// Represents symbols imported to the binding scope via using namespace, using alias, and extern alias.
     /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal sealed class Imports
     {
         internal static readonly Imports Empty = new Imports(
@@ -51,6 +52,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.Usings = usings;
             _diagnostics = diagnostics;
             this.ExternAliases = externs;
+        }
+
+        internal string GetDebuggerDisplay()
+        {
+            return string.Join("; ", 
+                UsingAliases.OrderBy(x => x.Value.UsingDirective.Location.SourceSpan.Start).Select(ua => $"{ua.Key} = {ua.Value.Alias.Target}").Concat(
+                Usings.Select(u => u.NamespaceOrType.ToString())).Concat(
+                ExternAliases.Select(ea => $"extern alias {ea.Alias.Name}")));
+
         }
 
         public static Imports FromSyntax(

--- a/src/Compilers/Core/Portable/PEWriter/IImportScope.cs
+++ b/src/Compilers/Core/Portable/PEWriter/IImportScope.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Cci
     {
         /// <summary>
         /// Zero or more used namespaces. These correspond to using directives in C# or Imports syntax in VB.
+        /// Multiple invocations return the same array instance.
         /// </summary>
         ImmutableArray<UsedNamespaceOrType> GetUsedNamespaces();
 

--- a/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/MetadataVisualizer.cs
@@ -142,7 +142,7 @@ namespace Roslyn.Test.MetadataUtilities
             WriteLocalScope();
             WriteLocalVariable();
             WriteLocalConstant();
-            WriteLocalImport();
+            WriteImportScope();
             WriteCustomDebugInformation();
 
             // heaps:
@@ -1716,7 +1716,7 @@ namespace Roslyn.Test.MetadataUtilities
             }
         }
 
-        private void WriteLocalImport()
+        public void WriteImportScope()
         {
             AddHeader(
                 "Parent",


### PR DESCRIPTION
Bound usings are associated with InContainerBinders. Since binders are allocated as needed and only some instances are cached usings can be bound multiple times resulting in multiple instances of ImportChain. Portable PDB needs to compare them by value equality instead of reference equality in order to avoid non-deterministic output.