### PR TITLE
Unskip InteractiveUsingTests.AliasHiding

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveUsingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InteractiveUsingTests.cs
@@ -176,7 +176,7 @@ using J = I;
             CreateSubmission(source).GetDiagnostics().Verify(expectedDiagnostics);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/5927")]
+        [Fact]
         public void AliasHiding()
         {
             var sub1 = CreateSubmission("using A = System.Int32; typeof(A)");


### PR DESCRIPTION
The flakiness seems to have been addressed in https://github.com/dotnet/roslyn/commit/ce3edeb69880740eb796480e30b1421722670902