### PR TITLE
Add specific csc & vbc nuspecs

### DIFF
--- a/src/NuGet/Microsoft.NETCore.Csc.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Csc.nuspec
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>Microsoft.NETCore.Csc</id>
+        <description>
+            CoreCLR-compatible version of the C# compiler.
+
+            Supported Platforms:
+            - .NET Core (dnxcore50)
+        </description>
+        <language>en-US</language>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <version>$version$</version>
+        <authors>$authors$</authors>
+        <licenseUrl>$licenseUrl$</licenseUrl>
+        <projectUrl>$projectUrl$</projectUrl>
+        <tags>$tags$</tags>
+        <dependencies>
+            <group targetFramework="dnxcore50">
+                <dependency id="Microsoft.CodeAnalysis.CSharp" version="[$version$]" />
+                <dependency id="System.AppContext" version="4.0.1-beta-23504" />
+                <dependency id="System.Collections" version="4.0.11-beta-23504" />
+                <dependency id="System.Collections.Immutable" version="1.1.38-beta-23504" />
+                <dependency id="System.Console" version="4.0.0-beta-23504" />
+                <dependency id="System.Diagnostics.Debug" version="4.0.11-beta-23504" />
+                <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0-beta-23504" />
+                <dependency id="System.Diagnostics.Process" version="4.1.0-beta-23504" />
+                <dependency id="System.Diagnostics.StackTrace" version="4.0.1-beta-23504" />
+                <dependency id="System.Diagnostics.Tools" version="4.0.1-beta-23504" />
+                <dependency id="System.Dynamic.Runtime" version="4.0.11-beta-23504" />
+                <dependency id="System.IO.FileSystem" version="4.0.1-beta-23504" />
+                <dependency id="System.IO.FileSystem.Watcher" version="4.0.0-beta-23504" />
+                <dependency id="System.IO.Pipes" version="4.0.0-beta-23504" />
+                <dependency id="System.Linq" version="4.0.1-beta-23504" />
+                <dependency id="System.Net.NameResolution" version="4.0.0-beta-23504" />
+                <dependency id="System.Net.Sockets" version="4.1.0-beta-23504" />
+                <dependency id="System.Private.Uri" version="4.0.1-beta-23504" />
+                <dependency id="System.Reflection" version="4.1.0-beta-23504" />
+                <dependency id="System.Reflection.Primitives" version="4.0.1-beta-23504" />
+                <dependency id="System.Resources.ResourceManager" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime" version="4.0.21-beta-23504" />
+                <dependency id="System.Runtime.Extensions" version="4.0.11-beta-23504" />
+                <dependency id="System.Runtime.Handles" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime.InteropServices" version="4.0.21-beta-23504" />
+                <dependency id="System.Runtime.Loader" version="4.0.0-beta-23504" />
+                <dependency id="System.Runtime.Numerics" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime.Serialization.Json" version="4.0.1-beta-23504" />
+                <dependency id="System.Security.Cryptography.Algorithms" version="4.0.0-beta-23504" />
+                <dependency id="System.Security.Cryptography.Encoding" version="4.0.0-beta-23504" />
+                <dependency id="System.Security.Cryptography.X509Certificates" version="4.0.0-beta-23504" />
+                <dependency id="System.Text.Encoding" version="4.0.11-beta-23504" />
+                <dependency id="System.Text.Encoding.CodePages" version="4.0.1-beta-23504" />
+                <dependency id="System.Text.Encoding.Extensions" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading.Tasks" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23504" />
+                <dependency id="System.Threading.Thread" version="4.0.0-beta-23504" />
+                <dependency id="System.Xml.XDocument" version="4.0.11-beta-23504" />
+                <dependency id="System.Xml.XmlDocument" version="4.0.1-beta-23504" />
+                <dependency id="System.Xml.XPath.XDocument" version="4.0.1-beta-23504" />
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="$emptyDirPath$" target="ref/dotnet" />
+        <file src="csccore/csc.exe" target="runtimes/any/native" />
+    </files>
+</package>

--- a/src/NuGet/Microsoft.NETCore.Vbc.nuspec
+++ b/src/NuGet/Microsoft.NETCore.Vbc.nuspec
@@ -1,0 +1,68 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+    <metadata>
+        <id>Microsoft.NETCore.Vbc</id>
+        <description>
+            CoreCLR-compatible version of the VB compiler.
+
+            Supported Platforms:
+            - .NET Core (dnxcore50)
+        </description>
+        <language>en-US</language>
+        <requireLicenseAcceptance>true</requireLicenseAcceptance>
+        <version>$version$</version>
+        <authors>$authors$</authors>
+        <licenseUrl>$licenseUrl$</licenseUrl>
+        <projectUrl>$projectUrl$</projectUrl>
+        <tags>$tags$</tags>
+        <dependencies>
+            <group targetFramework="dnxcore50">
+                <dependency id="Microsoft.CodeAnalysis.VisualBasic" version="[$version$]" />
+                <dependency id="System.AppContext" version="4.0.1-beta-23504" />
+                <dependency id="System.Collections" version="4.0.11-beta-23504" />
+                <dependency id="System.Collections.Immutable" version="1.1.38-beta-23504" />
+                <dependency id="System.Console" version="4.0.0-beta-23504" />
+                <dependency id="System.Diagnostics.Debug" version="4.0.11-beta-23504" />
+                <dependency id="System.Diagnostics.FileVersionInfo" version="4.0.0-beta-23504" />
+                <dependency id="System.Diagnostics.Process" version="4.1.0-beta-23504" />
+                <dependency id="System.Diagnostics.StackTrace" version="4.0.1-beta-23504" />
+                <dependency id="System.Diagnostics.Tools" version="4.0.1-beta-23504" />
+                <dependency id="System.Dynamic.Runtime" version="4.0.11-beta-23504" />
+                <dependency id="System.IO.FileSystem" version="4.0.1-beta-23504" />
+                <dependency id="System.IO.FileSystem.Watcher" version="4.0.0-beta-23504" />
+                <dependency id="System.IO.Pipes" version="4.0.0-beta-23504" />
+                <dependency id="System.Linq" version="4.0.1-beta-23504" />
+                <dependency id="System.Net.NameResolution" version="4.0.0-beta-23504" />
+                <dependency id="System.Net.Sockets" version="4.1.0-beta-23504" />
+                <dependency id="System.Private.Uri" version="4.0.1-beta-23504" />
+                <dependency id="System.Reflection" version="4.1.0-beta-23504" />
+                <dependency id="System.Reflection.Primitives" version="4.0.1-beta-23504" />
+                <dependency id="System.Resources.ResourceManager" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime" version="4.0.21-beta-23504" />
+                <dependency id="System.Runtime.Extensions" version="4.0.11-beta-23504" />
+                <dependency id="System.Runtime.Handles" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime.InteropServices" version="4.0.21-beta-23504" />
+                <dependency id="System.Runtime.Loader" version="4.0.0-beta-23504" />
+                <dependency id="System.Runtime.Numerics" version="4.0.1-beta-23504" />
+                <dependency id="System.Runtime.Serialization.Json" version="4.0.1-beta-23504" />
+                <dependency id="System.Security.Cryptography.Algorithms" version="4.0.0-beta-23504" />
+                <dependency id="System.Security.Cryptography.Encoding" version="4.0.0-beta-23504" />
+                <dependency id="System.Security.Cryptography.X509Certificates" version="4.0.0-beta-23504" />
+                <dependency id="System.Text.Encoding" version="4.0.11-beta-23504" />
+                <dependency id="System.Text.Encoding.CodePages" version="4.0.1-beta-23504" />
+                <dependency id="System.Text.Encoding.Extensions" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading.Tasks" version="4.0.11-beta-23504" />
+                <dependency id="System.Threading.Tasks.Parallel" version="4.0.1-beta-23504" />
+                <dependency id="System.Threading.Thread" version="4.0.0-beta-23504" />
+                <dependency id="System.Xml.XDocument" version="4.0.11-beta-23504" />
+                <dependency id="System.Xml.XmlDocument" version="4.0.1-beta-23504" />
+                <dependency id="System.Xml.XPath.XDocument" version="4.0.1-beta-23504" />
+            </group>
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="$emptyDirPath$" target="ref/dotnet" />
+        <file src="vbccore/vbc.exe" target="runtimes/any/native" />
+    </files>
+</package>


### PR DESCRIPTION
Right now there's only Microsoft.Net.Compiler.netcore, which
is fine if you want both compilers, but if you only want csc
or vbc this is cheaper.

/cc @dotnet/roslyn-compiler @jaredpar 