### PR TITLE
Update binding redirects in the compiler server.

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/app.config
+++ b/src/Compilers/Server/VBCSCompiler/app.config
@@ -8,15 +8,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.3.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />


### PR DESCRIPTION
Otherwise, we can't load our own compilation analyzers as they can't find a working version of Microsoft.CodeAnalysis.