### PR TITLE
Insert traces for cases when completion can not have a session.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Options;
@@ -146,6 +147,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             if (this.TextView.Selection.Mode == TextSelectionMode.Box)
             {
+                Trace.WriteLine("Box selection, cannot have completion");
+
                 // No completion with multiple selection
                 return false;
             }
@@ -154,6 +157,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             var caret = TextView.GetCaretPoint(SubjectBuffer);
             if (!caret.HasValue)
             {
+                Trace.WriteLine("Caret is not mappable to subject buffer, cannot have completion");
+
                 return false;
             }
 
@@ -197,6 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(this.SubjectBuffer.AsTextContainer(), out workspace))
             {
+                Trace.WriteLine("Failed to get a workspace, cannot have a completion session.");
                 return null;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
@@ -31,6 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             var completionService = this.GetCompletionService();
             if (completionService == null)
             {
+                Trace.WriteLine("Failed to get completion service, cannot have a completion session.");
                 return;
             }
 


### PR DESCRIPTION
To diagnose internal bug 199539 and possibly #9366 as well.

The `TRACE` constant seems to be defined in the project property page, though i don't see it reflected in the `.csproj` file. I guess this should be good for now.
![image](https://cloud.githubusercontent.com/assets/4213867/13887758/be889b62-ecfa-11e5-8e43-e58b8758398f.png)


When we are done with the bugs, we can choose to stop emitting the traces by removing the definition of `TRACE` constant or by rolling back this change.
