### PR TITLE
Fix crash in Inline Rename

### DIFF
--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -165,6 +165,7 @@
     <Compile Include="CallHierarchy\CallHierarchyTests.vb" />
     <Compile Include="Diagnostics\InMemoryAssemblyLoader.vb" />
     <Compile Include="Diagnostics\UseAutoProperty\UseAutoPropertyTests.vb" />
+    <Compile Include="Expansion\LambdaParameterExpansionTests.vb" />
     <Compile Include="GoToImplementation\GoToImplementationTests.vb" />
     <Compile Include="InteractivePaste\InteractivePasteCommandHandlerTests.vb" />
     <Compile Include="IntelliSense\CompletionRulesTests.vb" />

--- a/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
@@ -1,0 +1,175 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Expansion
+    Public Class LambdaParameterExpansionTests
+        Inherits AbstractExpansionTest
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithNoParameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action a = {|Expand:() => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+class C
+{
+    void M()
+    {
+        Action a = () => { };
+    }
+}
+</code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_NoParens() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = {|Expand:x => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = (System.Int32 x) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_WithParens() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = {|Expand:(x) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = (System.Int32 x) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithTwoParameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int> a = {|Expand:(x, y) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int> a = (System.Int32 x, System.Int32 y) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithThreearameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int, int> a = {|Expand:(x, y, z) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int, int> a = (System.Int32 x, System.Int32 y, System.Int32 z) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
@@ -40,7 +40,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_NoParens() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameter_NoParens() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -73,7 +73,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_WithParens() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameter_WithParens() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -139,7 +139,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithThreearameters() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithThreeParameters() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -197,7 +197,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                                 {
                                     var typeSyntax = parameterSymbols[i].Type.GenerateTypeSyntax().WithTrailingTrivia(s_oneWhitespaceSeparator);
                                     var newParameter = parameters[i].WithType(typeSyntax).WithAdditionalAnnotations(Simplifier.Annotation);
-                                    newParameters = newParameters.Replace(parameters[i], newParameter);
+
+                                    var currentParameter = newParameters[i];
+                                    newParameters = newParameters.Replace(currentParameter, newParameter);
                                 }
 
                                 var newParameterList = parameterList.WithParameters(newParameters);


### PR DESCRIPTION
Fixes #8412

As the types into an Inline Rename field, the Rename engine attempts to resolve conflicts at each reference. It does this by expanding nodes are the references and then simplifying them down to the smallest node that does not change semantics.

During this process, one of the expansion steps is to add explicit types to lambda parameters that were defined without types. However, the expander wasn't rewriting lambdas with multiple parameters correctly. Essentially, the rewriter assumed that, when replacing a node within a `SeparatedSyntaxList<T>`, the identities of other nodes within the list would not change. However, that's not the case. So, it would successfully replace the first parameter within a lambda's parameter list. However, when it attempted to replace the second parameter, the *original* second parameter could no longer be found in the `SeparatedSyntaxList<T>` because the identity of the second parameter in the list had changed. At this point, `SepratedSyntaxList<T>.Replace(...)` would throw an `ArgumentOutOfRangeException` and VS would crash.

The user scenario is that typing within an Inline Rename field can cause Visual Studio to simply crash, resulting in potenal data loss. Explicitly, this will happen if the user is renaming something that affects a lambda with two or parameters, which is not uncommon.

The fix changes the rewriter to not pass the original parameters to `SeparatedSyntaxList<T>.Replace(...)`. Instead, it passes the parameters that are contained when the new list as it builds it up.

This is a regression introduced after Update 1 with PR #6432.

cc @roslyn-ide, @davkean 

Also, @MattGertz to approve/disapprove the user scenario against the current bar.