### PR TITLE
Add a todo checklist for the pattern-matching feature.

### DIFF
--- a/docs/features/patterns.work.md
+++ b/docs/features/patterns.work.md
@@ -1,0 +1,126 @@
+This is a checklist (moved from #9375) of implementation of pattern matching as specified in [patterns.md](./patterns.md). For reference a previous prototype was at https://github.com/semihokur/pattern-matching-csharp
+
+Open design issues (needing LDM decisions)
+- [ ] Do we want pattern-matching in the switch statement? If so, what does “goto case” mean? Or do we want a separate statement-based construct instead? (#8821)
+- [ ] What syntax do we want for the match expression? (#8818)
+- [ ] Do they have to be complete? If not, what happens? Warning and exception?
+- [ ] Under what condition do we give diagnostics for pattern-matching based on subsumption or completion? See http://www.cs.tufts.edu/~nr/cs257/archive/norman-ramsey/match.pdf for a discussion of implementation approaches.
+- [ ] Should we combine the property pattern with the type pattern so as to allow giving the object a name? If so, what syntax?
+- [ ] What do we think about the let statement?
+- [ ] There are some scoping questions for pattern variables. #9452
+  - [ ] Need to get LDM approval for design change around scope of pattern variables declared within a constructor initializer #9452 
+- [ ] Need detailed spec for name lookup of property in a property pattern #9255
+  - [ ] [Pattern Matching] Should a property-pattern be capable of referencing an event? #9515
+- [ ] Two small clarifications need to be integrated into the spec (#7703)
+- [ ] We need to specify and implement the user-defined pattern forms: user-defined `operator is`
+  - [ ] static void with self-receiver
+  - [ ] static bool for active patterns
+  - [ ] instance bool for captured data (regex)
+  - [ ] Do we want to support "breakpoints inside" patterns (#9095)
+
+Progress checklist:
+- [ ] Add a decision tree to enable
+  - [ ] completeness checking: a mutli-armed pattern-matching expression is required to be complete
+  - [ ] subsumption checking: a branch of a switch statement or match expression may not be subsumed by the totality of previous branches (#8823)
+  - [ ] Generate efficient code like `switch` does in corresponding situations. (#8820)
+- [X] Scoping for variables introduced in patterns (binders)
+- [x] `SemanticModel.GetDeclaredSymbol` for pattern variable declarations.
+- [X] Simple pattern matching expressions `expression is Type Identifier` in most statements.
+- [x] Extend the parser to handle all of the other specified pattern-matching operations.
+  - [x] Add tests for the parser, including precedence tests for the edge cases.
+  - [ ] Augment `TestResource.AllInOneCSharpCode` to handle all pattern forms.
+- [x] Check for feature availability in the parser (error if feature not supported).
+- [X] Error pattern matching to a nullable value type
+- [x] Implement pattern matching to a type that is an unconstrained type variable (requires a double type test)
+- [ ] Implement and test scoping in remaining "odd" contexts (where the scope is not the enclosing statement)
+  - [x] pattern matching in ctor-initializers
+  - [x] pattern matching in catch filters
+  - [x] pattern matching in field initializers
+  - [x] pattern matching in expression-bodied methods and properties
+  - [x] pattern matching in an expression-bodied lambda
+  - [x] pattern matching in an expression-bodied local function
+  - [x] pattern matching in attributes and parameter defaults (lookup and error recovery)
+  - [x] test these "odd" contexts in `SemanticModel`.
+- [ ] Semantics and code-gen for all pattern forms
+  - [X] Type ID
+  - [x] *
+  - [x] 3
+    - [X] matching with exact type for integral constants (as a short-term hack)
+    - [ ] matching with appropriate integral conversions (#8819)
+  - [x] `var` ID
+  - [x] Type { ID is Pattern ... }
+  - ~~Type ( Pattern ... )~~ This will be done when Records are integrated.
+- [ ] Extend the switch statement to handle patterns
+  - [x] Parser
+  - [ ] Syntax Tests
+  - [x] Binding
+  - [ ] Binding (failure cases) tests
+  - [x] Flow analysis
+  - [x] Lowering
+  - [x] Code-gen tests
+- [ ] Allow declaration of `operator is`
+- [x] An expression form for mutli-armed pattern-matching (`match`?)
+- [ ] Extend the scope of a pattern variable declared in a catch filter to the catch block. (#8814)
+- [ ] Implement and test pattern variable scoping for all statements (#8817)
+  - [ ] Test for error on reusing a variable name, and lambda-capturing.
+- [ ] Test for name conflicts with locals in enclosing scopes for normal and "odd" contexts.
+- [ ] Need a custom diagnostic for accessing a static property in a property pattern. Are there other contexts where the diagnostics need improvement?
+- [ ] Data-flow analysis and region analysis should be modified to handle pattern variables, which are definitely assigned when a pattern match succeeds.
+  - [ ] Region analysis APIs versus pattern matching #9277 
+  - [ ] Can't extract method on case expression in match/case clause. #9105
+  - [ ] Consider pattern matching for extract method scenarios #9244
+  - [ ] PreciseAbstractFlowPass doesn't override visit for BoundMatchCase and BoundConstantPattern nodes #9422 
+- [ ] Control-flow analysis should be modified to handle patterns that either always match or never match.
+- [ ] Lots more Tests and code coverage; #9542
+  - [ ] Tests for error cases in a property pattern, such as when the named member
+    - [X] Does not exist
+    - [X] Is static
+    - [ ] Is an event
+    - [ ] Is a method
+    - [ ] Is an indexed property
+    - [ ] Is a nested type
+    - [X] In inaccessible
+    - [ ] Does not exist
+- [ ] `IOperation` support for pattern-matching (#8699)
+- [ ] Some unit tests that were disabled during development need to be re-enabled (#8778)
+- [ ] WRN_UnreferencedVarAssg "The variable '...' is assigned but its value is never used" is not reported for pattern variables #9021
+- [ ] ERR_BadEmbeddedStmt "Embedded statement cannot be a declaration or labeled statement" is not reported for a [let] statement #9029
+- [ ] Unexpected ERR_UseDefViolation error reported within an 'if' block #9121
+- [ ] Unexpected ERR_UseDefViolation error #9154
+- [ ] Internationalize diagnostics for pattern-matching #9283
+- [ ] SymbolInfo for bad property in a property pattern should contain candidate symbols #9284
+- [ ] Compiler crash with match expressions in lambda analysis. #9430
+- [ ] Allow throw expression on right of && and || #9453
+- [ ] PatternVariableFinder is lacking explicit visibility modifier #9530
+- [ ] PatternVariableFinder doesn't follow style conventions for field names #9531
+- [ ] Test code coverage of pattern-matching implementation. #9542
+
+IDE Features
+- [ ] 'let' not offered in statement context. #9083
+- [ ] After 'let' no completion to allow you specify the type. #9084
+- [ ] 'when' and 'else' not offered when typing a 'let' declaration.
+- [ ] Rename cannot be triggered from a `let` declaration name. #9086
+- [ ] Rename of a 'let' variable reference produce 'unresolvable conflicts' at every location. #9088
+- [ ] Generate type not offered for complex pattern type. #9089
+- [ ] Generate field/property not offered for complex pattern member. #9090
+- [ ] QuickInfo on 'let' declaration shows nothing. #9091
+- [ ] No formatting for match/case expressions. #9094
+- [ ] Indentation on colon not working with case clauses in a match/case expression. #9098
+- [ ] 'throw' not offered in expression contexts. #9099
+- [ ] No Property name completion in a complex pattern #9231
+
+Possible positional patterns inferred by constructor
+- [ ] Reorder parameters does not fix up use sites in patterns. #9100
+- [ ] Signature help not offered in positional pattern. #9101
+- [ ] can't extract method on condition in match/case clause. #9106
+- [ ] Find references on a constructor does not find usages in a position pattern. #9107
+- [ ] Generate constructor not offered on position pattern. #9108
+
+Related features possibly to be added at the same time as pattern-matching:
+- [x] #5154 expression-based switch ("match")
+- [x] #5143 make "throw expression" an expression form
+- [ ] #6183 "out var" declarations
+- [ ] #188 Completeness checking for "match" and Algebraic Data Types
+- [x] #6400 destructuring assignment (let statement)
+- [ ] #206 Record types
+- [ ] #5172 "with" expressions


### PR DESCRIPTION
@dotnet/roslyn-compiler Check out this doc-only addition.

See also https://github.com/gafter/roslyn/blob/patterns-todo/docs/features/patterns.work.md for a rendered view of the contents.