### PR TITLE
Clean-up skipped tests in Roslyn.Compilers.VisualBasic.Emit.UnitTests.DLL

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -4248,7 +4248,8 @@ BC32500: 'GuidAttribute' cannot be applied because the format of the GUID '69D3E
 
 #Region "WindowsRuntimeImportAttribute"
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/6190")>
+        <Fact>
+        <WorkItem(6190, "https://github.com/dotnet/roslyn/issues/6190")>
         <WorkItem(531295, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531295")>
         Public Sub TestWindowsRuntimeImportAttribute()
             Dim source = <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/InternalsVisibleToAndStrongNameTests.vb
@@ -397,7 +397,7 @@ End Class
         Assert.True(other.Assembly.Identity.PublicKey.IsEmpty)
     End Sub
 
-    <ConditionalFact(GetType(IsEnglishLocal))>
+    <Fact>
     Public Sub PubKeyContainerBogusOptions()
         Dim other As VisualBasicCompilation = CreateCompilationWithMscorlib(
 <compilation>
@@ -419,7 +419,7 @@ End Class
         Assert.Equal(ERRID.ERR_PublicKeyContainerFailure, err.Code)
         Assert.Equal(2, err.Arguments.Count)
         Assert.Equal("foo", DirectCast(err.Arguments(0), String))
-        Assert.True(DirectCast(err.Arguments(1), String).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal))
+        Assert.True(DirectCast(err.Arguments(1), String).Contains("HRESULT: 0x80090016"))
 
         Assert.True(other.Assembly.Identity.PublicKey.IsEmpty)
     End Sub
@@ -540,7 +540,7 @@ End Class
         c2.VerifyDiagnostics()
     End Sub
 
-    <ConditionalFact(GetType(IsEnglishLocal))>
+    <Fact>
     Public Sub SignModuleKeyContainerBogus()
         Dim c1 As VisualBasicCompilation = CreateCompilationWithMscorlib(
 <compilation name="WantsIVTAccess">
@@ -564,13 +564,15 @@ End Class
      </file>
  </compilation>), {reference}, TestOptions.ReleaseDll.WithStrongNameProvider(s_defaultProvider))
 
+        'BC36981: Error extracting public key from container 'bogus': Keyset does not exist (Exception from HRESULT: 0x80090016)
         'c2.VerifyDiagnostics(Diagnostic(ERRID.ERR_PublicKeyContainerFailure).WithArguments("bogus", "Keyset does not exist (Exception from HRESULT: 0x80090016)"))
+
         Dim err = c2.GetDiagnostics(CompilationStage.Emit).Single()
 
         Assert.Equal(ERRID.ERR_PublicKeyContainerFailure, err.Code)
         Assert.Equal(2, err.Arguments.Count)
         Assert.Equal("bogus", DirectCast(err.Arguments(0), String))
-        Assert.True(DirectCast(err.Arguments(1), String).EndsWith(" HRESULT: 0x80090016)", StringComparison.Ordinal))
+        Assert.True(DirectCast(err.Arguments(1), String).Contains("HRESULT: 0x80090016"))
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -3681,7 +3681,9 @@ End Module
 </compilation>, useLatestFramework:=True, expectedOutput:="1")
         End Sub
 
-        <Fact(Skip:="785170"), WorkItem(785170, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/785170")>
+        <Fact,
+         WorkItem(94940, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems#_a=edit&id=94940"),
+         WorkItem(785170, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/785170")>
         Public Sub Imported_AsyncWithEH()
             CompileAndVerify(
 <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenEvents.vb
@@ -997,7 +997,8 @@ hello from ev1
 ]]>)
         End Sub
 
-        <Fact(Skip:="529574")>
+        <Fact>
+        <WorkItem(529574, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems?_a=edit&id=529574")>
         Public Sub TestCrossLanguageOptionalAndParamarray1()
             Dim csCompilation = CreateCSharpCompilation("CS",
             <![CDATA[public class CSClass
@@ -1048,8 +1049,28 @@ Public Module Program
 End Module]]>,
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                 referencedCompilations:={csCompilation})
-            ' WARNING: Roslyn compiler produced errors while Native compiler didn't.
-            vbCompilation.VerifyDiagnostics()
+            ' WARNING: Roslyn compiler produced errors while Native compiler didn't. This is an intentional breaking change, see associated bug. 
+            vbCompilation.AssertTheseDiagnostics(
+<expected>
+BC31029: Method 'Foo' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo(x As String) Handles w.ev, MyBase.ev, MyClass.ev
+                                        ~~
+BC31029: Method 'Foo' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo(x As String) Handles w.ev, MyBase.ev, MyClass.ev
+                                                   ~~
+BC31029: Method 'Foo' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo(x As String) Handles w.ev, MyBase.ev, MyClass.ev
+                                                               ~~
+BC31029: Method 'Foo2' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo2(Optional x As String = "") Handles w.ev, MyBase.ev, MyClass.ev
+                                                       ~~
+BC31029: Method 'Foo2' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo2(Optional x As String = "") Handles w.ev, MyBase.ev, MyClass.ev
+                                                                  ~~
+BC31029: Method 'Foo2' cannot handle event 'ev' because they do not have a compatible signature.
+    Function Foo2(Optional x As String = "") Handles w.ev, MyBase.ev, MyClass.ev
+                                                                              ~~
+</expected>)
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenGetTypeOperator.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenGetTypeOperator.vb
@@ -303,9 +303,11 @@ Class2`2[T,U]
 ]]>).Compilation
         End Sub
 
-        <Fact(Skip:="542581"), WorkItem(542581, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542581")>
+        <Fact,
+         WorkItem(9850, "https://github.com/dotnet/roslyn/issues/9850"),
+         WorkItem(542581, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542581")>
         Public Sub CodeGen_GetType_InheritedNestedTypeThroughUnboundGeneric()
-            CompileAndVerify(
+            Dim compilation = CreateCompilationWithMscorlib(
 <compilation>
     <file name="a.vb">
 Imports System
@@ -323,9 +325,22 @@ Class DerivedGeneric(Of T)
     Inherits BaseNonGeneric
 End Class
     </file>
-</compilation>, expectedOutput:=<![CDATA[
+</compilation>)
+
+            Const bug9850IsFixed = False
+
+            If bug9850IsFixed Then
+                CompileAndVerify(compilation, expectedOutput:=<![CDATA[
 BaseNonGeneric+E
 ]]>)
+            Else
+                compilation.AssertTheseDiagnostics(
+    <expected>
+BC30002: Type 'DerivedGeneric.E' is not defined.
+        Console.WriteLine(GetType(DerivedGeneric(Of ).E))
+                                  ~~~~~~~~~~~~~~~~~~~~~
+</expected>)
+            End If
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenWithEvents.vb
@@ -1089,7 +1089,7 @@ End Interface
         <WorkItem(6214, "https://github.com/dotnet/roslyn/issues/6214")>
         <WorkItem(545182, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545182")>
         <WorkItem(545184, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545184")>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/6214")>
+        <Fact>
         Public Sub TestHandlesForWithEventsFromBaseFromADifferentAssembly()
             Dim assembly1Compilation = CreateVisualBasicCompilation("TestHandlesForWithEventsFromBaseFromADifferentAssembly_Assembly1",
             <![CDATA[Public Class c1
@@ -1137,7 +1137,7 @@ End Module]]>,
 
         <WorkItem(6214, "https://github.com/dotnet/roslyn/issues/6214")>
         <WorkItem(545185, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545185")>
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/6214")>
+        <Fact>
         Public Sub TestNameOfWithEventsSetterParameter()
             Dim comp = CreateVisualBasicCompilation("TestNameOfWithEventsSetterParameter",
             <![CDATA[Public Class c1

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DeterministicTests.vb
@@ -47,7 +47,8 @@ End Class"
             Assert.True(resultNonDeterministic.Success)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/5813")>
+        <Fact>
+        <WorkItem(5813, "https://github.com/dotnet/roslyn/issues/5813")>
         Public Sub CompareAllBytesEmitted_Release()
             Dim source =
 "Class Program
@@ -63,7 +64,9 @@ End Class"
             AssertEx.Equal(result3, result4)
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/5813"), WorkItem(926, "https://github.com/dotnet/roslyn/issues/926")>
+        <Fact,
+         WorkItem(5813, "https://github.com/dotnet/roslyn/issues/5813"),
+         WorkItem(926, "https://github.com/dotnet/roslyn/issues/926")>
         Public Sub CompareAllBytesEmitted_Debug()
             Dim source =
 "Class Program

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueClosureTests.vb
@@ -1692,7 +1692,7 @@ End Class
 ")
         End Sub
 
-        <Fact(Skip:="2504"), WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")>
+        <Fact, WorkItem(2504, "https://github.com/dotnet/roslyn/issues/2504")>
         Public Sub InsertConstructorInPresenceOfFieldInitializersWithLambdas()
             Dim source0 = MarkedSource("
 Imports System
@@ -1739,9 +1739,13 @@ End Class
                     New SemanticEdit(SemanticEditKind.Insert, Nothing, b1),
                     New SemanticEdit(SemanticEditKind.Insert, Nothing, ctor1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
+            Const bug2504IsFixed = False
+
             diff1.VerifySynthesizedMembers(
                 "C: {_Closure$__}",
-                "C._Closure$__: {$I0-0, $I0-1#1, $I0-2#1, _Lambda$__0-0, _Lambda$__0-1#1, _Lambda$__0-2#1}")
+                If(bug2504IsFixed,
+                   "C._Closure$__: {$I0-0, $I0-1#1, $I0-2#1, _Lambda$__0-0, _Lambda$__0-1#1, _Lambda$__0-2#1}",
+                   "C._Closure$__: {$I3#1-0#1, $I3#1-1#1, $I3#1-2#1, _Lambda$__3#1-0#1, _Lambda$__3#1-1#1, _Lambda$__3#1-2#1}"))
         End Sub
 
         <Fact, WorkItem(1170899, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1170899")>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueTests.vb
@@ -4391,7 +4391,8 @@ End Class
         ''' <summary>
         ''' Should not re-use locals with custom modifiers.
         ''' </summary>
-        <Fact(Skip:="TODO")>
+        <Fact(Skip:="9854")>
+        <WorkItem(9854, "https://github.com/dotnet/roslyn/issues/9854")>
         Public Sub LocalType_CustomModifiers()
             ' Equivalent method signature to VB, but
             ' with optional modifiers on locals.

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
@@ -904,7 +904,9 @@ End Class
 
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/6190"), WorkItem(90, "https://github.com/dotnet/roslyn/issues/90")>
+        <Fact,
+         WorkItem(6190, "https://github.com/dotnet/roslyn/issues/6190"),
+         WorkItem(90, "https://github.com/dotnet/roslyn/issues/90")>
         Public Sub EmitWithNoResourcesAllPlatforms()
             Dim comp = CreateCompilationWithMscorlib(
                 <compilation>
@@ -916,24 +918,17 @@ End Class
                     </file>
                 </compilation>)
 
-            VerifyEmitWithNoResources(comp, Platform.AnyCpu)
-            VerifyEmitWithNoResources(comp, Platform.AnyCpu32BitPreferred)
-            VerifyEmitWithNoResources(comp, Platform.Arm)     ' broken before fix
-            VerifyEmitWithNoResources(comp, Platform.Itanium) ' broken before fix
-            VerifyEmitWithNoResources(comp, Platform.X64)     ' broken before fix
-            VerifyEmitWithNoResources(comp, Platform.X86)
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_AnyCpu"), Platform.AnyCpu)
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_AnyCpu32BitPreferred"), Platform.AnyCpu32BitPreferred)
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_Arm"), Platform.Arm)     ' broken before fix
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_Itanium"), Platform.Itanium) ' broken before fix
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_X64"), Platform.X64)     ' broken before fix
+            VerifyEmitWithNoResources(comp.WithAssemblyName("EmitWithNoResourcesAllPlatforms_X86"), Platform.X86)
         End Sub
 
-        Private Shared Sub VerifyEmitWithNoResources(comp As VisualBasicCompilation, platform As Platform)
+        Private Sub VerifyEmitWithNoResources(comp As VisualBasicCompilation, platform As Platform)
             Dim options = TestOptions.ReleaseExe.WithPlatform(platform)
-
-            Using outputStream As New MemoryStream()
-                Dim success = comp.WithOptions(options).Emit(outputStream).Success
-                Assert.True(success)
-
-                Dim peVerifyOutput = CLRHelpers.PeVerify(outputStream.ToImmutable()).Join(Environment.NewLine)
-                Assert.Equal(String.Empty, peVerifyOutput)
-            End Using
+            CompileAndVerify(comp.WithOptions(options))
         End Sub
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/XmlLiteralTests.vb
@@ -4325,9 +4325,29 @@ End Class
         End Sub
 
         <WorkItem(531445, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531445")>
-        <Fact(Skip:="531445")>
+        <WorkItem(101597, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems#_a=edit&id=101597")>
+        <Fact>
         Public Sub SameNamespaceDifferentPrefixes()
             Dim options = TestOptions.ReleaseExe.WithGlobalImports(GlobalImport.Parse({"<xmlns:r=""http://roslyn/"">", "<xmlns:s=""http://roslyn/"">"}))
+
+            Dim expectedOutput As Xml.Linq.XCData
+
+            Const bug101597IsFixed = False
+
+            If bug101597IsFixed Then
+                expectedOutput = <![CDATA[
+<p:x xmlns:s="http://roslyn/" xmlns:r="http://roslyn/" xmlns:q="http://roslyn/" xmlns:p="http://roslyn/">
+  <p:y p:a="" p:b="" />
+</p:x>
+]]>
+            Else
+                expectedOutput = <![CDATA[
+<q:x xmlns:p="http://roslyn/" xmlns:s="http://roslyn/" xmlns:r="http://roslyn/" xmlns:q="http://roslyn/">
+  <q:y q:a="" q:b="" />
+</q:x>
+]]>
+            End If
+
             Dim compilation = CompileAndVerify(
 <compilation>
     <file name="a.vb"><![CDATA[
@@ -4342,11 +4362,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, options:=options, expectedOutput:=<![CDATA[
-<p:x xmlns:s="http://roslyn/" xmlns:r="http://roslyn/" xmlns:q="http://roslyn/" xmlns:p="http://roslyn/">
-  <p:y p:a="" p:b="" />
-</p:x>
-]]>)
+</compilation>, additionalRefs:=XmlReferences, options:=options, expectedOutput:=expectedOutput)
         End Sub
 
         <WorkItem(623035, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/623035")>


### PR DESCRIPTION
@dotnet/roslyn-compiler Please review.
CC @srivatsn 