### PR TITLE
csi.exe should emit exception to stderr, not stdout

### DIFF
--- a/src/Interactive/CsiCore/Csi.cs
+++ b/src/Interactive/CsiCore/Csi.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.ToString());
+                Console.Error.WriteLine(ex.ToString());
                 return 1;
             }
         }

--- a/src/Scripting/CSharpTest.Desktop/CsiTests.cs
+++ b/src/Scripting/CSharpTest.Desktop/CsiTests.cs
@@ -79,7 +79,7 @@ Type ""#help"" for more information.
             var result = ProcessUtilities.Run(CsiPath, "/r:C.dll a.csx", workingDirectory: cwd.Path, additionalEnvironmentVars: new[] { KeyValuePair.Create("LIB", dir.Path) });
 
             // error CS0006: Metadata file 'C.dll' could not be found
-            Assert.True(result.Output.StartsWith("error CS0006", StringComparison.Ordinal));
+            Assert.True(result.Errors.StartsWith("error CS0006", StringComparison.Ordinal));
             Assert.True(result.ContainsErrors);
         }
 

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -79,6 +79,10 @@ Type ""#help"" for more information.
 . select x * x
 Enumerable.WhereSelectArrayIterator<int, int> {{ 9, 16, 25 }}
 > ", runner.Console.Out.ToString());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                @"(1,19): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread.",
+                runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -185,6 +189,11 @@ Type ""#help"" for more information.
   + Submission#0.div(int, int)
 «Gray»
 > ", runner.Console.Out.ToString());
+
+            Assert.Equal(
+$@"{new System.DivideByZeroException().Message}
+  + Submission#0.div(int, int)
+", runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -211,6 +220,11 @@ Type ""#help"" for more information.
   + Submission#0.C<T>.div<U>(int, int)
 «Gray»
 > ", runner.Console.Out.ToString());
+
+            Assert.Equal(
+$@"{new System.DivideByZeroException().Message}
+  + Submission#0.C<T>.div<U>(int, int)
+", runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -241,9 +255,9 @@ Type ""#help"" for more information.
 
             runner.RunInteractive();
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(
-                $@"error CS2001: Source file '{Path.Combine(AppContext.BaseDirectory, "@arg1")}' could not be found.",
-                runner.Console.Out.ToString());
+            var error = $@"error CS2001: Source file '{Path.Combine(AppContext.BaseDirectory, "@arg1")}' could not be found.";
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -389,9 +403,9 @@ $@"""@arg1""
 
             Assert.Equal(1, runner.RunInteractive());
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences($@"
-error CS2001: Source file '{Path.Combine(AppContext.BaseDirectory, "a + b")}' could not be found.
-", runner.Console.Out.ToString());
+            var error = $@"error CS2001: Source file '{Path.Combine(AppContext.BaseDirectory, "a + b")}' could not be found.";
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -431,9 +445,9 @@ Options:
 
             Assert.Equal(1, runner.RunInteractive());
 
-            AssertEx.AssertEqualToleratingWhitespaceDifferences(@"
-error CS0246: The type or namespace name 'Foo' could not be found (are you missing a using directive or an assembly reference?)
-", runner.Console.Out.ToString());
+            const string error = @"error CS0246: The type or namespace name 'Foo' could not be found (are you missing a using directive or an assembly reference?)";
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Out.ToString());
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(error, runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -453,6 +467,10 @@ Type ""#help"" for more information.
 (1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)
 «Gray»
 > ", runner.Console.Out.ToString());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                "(1,8): error CS0234: The type or namespace name 'CodeAnalysis' does not exist in the namespace 'Microsoft' (are you missing an assembly reference?)",
+                runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -574,6 +592,10 @@ SearchPaths {{ }}
 1
 > 
 ", runner.Console.Out.ToString());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                @"(1,7): error CS1504: Source file 'a.csx' could not be opened -- Could not find file.",
+                runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -609,6 +631,10 @@ SearchPaths {{ }}
 C {{ }}
 > 
 ", runner.Console.Out.ToString());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                @"(1,1): error CS0006: Metadata file 'C.dll' could not be found",
+                runner.Console.Error.ToString());
         }
 
         [Fact]
@@ -689,6 +715,10 @@ int X = 1;
 C {{ }}
 > 
 ", runner.Console.Out.ToString());
+
+            AssertEx.AssertEqualToleratingWhitespaceDifferences(
+                $@"{init.Path}(2,3): error CS1002: ; expected",
+                runner.Console.Error.ToString());
         }
 
         [Fact]

--- a/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
+++ b/src/Scripting/Core/Hosting/CommandLine/CommandLineRunner.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             ErrorLogger errorLogger = null;
             if (_compiler.Arguments.ErrorLogPath != null)
             {
-                errorLogger = _compiler.GetErrorLogger(_console.Out, CancellationToken.None);
+                errorLogger = _compiler.GetErrorLogger(_console.Error, CancellationToken.None);
                 if (errorLogger == null)
                 {
                     return CommonCompiler.Failed;
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             var scriptOptions = GetScriptOptions(_compiler.Arguments, scriptPathOpt, _compiler.MessageProvider, diagnosticsInfos);
 
             var errors = _compiler.Arguments.Errors.Concat(diagnosticsInfos.Select(Diagnostic.Create));
-            if (_compiler.ReportErrors(errors, _console.Out, errorLogger))
+            if (_compiler.ReportErrors(errors, _console.Error, errorLogger))
             {
                 return CommonCompiler.Failed;
             }
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             }
             catch (CompilationErrorException e)
             {
-                _compiler.ReportErrors(e.Diagnostics, _console.Out, errorLogger);
+                _compiler.ReportErrors(e.Diagnostics, _console.Error, errorLogger);
                 return CommonCompiler.Failed;
             }
         }
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             catch (FileLoadException e) when (e.InnerException is InteractiveAssemblyLoaderException)
             {
                 _console.ForegroundColor = ConsoleColor.Red;
-                _console.Out.WriteLine(e.InnerException.Message);
+                _console.Error.WriteLine(e.InnerException.Message);
                 _console.ResetColor();
 
                 return false;
@@ -324,7 +324,7 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
             try
             {
                 _console.ForegroundColor = ConsoleColor.Red;
-                _console.Out.Write(_objectFormatter.FormatException(e));
+                _console.Error.Write(_objectFormatter.FormatException(e));
             }
             finally
             {
@@ -363,14 +363,14 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                 foreach (var diagnostic in ordered.Take(MaxDisplayCount))
                 {
                     _console.ForegroundColor = (diagnostic.Severity == DiagnosticSeverity.Error) ? ConsoleColor.Red : ConsoleColor.Yellow;
-                    _console.Out.WriteLine(diagnostic.ToString());
+                    _console.Error.WriteLine(diagnostic.ToString());
                 }
 
                 if (errorsAndWarnings.Length > MaxDisplayCount)
                 {
                     int notShown = errorsAndWarnings.Length - MaxDisplayCount;
                     _console.ForegroundColor = ConsoleColor.DarkRed;
-                    _console.Out.WriteLine(string.Format((notShown == 1) ? ScriptingResources.PlusAdditionalError : ScriptingResources.PlusAdditionalError, notShown));
+                    _console.Error.WriteLine(string.Format((notShown == 1) ? ScriptingResources.PlusAdditionalError : ScriptingResources.PlusAdditionalError, notShown));
                 }
             }
             finally

--- a/src/Scripting/CoreTest/TestConsoleIO.cs
+++ b/src/Scripting/CoreTest/TestConsoleIO.cs
@@ -17,7 +17,12 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
         }
 
         private TestConsoleIO(Reader reader)
-            : base(output: new Writer(reader), error: new StringWriter(), input: reader)
+            : this(reader, new Writer(reader))
+        {
+        }
+
+        private TestConsoleIO(Reader reader, TextWriter output)
+            : base(output: output, error: new TeeWriter(output), input: reader)
         {
         }
 
@@ -99,6 +104,41 @@ namespace Microsoft.CodeAnalysis.Scripting.Test
             public override void WriteLine()
             {
                 OnBeforeWrite();
+                base.WriteLine();
+            }
+        }
+
+        private sealed class TeeWriter : StringWriter
+        {
+            public override Encoding Encoding => Encoding.UTF8;
+            private readonly TextWriter _other;
+
+            public TeeWriter(TextWriter other)
+            {
+                _other = other;
+            }
+
+            public override void Write(char value)
+            {
+                _other.Write(value);
+                base.Write(value);
+            }
+
+            public override void Write(string value)
+            {
+                _other.Write(value);
+                base.Write(value);
+            }
+
+            public override void WriteLine(string value)
+            {
+                _other.WriteLine(value);
+                base.WriteLine(value);
+            }
+
+            public override void WriteLine()
+            {
+                _other.WriteLine();
                 base.WriteLine();
             }
         }


### PR DESCRIPTION
On error, `csi.exe` should dump the exception to `STDERR`, instead of `STDOUT` as it does currently, and this PR fixes that.

Try the following on a 64-bit Windows Command Prompt (tested against csi version 1.1.0.51109):

```
echo throw new Exception("BOOM!");> test.csx && "%ProgramFiles(x86)%\MSBuild\14.0\bin\csi.exe" test.csx 2>log.txt || echo NOK
```

The normal expectation is that only `NOK` should be displayed and `log.txt` contains the exception text. Instead, `log.txt` is empty and one gets the following output on the console:

```
System.AggregateException: One or more errors occurred. ---> System.Exception: BOOM!
   at Submission#0.<<Initialize>>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.<RunSubmissionsAsync>d__9`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Scripting.Script`1.<RunSubmissionsAsync>d__19.MoveNext()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunScript(ScriptOptions options, String code, ErrorLogger errorLogger, CancellationToken cancellationToken)
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunInteractiveCore(ErrorLogger errorLogger)
   at Microsoft.CodeAnalysis.Scripting.Hosting.CommandLineRunner.RunInteractive()
   at Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.Csi.Main(String[] args)
---> (Inner Exception #0) System.Exception: BOOM!
   at Submission#0.<<Initialize>>d__0.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Scripting.ScriptExecutionState.<RunSubmissionsAsync>d__9`1.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at Microsoft.CodeAnalysis.Scripting.Script`1.<RunSubmissionsAsync>d__19.MoveNext()<---

NOK
```

After applying/merging this PR, only `NOK` should appear on the console and the exception text should end up in `log.txt`

