### PR TITLE
Fix for #9274: adding empty VB file to sample

### DIFF
--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/BasicAnalyzers.Vsix.vbproj
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/BasicAnalyzers.Vsix.vbproj
@@ -66,6 +66,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Empty.vb" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\BasicAnalyzers\BasicAnalyzers.vbproj">
       <Project>{9E86BCE5-E095-4E9F-9C45-22D5AEB6AD2A}</Project>
       <Name>BasicAnalyzers</Name>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/Empty.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/Empty.vb
@@ -1,0 +1,1 @@
+' This solely exists to avoid BC2008


### PR DESCRIPTION
Dave and I investigated the problem on my machine. It is the result of some changes in update 2.
The VBC behavior after update 2 is the same as the native compiler's.

Fixes #9274 (BuildAndTest.proj fails with VS update 2 installed)
Related to #8477 (VBC crashes when no source)

CC @lgolding @TyOverby @davkean @tmat @jaredpar @AlekseyTs 