### PR TITLE
fixed analyzer mutating state when it shouldn't

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -95,6 +95,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             _reportSuppressedDiagnostics = reportSuppressedDiagnostics;
             _cancellationToken = cancellationToken;
             _lazyCompilationWithAnalyzers = cachedCompilationWithAnalyzersOpt;
+
+#if DEBUG
+            // this is a bit wierd, but if both analyzers and compilationWithAnalyzers are given,
+            // make sure both are same.
+            if (_lazyCompilationWithAnalyzers != null)
+            {
+                Contract.ThrowIfFalse(_lazyCompilationWithAnalyzers.Analyzers.SetEquals(_analyzers));
+            }
+#endif
         }
 
         public Document Document

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.AnalyzerExecutor.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 _owner = owner;
             }
 
-            public async Task<AnalysisData> GetSyntaxAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers, StateSet stateSet, VersionArgument versions)
+            public async Task<AnalysisData> GetSyntaxAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, VersionArgument versions)
             {
                 try
                 {
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         return existingData;
                     }
 
-                    var diagnosticData = await GetSyntaxDiagnosticsAsync(analyzerDriver, analyzers, stateSet.Analyzer).ConfigureAwait(false);
+                    var diagnosticData = await GetSyntaxDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
                     return new AnalysisData(versions.TextVersion, versions.DataVersion, GetExistingItems(existingData), diagnosticData.AsImmutableOrEmpty());
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 }
             }
 
-            public async Task<AnalysisData> GetDocumentAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers, StateSet stateSet, VersionArgument versions)
+            public async Task<AnalysisData> GetDocumentAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, VersionArgument versions)
             {
                 try
                 {
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         return existingData;
                     }
 
-                    var diagnosticData = await GetSemanticDiagnosticsAsync(analyzerDriver, analyzers, stateSet.Analyzer).ConfigureAwait(false);
+                    var diagnosticData = await GetSemanticDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
                     return new AnalysisData(versions.TextVersion, versions.DataVersion, GetExistingItems(existingData), diagnosticData.AsImmutableOrEmpty());
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             }
 
             public async Task<AnalysisData> GetDocumentBodyAnalysisDataAsync(
-                StateSet stateSet, VersionArgument versions, DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers,
+                StateSet stateSet, VersionArgument versions, DiagnosticAnalyzerDriver analyzerDriver,
                 SyntaxNode root, SyntaxNode member, int memberId, bool supportsSemanticInSpan, MemberRangeMap.MemberRanges ranges)
             {
                 try
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     ImmutableArray<DiagnosticData> diagnosticData;
                     if (supportsSemanticInSpan && CanUseRange(memberId, ranges.Ranges) && CanUseDocumentState(existingData, ranges.TextVersion, versions.DataVersion))
                     {
-                        var memberDxData = await GetSemanticDiagnosticsAsync(analyzerDriver, analyzers, stateSet.Analyzer).ConfigureAwait(false);
+                        var memberDxData = await GetSemanticDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
 
                         diagnosticData = _owner.UpdateDocumentDiagnostics(existingData, ranges.Ranges, memberDxData.AsImmutableOrEmpty(), root.SyntaxTree, member, memberId);
                         ValidateMemberDiagnostics(stateSet.Analyzer, document, root, diagnosticData);
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     else
                     {
                         // if we can't re-use existing document state, only option we have is updating whole document state here.
-                        var dx = await GetSemanticDiagnosticsAsync(analyzerDriver, analyzers, stateSet.Analyzer).ConfigureAwait(false);
+                        var dx = await GetSemanticDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
                         diagnosticData = dx.AsImmutableOrEmpty();
                     }
                     return new AnalysisData(versions.TextVersion, versions.DataVersion, GetExistingItems(existingData), diagnosticData);
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 return memberId >= 0 && memberId < ranges.Length;
             }
 
-            public async Task<AnalysisData> GetProjectAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers, StateSet stateSet, VersionArgument versions)
+            public async Task<AnalysisData> GetProjectAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, VersionArgument versions)
             {
                 try
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         return existingData;
                     }
 
-                    var diagnosticData = await GetProjectDiagnosticsAsync(analyzerDriver, analyzers, stateSet.Analyzer).ConfigureAwait(false);
+                    var diagnosticData = await GetProjectDiagnosticsAsync(analyzerDriver, stateSet.Analyzer).ConfigureAwait(false);
                     return new AnalysisData(versions.TextVersion, versions.DataVersion, GetExistingItems(existingData), diagnosticData.AsImmutableOrEmpty());
                 }
                 catch (Exception e) when (FatalError.ReportUnlessCanceled(e))

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.ProjectStates.cs
@@ -33,9 +33,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return map.Values;
                 }
 
-                public IEnumerable<DiagnosticAnalyzer> GetAnalyzers(Project project)
+                public IEnumerable<DiagnosticAnalyzer> GetOrCreateAnalyzers(Project project)
                 {
-                    var map = GetOrUpdateAnalyzerMap(project);
+                    var map = GetOrCreateAnalyzerMap(project);
                     return map.Keys;
                 }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -42,11 +42,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             public event EventHandler<ProjectAnalyzerReferenceChangedEventArgs> ProjectAnalyzerReferenceChanged;
 
             /// <summary>
-            /// Return <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>.
+            /// Return existing or new <see cref="DiagnosticAnalyzer"/>s for the given <see cref="Project"/>.
             /// </summary>
-            public IEnumerable<DiagnosticAnalyzer> GetAnalyzers(Project project)
+            public IEnumerable<DiagnosticAnalyzer> GetOrCreateAnalyzers(Project project)
             {
-                return _hostStates.GetAnalyzers(project.Language).Concat(_projectStates.GetAnalyzers(project));
+                return _hostStates.GetAnalyzers(project.Language).Concat(_projectStates.GetOrCreateAnalyzers(project));
             }
 
             /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer_GetDiagnostics.cs
@@ -16,37 +16,37 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
     {
         public async override Task<ImmutableArray<DiagnosticData>> GetSpecificCachedDiagnosticsAsync(Solution solution, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDECachedDiagnosticGetter(this).GetSpecificDiagnosticsAsync(solution, id, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDECachedDiagnosticGetter(this, solution, id).GetSpecificDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
         public async override Task<ImmutableArray<DiagnosticData>> GetCachedDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDECachedDiagnosticGetter(this).GetDiagnosticsAsync(solution, projectId, documentId, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDECachedDiagnosticGetter(this, solution, projectId, documentId).GetDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
         public async override Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(Solution solution, object id, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDELatestDiagnosticGetter(this).GetSpecificDiagnosticsAsync(solution, id, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDELatestDiagnosticGetter(this, solution, id).GetSpecificDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
         public async override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId documentId, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDELatestDiagnosticGetter(this).GetDiagnosticsAsync(solution, projectId, documentId, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDELatestDiagnosticGetter(this, solution, projectId, documentId).GetDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
         public async override Task<ImmutableArray<DiagnosticData>> GetDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, DocumentId documentId, ImmutableHashSet<string> diagnosticIds, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDELatestDiagnosticGetter(this, diagnosticIds).GetDiagnosticsAsync(solution, projectId, documentId, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDELatestDiagnosticGetter(this, diagnosticIds, solution, projectId, documentId).GetDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
         public async override Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsForIdsAsync(Solution solution, ProjectId projectId, ImmutableHashSet<string> diagnosticIds, bool includeSuppressedDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var diagnostics = await (new IDELatestDiagnosticGetter(this, diagnosticIds).GetProjectDiagnosticsAsync(solution, projectId, cancellationToken)).ConfigureAwait(false);
+            var diagnostics = await (new IDELatestDiagnosticGetter(this, diagnosticIds, solution, projectId).GetProjectDiagnosticsAsync(cancellationToken)).ConfigureAwait(false);
             return FilterSuppressedDiagnostics(diagnostics, includeSuppressedDiagnostics);
         }
 
@@ -84,11 +84,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private abstract class DiagnosticsGetter
         {
             protected readonly DiagnosticIncrementalAnalyzer Owner;
+
+            protected readonly Solution Solution;
+            protected readonly ProjectId ProjectId;
+            protected readonly DocumentId DocumentId;
+            protected readonly object Id;
+
             private ImmutableArray<DiagnosticData>.Builder _builder;
 
-            public DiagnosticsGetter(DiagnosticIncrementalAnalyzer owner)
+            public DiagnosticsGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId, object id)
             {
                 this.Owner = owner;
+                this.Solution = solution;
+                this.ProjectId = projectId;
+                this.DocumentId = documentId;
+                this.Id = id;
+
                 _builder = null;
             }
 
@@ -100,46 +111,46 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             protected abstract Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken);
             protected abstract Task AppendProjectStateDiagnosticsAsync(Project project, Document document, Func<DiagnosticData, bool> predicate, CancellationToken cancellationToken);
 
-            public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(Solution solution, ProjectId projectId, DocumentId documentId, CancellationToken cancellationToken)
+            public async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(CancellationToken cancellationToken)
             {
-                if (solution == null)
+                if (Solution == null)
                 {
                     return GetDiagnosticData();
                 }
 
-                if (documentId != null)
+                if (DocumentId != null)
                 {
-                    var document = solution.GetDocument(documentId);
+                    var document = Solution.GetDocument(DocumentId);
 
                     await AppendSyntaxAndDocumentDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
-                    await AppendProjectStateDiagnosticsAsync(document.Project, document, d => d.DocumentId == documentId, cancellationToken).ConfigureAwait(false);
+                    await AppendProjectStateDiagnosticsAsync(document.Project, document, d => d.DocumentId == DocumentId, cancellationToken).ConfigureAwait(false);
                     return GetDiagnosticData();
                 }
 
-                if (projectId != null)
+                if (ProjectId != null)
                 {
-                    await AppendDiagnosticsAsync(solution.GetProject(projectId), cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await AppendDiagnosticsAsync(Solution.GetProject(ProjectId), cancellationToken: cancellationToken).ConfigureAwait(false);
                     return GetDiagnosticData();
                 }
 
-                await AppendDiagnosticsAsync(solution, cancellationToken: cancellationToken).ConfigureAwait(false);
+                await AppendDiagnosticsAsync(Solution, cancellationToken: cancellationToken).ConfigureAwait(false);
                 return GetDiagnosticData();
             }
 
-            public async Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsAsync(Solution solution, ProjectId projectId, CancellationToken cancellationToken)
+            public async Task<ImmutableArray<DiagnosticData>> GetProjectDiagnosticsAsync(CancellationToken cancellationToken)
             {
-                if (solution == null)
+                if (Solution == null)
                 {
                     return GetDiagnosticData();
                 }
 
-                if (projectId != null)
+                if (ProjectId != null)
                 {
-                    await AppendProjectDiagnosticsAsync(solution.GetProject(projectId), cancellationToken: cancellationToken).ConfigureAwait(false);
+                    await AppendProjectDiagnosticsAsync(Solution.GetProject(ProjectId), cancellationToken: cancellationToken).ConfigureAwait(false);
                     return GetDiagnosticData();
                 }
 
-                await AppendProjectDiagnosticsAsync(solution, cancellationToken).ConfigureAwait(false);
+                await AppendProjectDiagnosticsAsync(Solution, cancellationToken).ConfigureAwait(false);
                 return GetDiagnosticData();
             }
 
@@ -267,25 +278,31 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private class IDECachedDiagnosticGetter : DiagnosticsGetter
         {
-            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner) : base(owner)
+            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id) :
+                base(owner, solution, projectId: null, documentId: null, id: id)
             {
             }
 
-            public async Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(Solution solution, object id, CancellationToken cancellationToken)
+            public IDECachedDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId) :
+                base(owner, solution, projectId, documentId, id: null)
             {
-                if (solution == null)
+            }
+
+            public async Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(CancellationToken cancellationToken)
+            {
+                if (Solution == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var key = id as ArgumentKey;
+                var key = Id as ArgumentKey;
                 if (key == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
                 var projectId = GetProjectId(key.Key);
-                var project = solution.GetProject(projectId);
+                var project = Solution.GetProject(projectId);
 
                 // when we return cached result, make sure we at least return something that exist in current solution
                 if (project == null)
@@ -306,7 +323,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                 }
 
                 // for now, it just use wait and get result
-                var documentOrProject = GetProjectOrDocument(solution, key.Key);
+                var documentOrProject = GetProjectOrDocument(Solution, key.Key);
                 if (documentOrProject == null)
                 {
                     // Document or project might have been removed from the solution.
@@ -377,15 +394,22 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private abstract class LatestDiagnosticsGetter : DiagnosticsGetter
         {
             protected readonly ImmutableHashSet<string> DiagnosticIds;
-            private readonly Dictionary<ProjectId, CompilationWithAnalyzers> _compilationWithAnalyzersMap;
 
-            public LatestDiagnosticsGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds) : base(owner)
+            private IEnumerable<DiagnosticAnalyzer> _analyzers;
+            private CompilationWithAnalyzers _compilationWithAnalyzers;
+
+            public LatestDiagnosticsGetter(
+                DiagnosticIncrementalAnalyzer owner,
+                ImmutableHashSet<string> diagnosticIds,
+                Solution solution, ProjectId projectId, DocumentId documentId, object id) :
+                base(owner, solution, projectId, documentId, id)
             {
                 this.DiagnosticIds = diagnosticIds;
-                _compilationWithAnalyzersMap = new Dictionary<ProjectId, CompilationWithAnalyzers>();
+
+                _compilationWithAnalyzers = null;
             }
 
-            protected abstract Task<AnalysisData> GetDiagnosticAnalysisDataAsync(Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions);
+            protected abstract Task<AnalysisData> GetDiagnosticAnalysisDataAsync(DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers, StateSet stateSet, StateType stateType, VersionArgument versions);
             protected abstract void FilterDiagnostics(AnalysisData analysisData, Func<DiagnosticData, bool> predicateOpt = null);
 
             protected override Task AppendDocumentDiagnosticsOfStateTypeAsync(Document document, StateType stateType, CancellationToken cancellationToken)
@@ -428,31 +452,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             private async Task<CompilationWithAnalyzers> GetCompilationWithAnalyzersAsync(Project project, bool concurrentAnalysis, bool reportSuppressedDiagnostics, CancellationToken cancellationToken)
             {
-                CompilationWithAnalyzers compilationWithAnalyzers;
-                lock (_compilationWithAnalyzersMap)
-                {
-                    if (_compilationWithAnalyzersMap.TryGetValue(project.Id, out compilationWithAnalyzers))
-                    {
-                        return compilationWithAnalyzers;
-                    }
-                }
-
-                if (project.SupportsCompilation)
+                if (_compilationWithAnalyzers == null && project.SupportsCompilation)
                 {
                     var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                    compilationWithAnalyzers = Owner.GetCompilationWithAnalyzers(project, compilation, concurrentAnalysis, reportSuppressedDiagnostics);
-                }
-                else
-                {
-                    compilationWithAnalyzers = null;
+                    var analyzers = GetAnalyzers(project);
+
+                    _compilationWithAnalyzers = Owner.GetCompilationWithAnalyzers(project, analyzers, compilation, concurrentAnalysis, reportSuppressedDiagnostics);
                 }
 
-                lock (_compilationWithAnalyzersMap)
+                return _compilationWithAnalyzers;
+            }
+
+            protected IEnumerable<DiagnosticAnalyzer> GetAnalyzers(Project project)
+            {
+                if (_analyzers == null)
                 {
-                    _compilationWithAnalyzersMap[project.Id] = compilationWithAnalyzers;
+                    _analyzers = Owner._stateManager.GetOrCreateAnalyzers(project);
                 }
 
-                return compilationWithAnalyzers;
+                return _analyzers;
             }
 
             protected async Task<VersionArgument> GetVersionsAsync(object documentOrProject, StateType stateType, CancellationToken cancellationToken)
@@ -493,12 +511,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             {
                 Contract.ThrowIfNull(documentOrProject);
                 var project = GetProject(documentOrProject);
-                var solution = project.Solution;
 
                 var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, stateType, cancellationToken).ConfigureAwait(false);
                 var versions = await GetVersionsAsync(documentOrProject, stateType, cancellationToken).ConfigureAwait(false);
 
-                foreach (var stateSet in this.StateManager.GetOrCreateStateSets(project))
+                var stateSets = this.StateManager.GetOrCreateStateSets(project);
+                var analyzers = stateSets.Select(s => s.Analyzer);
+
+                foreach (var stateSet in stateSets)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
@@ -508,7 +528,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                         continue;
                     }
 
-                    var analysisData = await GetDiagnosticAnalysisDataAsync(solution, driver, stateSet, stateType, versions).ConfigureAwait(false);
+                    var analysisData = await GetDiagnosticAnalysisDataAsync(driver, analyzers, stateSet, stateType, versions).ConfigureAwait(false);
                     FilterDiagnostics(analysisData, predicateOpt);
                 }
             }
@@ -532,28 +552,40 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
         private class IDELatestDiagnosticGetter : LatestDiagnosticsGetter
         {
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner) : this(owner, null)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, object id) :
+                base(owner, diagnosticIds: null, solution: solution, projectId: null, documentId: null, id: id)
             {
             }
 
-            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds) : base(owner, diagnosticIds)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, Solution solution, ProjectId projectId, DocumentId documentId) :
+                base(owner, diagnosticIds: null, solution: solution, projectId: projectId, documentId: documentId, id: null)
             {
             }
 
-            public async Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(Solution solution, object id, CancellationToken cancellationToken)
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId, DocumentId documentId) :
+                base(owner, diagnosticIds: diagnosticIds, solution: solution, projectId: projectId, documentId: documentId, id: null)
             {
-                if (solution == null)
+            }
+
+            public IDELatestDiagnosticGetter(DiagnosticIncrementalAnalyzer owner, ImmutableHashSet<string> diagnosticIds, Solution solution, ProjectId projectId) :
+                base(owner, diagnosticIds: diagnosticIds, solution: solution, projectId: projectId, documentId: null, id: null)
+            {
+            }
+
+            public async Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(CancellationToken cancellationToken)
+            {
+                if (Solution == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var key = id as ArgumentKey;
+                var key = Id as ArgumentKey;
                 if (key == null)
                 {
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var documentOrProject = GetProjectOrDocument(solution, key.Key);
+                var documentOrProject = GetProjectOrDocument(Solution, key.Key);
                 if (documentOrProject == null)
                 {
                     // Document or project might have been removed from the solution.
@@ -562,13 +594,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                 if (key.StateType != StateType.Project)
                 {
-                    return await GetDiagnosticsAsync(documentOrProject, key, cancellationToken).ConfigureAwait(false);
+                    return await GetSpecificDiagnosticsAsync(documentOrProject, key, cancellationToken).ConfigureAwait(false);
                 }
 
-                return await GetDiagnosticsAsync(GetProject(documentOrProject), key, cancellationToken).ConfigureAwait(false);
+                return await GetSpecificDiagnosticsAsync(GetProject(documentOrProject), key, cancellationToken).ConfigureAwait(false);
             }
 
-            private async Task<ImmutableArray<DiagnosticData>> GetDiagnosticsAsync(object documentOrProject, ArgumentKey key, CancellationToken cancellationToken)
+            private async Task<ImmutableArray<DiagnosticData>> GetSpecificDiagnosticsAsync(object documentOrProject, ArgumentKey key, CancellationToken cancellationToken)
             {
                 var driver = await GetDiagnosticAnalyzerDriverAsync(documentOrProject, key.StateType, cancellationToken).ConfigureAwait(false);
                 var versions = await GetVersionsAsync(documentOrProject, key.StateType, cancellationToken).ConfigureAwait(false);
@@ -580,7 +612,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return ImmutableArray<DiagnosticData>.Empty;
                 }
 
-                var analysisData = await GetDiagnosticAnalysisDataAsync(project.Solution, driver, stateSet, key.StateType, versions).ConfigureAwait(false);
+                var analyzers = GetAnalyzers(project);
+                var analysisData = await GetDiagnosticAnalysisDataAsync(driver, analyzers, stateSet, key.StateType, versions).ConfigureAwait(false);
                 if (key.StateType != StateType.Project)
                 {
                     return analysisData.Items;
@@ -614,16 +647,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
             }
 
             protected override Task<AnalysisData> GetDiagnosticAnalysisDataAsync(
-                Solution solution, DiagnosticAnalyzerDriver analyzerDriver, StateSet stateSet, StateType stateType, VersionArgument versions)
+                DiagnosticAnalyzerDriver analyzerDriver, IEnumerable<DiagnosticAnalyzer> analyzers, StateSet stateSet, StateType stateType, VersionArgument versions)
             {
                 switch (stateType)
                 {
                     case StateType.Syntax:
-                        return this.AnalyzerExecutor.GetSyntaxAnalysisDataAsync(analyzerDriver, stateSet, versions);
+                        return this.AnalyzerExecutor.GetSyntaxAnalysisDataAsync(analyzerDriver, analyzers, stateSet, versions);
                     case StateType.Document:
-                        return this.AnalyzerExecutor.GetDocumentAnalysisDataAsync(analyzerDriver, stateSet, versions);
+                        return this.AnalyzerExecutor.GetDocumentAnalysisDataAsync(analyzerDriver, analyzers, stateSet, versions);
                     case StateType.Project:
-                        return this.AnalyzerExecutor.GetProjectAnalysisDataAsync(analyzerDriver, stateSet, versions);
+                        return this.AnalyzerExecutor.GetProjectAnalysisDataAsync(analyzerDriver, analyzers, stateSet, versions);
                     default:
                         return Contract.FailWithReturn<Task<AnalysisData>>("Can't reach here");
                 }


### PR DESCRIPTION
analyzer state should be only mutated in solution crawler code path. all others either should use cached one or create new one (ex, forked solution)

we had a bug where we violating it in some cases. this should fix it.