### PR TITLE
Fix samples test projects

### DIFF
--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -165,6 +165,7 @@
     <Compile Include="CallHierarchy\CallHierarchyTests.vb" />
     <Compile Include="Diagnostics\InMemoryAssemblyLoader.vb" />
     <Compile Include="Diagnostics\UseAutoProperty\UseAutoPropertyTests.vb" />
+    <Compile Include="Expansion\LambdaParameterExpansionTests.vb" />
     <Compile Include="GoToImplementation\GoToImplementationTests.vb" />
     <Compile Include="InteractivePaste\InteractivePasteCommandHandlerTests.vb" />
     <Compile Include="IntelliSense\CompletionRulesTests.vb" />

--- a/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
@@ -1,0 +1,175 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading.Tasks
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Expansion
+    Public Class LambdaParameterExpansionTests
+        Inherits AbstractExpansionTest
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithNoParameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action a = {|Expand:() => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+class C
+{
+    void M()
+    {
+        Action a = () => { };
+    }
+}
+</code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_NoParens() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = {|Expand:x => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = (System.Int32 x) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_WithParens() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = {|Expand:(x) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int> a = (System.Int32 x) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithTwoParameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int> a = {|Expand:(x, y) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int> a = (System.Int32 x, System.Int32 y) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
+        Public Async Function TestCSharp_ExpandLambdaWithThreearameters() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int, int> a = {|Expand:(x, y, z) => { }|};
+    }
+}
+        ]]></Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+using System;
+class C
+{
+    void M()
+    {
+        Action<int, int, int> a = (System.Int32 x, System.Int32 y, System.Int32 z) => { };
+    }
+}
+]]></code>
+
+            Await TestAsync(input, expected, expandParameter:=True)
+        End Function
+
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
+++ b/src/EditorFeatures/Test2/Expansion/LambdaParameterExpansionTests.vb
@@ -40,7 +40,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_NoParens() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameter_NoParens() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -73,7 +73,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithSingleParameters_WithParens() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithSingleParameter_WithParens() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -139,7 +139,7 @@ class C
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Expansion)>
-        Public Async Function TestCSharp_ExpandLambdaWithThreearameters() As Task
+        Public Async Function TestCSharp_ExpandLambdaWithThreeParameters() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">

--- a/src/Samples/CSharp/APISampleUnitTests/APISampleUnitTestsCS.csproj
+++ b/src/Samples/CSharp/APISampleUnitTests/APISampleUnitTestsCS.csproj
@@ -68,5 +68,6 @@
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>

--- a/src/Samples/CSharp/ConvertToConditional/Test/ConvertToConditionalCS.UnitTests.csproj
+++ b/src/Samples/CSharp/ConvertToConditional/Test/ConvertToConditionalCS.UnitTests.csproj
@@ -64,7 +64,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup />

--- a/src/Samples/CSharp/ConvertToConditional/Test/app.config
+++ b/src/Samples/CSharp/ConvertToConditional/Test/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedCS.UnitTests.csproj
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedCS.UnitTests.csproj
@@ -18,7 +18,6 @@
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup Label="File References">
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup Label="Project References">
@@ -68,5 +67,6 @@
   <ItemGroup />
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/app.config
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.appDomain" value="denied"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Samples/Shared/UnitTestFramework/UnitTestFramework.csproj
+++ b/src/Samples/Shared/UnitTestFramework/UnitTestFramework.csproj
@@ -64,7 +64,6 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ImportGroup Label="Targets">

--- a/src/Samples/Shared/UnitTestFramework/app.config
+++ b/src/Samples/Shared/UnitTestFramework/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.appDomain" value="denied"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Samples/VisualBasic/APISampleUnitTests/APISampleUnitTestsVB.vbproj
+++ b/src/Samples/VisualBasic/APISampleUnitTests/APISampleUnitTestsVB.vbproj
@@ -86,5 +86,6 @@
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/ConvertToAutoPropertyVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/ConvertToAutoPropertyVB.UnitTests.vbproj
@@ -71,10 +71,10 @@
     <Compile Include="My Project\AssemblyInfo.vb" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/app.config
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.appDomain" value="denied"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/ImplementNotifyPropertyChangedVB.UnitTests.vbproj
@@ -61,10 +61,10 @@
     <Compile Include="CodeRefactoringTests.vb" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\..\build\Targets\VSL.Imports.targets" />
+    <Import Project="..\..\..\..\..\build\Targets\Roslyn.Toolsets.Xunit.targets" />
   </ImportGroup>
 </Project>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/app.config
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.appDomain" value="denied"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Samples/VisualBasic/RemoveByVal/Test/RemoveByValVB.UnitTests.vbproj
+++ b/src/Samples/VisualBasic/RemoveByVal/Test/RemoveByValVB.UnitTests.vbproj
@@ -79,7 +79,6 @@
     <Compile Include="RemoveByValTests.vb" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
     <None Include="project.json" />
   </ItemGroup>
   <ImportGroup Label="Targets">

--- a/src/Samples/VisualBasic/RemoveByVal/Test/app.config
+++ b/src/Samples/VisualBasic/RemoveByVal/Test/app.config
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="xunit.useAppDomain" value="true"/>
-    <add key="xunit.diagnosticMessages" value="false"/>
-    <add key="xunit.parallelizeTestCollections" value="false"/>
-  </appSettings>
-</configuration>

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -197,7 +197,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                                 {
                                     var typeSyntax = parameterSymbols[i].Type.GenerateTypeSyntax().WithTrailingTrivia(s_oneWhitespaceSeparator);
                                     var newParameter = parameters[i].WithType(typeSyntax).WithAdditionalAnnotations(Simplifier.Annotation);
-                                    newParameters = newParameters.Replace(parameters[i], newParameter);
+
+                                    var currentParameter = newParameters[i];
+                                    newParameters = newParameters.Replace(currentParameter, newParameter);
                                 }
 
                                 var newParameterList = parameterList.WithParameters(newParameters);


### PR DESCRIPTION
Remove unneeded app.config files from samples test projects.
Add missing xunit toolset imports to samples test projects.

Fixes #9707.