### PR TITLE
Turn off hard-linking during the build

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -16,9 +16,6 @@
         is specified on the command line of MSBuild
     -->
     <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win7</BaseNuGetRuntimeIdentifier>
-
-    <!-- Turn on hard-linking on Windows to reduce copy time and disk space -->
-    <CreateHardLinksForCopyLocalIfPossible Condition="'$(OS)' == 'Windows_NT'">true</CreateHardLinksForCopyLocalIfPossible>
   </PropertyGroup>
 
   <!-- Import the global NuGet packages -->


### PR DESCRIPTION
We turned on hard-linking to reduce copy and build time, however, this would result in behavior where copying a NuGet binary from .nuget\packages to the output directly which was then subsequently overwritten with a different version would result in the .nuget\packages folder to be corrupted because they were now linked.