### PR TITLE
Move to RC toolset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /usr/bin/env bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.64
+NUGET_PACKAGE_NAME = nuget.67
 BUILD_CONFIGURATION = Debug
 BOOTSTRAP_PATH = $(shell pwd)/Binaries/Bootstrap
 BUILD_LOG_PATH =

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -24,7 +24,7 @@
   <!-- Import the global NuGet packages -->
   <PropertyGroup>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
-    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-beta1-20160202-02\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
+    <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-rc\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\1.1.1-beta1-20150818-01\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
     <RoslynBuildUtilFilePath>$(NuGetPackageRoot)\Roslyn.MSBuild.Util\0.9.1\lib\net45\Roslyn.MSBuild.Util.dll</RoslynBuildUtilFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -3,7 +3,7 @@
         "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
         "Microsoft.Build.Mono.Debug": "14.1.0",
         "Microsoft.DiaSymReader.Native": "1.3.3",
-        "Microsoft.Net.Compilers": "1.2.0-beta1-20160202-02",
+        "Microsoft.Net.Compilers": "1.2.0-rc",
         "Microsoft.Net.RoslynDiagnostics": "1.1.1-beta1-20150818-01",
         "FakeSign": "0.9.2",
         "xunit": "2.1.0-beta4-build3109",


### PR DESCRIPTION
This changes the toolset we use to build Roslyn on our developer boxes to 1.2.0-rc.  Very close to release, need to make sure we're eating the latest brand of dogfood :smile: