### PR TITLE
DryDock Effort: Enabling the skipped test marked with xunit

### DIFF
--- a/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/DiagnosticsSquiggleTaggerProviderTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 
     public class DiagnosticsSquiggleTaggerProviderTests
     {
-        [WpfFact(Skip = "xunit"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public async Task Test_TagSourceDiffer()
         {
             var analyzer = new Analyzer();
@@ -191,7 +191,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             }
         }
 
-        [WpfFact(Skip = "xunit"), Trait(Traits.Feature, Traits.Features.Diagnostics)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)]
         public async Task MultipleTaggersAndDispose()
         {
             using (var workspace = await TestWorkspace.CreateCSharpAsync(new string[] { "class A {" }, CSharpParseOptions.Default))

--- a/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/InteractiveSessionTests.cs
@@ -169,7 +169,7 @@ var x = from a in new[] { 1, 2 ,3 } select a + 1;
             AssertEx.Equal(new[] { 2, 3, 4 }, state.ReturnValue);
         }
 
-        [Fact(Skip = "xunit2")]
+        [Fact]
         public async Task References1()
         {
             var options0 = ScriptOptions.Default.AddReferences(


### PR DESCRIPTION
I am not sure why this were skipped, enabling them seems to work.
Not sure if they are flaky in nature. tested in couple of times.
Let me know if there is any reason why this should not be enabled.

@dotnet/roslyn-ide 