### PR TITLE
Fix for #9463: Async rewriter to fail gracefully when types are missing

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -456,7 +456,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' type isn't found.
         ''' </summary>
         Friend Function GetWellKnownType(type As WellKnownType, syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
-            Dim typeSymbol As NamedTypeSymbol = Me.Compilation.GetWellKnownType(type)
+            Return GetWellKnownType(Me.Compilation, type, syntax, diagBag)
+        End Function
+
+        Friend Shared Function GetWellKnownType(compilation As VisualBasicCompilation, type As WellKnownType, syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As NamedTypeSymbol
+            Dim typeSymbol As NamedTypeSymbol = compilation.GetWellKnownType(type)
             Debug.Assert(typeSymbol IsNot Nothing)
 
             Dim useSiteError = GetUseSiteErrorForWellKnownType(typeSymbol)
@@ -567,8 +571,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' member isn't found.
         ''' </summary>
         Friend Function GetWellKnownTypeMember(member As WellKnownMember, syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As Symbol
+            Return GetWellKnownTypeMember(Me.Compilation, member, syntax, diagBag)
+        End Function
+
+        Friend Shared Function GetWellKnownTypeMember(compilation As VisualBasicCompilation, member As WellKnownMember, syntax As VisualBasicSyntaxNode, diagBag As DiagnosticBag) As Symbol
             Dim useSiteError As DiagnosticInfo = Nothing
-            Dim memberSymbol As Symbol = GetWellKnownTypeMember(Me.Compilation, member, useSiteError)
+            Dim memberSymbol As Symbol = GetWellKnownTypeMember(compilation, member, useSiteError)
 
             If useSiteError IsNot Nothing Then
                 ReportDiagnostic(diagBag, syntax, useSiteError)

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.vb
@@ -372,15 +372,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Binder.GetSpecialType(F.Compilation.Assembly, type, Me.Body.Syntax, bag)
         End Function
 
-        Friend Sub EnsureSpecialType(type As SpecialType, <[In], Out> ByRef hasErrors As Boolean)
-            Dim sType = Me.F.SpecialType(type)
-            If sType.GetUseSiteErrorInfo IsNot Nothing Then
-                hasErrors = True
-            End If
-        End Sub
+        Friend Function EnsureWellKnownType(type As WellKnownType, bag As DiagnosticBag) As Symbol
+            Return Binder.GetWellKnownType(F.Compilation, type, Me.Body.Syntax, bag)
+        End Function
 
         Friend Function EnsureSpecialMember(member As SpecialMember, bag As DiagnosticBag) As Symbol
             Return Binder.GetSpecialTypeMember(F.Compilation.Assembly, member, Me.Body.Syntax, bag)
+        End Function
+
+        Friend Function EnsureWellKnownMember(member As WellKnownMember, bag As DiagnosticBag) As Symbol
+            Return Binder.GetWellKnownTypeMember(F.Compilation, member, Me.Body.Syntax, bag)
         End Function
 
         ''' <summary>
@@ -401,20 +402,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If useSiteError IsNot Nothing Then
                     Binder.ReportDiagnostic(bag, Body.Syntax, useSiteError)
                 End If
-            End If
-        End Sub
-
-        Friend Sub EnsureWellKnownType(type As WellKnownType, <[In], Out> ByRef hasErrors As Boolean)
-            Dim wkType = Me.F.WellKnownType(type)
-            If wkType.GetUseSiteErrorInfo IsNot Nothing Then
-                hasErrors = True
-            End If
-        End Sub
-
-        Friend Sub EnsureWellKnownMember(Of T As Symbol)(member As WellKnownMember, <[In], Out> ByRef hasErrors As Boolean)
-            Dim wkMember = Me.F.WellKnownMember(Of T)(member)
-            If wkMember Is Nothing OrElse wkMember.GetUseSiteErrorInfo IsNot Nothing Then
-                hasErrors = True
             End If
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -320,7 +320,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Assignment expressions in lowered form should always have suppressObjectClone = True
         ''' </summary>
         Public Function AssignmentExpression(left As BoundExpression, right As BoundExpression) As BoundAssignmentOperator
-            Debug.Assert(left.Type = right.Type)
+            Debug.Assert(left.Type = right.Type OrElse right.Type.IsErrorType() OrElse left.Type.IsErrorType())
             Dim boundNode = New BoundAssignmentOperator(_syntax, left, right, True)
             boundNode.SetWasCompilerGenerated()
             Return boundNode


### PR DESCRIPTION
I did find a few ways to make the async rewriter crash with missing types. 
I tried to keep the fixes consistent with what I just did in iterator rewriter and use the same solution (as much as possible) on both the VB and C# sides.

Fixes #9463 
@dotnet/roslyn-compiler for code review.