### PR TITLE
Put the 'Add Nuget Reference' feature behind a disabled regkey option.

### DIFF
--- a/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptions.cs
@@ -12,5 +12,7 @@ namespace Microsoft.CodeAnalysis.Shared.Options
         public const string OptionName = "FeatureManager/Components";
 
         public static readonly Option<bool> DiagnosticProvider = new Option<bool>(OptionName, "Diagnostic Provider", defaultValue: true);
+
+        public static readonly Option<bool> PackageSearch = new Option<bool>(OptionName, nameof(PackageSearch), defaultValue: false);
     }
 }

--- a/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptionsProvider.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceComponentOnOffOptionsProvider.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Options.Providers;
@@ -11,7 +12,10 @@ namespace Microsoft.CodeAnalysis.Shared.Options
     [ExportOptionProvider, Shared]
     internal class ServiceComponentOnOffOptionsProvider : IOptionProvider
     {
-        private readonly IEnumerable<IOption> _options = SpecializedCollections.SingletonEnumerable(ServiceComponentOnOffOptions.DiagnosticProvider);
+        private readonly IEnumerable<IOption> _options = ImmutableArray.Create(
+            ServiceComponentOnOffOptions.DiagnosticProvider,
+            ServiceComponentOnOffOptions.PackageSearch);
+
         public IEnumerable<IOption> GetOptions() => _options;
     }
 }

--- a/src/VisualStudio/Core/Def/Packaging/PackageSearchServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageSearchServiceFactory.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Packaging;
+using Microsoft.CodeAnalysis.Shared.Options;
 using Roslyn.Utilities;
 using VSShell = Microsoft.VisualStudio.Shell;
 
@@ -26,10 +27,17 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
 
         public IWorkspaceService CreateService(HostWorkspaceServices workspaceServices)
         {
-            // Only support package search in vs workspace.
-            return workspaceServices.Workspace is VisualStudioWorkspace
-                ? new PackageSearchService(_serviceProvider, workspaceServices.GetService<IPackageInstallerService>())
-                : (IPackageSearchService)new NullPackageSearchService();
+            var options = workspaceServices.Workspace.Options;
+            if (options.GetOption(ServiceComponentOnOffOptions.PackageSearch))
+            {
+                // Only support package search in vs workspace.
+                if (workspaceServices.Workspace is VisualStudioWorkspace)
+                {
+                    return new PackageSearchService(_serviceProvider, workspaceServices.GetService<IPackageInstallerService>());
+                }
+            }
+
+            return new NullPackageSearchService();
         }
 
         private class NullPackageSearchService : IPackageSearchService


### PR DESCRIPTION
To enable the feature set the following DWORD regkey to 1:
Key: ```HKEY_CURRENT_USER\SOFTWARE\Microsoft\VisualStudio\<your hive>\Roslyn\Internal\OnOff\Components```
Name: PackageSearch

To disable, set it to 0.