### PR TITLE
Code Model: Implement OverrideKind and ReadWrite on ExternalCodeProperty

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -2697,6 +2697,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             var hasGetter = property.AccessorList != null && property.AccessorList.Accessors.Any(SyntaxKind.GetAccessorDeclaration);
             var hasSetter = property.AccessorList != null && property.AccessorList.Accessors.Any(SyntaxKind.SetAccessorDeclaration);
 
+            if (!hasGetter && !hasSetter)
+            {
+                var expressionBody = property.GetExpressionBody();
+                if (expressionBody != null)
+                {
+                    hasGetter = true;
+                }
+            }
+
             if (hasGetter && hasSetter)
             {
                 return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite;

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
@@ -123,23 +123,61 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
         {
             get
             {
-                throw new NotImplementedException();
+                var symbol = PropertySymbol;
+                var result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone;
+
+                if (symbol.IsAbstract)
+                {
+                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract;
+                }
+
+                if (symbol.IsVirtual)
+                {
+                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual;
+                }
+
+                if (symbol.IsOverride)
+                {
+                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride;
+                }
+
+                if (symbol.IsSealed)
+                {
+                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed;
+                }
+
+                return result;
             }
 
             set
             {
-                throw new NotImplementedException();
+                throw Exceptions.ThrowEFail();
             }
         }
 
         public EnvDTE.CodeElement Parent2
         {
-            get { throw new NotImplementedException(); }
+            get { return (EnvDTE.CodeElement)base.Parent; }
         }
 
         public EnvDTE80.vsCMPropertyKind ReadWrite
         {
-            get { throw new NotImplementedException(); }
+            get
+            {
+                var symbol = PropertySymbol;
+                if (symbol.GetMethod != null)
+                {
+                    return symbol.SetMethod != null
+                        ? EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite
+                        : EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly;
+                }
+                else if (symbol.SetMethod != null)
+                {
+                    return EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly;
+                }
+
+                throw Exceptions.ThrowEUnexpected();
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
@@ -121,22 +121,22 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
 
                 if (symbol.IsAbstract)
                 {
-                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract;
+                    result |= EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract;
                 }
 
                 if (symbol.IsVirtual)
                 {
-                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual;
+                    result |= EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual;
                 }
 
                 if (symbol.IsOverride)
                 {
-                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride;
+                    result |= EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride;
                 }
 
                 if (symbol.IsSealed)
                 {
-                    result = EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed;
+                    result |= EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed;
                 }
 
                 return result;

--- a/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ExternalElements/ExternalCodeProperty.cs
@@ -33,13 +33,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Exter
             return this.Parameters;
         }
 
-        protected override EnvDTE.CodeElements GetParameters()
-        {
-            // TODO: Need to figure out what to do here. This comes from CodeProperty2, but C# apparently never
-            // that interface for external code elements.
-            throw new NotImplementedException();
-        }
-
         public override EnvDTE.vsCMElement Kind
         {
             get { return EnvDTE.vsCMElement.vsCMElementProperty; }

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodePropertyTests.vb
@@ -1003,7 +1003,7 @@ class C
 #Region "OverrideKind tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind1() As Task
+        Public Async Function TestOverrideKind_None() As Task
             Dim code =
 <Code>
 class C
@@ -1025,7 +1025,7 @@ class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind2() As Task
+        Public Async Function TestOverrideKind_Abstract() As Task
             Dim code =
 <Code>
 abstract class C
@@ -1041,12 +1041,114 @@ abstract class C
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
         End Function
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Virtual() As Task
+            Dim code =
+<Code>
+class C
+{
+    public virtual int $$P
+    {
+        get
+        {
+            return default(int);
+        }
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Override() As Task
+            Dim code =
+<Code>
+abstract class B
+{
+    public abstract int P { get; set; }
+}
+
+class C : B
+{
+    public override int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Sealed() As Task
+            Dim code =
+<Code>
+abstract class B
+{
+    public abstract int P { get; set; }
+}
+
+class C : B
+{
+    public override sealed int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride Or EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_New() As Task
+            Dim code =
+<Code>
+abstract class B
+{
+    public int P { get; set; }
+}
+
+class C : B
+{
+    public new int $$P { get; set; }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNew)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Override_ExpressionBody() As Task
+            Dim code =
+<Code>
+abstract class A
+{
+    public abstract int P { get; }
+}
+
+class C : A
+{
+    public override int $$P => 42;
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
+        End Function
+
 #End Region
 
 #Region "ReadWrite tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite1() As Task
+        Public Async Function TestReadWrite_GetSet() As Task
             Dim code =
 <Code>
 class C
@@ -1068,7 +1170,7 @@ class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite2() As Task
+        Public Async Function TestReadWrite_Get() As Task
             Dim code =
 <Code>
 class C
@@ -1087,7 +1189,7 @@ class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite3() As Task
+        Public Async Function TestReadWrite_Set() As Task
             Dim code =
 <Code>
 class C
@@ -1105,7 +1207,7 @@ class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite4() As Task
+        Public Async Function TestReadWrite_GetSet_AutoProperty() As Task
             Dim code =
 <Code>
 class C
@@ -1117,12 +1219,38 @@ class C
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
         End Function
 
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite_Get_AutoProperty() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P { get; }
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite_Get_ExpressionBody() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P => 42;
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Function
+
 #End Region
 
 #Region "Set OverrideKind tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestSetOverrideKind1() As Task
+        Public Async Function TestSetOverrideKind_NoneToAbstract() As Task
             Dim code =
 <Code>
 abstract class C
@@ -1155,7 +1283,7 @@ abstract class C
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestSetOverrideKind2() As Task
+        Public Async Function TestSetOverrideKind_AbstractToNone() As Task
             Dim code =
 <Code>
 abstract class C
@@ -1184,6 +1312,26 @@ abstract class C
 </Code>
 
             Await TestSetOverrideKind(code, expected, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetOverrideKind_NoneToOverride_ExpressionBody() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P => 42;
+}
+</Code>
+            Dim expected =
+<Code>
+class C
+{
+    public override int P => 42;
+}
+</Code>
+
+            Await TestSetOverrideKind(code, expected, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
         End Function
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
@@ -10,6 +10,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
 
 #Region "OverrideKind tests"
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestOverrideKind1() As Task
             Dim code =
@@ -32,6 +33,7 @@ class C
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestOverrideKind2() As Task
             Dim code =
@@ -51,8 +53,31 @@ abstract class C
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestParameterNameWithEscapeCharacters() As Task
+            Dim code =
+<Code>
+class Program
+{
+    public int $$this[int x, int y]
+    {
+        get { return x * y; }
+        set { }
+    }
+}
+</Code>
+
+            Await TestAllParameterNames(code, "x", "y")
+        End Function
+
+#End Region
+
 #Region "ReadWrite tests"
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite1() As Task
             Dim code =
@@ -75,6 +100,7 @@ class C
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite2() As Task
             Dim code =
@@ -94,6 +120,7 @@ class C
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite3() As Task
             Dim code =
@@ -112,6 +139,7 @@ class C
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite4() As Task
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
@@ -1,0 +1,134 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
+    Public Class ExternalCodePropertyTests
+        Inherits AbstractCodePropertyTests
+
+#Region "OverrideKind tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind1() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P
+    {
+        get
+        {
+            return default(int);
+        }
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind2() As Task
+            Dim code =
+<Code>
+abstract class C
+{
+    public abstract int $$P
+    {
+        get;
+        set;
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
+        End Function
+
+#End Region
+
+#Region "ReadWrite tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite1() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P
+    {
+        get
+        {
+            return default(int);
+        }
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite2() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P
+    {
+        get
+        {
+            return default(int);
+        }
+    }
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite3() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P
+    {
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite4() As Task
+            Dim code =
+<Code>
+class C
+{
+    public int $$P { get; set; }
+}
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.CSharp
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/ExternalCodePropertyTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind1() As Task
+        Public Async Function TestOverrideKind_None() As Task
             Dim code =
 <Code>
 class C
@@ -35,7 +35,7 @@ class C
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind2() As Task
+        Public Async Function TestOverrideKind_Abstract() As Task
             Dim code =
 <Code>
 abstract class C
@@ -49,6 +49,75 @@ abstract class C
 </Code>
 
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Virtual() As Task
+            Dim code =
+<Code>
+class C
+{
+    public virtual int $$P
+    {
+        get
+        {
+            return default(int);
+        }
+        set
+        {
+        }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Override() As Task
+            Dim code =
+<Code>
+abstract class B
+{
+    public abstract int P { get; set; }
+}
+
+class C : B
+{
+    public override int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Sealed() As Task
+            Dim code =
+<Code>
+abstract class B
+{
+    public abstract int P { get; set; }
+}
+
+class C : B
+{
+    public override sealed int $$P
+    {
+        get { return default(int); }
+        set { }
+    }
+}
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride Or EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed)
         End Function
 
 #End Region
@@ -79,7 +148,7 @@ class Program
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite1() As Task
+        Public Async Function TestReadWrite_GetSet() As Task
             Dim code =
 <Code>
 class C
@@ -102,7 +171,7 @@ class C
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite2() As Task
+        Public Async Function TestReadWrite_Get() As Task
             Dim code =
 <Code>
 class C
@@ -122,7 +191,7 @@ class C
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite3() As Task
+        Public Async Function TestReadWrite_Set() As Task
             Dim code =
 <Code>
 class C
@@ -137,20 +206,6 @@ class C
 </Code>
 
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
-        End Function
-
-        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
-        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite4() As Task
-            Dim code =
-<Code>
-class C
-{
-    public int $$P { get; set; }
-}
-</Code>
-
-            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
         End Function
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodePropertyTests.vb
@@ -442,7 +442,7 @@ End Class
 #Region "OverrideKind tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind1() As Task
+        Public Async Function TestOverrideKind_None() As Task
             Dim code =
 <Code>
 Class C
@@ -459,15 +459,101 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind2() As Task
+        Public Async Function TestOverrideKind_Abstract() As Task
             Dim code =
 <Code>
-Class C
+MustInherit Class C
     Public MustOverride Property $$P As Integer
 End Class
 </Code>
 
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Virtual() As Task
+            Dim code =
+<Code>
+Class C
+    Public Overridable Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Override() As Task
+            Dim code =
+<Code>
+MustInherit Class A
+    Public MustOverride Property P As Integer
+End Class
+
+Class C
+    Inherits A
+
+    Public Overrides Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Sealed() As Task
+            Dim code =
+<Code>
+MustInherit Class A
+    Public MustOverride Property P As Integer
+End Class
+
+Class C
+    Inherits A
+
+    Public NotOverridable Overrides Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride Or EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_New() As Task
+            Dim code =
+<Code>
+MustInherit Class A
+    Public Property P As Integer
+End Class
+
+Class C
+    Inherits A
+
+    Public Shadows Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNew)
         End Function
 
 #End Region
@@ -692,7 +778,7 @@ End Namespace
 #Region "ReadWrite tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite1() As Task
+        Public Async Function TestReadWrite_GetSet() As Task
             Dim code =
 <Code>
 Class C
@@ -709,7 +795,7 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite2() As Task
+        Public Async Function TestReadWrite_Get() As Task
             Dim code =
 <Code>
 Class C
@@ -724,7 +810,7 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite3() As Task
+        Public Async Function TestReadWrite_Set() As Task
             Dim code =
 <Code>
 Class C
@@ -739,7 +825,7 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite4() As Task
+        Public Async Function TestReadWrite_GetSet_AutoProperty() As Task
             Dim code =
 <Code>
 Class C
@@ -751,7 +837,7 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite5() As Task
+        Public Async Function TestReadWrite_Get_AutoProperty() As Task
             Dim code =
 <Code>
 Class C
@@ -763,7 +849,7 @@ End Class
         End Function
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite6() As Task
+        Public Async Function TestReadWrite_Set_AutoProperty() As Task
             Dim code =
 <Code>
 Class C

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodeFunctionTests.vb
@@ -4,7 +4,7 @@ Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
 Imports Roslyn.Test.Utilities
 
-Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp.VisualBasic
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
     Public Class ExternalCodeFunctionTests
         Inherits AbstractCodeFunctionTests
 

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
@@ -10,6 +10,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasi
 
 #Region "OverrideKind tests"
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestOverrideKind1() As Task
             Dim code =
@@ -27,6 +28,7 @@ End Class
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestOverrideKind2() As Task
             Dim code =
@@ -41,8 +43,33 @@ End Class
 
 #End Region
 
+#Region "Parameter name tests"
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestParameterName() As Task
+            Dim code =
+<Code>
+Class C
+    Property $$P(x As Integer, y as String) As Integer
+        Get
+            Return x * y
+        End Get
+        Set(value As Integer)
+
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestAllParameterNames(code, "x", "y")
+        End Function
+
+#End Region
+
 #Region "ReadWrite tests"
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite1() As Task
             Dim code =
@@ -60,6 +87,7 @@ End Class
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite2() As Task
             Dim code =
@@ -75,6 +103,7 @@ End Class
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite3() As Task
             Dim code =
@@ -90,6 +119,7 @@ End Class
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite4() As Task
             Dim code =
@@ -102,6 +132,7 @@ End Class
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite5() As Task
             Dim code =
@@ -114,6 +145,7 @@ End Class
             Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
         End Function
 
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestReadWrite6() As Task
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
@@ -1,0 +1,134 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis
+Imports Roslyn.Test.Utilities
+
+Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
+    Public Class ExternalCodePropertyTests
+        Inherits AbstractCodePropertyTests
+
+#Region "OverrideKind tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind1() As Task
+            Dim code =
+<Code>
+Class C
+    Public Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindNone)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind2() As Task
+            Dim code =
+<Code>
+Class C
+    Public MustOverride Property $$P As Integer
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
+        End Function
+
+#End Region
+
+#Region "ReadWrite tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite1() As Task
+            Dim code =
+<Code>
+Class C
+    Public Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite2() As Task
+            Dim code =
+<Code>
+Class C
+    Public ReadOnly Property $$P As Integer
+        Get
+        End Get
+    End Property
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite3() As Task
+            Dim code =
+<Code>
+Class C
+    Public WriteOnly Property $$P As Integer
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite4() As Task
+            Dim code =
+<Code>
+Class C
+    Public Property $$P As Integer
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite5() As Task
+            Dim code =
+<Code>
+Class C
+    Public ReadOnly Property $$P As Integer
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestReadWrite6() As Task
+            Dim code =
+<Code>
+Class C
+    Public WriteOnly Property $$P As Integer
+End Class
+</Code>
+
+            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
+        End Function
+
+#End Region
+
+        Protected Overrides ReadOnly Property LanguageName As String = LanguageNames.VisualBasic
+        Protected Overrides ReadOnly Property TargetExternalCodeElements As Boolean = True
+    End Class
+End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/ExternalCodePropertyTests.vb
@@ -12,7 +12,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasi
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind1() As Task
+        Public Async Function TestOverrideKind_None() As Task
             Dim code =
 <Code>
 Class C
@@ -30,15 +30,81 @@ End Class
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestOverrideKind2() As Task
+        Public Async Function TestOverrideKind_Abstract() As Task
             Dim code =
 <Code>
-Class C
+MustInherit Class C
     Public MustOverride Property $$P As Integer
 End Class
 </Code>
 
             Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindAbstract)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Virtual() As Task
+            Dim code =
+<Code>
+Class C
+    Public Overridable Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindVirtual)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Override() As Task
+            Dim code =
+<Code>
+MustInherit Class A
+    Public MustOverride Property P As Integer
+End Class
+
+Class C
+    Inherits A
+
+    Public Overrides Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride)
+        End Function
+
+        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestOverrideKind_Sealed() As Task
+            Dim code =
+<Code>
+MustInherit Class A
+    Public MustOverride Property P As Integer
+End Class
+
+Class C
+    Inherits A
+
+    Public NotOverridable Overrides Property $$P As Integer
+        Get
+        End Get
+        Set(value As Integer)
+        End Set
+    End Property
+End Class
+</Code>
+
+            Await TestOverrideKind(code, EnvDTE80.vsCMOverrideKind.vsCMOverrideKindOverride Or EnvDTE80.vsCMOverrideKind.vsCMOverrideKindSealed)
         End Function
 
 #End Region
@@ -71,7 +137,7 @@ End Class
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite1() As Task
+        Public Async Function TestReadWrite_GetSet() As Task
             Dim code =
 <Code>
 Class C
@@ -89,7 +155,7 @@ End Class
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite2() As Task
+        Public Async Function TestReadWrite_Get() As Task
             Dim code =
 <Code>
 Class C
@@ -105,7 +171,7 @@ End Class
 
         <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite3() As Task
+        Public Async Function TestReadWrite_Set() As Task
             Dim code =
 <Code>
 Class C
@@ -113,45 +179,6 @@ Class C
         Set(value As Integer)
         End Set
     End Property
-End Class
-</Code>
-
-            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindWriteOnly)
-        End Function
-
-        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
-        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite4() As Task
-            Dim code =
-<Code>
-Class C
-    Public Property $$P As Integer
-End Class
-</Code>
-
-            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadWrite)
-        End Function
-
-        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
-        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite5() As Task
-            Dim code =
-<Code>
-Class C
-    Public ReadOnly Property $$P As Integer
-End Class
-</Code>
-
-            Await TestReadWrite(code, EnvDTE80.vsCMPropertyKind.vsCMPropertyKindReadOnly)
-        End Function
-
-        <WorkItem(9646, "https://github.com/dotnet/roslyn/issues/9646")>
-        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
-        Public Async Function TestReadWrite6() As Task
-            Dim code =
-<Code>
-Class C
-    Public WriteOnly Property $$P As Integer
 End Class
 </Code>
 

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -282,6 +282,7 @@
     <Compile Include="CodeModel\CSharp\ExternalCodeClassTests.vb" />
     <Compile Include="CodeModel\CSharp\ExternalCodeFunctionTests.vb" />
     <Compile Include="CodeModel\CSharp\ExternalCodeParameterTests.vb" />
+    <Compile Include="CodeModel\CSharp\ExternalCodePropertyTests.vb" />
     <Compile Include="CodeModel\CSharp\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\RootCodeModelTests.vb" />
     <Compile Include="CodeModel\CSharp\SyntaxNodeKeyTests.vb" />
@@ -318,6 +319,7 @@
     <Compile Include="CodeModel\VisualBasic\ExternalCodeClassTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ExternalCodeFunctionTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ExternalCodeParameterTests.vb" />
+    <Compile Include="CodeModel\VisualBasic\ExternalCodePropertyTests.vb" />
     <Compile Include="CodeModel\VisualBasic\FileCodeModelTests.vb" />
     <Compile Include="CodeModel\VisualBasic\ImplementsStatementTests.vb" />
     <Compile Include="CodeModel\VisualBasic\InheritsStatementTests.vb" />


### PR DESCRIPTION
Fixes #9646

These were missed in the original code model re-implementation on top of Roslyn. The properties were forgotten primarily because they are part of EnvDTE80.CodeProperty2, which C# had forgot to implement for "external", that is out-of-source--i.e. metadata, code properties for years. VB had implemented CodeProperty2 though, and some tools dynamically cast to CodeProperty2 to access the ReadWrite and OverrideKind properties, notably, ASP.NET scaffolding. Prior to Roslyn, those dynamic casts only worked for VB, but since Roslyn shares the same classes between C# and VB for code model objects, they now succeed for C# as well.

cc @dotnet/roslyn-ide 