### PR TITLE
Allow interactive window evaluation of empty line.

### DIFF
--- a/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
+++ b/src/InteractiveWindow/Editor/InteractiveWindow.UIThreadOnly.cs
@@ -844,8 +844,12 @@ namespace Microsoft.VisualStudio.InteractiveWindow
                     _history.UncommittedInput = null;
 
                     var snapshotSpan = CurrentLanguageBuffer.CurrentSnapshot.GetExtent();
+                    var trimmedSpan = snapshotSpan.TrimEnd();
+                    if (trimmedSpan.Length > 0)
+                    {
+                        _history.Add(historySpan);
+                    }
 
-                    _history.Add(historySpan);
                     State = State.ExecutingInput;
 
                     StartCursorTimer();

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowHistoryTests.cs
@@ -77,6 +77,29 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
         }
 
         [WpfFact]
+        public async Task CheckHistoryPreviousWithAnEmptySubmission() {
+            //submit, submit, submit, up, up, up
+            const string inputString1 = "1 ";
+            const string inputString2 = " ";
+            const string inputString3 = "3 ";
+
+            await InsertAndExecuteInput(inputString1).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString2).ConfigureAwait(true);
+            await InsertAndExecuteInput(inputString3).ConfigureAwait(true);
+
+            _operations.HistoryPrevious();
+            AssertCurrentSubmission(inputString3);
+
+            //second input was empty, so it wasn't added to history
+            _operations.HistoryPrevious();
+            AssertCurrentSubmission(inputString1);
+
+            //has reached the top, no change
+            _operations.HistoryPrevious();
+            AssertCurrentSubmission(inputString1);
+        }
+
+        [WpfFact]
         public async Task CheckHistoryPreviousNotCircular()
         {
             //submit, submit, up, up, up

--- a/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
+++ b/src/InteractiveWindow/EditorTest/InteractiveWindowTests.cs
@@ -1089,6 +1089,13 @@ namespace Microsoft.VisualStudio.InteractiveWindow.UnitTests
             await SubmitAsync("1", "2", "1 + 2").ConfigureAwait(true);
         }
 
+        [WorkItem(8569, "https://github.com/dotnet/roslyn/issues/8569")]
+        [WpfFact]
+        public async Task SubmitAsyncEmptyLine()
+        {
+            await SubmitAsync("1", "", "1 + 2").ConfigureAwait(true);
+        }
+
         private async Task SubmitAsync(params string[] submissions)
         {
             var actualSubmissions = new List<string>();


### PR DESCRIPTION
In R Tools for Visual Studio (http://github.com/Microsoft/RTVS), we are having an issue with scenarios where the user runs built-in demos in the interactive window, and those prompt the user to hit return to continue.

https://github.com/dotnet/roslyn/issues/8569
https://github.com/Microsoft/RTVS/issues/626 (see the image in my Feb 5 comment)

This is a case where the input code is empty, ie. after it's trimmed, its length is 0.  While most examples will work fine if the user types anything but spaces before hitting return, the user just doesn't know that.

With the existing interactive window code, when the user presses return without typing any code, the interactive window asks our evaluator if the code can be executed, to which we say yes, but then the evaluator never gets called to execute the code.

Unfortunately, with the way things are with the R interpreter, we are not able to tell the difference between reading code and reading standard input.  In Python, we can, and we call ReadStandardInput when scripts call things such as `input()`, so we do not run into this issue.  In R, this all goes through evaluate code.

The existing automated tests indicate that there are no regressions if I just remove the code that tries to special case empty lines, which is what I did in this PR.  Manually poking around using C# interactive, I have not noticed any change in behavior.

I've also experimented with making this opt-in, by adding an InteractiveWindowOptions.EvaluateEmptyLine option to Window.TextView.Options.

If you think you would prefer that, I can issue a PR with those changes.  Adding options add more complexity, and I felt it wasn't worth it in this case.

Let me know what you think.  Thanks!
