### PR TITLE
Fix memory leak in ProjectCacheService...

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.SimpleMRUCache.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.SimpleMRUCache.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 
             private readonly Node[] _nodes = new Node[CacheSize];
 
-            public bool Empty
+            public bool IsEmpty
             {
                 get
                 {

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
@@ -8,6 +8,14 @@ using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
+    /// <summary>
+    /// This service will implicitly cache previous Compilations used by each supported Workspace implementation.
+    /// The number of Compilations cached is determined by <see cref="ImplicitCacheSize"/>.  For now, we'll only
+    /// support implicit caching for VS Workspaces (<see cref="WorkspaceKind.Host"/>), as caching is known to
+    /// reduce latency in designer scenarios using the VS workspace.  For other Workspace kinds, the cost of the
+    /// cache is likely to outweigh the benefit (for example, in Misc File Workspace cases, we can end up holding
+    /// onto a lot of memory even after a file is closed).  We can opt in other kinds of Workspaces as needed.
+    /// </summary>
     internal partial class ProjectCacheService : IProjectCacheHostService
     {
         internal const int ImplicitCacheSize = 3;
@@ -19,7 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 
         private readonly SimpleMRUCache _implicitCache;
         private readonly ImplicitCacheMonitor _implicitCacheMonitor;
-
+        
         public ProjectCacheService(Workspace workspace, int implicitCacheTimeout)
         {
             _workspace = workspace;

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
             {
                 lock (_gate)
                 {
-                    return _implicitCache.Empty;
+                    return _implicitCache?.IsEmpty ?? false;
                 }
             }
         }
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         {
             lock (_gate)
             {
-                _implicitCache.Clear();
+                _implicitCache?.Clear();
             }
         }
 
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         {
             lock (_gate)
             {
-                _implicitCache.ClearExpiredItems(expirationTime);
+                _implicitCache?.ClearExpiredItems(expirationTime);
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/ProjectCacheService.cs
@@ -17,17 +17,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
         private readonly Workspace _workspace;
         private readonly Dictionary<ProjectId, Cache> _activeCaches = new Dictionary<ProjectId, Cache>();
 
-        private readonly SimpleMRUCache _implicitCache = new SimpleMRUCache();
+        private readonly SimpleMRUCache _implicitCache;
         private readonly ImplicitCacheMonitor _implicitCacheMonitor;
 
-        public ProjectCacheService(Workspace workspace, int implicitCacheTimeout, bool forceCleanup = false)
+        public ProjectCacheService(Workspace workspace, int implicitCacheTimeout)
         {
             _workspace = workspace;
 
-            // forceCleanup is for testing
-            if (workspace?.Kind == WorkspaceKind.Host || forceCleanup)
+            // Only create implicit cache for Visual Studio Workspace (the cost of the
+            // cache likely outweighs the benefit for the other types of Workspaces).
+            if (workspace?.Kind == WorkspaceKind.Host)
             {
-                // monitor implicit cache for host
+                _implicitCache = new SimpleMRUCache();
                 _implicitCacheMonitor = new ImplicitCacheMonitor(this, implicitCacheTimeout);
             }
         }
@@ -84,10 +85,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
                 {
                     cache.CreateStrongReference(owner, instance);
                 }
-                else if (!PartOfP2PReferences(key))
+                else if ((_implicitCache != null) && !PartOfP2PReferences(key))
                 {
                     _implicitCache.Touch(instance);
-                    _implicitCacheMonitor?.Touch();
+                    _implicitCacheMonitor.Touch();
                 }
 
                 return instance;

--- a/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
+++ b/src/EditorFeatures/Test/Workspaces/ProjectCacheHostServiceFactoryTests.cs
@@ -107,7 +107,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
         [Fact]
         public void TestImplicitCacheKeepsObjectAlive1()
         {
-            var cacheService = new ProjectCacheService(null, int.MaxValue);
+            var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
+            var cacheService = new ProjectCacheService(workspace, int.MaxValue);
             var instance = new object();
             var weak = new WeakReference(instance);
             cacheService.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, instance);
@@ -201,7 +202,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weakFirst = new WeakReference(compilations[0]);
             var weakLast = new WeakReference(compilations[compilations.Count - 1]);
 
-            var cache = new ProjectCacheService(null, int.MaxValue);
+            var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
+            var cache = new ProjectCacheService(workspace, int.MaxValue);
             for (int i = 0; i < ProjectCacheService.ImplicitCacheSize + 1; i++)
             {
                 cache.CacheObjectIfCachingEnabledForKey(ProjectId.CreateNewId(), (object)null, compilations[i]);
@@ -225,7 +227,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
             var weak3 = new WeakReference(comp3);
             var weak1 = new WeakReference(comp1);
 
-            var cache = new ProjectCacheService(null, int.MaxValue);
+            var workspace = new AdhocWorkspace(MockHostServices.Instance, workspaceKind: WorkspaceKind.Host);
+            var cache = new ProjectCacheService(workspace, int.MaxValue);
             var key = ProjectId.CreateNewId();
             var owner = new object();
             cache.CacheObjectIfCachingEnabledForKey(key, owner, comp1);


### PR DESCRIPTION
We create a SimpleMRUCache for all Workspace types, but we only monitor it
(clean up) for the Visual Studio Workspace.  If you repeatedly
opened/closed files in the Miscellaneous Files Workspace, we'd cache every
Solution and never clean them up (as described in DevDiv 126519).

Alternatively, we could consider only creating a cache in the ```WorkspaceKind.Host``` case.