### PR TITLE
Fix for #8625: SyntaxNode.Contains can use FullSpan.Contains

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNode.cs
@@ -421,7 +421,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool Contains(SyntaxNode node)
         {
-            if (node == null || !this.FullSpan.IntersectsWith(node.FullSpan))
+            if (node == null || !this.FullSpan.Contains(node.FullSpan))
             {
                 return false;
             }


### PR DESCRIPTION
I forgot to address this suggestion on [last PR](https://github.com/dotnet/roslyn/pull/9616).

@cston @VSadov for code review. 