### PR TITLE
Clean-up skipped tests in Roslyn.Compilers.VisualBasic.Syntax.UnitTests.DLL

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -796,31 +796,27 @@ Public Module VerificationHelpers
                 InternalVerifyNoAdjacentTriviaHaveSameKind(child)
             Next
         Else
-            Dim prev As SyntaxTrivia? = Nothing
-            For Each tr In node.AsToken.LeadingTrivia
-                If tr.HasStructure Then
-                    InternalVerifyNoAdjacentTriviaHaveSameKind(tr.GetStructure)
-                End If
-                If prev IsNot Nothing Then
-                    Assert.True(prev.Value.Kind <> tr.Kind,
-                                "Both current and previous trivia have Kind=" & tr.Kind.ToString &
-                                " [See under TokenKind=" & node.Kind().ToString & ", NonTerminalKind=" & node.Parent.Kind.ToString & "]")
-                End If
-                prev = tr
-            Next
-            prev = Nothing
-            For Each tr In node.AsToken.LeadingTrivia
-                If tr.HasStructure Then
-                    InternalVerifyNoAdjacentTriviaHaveSameKind(tr.GetStructure)
-                End If
-                If prev IsNot Nothing Then
-                    Assert.True(prev.Value.Kind <> tr.Kind,
-                                "Both current and previous trivia have Kind=" & tr.Kind.ToString &
-                                " [See under TokenKind=" & node.Kind().ToString & ", NonTerminalKind=" & node.Parent.Kind.ToString & "]")
-                End If
-                prev = tr
-            Next
+            InternalVerifyNoAdjacentTriviaHaveSameKind(node, node.AsToken.LeadingTrivia)
+            InternalVerifyNoAdjacentTriviaHaveSameKind(node, node.AsToken.TrailingTrivia)
         End If
+    End Sub
+
+    Private Sub InternalVerifyNoAdjacentTriviaHaveSameKind(node As SyntaxNodeOrToken, triviaList As SyntaxTriviaList)
+        Dim prev As SyntaxTrivia? = Nothing
+        For Each tr In triviaList
+            If tr.HasStructure Then
+                InternalVerifyNoAdjacentTriviaHaveSameKind(tr.GetStructure)
+            End If
+
+            ' Based on http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems?_a=edit&id=527553
+            ' it is Ok to have adjacent SkippedTokensTrivias
+            If tr.Kind <> SyntaxKind.SkippedTokensTrivia AndAlso prev IsNot Nothing Then
+                Assert.True(prev.Value.Kind <> tr.Kind,
+                            "Both current and previous trivia have Kind=" & tr.Kind.ToString &
+                            " [See under TokenKind=" & node.Kind().ToString & ", NonTerminalKind=" & node.Parent.Kind.ToString & "]")
+            End If
+            prev = tr
+        Next
     End Sub
 
     Private Sub InternalVerifySpanOfChildWithinSpanOfParent(node As SyntaxNodeOrToken)

--- a/src/Compilers/VisualBasic/Portable/Preprocessor/ExpressionEvaluator.vb
+++ b/src/Compilers/VisualBasic/Portable/Preprocessor/ExpressionEvaluator.vb
@@ -851,16 +851,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                 Return ReportSemanticError(ERRID.ERR_BadCCExpression, expr)
             End If
 
-            If specialType = SpecialType.System_String Then
-                Return ReportSemanticError(ERRID.ERR_CannotConvertValue2, expr)
-            End If
-
-            If specialType = SpecialType.System_Object AndAlso Not IsNothing(val) Then
-                Return ReportSemanticError(ERRID.ERR_CannotConvertValue2, expr)
-            End If
-
-            If specialType = SpecialType.System_Char OrElse specialType = SpecialType.System_DateTime Then
-                Return ReportSemanticError(ERRID.ERR_CannotConvertValue2, expr)
+            If specialType = SpecialType.System_String OrElse
+               (specialType = SpecialType.System_Object AndAlso Not IsNothing(val)) OrElse
+               specialType = SpecialType.System_Char OrElse specialType = SpecialType.System_DateTime Then
+                Return ReportSemanticError(ERRID.ERR_UnaryOperand2, expr, expr.OperatorToken.ValueText, specialType.GetDisplayName())
             End If
 
             Try

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -2316,18 +2316,8 @@ End Module
         VerifyEquivalent(newTree, VisualBasicSyntaxTree.ParseText(newText))
     End Sub
 
-    'Skip 66178
-    'TODO CaseBlockContext / Case or CaseElse Statement
-    'TODO SelectBlockContext / Case or CaseElse Statement
-    'TODO TryBlockContext / Catch or Finally Statement or Catch or Finally Part    
-    'TODO CatchPartContext / Catch or Finally Statement
-    'TODO FinallyPartBlock / Catch or Finally Statement    
-    'TODO IfPartContext / Elseif or Else Statement
-    'TODO IfBlockContext  / Elseif or Else part
-
-    <Fact(Skip:="66178")>
+    <Fact>
     Public Sub IncrementalParsing_CaseBlockContext_TryLinkSyntaxCase()
-        'TODO  CaseBlockContext  CaseBlock/CaseElse
         Dim source = ToText(<![CDATA[
 Module Module1
     Sub Foo()
@@ -2359,9 +2349,8 @@ End Module
         VerifyEquivalent(newTree, VisualBasicSyntaxTree.ParseText(newText))
     End Sub
 
-    <Fact(Skip:="66178")>
+    <Fact>
     Public Sub IncrementalParsing_CatchContext_TryLinkSyntaxCatch()
-        'TODO  CatchContext / Catch Or Finally Statement
         Dim source = ToText(<![CDATA[
 Module Module1
     Sub Foo()
@@ -2425,9 +2414,8 @@ End Namespace
         VerifyEquivalent(newTree, VisualBasicSyntaxTree.ParseText(newText))
     End Sub
 
-    <Fact(Skip:="66178")>
+    <Fact>
     Public Sub IncrementalParsing_IfBlockContext_TryLinkSyntax()
-        'TODO IfBlockContext / IF ELSE Statement
         Dim source = ToText(<![CDATA[
 
 Module Module1

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAttributes.vb
@@ -318,22 +318,36 @@ End Module
     End Sub
 
     <WorkItem(638911, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638911")>
-    <Fact(Skip:="638911")>
+    <WorkItem(108689, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems#_a=edit&id=108689")>
+    <Fact>
     Public Sub ParseFileLevelAttributesWithExtraColon_2()
-        ParseAndVerify(<![CDATA[
+        Const bug108689IsFixed = False
+
+        Dim source1 = <![CDATA[
 <Assembly::A>
-]]>,
-            <errors>
-                <error id="30203" message="Identifier expected."/>
-                <error id="30636" message="'>' expected."/>
-            </errors>)
-        ParseAndVerify(<![CDATA[
+]]>
+
+        Dim source2 = <![CDATA[
 <Module : : A>
-]]>.Value.Replace(":"c, FULLWIDTH_COLON),
+]]>.Value.Replace(":"c, FULLWIDTH_COLON)
+
+        If bug108689IsFixed Then
+            ParseAndVerify(source1,
             <errors>
                 <error id="30203" message="Identifier expected."/>
                 <error id="30636" message="'>' expected."/>
             </errors>)
+
+            ParseAndVerify(source2,
+            <errors>
+                <error id="30203" message="Identifier expected."/>
+                <error id="30636" message="'>' expected."/>
+            </errors>)
+        Else
+            ParseAndVerify(source1)
+            ParseAndVerify(source2)
+        End If
+
     End Sub
 
     <WorkItem(570808, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/570808")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseErrorTests.vb
@@ -1791,7 +1791,8 @@ End Module
 
 
     <WorkItem(527673, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527673")>
-    <Fact(Skip:="527673")>
+    <WorkItem(99258, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems#_a=edit&id=99258")>
+    <Fact>
     Public Sub BC30357ERR_BadInterfaceOrderOnInherits()
         Dim code = <![CDATA[
                 	Interface I1
@@ -1800,9 +1801,17 @@ End Module
                     End Interface
             ]]>.Value
 
-        ParseAndVerify(code, <errors>
-                                 <error id="30357"/>
-                             </errors>)
+        Const bug99258IsFixed = False
+
+        If bug99258IsFixed Then
+            ParseAndVerify(code, <errors>
+                                     <error id="30357"/>
+                                 </errors>)
+        Else
+            ParseAndVerify(code, <errors>
+                                     <error id="30603"/>
+                                 </errors>)
+        End If
     End Sub
 
     <Fact()>
@@ -4517,7 +4526,7 @@ End Namespace
                              </errors>).VerifyErrorsOnChildrenAlsoPresentOnParent()
     End Sub
 
-    <Fact(Skip:="527553"), WorkItem(537131, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537131"), WorkItem(527922, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527922"), WorkItem(527553, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527553")>
+    <Fact, WorkItem(537131, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537131"), WorkItem(527922, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527922"), WorkItem(527553, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527553")>
     Public Sub TestNoAdjacentTriviaWithSameKind()
         Dim code = <![CDATA[
     module m1

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseXml.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseXml.vb
@@ -4462,19 +4462,49 @@ End Module]]>.Value.Replace("~"c, FULLWIDTH_COLON))
     End Sub
 
     <WorkItem(969980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/969980")>
-    <Fact(Skip:="969980")>
+    <WorkItem(123533, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems?_a=edit&id=123533")>
+    <Fact>
     Public Sub UnaliasedXmlImport_Local()
         Dim source = "
 Imports <xmlns = ""http://xml"">
 "
-        CreateCompilationWithMscorlib({source}, options:=TestOptions.ReleaseDll).VerifyDiagnostics(
-            Diagnostic(ERRID.HDN_UnusedImportStatement, "Imports <xmlns = ""http://xml"">").WithLocation(2, 1))
+        Dim compilation = CreateCompilationWithMscorlib({source}, options:=TestOptions.ReleaseDll)
+
+        Const bug123533IsFixed = False
+
+        If bug123533IsFixed Then
+            compilation.AssertTheseDiagnostics(<expected><![CDATA[
+BC50001: Unused import statement.
+Imports <xmlns = "http://xml">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                               ]]></expected>, False)
+        Else
+            compilation.AssertTheseDiagnostics(<expected><![CDATA[
+BC50001: Unused import statement.
+Imports <xmlns = "http://xml">
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC31187: Namespace declaration must start with 'xmlns'.
+Imports <xmlns = "http://xml">
+         ~
+BC30636: '>' expected.
+Imports <xmlns = "http://xml">
+         ~~~~~
+                                               ]]></expected>, False)
+        End If
     End Sub
 
     <WorkItem(969980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/969980")>
-    <Fact(Skip:="969980")>
+    <WorkItem(123533, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems?_a=edit&id=123533")>
+    <Fact>
     Public Sub UnaliasedXmlImport_Project()
-        CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll.WithGlobalImports(GlobalImport.Parse("<xmlns = ""http://xml"">"))).VerifyDiagnostics()
+        Dim import = "<xmlns = ""http://xml"">"
+        Const bug123533IsFixed = False
+
+        If bug123533IsFixed Then
+            CreateCompilationWithMscorlib({""}, options:=TestOptions.ReleaseDll.WithGlobalImports(GlobalImport.Parse(import))).VerifyDiagnostics()
+        Else
+            Assert.Throws(Of ArgumentException)(Sub() GlobalImport.Parse(import))
+        End If
     End Sub
 
     <WorkItem(1042696, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1042696")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParserRegressionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParserRegressionTests.vb
@@ -746,13 +746,20 @@ End Select
         VisualBasicSyntaxTree.ParseText(text)
     End Sub
 
-    <Fact(Skip:="658140"), WorkItem(658140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/658140")>
+    <Fact, WorkItem(658140, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/658140")>
+    <WorkItem(103047, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems?_a=edit&id=103047")>
     Public Sub ParseFileOnBinaryFile()
         ' This is doing the same thing as ParseFile, but using a MemoryStream
         ' instead of FileStream (because I don't want to write a file to disk).
         Using data As New MemoryStream(TestResources.NetFX.v4_0_30319.mscorlib)
-            Dim tree As SyntaxTree = VisualBasicSyntaxTree.ParseText(EncodedStringText.Create(data))
-            tree.GetDiagnostics().VerifyErrorCodes(Diagnostic(ERRID.ERR_BinaryFile))
+            Const bug103047IsFixed = False
+
+            If bug103047IsFixed Then
+                Dim tree As SyntaxTree = VisualBasicSyntaxTree.ParseText(EncodedStringText.Create(data))
+                tree.GetDiagnostics().VerifyErrorCodes(Diagnostic(ERRID.ERR_BinaryFile))
+            Else
+                Assert.Throws(Of System.IO.InvalidDataException)(Sub() VisualBasicSyntaxTree.ParseText(EncodedStringText.Create(data)))
+            End If
         End Using
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/VisualBasicParseOptionsTests.vb
@@ -114,15 +114,15 @@ Public Class VisualBasicParseOptionsTests
         Assert.Equal(highest, CInt(PredefinedPreprocessorSymbols.CurrentVersionNumber))
     End Sub
 
-    <Fact(Skip:="Win8 targets")>
+    <Fact>
     Public Sub PredefinedPreprocessorSymbols_Win8()
         Dim options = VisualBasicParseOptions.Default
 
-        ' TODO: Dim symbols = AddPredefinedPreprocessorSymbols(OutputKind.WinMD)
-        ' AssertEx.SetEqual({New KeyValuePair(Of String, Object)("VBC_VER", 11.0), New KeyValuePair(Of String, Object)("TARGET", "appcontainerexe")}, symbols.AsEnumerable)
+        Dim symbols = AddPredefinedPreprocessorSymbols(OutputKind.WindowsRuntimeApplication)
+        AssertEx.SetEqual({New KeyValuePair(Of String, Object)("VBC_VER", PredefinedPreprocessorSymbols.CurrentVersionNumber), New KeyValuePair(Of String, Object)("TARGET", "appcontainerexe")}, symbols.AsEnumerable)
 
-        'TODO: symbols = AddPredefinedPreprocessorSymbols(OutputKind.AppContainer)
-        ' AssertEx.SetEqual({New KeyValuePair(Of String, Object)("VBC_VER", 11.0), New KeyValuePair(Of String, Object)("TARGET", "winmdobj")}, symbols.AsEnumerable)
+        symbols = AddPredefinedPreprocessorSymbols(OutputKind.WindowsRuntimeMetadata)
+        AssertEx.SetEqual({New KeyValuePair(Of String, Object)("VBC_VER", PredefinedPreprocessorSymbols.CurrentVersionNumber), New KeyValuePair(Of String, Object)("TARGET", "winmdobj")}, symbols.AsEnumerable)
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/XmlDocComments.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/XmlDocComments.vb
@@ -466,16 +466,13 @@ End Module
 
     <WorkItem(530663, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530663")>
     <WorkItem(547297, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547297")>
-    <Fact(Skip:="547297")>
+    <Fact>
     Public Sub ParseOpenBracket()
         ParseAndVerify(<![CDATA[
 ''' < 
 Module M
 End Module
-]]>,
-        <errors>
-            <error id="42304" warning="True"/>
-        </errors>)
+]]>)
     End Sub
 
     <WorkItem(697115, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/697115")>

--- a/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/TestSyntaxNodes.vb
@@ -2056,7 +2056,8 @@ End Class
         End Sub
 
         <WorkItem(755236, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/755236")>
-        <Fact(Skip:="802431")>
+        <WorkItem(9896, "https://github.com/dotnet/roslyn/issues/9896")>
+        <Fact>
         Public Sub TestFindNode()
             Dim code = <code><![CDATA[
 ''' <see cref="Foo"/>
@@ -2079,7 +2080,8 @@ End Class]]>
             Dim position = identifier.Span.Start + 1
 
             Assert.Equal(classStatement, root.FindNode(identifier.Span, findInsideTrivia:=False))
-            Assert.Equal(identifier, root.FindNode(identifier.Span, findInsideTrivia:=True))
+            Assert.Equal(identifier.Parent, root.FindNode(identifier.Span, findInsideTrivia:=True))
+            Assert.Equal(identifier.Parent.Span, identifier.Span)
 
             ' Token span.
             Assert.Equal(classStatement, root.FindNode(classStatement.Identifier.Span, findInsideTrivia:=False))
@@ -2938,7 +2940,9 @@ End Module
             compilation.VerifyDiagnostics()
         End Sub
 
-        <Fact(Skip:="658398")>
+        <Fact>
+        <WorkItem(111538, "https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems?_a=edit&id=111538")>
+        <WorkItem(658398, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems?_a=edit&id=658398")>
         Public Sub Test_UnaryOperatorsInvalid()
             'Added for Code Coverage 
             Dim compilationDef =
@@ -2983,8 +2987,42 @@ End Module
 </compilation>
 
             Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
-            compilation.VerifyDiagnostics()
-            'TODO add the appropriate errors once bug is fixed
+            compilation.AssertTheseDiagnostics(
+<expected>
+BC30487: Operator '-' is not defined for type 'Char'.
+#If -"1"c Then
+~~~~~~~~~~~~~~
+BC30487: Operator '+' is not defined for type 'String'.
+#If +"1" Then
+~~~~~~~~~~~~~
+BC30487: Operator '+' is not defined for type 'Char'.
+#If +" "c Then
+~~~~~~~~~~~~~~
+BC30037: Character is not valid.
+#If +"test"$ Then
+           ~
+BC30205: End of statement expected.
+#If +"test"$ Then
+           ~
+BC30487: Operator 'Not' is not defined for type 'Char'.
+#If Not " "c Then
+~~~~~~~~~~~~~~~~~
+BC30037: Character is not valid.
+#If NOT "test"$ Then
+              ~
+BC30205: End of statement expected.
+#If NOT "test"$ Then
+              ~
+BC31427: Syntax error in conditional compilation expression.
+#If - Then
+      ~~~~
+BC31427: Syntax error in conditional compilation expression.
+#If + Then
+      ~~~~
+BC31427: Syntax error in conditional compilation expression.
+#If NOT Then
+        ~~~~
+</expected>)
         End Sub
 
         <Fact>


### PR DESCRIPTION
There is a small product change to fix https://devdiv.visualstudio.com/defaultcollection/DevDiv/_workitems?_a=edit&id=111538 and enable corresponding unit-test.

@dotnet/roslyn-compiler Please review.
CC @srivatsn 
