### PR TITLE
more allocation reduction.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -253,8 +253,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             var rightType = right.Type;
             var simpleCase = leftType?.IsValueType == true &&
                              rightType?.IsValueType == true &&
-                             leftType?.IsNullableType() == false &&
-                             rightType?.IsNullableType() == false;
+                             leftType.IsNullableType() == false &&
+                             rightType.IsNullableType() == false;
 
             if (!simpleCase)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -245,25 +245,45 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)underlying != null);
             Debug.Assert(underlying.SpecialType != SpecialType.None);
 
-            var nullable = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
-            var nullableEnum = nullable.Construct(enumType);
-            var nullableUnderlying = nullable.Construct(underlying);
+            NamedTypeSymbol nullableEnum = null;
+            NamedTypeSymbol nullableUnderlying = null;
+
+            // PERF: avoid instantiating nullable types in common simple cases.
+            var leftType = left.Type;
+            var rightType = right.Type;
+            var simpleCase = leftType?.IsValueType == true &&
+                             rightType?.IsValueType == true &&
+                             leftType?.IsNullableType() == false &&
+                             rightType?.IsNullableType() == false;
+
+            if (!simpleCase)
+            {
+                var nullable = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
+                nullableEnum = nullable.Construct(enumType);
+                nullableUnderlying = nullable.Construct(underlying);
+            }
 
             switch (kind)
             {
                 case BinaryOperatorKind.Addition:
                     operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingAddition, enumType, underlying, enumType));
                     operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UnderlyingAndEnumAddition, underlying, enumType, enumType));
-                    operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingAddition, nullableEnum, nullableUnderlying, nullableEnum));
-                    operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumAddition, nullableUnderlying, nullableEnum, nullableEnum));
+                    if (!simpleCase)
+                    {
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingAddition, nullableEnum, nullableUnderlying, nullableEnum));
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumAddition, nullableUnderlying, nullableEnum, nullableEnum));
+                    }
                     break;
                 case BinaryOperatorKind.Subtraction:
                     if (Strict)
                     {
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumSubtraction, enumType, enumType, underlying));
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingSubtraction, enumType, underlying, enumType));
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying));
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum));
+                        if (!simpleCase)
+                        {
+                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying));
+                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum));
+                        }
                     }
                     else
                     {
@@ -277,16 +297,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                         { Priority = 2 });
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingSubtraction, enumType, underlying, enumType)
                         { Priority = isExactSubtraction ? 1 : 3 });
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying)
-                        { Priority = 12 });
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum)
-                        { Priority = isExactSubtraction ? 11 : 13 });
+                        if (!simpleCase)
+                        {
+                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying)
+                            { Priority = 12 });
+                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum)
+                            { Priority = isExactSubtraction ? 11 : 13 });
+                        }
 
                         // Due to a bug, the native compiler allows "underlying - enum", so Roslyn does as well.
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UnderlyingAndEnumSubtraction, underlying, enumType, enumType)
                         { Priority = 4 });
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumSubtraction, nullableUnderlying, nullableEnum, nullableEnum)
-                        { Priority = 14 });
+                        if (!simpleCase)
+                        {
+                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumSubtraction, nullableUnderlying, nullableEnum, nullableEnum)
+                            { Priority = 14 });
+                        }
                     }
                     break;
                 case BinaryOperatorKind.Equal:
@@ -297,13 +323,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.LessThanOrEqual:
                     var boolean = Compilation.GetSpecialType(SpecialType.System_Boolean);
                     operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Enum, enumType, enumType, boolean));
-                    operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, boolean));
+                    if (!simpleCase)
+                    {
+                        operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, boolean));
+                    }
                     break;
                 case BinaryOperatorKind.And:
                 case BinaryOperatorKind.Or:
                 case BinaryOperatorKind.Xor:
                     operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Enum, enumType, enumType, enumType));
-                    operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, nullableEnum));
+                    if (!simpleCase)
+                    {
+                        operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, nullableEnum));
+                    }
                     break;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             diagnosticsBuilder.Free();
 
-            if (!InterfacesAreDistinct(type, basesBeingResolved))
+            if (HasDuplicateInterfaces(type, basesBeingResolved))
             {
                 result = false;
                 diagnostics.Add(ErrorCode.ERR_BogusType, typeSyntax.Location, type);
@@ -461,7 +461,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we only check for distinct interfaces when the type is not from source, as we
             // trust that types that are from source have already been checked by the compiler
             // to prevent this from happening in the first place.
-            if (!(currentCompilation != null && type.IsFromCompilation(currentCompilation)) && !InterfacesAreDistinct(type, null))
+            if (!(currentCompilation != null && type.IsFromCompilation(currentCompilation)) && HasDuplicateInterfaces(type, null))
             {
                 result = false;
                 diagnostics.Add(ErrorCode.ERR_BogusType, location, type);
@@ -473,9 +473,47 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         // C# does not let you declare a type in which it would be possible for distinct base interfaces
         // to unify under some instantiations.  But such ill-formed classes can come in through
         // metadata and be instantiated in C#.  We check to see if that's happened.
-        private static bool InterfacesAreDistinct(NamedTypeSymbol type, ConsList<Symbol> basesBeingResolved)
+        private static bool HasDuplicateInterfaces(NamedTypeSymbol type, ConsList<Symbol> basesBeingResolved)
         {
-            return !type.InterfacesNoUseSiteDiagnostics(basesBeingResolved).HasDuplicates(TypeSymbol.EqualsIgnoringDynamicComparer);
+            // PERF: avoid instantiating all interfaces here
+            //       Ex: if class implements just IEnumerable<> and IComparable<> it cannot have conflicting implementations
+            var array = type.OriginalDefinition.InterfacesNoUseSiteDiagnostics(basesBeingResolved);
+
+            switch (array.Length)
+            {
+                case 0:
+                case 1:
+                    // less than 2 interfaces
+                    return false;
+
+                case 2:
+                    if (ReferenceEquals(array[0].OriginalDefinition, array[1].OriginalDefinition))
+                    {
+                        break;
+                    }
+
+                    // two unrelated interfaces 
+                    return false;
+
+                default:
+                    var set = new HashSet<NamedTypeSymbol>(ReferenceEqualityComparer.Instance);
+                    foreach (var i in array)
+                    {
+                        if (!set.Add(i.OriginalDefinition))
+                        {
+                            goto hasRelatedInterfaces;
+                        }
+                    }
+
+                    // all interfaces are unrelated
+                    return false;
+            }
+            
+            // very rare case. 
+            // some implemented interfaces are related
+            // will have to instantiate interfaces and check
+            hasRelatedInterfaces:
+            return type.InterfacesNoUseSiteDiagnostics(basesBeingResolved).HasDuplicates(TypeSymbol.EqualsIgnoringDynamicComparer);
         }
 
         public static bool CheckConstraints(

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -487,7 +487,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return false;
 
                 case 2:
-                    if (ReferenceEquals(array[0].OriginalDefinition, array[1].OriginalDefinition))
+                    if ((object)array[0].OriginalDefinition == array[1].OriginalDefinition)
                     {
                         break;
                     }

--- a/src/Compilers/Core/Portable/CodeGen/MethodBody.cs
+++ b/src/Compilers/Core/Portable/CodeGen/MethodBody.cs
@@ -101,18 +101,16 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public ImmutableArray<byte> IL => _ilBits;
 
-        public ImmutableArray<Cci.SequencePoint> GetSequencePoints()
+        public void GetSequencePoints(ArrayBuilder<Cci.SequencePoint> builder)
         {
-            return HasAnySequencePoints ?
-                _sequencePoints.GetSequencePoints(_debugDocumentProvider) :
-                ImmutableArray<Cci.SequencePoint>.Empty;
+            if (HasAnySequencePoints)
+            {
+                _sequencePoints.GetSequencePoints(_debugDocumentProvider, builder);
+            }
         }
 
         public bool HasAnySequencePoints
             => _sequencePoints != null && !_sequencePoints.IsEmpty;
-
-        public ImmutableArray<Cci.SequencePoint> GetLocations()
-            => GetSequencePoints();
 
         ImmutableArray<Cci.LocalScope> Cci.IMethodBody.LocalScopes => _localScopes;
 

--- a/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
+++ b/src/Compilers/Core/Portable/CodeGen/SequencePointList.cs
@@ -109,7 +109,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
         /// file names to debug documents with the given mapping function.
         /// </summary>
         /// <param name="documentProvider">Function that maps file paths to CCI debug documents</param>
-        public ImmutableArray<Cci.SequencePoint> GetSequencePoints(DebugDocumentProvider documentProvider)
+        /// <param name="builder">where sequence points should be deposited</param>
+        public void GetSequencePoints(
+            DebugDocumentProvider documentProvider,
+            ArrayBuilder<Cci.SequencePoint> builder)
         {
             bool lastPathIsMapped = false;
             string lastPath = null;
@@ -124,12 +127,10 @@ namespace Microsoft.CodeAnalysis.CodeGen
                 current = current._next;
             }
 
-            ArrayBuilder<Cci.SequencePoint> result = ArrayBuilder<Cci.SequencePoint>.GetInstance(count);
-
             FileLinePositionSpan? firstReal = FindFirstRealSequencePoint(documentProvider);
             if (!firstReal.HasValue)
             {
-                return result.ToImmutableAndFree();
+                return;
             }
             lastPath = firstReal.Value.Path;
             lastPathIsMapped = firstReal.Value.HasMappedPath;
@@ -165,7 +166,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                         if (lastDebugDocument != null)
                         {
-                            result.Add(new Cci.SequencePoint(
+                            builder.Add(new Cci.SequencePoint(
                                 lastDebugDocument,
                                 offset: offsetAndSpan.Offset,
                                 startLine: HiddenSequencePointLine,
@@ -185,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                         if (lastDebugDocument != null)
                         {
-                            result.Add(new Cci.SequencePoint(
+                            builder.Add(new Cci.SequencePoint(
                                 lastDebugDocument,
                                 offset: offsetAndSpan.Offset,
                                 startLine: (fileLinePositionSpan.StartLinePosition.Line == -1) ? 0 : fileLinePositionSpan.StartLinePosition.Line + 1,
@@ -199,8 +200,6 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
                 current = current._next;
             }
-
-            return result.ToImmutableAndFree();
         }
 
         // Find the document for the first non-hidden sequence point (issue #4370)

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -149,28 +149,18 @@ namespace Microsoft.CodeAnalysis
             public override Node Next => next;
         }
 
-        // separate class to ensure that HashCode field 
-        // is layed out in ram  before other AvlNode fields
-        private abstract class HashedNode : Node
+        private class AvlNode : Node
         {
+            public AvlNode Left;
+            public AvlNode Right;
             public readonly int HashCode;
+            public sbyte Balance;
 
-            protected HashedNode(int hashCode, K key, V value)
+            public AvlNode(int hashCode, K key, V value)
                 : base(key, value)
             {
                 this.HashCode = hashCode;
             }
-        }
-
-        private class AvlNode : HashedNode
-        {
-            public AvlNode Left;
-            public AvlNode Right;
-            public sbyte Balance;
-
-            public AvlNode(int hashCode, K key, V value)
-                : base(hashCode, key, value)
-            { }
 
 #if DEBUG
             public static int AssertBalanced(AvlNode V)

--- a/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/SmallDictionary.cs
@@ -149,18 +149,29 @@ namespace Microsoft.CodeAnalysis
             public override Node Next => next;
         }
 
-        private class AvlNode : Node
+        // separate class to ensure that HashCode field 
+        // is located before other AvlNode fields
+        // Balance is also here for better packing of AvlNode on 64bit
+        private abstract class HashedNode : Node
         {
-            public AvlNode Left;
-            public AvlNode Right;
             public readonly int HashCode;
             public sbyte Balance;
 
-            public AvlNode(int hashCode, K key, V value)
+            protected HashedNode(int hashCode, K key, V value)
                 : base(key, value)
             {
                 this.HashCode = hashCode;
             }
+        }
+
+        private class AvlNode : HashedNode
+        {
+            public AvlNode Left;
+            public AvlNode Right;
+
+            public AvlNode(int hashCode, K key, V value)
+                : base(hashCode, key, value)
+            { }
 
 #if DEBUG
             public static int AssertBalanced(AvlNode V)
@@ -204,7 +215,7 @@ namespace Microsoft.CodeAnalysis
             value = default(V);
             return false;
 
-        hasBucket:
+            hasBucket:
             if (CompareKeys(b.Key, key))
             {
                 value = b.Value;

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedMethod.cs
@@ -131,15 +131,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
 
                 bool Cci.IMethodBody.HasAnySequencePoints => false;
 
-                ImmutableArray<Cci.SequencePoint> Cci.IMethodBody.GetSequencePoints()
-                {
-                    return ImmutableArray<Cci.SequencePoint>.Empty;
-                }
-
-                ImmutableArray<Cci.SequencePoint> Cci.IMethodBody.GetLocations()
-                {
-                    return ImmutableArray<Cci.SequencePoint>.Empty;
-                }
+                void Cci.IMethodBody.GetSequencePoints(ArrayBuilder<Cci.SequencePoint> builder) { }
 
                 bool Cci.IMethodBody.HasDynamicLocalVariables => false;
 

--- a/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
+++ b/src/Compilers/Core/Portable/NativePdbWriter/PdbWriter.cs
@@ -358,8 +358,10 @@ namespace Microsoft.Cci
             }
 
             DefineLocalScopes(localScopes, localSignatureToken);
-
-            EmitSequencePoints(methodBody.GetSequencePoints());
+            ArrayBuilder<Cci.SequencePoint> sequencePoints = ArrayBuilder<Cci.SequencePoint>.GetInstance();
+            methodBody.GetSequencePoints(sequencePoints);
+            EmitSequencePoints(sequencePoints);
+            sequencePoints.Free();
 
             AsyncMethodBodyDebugInfo asyncDebugInfo = methodBody.AsyncDebugInfo;
             if (asyncDebugInfo != null)
@@ -1105,7 +1107,7 @@ namespace Microsoft.Cci
             Array.Resize(ref _sequencePointEndColumns, newCapacity);
         }
 
-        private void EmitSequencePoints(ImmutableArray<SequencePoint> sequencePoints)
+        private void EmitSequencePoints(ArrayBuilder<Cci.SequencePoint> sequencePoints)
         {
             DebugSourceDocument document = null;
             ISymUnmanagedDocumentWriter symDocumentWriter = null;

--- a/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
@@ -123,6 +123,9 @@ namespace Microsoft.Cci
         // internal for testing
         internal static void SerializeCustomDebugInformation(EditAndContinueMethodDebugInformation debugInfo, ArrayBuilder<PooledBlobBuilder> customDebugInfo)
         {
+            // PERF: note that we pass debugInfo as explicit parameter
+            //       that is intentional to avoid capturing debugInfo as that 
+            //       would result in a lot of delegate allocations here that are otherwise can be avoided.
             if (!debugInfo.LocalSlots.IsDefaultOrEmpty)
             {
                 customDebugInfo.Add(

--- a/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/CustomDebugInfoWriter.cs
@@ -125,16 +125,27 @@ namespace Microsoft.Cci
         {
             if (!debugInfo.LocalSlots.IsDefaultOrEmpty)
             {
-                customDebugInfo.Add(SerializeRecord(CDI.CdiKindEditAndContinueLocalSlotMap, debugInfo.SerializeLocalSlots));
+                customDebugInfo.Add(
+                    SerializeRecord(
+                        CDI.CdiKindEditAndContinueLocalSlotMap, 
+                        debugInfo,
+                        (info, builder) => info.SerializeLocalSlots(builder)));
             }
 
             if (!debugInfo.Lambdas.IsDefaultOrEmpty)
             {
-                customDebugInfo.Add(SerializeRecord(CDI.CdiKindEditAndContinueLambdaMap, debugInfo.SerializeLambdaMap));
+                customDebugInfo.Add(
+                    SerializeRecord(
+                        CDI.CdiKindEditAndContinueLambdaMap,
+                        debugInfo,
+                        (info, builder) => info.SerializeLambdaMap(builder)));
             }
         }
 
-        private static PooledBlobBuilder SerializeRecord(byte kind, Action<BlobBuilder> data)
+        private static PooledBlobBuilder SerializeRecord(
+            byte kind,
+            EditAndContinueMethodDebugInformation debugInfo,
+            Action<EditAndContinueMethodDebugInformation, BlobBuilder> recordSerializer)
         {
             var cmw = PooledBlobBuilder.GetInstance();
             cmw.WriteByte(CDI.CdiVersion);
@@ -144,7 +155,7 @@ namespace Microsoft.Cci
             // alignment size and length (will be patched)
             var alignmentSizeAndLengthWriter = cmw.ReserveBytes(sizeof(byte) + sizeof(uint));
 
-            data(cmw);
+            recordSerializer(debugInfo, cmw);
 
             int length = cmw.Position;
             int alignedLength = 4 * ((length + 3) / 4);

--- a/src/Compilers/Core/Portable/PEWriter/Members.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Members.cs
@@ -409,8 +409,7 @@ namespace Microsoft.Cci
 
         ImmutableArray<byte> IL { get; }
         bool HasAnySequencePoints { get; }
-        ImmutableArray<SequencePoint> GetSequencePoints();
-        ImmutableArray<SequencePoint> GetLocations();
+        void GetSequencePoints(ArrayBuilder<SequencePoint> builder);
 
         /// <summary>
         /// Returns true if there is at least one dynamic local within the MethodBody

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.PortablePdb.cs
@@ -102,7 +102,9 @@ namespace Microsoft.Cci
 
             // documents & sequence points:
             int singleDocumentRowId;
-            BlobIdx sequencePointsBlob = SerializeSequencePoints(localSignatureRowId, bodyOpt.GetSequencePoints(), _documentIndex, out singleDocumentRowId);
+            ArrayBuilder<Cci.SequencePoint> sequencePoints = ArrayBuilder<Cci.SequencePoint>.GetInstance();
+            bodyOpt.GetSequencePoints(sequencePoints);
+            BlobIdx sequencePointsBlob = SerializeSequencePoints(localSignatureRowId, sequencePoints.ToImmutableAndFree(), _documentIndex, out singleDocumentRowId);
             _methodDebugInformationTable.Add(new MethodDebugInformationRow { Document = (uint)singleDocumentRowId, SequencePoints = sequencePointsBlob });
 
             // Unlike native PDB we don't emit an empty root scope.


### PR DESCRIPTION
- avoid instantiating nullable type when doing operator overloading on enums
- avoid instantiating generics when checking for impossibly rare case of duplicated interface implementations
- skipping materializing of sequence point array