### PR TITLE
Fix null ref in C# expander when adding cast to lambda return statement

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3888,5 +3888,45 @@ class C
 }";
             await TestAsync(initial, expected, compareTokens: false);
         }
+
+        [WorkItem(9576, "https://github.com/dotnet/roslyn/issues/9576")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task InlineIntoLambdaWithReturnStatementWithNoExpression()
+        {
+            const string initial = @"
+using System;
+class C
+{
+    static void M(Action a) { }
+
+    static void N()
+    {
+        var [||]x = 42;
+        M(() =>
+        {
+            Console.WriteLine(x);
+            return;
+        });
+    }
+}";
+
+            const string expected = @"
+using System;
+class C
+{
+    static void M(Action a) { }
+
+    static void N()
+    {
+        M(() =>
+        {
+            Console.WriteLine(42);
+            return;
+        });
+    }
+}";
+
+            await TestAsync(initial, expected, compareTokens: false);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -141,17 +141,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                 if (newNode is ReturnStatementSyntax)
                 {
                     var newReturnStatement = (ReturnStatementSyntax)newNode;
-
-                    var parentLambda = node.FirstAncestorOrSelf<LambdaExpressionSyntax>();
-                    if (parentLambda != null)
+                    if (newReturnStatement.Expression != null)
                     {
-                        var returnType = (_semanticModel.GetSymbolInfo(parentLambda).Symbol as IMethodSymbol)?.ReturnType;
-                        if (returnType != null)
+                        var parentLambda = node.FirstAncestorOrSelf<LambdaExpressionSyntax>();
+                        if (parentLambda != null)
                         {
-                            ExpressionSyntax newExpressionWithCast;
-                            if (TryCastTo(returnType, node.Expression, newReturnStatement.Expression, out newExpressionWithCast))
+                            var returnType = (_semanticModel.GetSymbolInfo(parentLambda).Symbol as IMethodSymbol)?.ReturnType;
+                            if (returnType != null)
                             {
-                                newNode = newReturnStatement.WithExpression(newExpressionWithCast);
+                                ExpressionSyntax newExpressionWithCast;
+                                if (TryCastTo(returnType, node.Expression, newReturnStatement.Expression, out newExpressionWithCast))
+                                {
+                                    newNode = newReturnStatement.WithExpression(newExpressionWithCast);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #9576

In the C# expander, we added a step to expand return statement expressions within lambda bodies to aid in conflict resolution for refactoring. However, we failed to account for the fact that lambda return statements can legally have no expression. A simple null-ref is all that's necessary to fix the crash.

Note: This bug was introduced (by me!) in #6432. It was not included in Update 1, so this is a newly-introduced regression in Update 2.

cc @dotnet/roslyn-ide, @Pilchie, @davkean, @CyrusNajmabadi, @MattGertz