### PR TITLE
Properly escape a line separator in a character literal

### DIFF
--- a/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/ObjectDisplay.cs
@@ -149,8 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Returns true if the character should be replaced and sets
-        /// <paramref name="replaceWith"/> to the replacement text if the
-        /// character is replaced with text other than the Unicode escape sequence.
+        /// <paramref name="replaceWith"/> to the replacement text.
         /// </summary>
         private static bool TryReplaceChar(char c, out string replaceWith)
         {
@@ -196,6 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case UnicodeCategory.Control:
                 case UnicodeCategory.OtherNotAssigned:
                 case UnicodeCategory.ParagraphSeparator:
+                case UnicodeCategory.LineSeparator:
                     replaceWith = "\\u" + ((int)c).ToString("x4");
                     return true;
                 default:

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxFactoryTests.cs
@@ -352,6 +352,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CultureInfo.CurrentCulture = culture;
         }
 
+        [WorkItem(9484, "https://github.com/dotnet/roslyn/issues/9484")]
+        [Fact]
+        public void TestEscapeLineSeparator()
+        {
+            var literal = SyntaxFactory.Literal("\u2028");
+            Assert.Equal("\"\\u2028\"", literal.Text);
+        }
+
         private static void CheckLiteralToString(dynamic value, string expected)
         {
             var literal = SyntaxFactory.Literal(value);


### PR DESCRIPTION
Fixes #9484 

@dotnet/roslyn-compiler Please review. Third time's the charm?