### PR TITLE
Test/fix scoping rules for pattern locals declared within a local declaration statement

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -791,7 +791,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             associatedSyntaxNode = associatedSyntaxNode ?? declarator;
 
             // Check for variable declaration errors.
-            bool hasErrors = this.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
+            Binder nameConflictChecker = this;
+
+            // Step out of the PatternVariableBinder for locals declared in variable declaration statement
+            if (this is PatternVariableBinder)
+            {
+                CSharpSyntaxNode parent;
+                if ((parent = declarator.Parent)?.Kind() == SyntaxKind.VariableDeclaration &&
+                     parent.Parent?.Kind() == SyntaxKind.LocalDeclarationStatement)
+                {
+                    nameConflictChecker = this.Next;
+                }
+            }
+
+            bool hasErrors = nameConflictChecker.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
             var containingMethod = this.ContainingMemberOrLambda as MethodSymbol;
             if (containingMethod != null && containingMethod.IsAsync && localSymbol.RefKind != RefKind.None)


### PR DESCRIPTION
Fixes #9612.
Related to #8817.

@gafter, @jaredpar, @dotnet/roslyn-compiler Please review.
CC @MattGertz For Ask Mode approval.