### PR TITLE
Update NuGet zip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /usr/bin/env bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.68
+NUGET_PACKAGE_NAME = nuget.69
 BUILD_CONFIGURATION = Debug
 BINARIES_PATH = $(shell pwd)/Binaries
 TOOLSET_TMP_PATH = $(BINARIES_PATH)/toolset


### PR DESCRIPTION
Looks like the previous one is missing S.R.M 1.2.0 and the unix builds are succeeding because of the caching.

/cc @dotnet/roslyn-infrastructure @jaredpar @davkean 