### PR TITLE
[Stabilization] Codefix ordering: Prevent Low Priority fixes from interfering with Medium Priority fix ordering

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -30,6 +30,8 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
 {
+    using CodeFixGroupKey = Tuple<DiagnosticData, CodeActionPriority>;
+
     [Export(typeof(ISuggestedActionsSourceProvider))]
     [VisualStudio.Utilities.ContentType(ContentTypeNames.RoslynContentType)]
     [VisualStudio.Utilities.Name("Roslyn Code Fix")]
@@ -317,10 +319,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// </summary>
             private IEnumerable<SuggestedActionSet> OrganizeFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, bool hasSuppressionFixes)
             {
-                var map = ImmutableDictionary.CreateBuilder<DiagnosticData, IList<SuggestedAction>>();
-                var order = ImmutableArray.CreateBuilder<DiagnosticData>();
+                var map = ImmutableDictionary.CreateBuilder<CodeFixGroupKey, IList<SuggestedAction>>();
+                var order = ImmutableArray.CreateBuilder<CodeFixGroupKey>();
 
-                // First group fixes by issue (diagnostic).
+                // First group fixes by diagnostic and priority.
                 GroupFixes(workspace, fixCollections, map, order, hasSuppressionFixes);
 
                 // Then prioritize between the groups.
@@ -330,7 +332,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// <summary>
             /// Groups fixes by the diagnostic being addressed by each fix.
             /// </summary>
-            private void GroupFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, IDictionary<DiagnosticData, IList<SuggestedAction>> map, IList<DiagnosticData> order, bool hasSuppressionFixes)
+            private void GroupFixes(Workspace workspace, IEnumerable<CodeFixCollection> fixCollections, IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, IList<CodeFixGroupKey> order, bool hasSuppressionFixes)
             {
                 foreach (var fixCollection in fixCollections)
                 {
@@ -404,17 +406,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 }
             }
 
-            private static void AddFix(CodeFix fix, SuggestedAction suggestedAction, IDictionary<DiagnosticData, IList<SuggestedAction>> map, IList<DiagnosticData> order)
+            private static void AddFix(CodeFix fix, SuggestedAction suggestedAction, IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, IList<CodeFixGroupKey> order)
             {
                 var diag = fix.GetPrimaryDiagnosticData();
-                if (!map.ContainsKey(diag))
+
+                var groupKey = new CodeFixGroupKey(diag, fix.Action.Priority);
+                if (!map.ContainsKey(groupKey))
                 {
-                    // Remember the order of the keys for the 'map' dictionary.
-                    order.Add(diag);
-                    map[diag] = ImmutableArray.CreateBuilder<SuggestedAction>();
+                    order.Add(groupKey);
+                    map[groupKey] = ImmutableArray.CreateBuilder<SuggestedAction>();
                 }
 
-                map[diag].Add(suggestedAction);
+                map[groupKey].Add(suggestedAction);
             }
 
             /// <summary>
@@ -427,7 +430,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             /// the priority of such <see cref="SuggestedActionSet"/>s is set to <see cref="SuggestedActionSetPriority.None"/> so that suppression fixes
             /// always show up last after all other fixes (and refactorings) for the selected line of code.
             /// </remarks>
-            private static IEnumerable<SuggestedActionSet> PrioritizeFixGroups(IDictionary<DiagnosticData, IList<SuggestedAction>> map, IList<DiagnosticData> order)
+            private static IEnumerable<SuggestedActionSet> PrioritizeFixGroups(IDictionary<CodeFixGroupKey, IList<SuggestedAction>> map, IList<CodeFixGroupKey> order)
             {
                 var sets = ImmutableArray.CreateBuilder<SuggestedActionSet>();
 
@@ -440,8 +443,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                         var priority = GetSuggestedActionSetPriority(group.Key);
 
                         // diagnostic from things like build shouldn't reach here since we don't support LB for those diagnostics
-                        Contract.Requires(diag.HasTextSpan);
-                        sets.Add(new SuggestedActionSet(group, priority, diag.TextSpan.ToSpan()));
+                        Contract.Requires(diag.Item1.HasTextSpan);
+                        sets.Add(new SuggestedActionSet(group, priority, diag.Item1.TextSpan.ToSpan()));
                     }
                 }
 


### PR DESCRIPTION
Fixes #9596

Scenario -- user is trying to rename via Rename Tracking, but Fuzzy Add Using also wants to do it's "spellcheck" behavior and add a using for the spellcheck'd name. We want `<Ctrl+<dot>, Enter>` to do the rename in this case, not the fuzzy add using.

Because fuzzy using is new to Update 2, this is a regression in behavior that folks might find unexpected, reducing trust in `Ctrl+<dot>` correctness.