### PR TITLE
Change the assembly scheduler to ignore generated VB types

### DIFF
--- a/src/Tools/Source/RunTests/AssemblyScheduler.cs
+++ b/src/Tools/Source/RunTests/AssemblyScheduler.cs
@@ -314,6 +314,7 @@ namespace RunTests
                 {
                     case '<':
                     case '>':
+                    case '$':
                         return false;
                 }
             }


### PR DESCRIPTION
In release builds VB generates more prolific state machine types where all of the methods have attributes on them.  To the scheduler this looks like a unit test method and hence it becomes part of the schedule.

In our larger DLLs like Roslyn.Services.Editor.VisualBasic.UnitTests.dll this caused chunks to be scheduled that had 0 actual tests in them.  That's actaully fine to xUnit, it will just report it successfully executed 0 tests.  The problem is these DLLs still use `AppDomain` isolation and hence run into the .Net Framework `AppDomain` unload bug.  As a result our release tests were needlessly failing.