### PR TITLE
Fix culture conditional fact attribute

### DIFF
--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -44,8 +44,7 @@ namespace Roslyn.Test.Utilities
 
     public class IsEnglishLocal : ExecutionCondition
     {
-        public override bool ShouldSkip =>
-                System.Globalization.CultureInfo.CurrentCulture != new System.Globalization.CultureInfo("en-US");
+        public override bool ShouldSkip => System.Globalization.CultureInfo.CurrentCulture.ToString() != "en-US";
 
         public override string SkipReason => "Current culture is not en-US";
     }

--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -44,7 +44,8 @@ namespace Roslyn.Test.Utilities
 
     public class IsEnglishLocal : ExecutionCondition
     {
-        public override bool ShouldSkip => System.Globalization.CultureInfo.CurrentCulture.ToString() != "en-US";
+        public override bool ShouldSkip =>
+            !System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase);
 
         public override string SkipReason => "Current culture is not en-US";
     }


### PR DESCRIPTION
Apparently `!=` isn't implemented for `System.Globalization.CultureInfo`, so this change compares against the culture-code in string form.

Closes #9892 