### PR TITLE
Bump the Roslyn.Build.Util version to 0.9.3-portable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL = /usr/bin/env bash
 OS_NAME = $(shell uname -s)
-NUGET_PACKAGE_NAME = nuget.70
+NUGET_PACKAGE_NAME = nuget.71
 BUILD_CONFIGURATION = Debug
 BINARIES_PATH = $(shell pwd)/Binaries
 TOOLSET_TMP_PATH = $(BINARIES_PATH)/toolset

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -23,7 +23,7 @@
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
     <ToolsetCompilerPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.Compilers\1.2.0-rc\build\Microsoft.Net.Compilers.props</ToolsetCompilerPropsFilePath>
     <RoslynDiagnosticsPropsFilePath>$(NuGetPackageRoot)\Microsoft.Net.RoslynDiagnostics\1.1.1-beta1-20150818-01\build\Microsoft.Net.RoslynDiagnostics.props</RoslynDiagnosticsPropsFilePath>
-    <RoslynBuildUtilFilePath>$(NuGetPackageRoot)\Roslyn.Build.Util\0.9.2-portable\lib\dotnet\Roslyn.MSBuild.Util.dll</RoslynBuildUtilFilePath>
+    <RoslynBuildUtilFilePath>$(NuGetPackageRoot)\Roslyn.Build.Util\0.9.3-portable\lib\dotnet\Roslyn.MSBuild.Util.dll</RoslynBuildUtilFilePath>
     <AdditionalFileItemNames>$(AdditionalFileItemNames);PublicAPI</AdditionalFileItemNames>
   </PropertyGroup>
 

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -8,7 +8,7 @@
         "FakeSign": "0.9.2",
         "xunit": "2.1.0-beta4-build3109",
         "xunit.runner.console": "2.1.0-beta4-build3109",
-        "Roslyn.Build.Util": "0.9.2-portable"
+        "Roslyn.Build.Util": "0.9.3-portable"
     },
     "frameworks": {
         "net45": {}

--- a/src/Tools/BuildUtil/BuildUtil/BuildUtil.nuspec
+++ b/src/Tools/BuildUtil/BuildUtil/BuildUtil.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Roslyn.Build.Util</id>
-    <version>0.9.2-portable</version>
+    <version>0.9.3-portable</version>
     <title>Roslyn.Build.Util</title>
     <authors>RoslynTeam</authors>
     <owners>RoslynTeam</owners>


### PR DESCRIPTION
The current task references 14.1.0 MSBuild references, which fails
the VS design-time build, but succeeds when running MSBuild since
MSBuild has a binding redirect that VS does not.

I temporarily hacked this by ildasm/asming the DLL to downgrade
the reference to 14.0.0.