### PR TITLE
DryDock Effort: Removing the skipped test from ReorderParametersTests

### DIFF
--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.cs
@@ -369,63 +369,7 @@ class Program
 
             await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
         }
-
-        [WpfFact(Skip = "908023"), Trait(Traits.Feature, Traits.Features.ChangeSignature)]
-        public async Task ReorderCollectionInitializerAddMethodParametersAndArguments()
-        {
-            var markup = @"
-using System;
-using System.Collections;
-
-class Program : IEnumerable
-{
-    static void Main(string[] args)
-    {
-        new Program { { 1, 2 }, { ""three"", ""four"" }, { 5, 6 } };
-    }
-
-    public void Add(int x, int y)$$
-    {
-    }
-
-    public void Add(string x, string y)
-    {
-    }
-
-    public IEnumerator GetEnumerator()
-    {
-        throw new NotImplementedException();
-    }
-}";
-            var permutation = new[] { 1, 0 };
-            var updatedCode = @"
-using System;
-using System.Collections;
-
-class Program : IEnumerable
-{
-    static void Main(string[] args)
-    {
-        new Program { { 2, 1 }, { ""three"", ""four"" }, { 6, 5 } };
-    }
-
-    public void Add(int y, int x)
-    {
-    }
-
-    public void Add(string x, string y)
-    {
-    }
-
-    public IEnumerator GetEnumerator()
-    {
-        throw new NotImplementedException();
-    }
-}";
-
-            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
-        }
-
+        
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ReorderParamTagsInDocComments_SingleLineDocComments_OnIndividualLines()
         {

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.vb
@@ -325,48 +325,6 @@ End Class]]></Text>.NormalizedValue()
             Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
         End Function
 
-        <WpfFact(Skip:="908023"), Trait(Traits.Feature, Traits.Features.ChangeSignature)>
-        Public Async Function TestReorderCollectionInitializerAddMethodParametersAndArguments() As Task
-
-            Dim markup = <Text><![CDATA[
-Imports System.Collections
-
-Class C
-    Implements IEnumerable
-
-    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
-        Throw New NotImplementedException()
-    End Function
-
-    $$Sub Add(x As Integer, y As Integer)
-    End Sub
-
-    Sub M()
-        Dim c = New C From {{1, 2}, {3, 4}}
-    End Sub
-End Class]]></Text>.NormalizedValue()
-            Dim permutation = {1, 0}
-            Dim updatedCode = <Text><![CDATA[
-Imports System.Collections
-
-Class C
-    Implements IEnumerable
-
-    Public Function GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator
-        Throw New NotImplementedException()
-    End Function
-
-    Sub Add(y As Integer, x As Integer)
-    End Sub
-
-    Sub M()
-        Dim c = New C From {{2, 1}, {4, 3}}
-    End Sub
-End Class]]></Text>.NormalizedValue()
-
-            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
-        End Function
-
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestReorderParamTagsInDocComments_OnIndividualLines() As Task
 


### PR DESCRIPTION
@dpoeschl  (http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems?_a=edit&id=908023 ) this work item is assigned to you 

I have enabled the tests with the current expected behavior and renamed the methods.
Let me know if you think otherwise.

@dotnet/roslyn-ide 
