### PR TITLE
Fixed race in diagnostic tagger

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -124,8 +124,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 {
                     if (_owner.IncludeDiagnostic(diagnosticData))
                     {
-                        var actualSpan = diagnosticData
-                            .GetExistingOrCalculatedTextSpan(sourceText)
+                        var actualSpan = AdjustSpan(diagnosticData.GetExistingOrCalculatedTextSpan(sourceText), sourceText)
                             .ToSnapshotSpan(editorSnapshot)
                             .TranslateTo(requestedSnapshot, SpanTrackingMode.EdgeExclusive);
 
@@ -140,6 +139,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                         }
                     }
                 }
+            }
+
+            private TextSpan AdjustSpan(TextSpan span, SourceText text)
+            {
+                var start = Math.Max(0, Math.Min(span.Start, text.Length));
+                var end = Math.Max(0, Math.Min(span.End, text.Length));
+
+                if (start > end)
+                {
+                    var temp = end;
+                    end = start;
+                    start = temp;
+                }
+
+                return TextSpan.FromBounds(start, end);
             }
 
             private bool IsSuppressed(NormalizedSnapshotSpanCollection suppressedSpans, SnapshotSpan span)


### PR DESCRIPTION
there was race when we populate initial diagnostic tags in diagnostic tagger. it was associating staled diagnostic info with latest solution snapshot.

any feature that uses stale diagnostic info to make feature to response faster with slightly stale data which will be fixed up later such as tagger, error list should deal with the fact diagnostic info it has might be stale data.

this is a product bug, this can cause VS to crash.

this should also fix crash on BasicVenus.xml test.

