### PR TITLE
DryDock Effort: Enableing the skipped unit tests in CompletionProviders with "now expected behaviour"

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -776,7 +776,7 @@ public class SomeClass : Base
 
         [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task GenericMethodTypeParametersRenamed()
+        public async Task GenericMethodTypeParametersNotRenamed()
         {
             var markup = @"abstract class CFoo    
 {    
@@ -816,7 +816,7 @@ class Derived<X> : CFoo
 
         [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task CommitGenericMethodTypeParametersRenamed()
+        public async Task CommitGenericMethodTypeParametersNotRenamed()
         {
             var markupBeforeCommit = @"abstract class CFoo    
 {    

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -794,6 +794,26 @@ class Derived<X> : CFoo
         #endregion
 
         #region "Commit tests"
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitInEmptyClass()
+        {
+            var markupBeforeCommit = @"class c
+{
+        override $$
+}";
+
+            var expectedCodeAfterCommit = @"class c
+{
+    public override bool Equals(object obj)
+    {
+        return base.Equals(obj);$$
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Equals(object obj)", expectedCodeAfterCommit);
+        }
+
         [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitGenericMethodTypeParametersRenamed()
@@ -825,25 +845,6 @@ class Derived<X> : CFoo
     }
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Something<X>(X arg)", expectedCodeAfterCommit);
-        }
-
-    [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task CommitInEmptyClass()
-        {
-            var markupBeforeCommit = @"class c
-{
-        override $$
-}";
-
-            var expectedCodeAfterCommit = @"class c
-{
-    public override bool Equals(object obj)
-    {
-        return base.Equals(obj);$$
-    }
-}";
-
-            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Equals(object obj)", expectedCodeAfterCommit);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -773,28 +773,7 @@ public class SomeClass : Base
 
             await VerifyItemExistsAsync(markup, "foo(int x, out string y)", "void Base.foo(int x, out string y)");
         }
-
-        [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
-        [WpfFact(Skip = "529714"), Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task GenericMethodTypeParametersRenamed()
-        {
-            var markup = @"abstract class CFoo
-{
-    public virtual X Something<X>(X arg)
-    {
-        return default(X);
-    }
-}
-
-class Derived<X> : CFoo
-{
-    override $$
-}";
-
-            await VerifyItemExistsAsync(markup, "Something<X1>(X1 arg)");
-            await VerifyItemIsAbsentAsync(markup, "Something<X>(X arg)");
-        }
-
+        
         #endregion
 
         #region "Commit tests"
@@ -1857,42 +1836,6 @@ public class SomeClass : Base
 }";
 
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "foo(int x, out string y)", expectedCodeAfterCommit);
-        }
-
-        [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
-        [WpfFact(Skip = "529714"), Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task CommitGenericMethodTypeParametersRenamed()
-        {
-            var markupBeforeCommit = @"abstract class CFoo
-{
-    public virtual X Something<X>(X arg)
-    {
-        return default(X);
-    }
-}
-
-class Derived<X> : CFoo
-{
-    override $$
-}";
-
-            var expectedCodeAfterCommit = @"abstract class CFoo
-{
-    public virtual X Something<X>(X arg)
-    {
-        return default(X);
-    }
-}
-
-class Derived<X> : CFoo
-{
-    public override X1 Something<X1>(X1 arg)
-    {
-        return base.Something<X1>(arg);
-    }
-}";
-
-            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Something<X1>(X1 arg)", expectedCodeAfterCommit);
         }
 
         [WorkItem(544560, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544560")]

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -773,12 +773,61 @@ public class SomeClass : Base
 
             await VerifyItemExistsAsync(markup, "foo(int x, out string y)", "void Base.foo(int x, out string y)");
         }
-        
+
+        [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task GenericMethodTypeParametersRenamed()
+        {
+            var markup = @"abstract class CFoo    
+{    
+   public virtual X Something<X>(X arg)    
+   {    
+       return default(X);    
+    }    
+}    
+class Derived<X> : CFoo    
+{    
+    override $$    
+}";
+            await VerifyItemExistsAsync(markup, "Something<X>(X arg)");
+        }
         #endregion
 
         #region "Commit tests"
-
+        [WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CommitGenericMethodTypeParametersRenamed()
+        {
+            var markupBeforeCommit = @"abstract class CFoo    
+{    
+    public virtual X Something<X>(X arg)    
+    {    
+        return default(X);    
+    }    
+}    
+class Derived<X> : CFoo    
+{    
+    override $$    
+}";
+
+            var expectedCodeAfterCommit = @"abstract class CFoo    
+{    
+    public virtual X Something<X>(X arg)    
+    {    
+        return default(X);    
+    }    
+}    
+class Derived<X> : CFoo    
+{
+    public override X Something<X>(X arg)
+    {
+        return base.Something<X>(arg);$$
+    }
+}";
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Something<X>(X arg)", expectedCodeAfterCommit);
+        }
+
+    [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitInEmptyClass()
         {
             var markupBeforeCommit = @"class c

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -518,24 +518,6 @@ End Class</a>
             Await VerifyItemIsAbsentAsync(markup.Value, "Foo(t As T, s As S)")
         End Function
 
-        <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
-        <WpfFact(Skip:="529714"), Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestGenericMethodTypeParametersRenamed() As Task
-            Dim text = <a>Class CFoo
-    Overridable Function Something(Of X)(arg As X) As X
-    End Function
-End Class
-
-Class Derived(Of X)
-    Inherits CFoo
-
-    Overrides $$
-End Class</a>
-
-            Await VerifyItemExistsAsync(text.Value, "Something(Of X1)(arg As X1)")
-            Await VerifyItemIsAbsentAsync(text.Value, "Something(Of X)(arg As X)")
-        End Function
-
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestParameterTypeSimplified() As Task
             Dim text = <a>Imports System
@@ -1369,36 +1351,6 @@ Class CDerived
 End Class</a>
 
             Await VerifyCustomCommitProviderAsync(markupBeforeCommit.Value.Replace(vbLf, vbCrLf), "foo(ByRef x As Integer, y As String)", expectedCode.Value.Replace(vbLf, vbCrLf))
-        End Function
-
-        <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
-        <WpfFact(Skip:="529714"), Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestCommitGenericMethodTypeParametersRenamed() As Task
-            Dim markupBeforeCommit = <a>Class CFoo
-    Overridable Function Something(Of X)(arg As X) As X
-    End Function
-End Class
-
-Class Derived(Of X)
-    Inherits CFoo
-
-    Overrides $$
-End Class</a>
-
-            Dim expectedCode = <a>Class CFoo
-    Overridable Function Something(Of X)(arg As X) As X
-    End Function
-End Class
-
-Class Derived(Of X)
-    Inherits CFoo
-
-    Public Overrides Function Something(Of X1)(arg As X1) As X1
-        Return MyBase.Something(Of X1)(arg)$$
-    End Function
-End Class</a>
-
-            Await VerifyCustomCommitProviderAsync(markupBeforeCommit.Value.Replace(vbLf, vbCrLf), "Something(Of X1)(arg As X1)", expectedCode.Value.Replace(vbLf, vbCrLf))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -518,6 +518,22 @@ End Class</a>
             Await VerifyItemIsAbsentAsync(markup.Value, "Foo(t As T, s As S)")
         End Function
 
+        <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestGenericMethodTypeParametersRenamed() As Task
+            Dim text = <a>Class CFoo    
+    Overridable Function Something(Of X)(arg As X) As X    
+    End Function    
+    End Class    
+   
+    Class Derived(Of X)    
+     Inherits CFoo    
+     Overrides $$    
+     End Class</a>
+
+            Await VerifyItemExistsAsync(text.Value, "Something(Of X)(arg As X)")
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestParameterTypeSimplified() As Task
             Dim text = <a>Imports System
@@ -1351,6 +1367,33 @@ Class CDerived
 End Class</a>
 
             Await VerifyCustomCommitProviderAsync(markupBeforeCommit.Value.Replace(vbLf, vbCrLf), "foo(ByRef x As Integer, y As String)", expectedCode.Value.Replace(vbLf, vbCrLf))
+        End Function
+
+        <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestCommitGenericMethodTypeParametersRenamed() As Task
+            Dim markupBeforeCommit = <a>Class CFoo    
+    Overridable Function Something(Of X)(arg As X) As X    
+    End Function    
+End Class    
+    
+Class Derived(Of X)    
+    Inherits CFoo    
+      Overrides $$    
+End Class</a>
+
+            Dim expectedCode = <a>Class CFoo    
+    Overridable Function Something(Of X)(arg As X) As X    
+    End Function    
+End Class    
+    
+Class Derived(Of X)
+    Inherits CFoo
+    Public Overrides Function Something(Of X)(arg As X) As X
+        Return MyBase.Something(arg)$$
+    End Function
+End Class</a>
+            Await VerifyCustomCommitProviderAsync(markupBeforeCommit.Value.Replace(vbLf, vbCrLf), "Something(Of X)(arg As X)", expectedCode.Value.Replace(vbLf, vbCrLf))
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -520,7 +520,7 @@ End Class</a>
 
         <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestGenericMethodTypeParametersRenamed() As Task
+        Public Async Function TestGenericMethodTypeParametersNotRenamed() As Task
             Dim text = <a>Class CFoo    
     Overridable Function Something(Of X)(arg As X) As X    
     End Function    
@@ -1371,7 +1371,7 @@ End Class</a>
 
         <WorkItem(529714, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714")>
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TestCommitGenericMethodTypeParametersRenamed() As Task
+        Public Async Function TestCommitGenericMethodTypeParametersNotRenamed() As Task
             Dim markupBeforeCommit = <a>Class CFoo    
     Overridable Function Something(Of X)(arg As X) As X    
     End Function    


### PR DESCRIPTION
http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529714 marked as won't fix
@Srivatsn
@dotnet/roslyn-ide 