### PR TITLE
Reenable the CurrentWorkingDirectory test

### DIFF
--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests
             Assert.False(result.ContainsErrors);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/7826")]
+        [Fact]
         public void CurrentWorkingDirectory_Change()
         {
             var dir = Temp.CreateDirectory();

--- a/src/Test/Utilities/Desktop/ProcessUtilities.cs
+++ b/src/Test/Utilities/Desktop/ProcessUtilities.cs
@@ -66,6 +66,7 @@ namespace Roslyn.Test.Utilities
                 if (stdInput != null)
                 {
                     process.StandardInput.Write(stdInput);
+                    process.StandardInput.Close();
                 }
 
                 process.WaitForExit();

--- a/src/Test/Utilities/Desktop/ProcessUtilities.cs
+++ b/src/Test/Utilities/Desktop/ProcessUtilities.cs
@@ -28,12 +28,19 @@ namespace Roslyn.Test.Utilities
                 FileName = fileName,
                 Arguments = arguments,
                 UseShellExecute = false,
-                CreateNoWindow = true,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 RedirectStandardInput = stdInput != null,
                 WorkingDirectory = workingDirectory
             };
+
+            // In case the process is a console application that expects standard input
+            // do not set CreateNoWindow to true to ensure that the input encoding
+            // of both the test and the process fileName is equal.
+            if (stdInput == null)
+            {
+                startInfo.CreateNoWindow = true;
+            }
 
             if (additionalEnvironmentVars != null)
             {


### PR DESCRIPTION
Enables the current working directory test and adds additional assertions to increase the amount of information in case of failure.