### PR TITLE
Address flakiness of EmitSequenceOfBinaryExpressions_03 unit-test

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOperators.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.CSharp.UnitTests.Emit;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using System.Collections.Immutable;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
@@ -4754,13 +4755,21 @@ class Test
             var result = CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: "11461640193");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/6077")]
+        [Fact]
         [WorkItem(6077, "https://github.com/dotnet/roslyn/issues/6077")]
         [WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")]
         public void EmitSequenceOfBinaryExpressions_03()
         {
-            var source =
-@"
+            var diagnostics = ImmutableArray<Diagnostic>.Empty;
+
+            const int start = 8192;
+            const int step = 4096;
+            const int limit = start * 4;
+
+            for (int count = start; count <= limit && diagnostics.IsEmpty; count += step)
+            {
+                var source =
+    @"
 class Test
 { 
     static void Main()
@@ -4769,24 +4778,27 @@ class Test
 
     public static bool Calculate(bool[] a, bool[] f)
     {
-" + $"        return { BuildSequenceOfBinaryExpressions_03() };" + @"
+" + $"        return { BuildSequenceOfBinaryExpressions_03(count) };" + @"
     }
 }
 ";
 
-            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
-            compilation.VerifyEmitDiagnostics(
+                var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe);
+                diagnostics = compilation.GetEmitDiagnostics();
+            }
+
+            diagnostics.Verify(
     // (10,16): error CS8078: An expression is too long or complex to compile
     //         return a[0] && f[0] || a[1] && f[1] || a[2] && f[2] || ...
     Diagnostic(ErrorCode.ERR_InsufficientStack, "a").WithLocation(10, 16)
                 );
         }
 
-        private static string BuildSequenceOfBinaryExpressions_03()
+        private static string BuildSequenceOfBinaryExpressions_03(int count = 8192)
         {
             var builder = new System.Text.StringBuilder();
             int i;
-            for (i = 0; i < 8192; i++)
+            for (i = 0; i < count; i++)
             {
                 builder.Append("a[");
                 builder.Append(i);

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -235,9 +235,18 @@ namespace Microsoft.CodeAnalysis
         public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, EmitOptions options, params DiagnosticDescription[] expected)
             where TCompilation : Compilation
         {
-            var pdbStream = MonoHelpers.IsRunningOnMono() ? null : new MemoryStream();
-            c.Emit(new MemoryStream(), pdbStream: pdbStream, options: options).Diagnostics.Verify(expected);
+            c.GetEmitDiagnostics(options: options).Verify(expected);
             return c;
+        }
+
+        public static ImmutableArray<Diagnostic> GetEmitDiagnostics<TCompilation>(
+            this TCompilation c,
+            EmitOptions options = null,
+            IEnumerable<ResourceDescription> manifestResources = null)
+            where TCompilation : Compilation
+        {
+            var pdbStream = MonoHelpers.IsRunningOnMono() ? null : new MemoryStream();
+            return c.Emit(new MemoryStream(), pdbStream: pdbStream, options: options, manifestResources: manifestResources).Diagnostics;
         }
 
         public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, params DiagnosticDescription[] expected)
@@ -246,11 +255,16 @@ namespace Microsoft.CodeAnalysis
             return VerifyEmitDiagnostics(c, EmitOptions.Default, expected);
         }
 
+        public static ImmutableArray<Diagnostic> GetEmitDiagnostics<TCompilation>(this TCompilation c)
+            where TCompilation : Compilation
+        {
+            return GetEmitDiagnostics(c, EmitOptions.Default);
+        }
+
         public static TCompilation VerifyEmitDiagnostics<TCompilation>(this TCompilation c, IEnumerable<ResourceDescription> manifestResources, params DiagnosticDescription[] expected)
             where TCompilation : Compilation
         {
-            var pdbStream = MonoHelpers.IsRunningOnMono() ? null : new MemoryStream();
-            c.Emit(new MemoryStream(), pdbStream: pdbStream, manifestResources: manifestResources).Diagnostics.Verify(expected);
+            c.GetEmitDiagnostics(manifestResources: manifestResources).Verify(expected);
             return c;
         }
 


### PR DESCRIPTION
by gradually increasing amount of binary expressions until we get an error.

Fixes #6077.

@dotnet/roslyn-compiler Please review.