### PR TITLE
Tuples: adding well-known types and members for tuples 3-7

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
@@ -56,11 +56,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case 2:
                     {
-                        var tupleType = binder.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2, diagnostics, syntax);
+                        var tupleType = binder.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2, diagnostics, syntax);
                         underlyingType = tupleType.Construct(elementTypes);
 
-                        var underlyingField1 = Binder.GetWellKnownTypeMember(binder.Compilation, WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item1, diagnostics, syntax: syntax) as FieldSymbol;
-                        var underlyingField2 = Binder.GetWellKnownTypeMember(binder.Compilation, WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item2, diagnostics, syntax: syntax) as FieldSymbol;
+                        var underlyingField1 = (FieldSymbol) Binder.GetWellKnownTypeMember(binder.Compilation, WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1, diagnostics, syntax: syntax);
+                        var underlyingField2 = (FieldSymbol) Binder.GetWellKnownTypeMember(binder.Compilation, WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2, diagnostics, syntax: syntax);
 
                         fields = ImmutableArray.Create(
                                     new TupleFieldSymbol(elementNames.IsEmpty ? "Item1" : elementNames[0],
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 default:
                     {
                         // TODO: VS if this eventually still stays reachable, need to make some error type symbol
-                        var tupleType = binder.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2, diagnostics, syntax);
+                        var tupleType = binder.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2, diagnostics, syntax);
                         underlyingType = tupleType.Construct(elementTypes);
                         break;
                     }

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Semantics\UserDefinedConversionTests.cs" />
     <Compile Include="Semantics\UseSiteErrorTests.cs" />
     <Compile Include="Semantics\UsingStatementTests.cs" />
+    <Compile Include="Semantics\ValueTupleTests.cs" />
     <Compile Include="Semantics\VarianceTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
@@ -1,0 +1,167 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.UnitTests;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
+{
+    class ValueTupleTests : CompilingTestBase
+    {
+        [Fact]
+        public void TestWellKnownMembersForValueTuple()
+        {
+            var source = @"
+namespace System.Runtime.CompilerServices
+{
+    struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+    }
+    struct ValueTuple<T1, T2, T3>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+    }
+    struct ValueTuple<T1, T2, T3, T4>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+    }
+    struct ValueTuple<T1, T2, T3, T4, T5>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+    }
+    struct ValueTuple<T1, T2, T3, T4, T5, T6>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+    }
+    struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source);
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2>.Item1", 
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2).ToTestDisplayString());
+
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3>.Item1",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2).ToTestDisplayString());
+            Assert.Equal("T3 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3>.Item3",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3).ToTestDisplayString());
+
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4>.Item1",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2).ToTestDisplayString());
+            Assert.Equal("T3 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4>.Item3",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3).ToTestDisplayString());
+            Assert.Equal("T4 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4>.Item4",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4).ToTestDisplayString());
+
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5>.Item1",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2).ToTestDisplayString());
+            Assert.Equal("T3 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5>.Item3",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3).ToTestDisplayString());
+            Assert.Equal("T4 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5>.Item4",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4).ToTestDisplayString());
+            Assert.Equal("T5 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5>.Item5",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5).ToTestDisplayString());
+
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item1",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2).ToTestDisplayString());
+            Assert.Equal("T3 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item3",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3).ToTestDisplayString());
+            Assert.Equal("T4 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item4",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4).ToTestDisplayString());
+            Assert.Equal("T5 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item5",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5).ToTestDisplayString());
+            Assert.Equal("T6 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6>.Item6",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6).ToTestDisplayString());
+
+            Assert.Equal("T1 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item1",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1).ToTestDisplayString());
+            Assert.Equal("T2 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item2",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2).ToTestDisplayString());
+            Assert.Equal("T3 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item3",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3).ToTestDisplayString());
+            Assert.Equal("T4 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item4",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4).ToTestDisplayString());
+            Assert.Equal("T5 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item5",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5).ToTestDisplayString());
+            Assert.Equal("T6 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item6",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6).ToTestDisplayString());
+            Assert.Equal("T7 System.Runtime.CompilerServices.ValueTuple<T1, T2, T3, T4, T5, T6, T7>.Item7",
+                comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void TestMissingWellKnownMembersForValueTuple()
+        {
+            var comp = CreateCompilationWithMscorlib("");
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2));
+
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3));
+
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4));
+
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5));
+
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6));
+
+            Assert.True(comp.GetWellKnownType(WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7).IsErrorType());
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6));
+            Assert.Null(comp.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -557,7 +557,12 @@ namespace System
                         continue;
                     case WellKnownType.System_FormattableString:
                     case WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory:
-                    case WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6:
+                    case WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7:
                         // Not yet in the platform.
                         continue;
                 }
@@ -597,8 +602,38 @@ namespace System
                         // C# can't embed VB core.
                         continue;
                     case WellKnownMember.System_Array__Empty:
-                    case WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item1:
-                    case WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2:
+
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3:
+
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4:
+
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5:
+
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6:
+
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6:
+                    case WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7:
                         // Not available yet, but will be in upcoming release.
                         continue;
                 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -354,8 +354,38 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_GCLatencyMode__SustainedLowLatency,
 
-        System_Runtime_CompilerServices_Tuple_T1_T2__Item1,
-        System_Runtime_CompilerServices_Tuple_T1_T2__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2,
+
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3,
+
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4,
+
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5,
+
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6,
+
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7,
 
         System_String__Format_IFormatProvider,
         Count

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2519,17 +2519,167 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_GCLatencyMode,                   // Field Signature
 
-                // System_Runtime_CompilerServices_Tuple_T1_T2__Item1
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2,                                            // DeclaringTypeId
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2,                                       // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
 
-                // System_Runtime_CompilerServices_Tuple_T1_T2__Item2
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2
                 (byte)MemberFlags.Field,                                                                                    // Flags
-                (byte)WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2,                                            // DeclaringTypeId
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2,                                       // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,                                    // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,                                    // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,                                    // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,                              // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,                              // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,                              // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,                              // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,                              // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,                           // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 5,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 5,                                                        // Field Signature
+
+                // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7
+                (byte)MemberFlags.Field,                                                                                    // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                        // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    (byte)SignatureTypeCode.GenericTypeParameter, 6,                                                        // Field Signature
 
                 // System_String__Format_IFormatProvider
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
@@ -2837,8 +2987,40 @@ namespace Microsoft.CodeAnalysis
                 "CurrentManagedThreadId",                   // System_Environment__CurrentManagedThreadId
                 ".ctor",                                    // System_ComponentModel_EditorBrowsableAttribute__ctor
                 "SustainedLowLatency",                      // System_Runtime_GCLatencyMode__SustainedLowLatency
-                "Item1",                                    // System_Runtime_CompilerServices_Tuple_T1_T2__Item1
-                "Item2",                                    // System_Runtime_CompilerServices_Tuple_T1_T2__Item2
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2
+                "Item3",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2
+                "Item3",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3
+                "Item4",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2
+                "Item3",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3
+                "Item4",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4
+                "Item5",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2
+                "Item3",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3
+                "Item4",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4
+                "Item5",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5
+                "Item6",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6
+
+                "Item1",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1
+                "Item2",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2
+                "Item3",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3
+                "Item4",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4
+                "Item5",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5
+                "Item6",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6
+                "Item7",                                    // System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7
+
                 "Format",                                   // System_String__Format_IFormatProvider
             };
 

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -245,7 +245,12 @@ namespace Microsoft.CodeAnalysis
 
         System_Runtime_GCLatencyMode,
 
-        System_Runtime_CompilerServices_Tuple_T1_T2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,
+        System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7,
 
         System_IFormatProvider,
 
@@ -489,7 +494,12 @@ namespace Microsoft.CodeAnalysis
 
             "System.Runtime.GCLatencyMode",
 
-            "System.Runtime.CompilerServices.Tuple`2",
+            "System.Runtime.CompilerServices.ValueTuple`2",
+            "System.Runtime.CompilerServices.ValueTuple`3",
+            "System.Runtime.CompilerServices.ValueTuple`4",
+            "System.Runtime.CompilerServices.ValueTuple`5",
+            "System.Runtime.CompilerServices.ValueTuple`6",
+            "System.Runtime.CompilerServices.ValueTuple`7",
 
             "System.IFormatProvider",
         };

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -500,7 +500,12 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7
                         ' Not available on all platforms.
                         Continue For
                 End Select
@@ -530,7 +535,12 @@ End Namespace
                         Continue For
                     Case WellKnownType.System_FormattableString,
                          WellKnownType.System_Runtime_CompilerServices_FormattableStringFactory,
-                         WellKnownType.System_Runtime_CompilerServices_Tuple_T1_T2
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6,
+                         WellKnownType.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7
                         ' Not available on all platforms.
                         Continue For
                 End Select
@@ -565,8 +575,33 @@ End Namespace
                         ' Not a real value.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item1,
-                         WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item2
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                 End Select
@@ -644,8 +679,33 @@ End Namespace
                         ' The type is not embedded, so the member is not available.
                         Continue For
                     Case WellKnownMember.System_Array__Empty,
-                         WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item1,
-                         WellKnownMember.System_Runtime_CompilerServices_Tuple_T1_T2__Item2
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6__Item6,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item1,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item2,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item3,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item4,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item5,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item6,
+                         WellKnownMember.System_Runtime_CompilerServices_ValueTuple_T1_T2_T3_T4_T5_T6_T7__Item7
                         ' Not available yet, but will be in upcoming release.
                         Continue For
                 End Select


### PR DESCRIPTION
@VSadov @jaredpar for code review.

I will add the 8-tuple later, as it requires changing `WellKnownMembers.initializationBytes` from byte to short, because we just reached 256 well-known members...

CC @dotnet/roslyn-compiler 