### PR TITLE
Fix for #8625: allow SyntaxNode.Contains to return quicker in simplest case

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxNodeTests.cs
@@ -2962,5 +2962,19 @@ namespace HelloWorld
             var trivia = tree.GetCompilationUnitRoot().FindTrivia(position);
             // no stack overflow
         }
+
+        [Fact, WorkItem(8625, "https://github.com/dotnet/roslyn/issues/8625")]
+        public void SyntaxNodeContains()
+        {
+            var text = "a + (b - (c * (d / e)))";
+            var expression = SyntaxFactory.ParseExpression(text);
+            var a = expression.DescendantNodes().OfType<IdentifierNameSyntax>().First(n => n.Identifier.Text == "a");
+            var e = expression.DescendantNodes().OfType<IdentifierNameSyntax>().First(n => n.Identifier.Text == "e");
+
+            var firstParens = e.FirstAncestorOrSelf<ExpressionSyntax>(n => n.Kind() == SyntaxKind.ParenthesizedExpression);
+
+            Assert.False(firstParens.Contains(a));  // fixing #8625 allows this to return quicker
+            Assert.True(firstParens.Contains(e));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool Contains(SyntaxNode node)
         {
-            if (node == null || !node.FullSpan.IntersectsWith(node.FullSpan))
+            if (node == null || !this.FullSpan.IntersectsWith(node.FullSpan))
             {
                 return false;
             }


### PR DESCRIPTION
There was indeed a typo. 
The behavior change is not observable, except that the method returns quicker.

I validated by stepping through this [test](https://gist.github.com/jcouv/d20e55eb4804b791c7d4).

Fixes #8625.
CC @dotnet/roslyn-compiler for code review.