### PR TITLE
Simple tuple construction and underlying field access

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -615,20 +615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return BindThrowExpression((ThrowExpressionSyntax)node, diagnostics);
 
                 case SyntaxKind.TupleExpression:
-                    {
-                        var tuple = (TupleExpressionSyntax)node;
-
-                        if (tuple.Arguments.Count == 0)
-                        {
-                            // this should be a parse error already.
-                            return BadExpression(node);
-                        }
-
-                        // UNDONE: bind the value of the first element for now.
-                        //         just to not crash in tests.
-                        //         Actual binding implementation is coming.
-                        return BindExpression(((TupleExpressionSyntax)node).Arguments[0].Expression, diagnostics);
-                    }
+                    return BindTupleExpression((TupleExpressionSyntax)node, diagnostics);
 
                 default:
                     // NOTE: We could probably throw an exception here, but it's conceivable
@@ -637,6 +624,63 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(false, "Unexpected SyntaxKind " + node.Kind());
                     return BadExpression(node);
             }
+        }
+
+        private BoundExpression BindTupleExpression(TupleExpressionSyntax node, DiagnosticBag diagnostics)
+        {
+            var arguments = node.Arguments;
+            if (arguments.Count < 2)
+            {
+                // this should be a parse error already.
+                return BadExpression(node);
+            }
+
+            var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
+            var elementTypes = ArrayBuilder<TypeSymbol>.GetInstance(arguments.Count);
+            ArrayBuilder<string> elementNames = null;
+
+            for (int i = 0, l = arguments.Count; i < l; i++)
+            {
+                var argumentSyntax = arguments[i];
+                var name = argumentSyntax.NameColon?.Name.Identifier.ValueText;
+
+                // names would typically all be there or none at all
+                // but in case we need to handle this in error cases
+                if (elementNames != null)
+                {
+                    elementNames.Add(name ?? "Item" + i);
+                }
+                else
+                {
+                    if (name != null)
+                    {
+                        elementNames = ArrayBuilder<string>.GetInstance(arguments.Count);
+                        for (int j = 0; j < i; j++)
+                        {
+                            elementNames.Add(name ?? "Item" + j);
+                        }
+                        elementNames.Add(name);
+                    }
+                }
+
+                var boundArgument = BindExpression(argumentSyntax.Expression, diagnostics);
+                boundArguments.Add(boundArgument);
+                elementTypes.Add(boundArgument.Type);
+            }
+
+            var type = new TupleTypeSymbol(
+                elementTypes.ToImmutableAndFree(),
+                elementNames == null ?
+                                ImmutableArray<string>.Empty :
+                                elementNames.ToImmutableAndFree(),
+                node,
+                this,
+                diagnostics);
+
+            //PROTOTYPE: should be a wellknown member?
+            var ctor = type.UnderlyingTupleType?.InstanceConstructors.FirstOrDefault();
+
+            return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type);
         }
 
         private BoundExpression BindRefValue(RefValueExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -632,8 +632,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (arguments.Count < 2)
             {
                 // this should be a parse error already.
-                return BadExpression(node);
+                var args = arguments.Count == 1 ?
+                    new BoundExpression[] { BindValue(arguments[0].Expression, diagnostics, BindValueKind.RValue) } :
+                    new BoundExpression[0];
+                    
+                return BadExpression(node, args);
             }
+
+            bool hasErrors = false;
+
+            // set of names already used
+            HashSet<string> uniqueFieldNames = new HashSet<string>();
 
             var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
             var elementTypes = ArrayBuilder<TypeSymbol>.GetInstance(arguments.Count);
@@ -642,8 +651,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             for (int i = 0, l = arguments.Count; i < l; i++)
             {
                 var argumentSyntax = arguments[i];
-                var name = argumentSyntax.NameColon?.Name.Identifier.ValueText;
+                var name = argumentSyntax.NameColon?.Name?.Identifier.ValueText;
 
+                // validate name if we have one
+                if (name != null)
+                {
+                    // PROTOTYPE: check for a case "ItemX" where X is not i
+
+                    if (!uniqueFieldNames.Add(name))
+                    {
+                        hasErrors = true;
+                        // PROTOTYPE: need specific duplicate name error for tuples
+                        Error(diagnostics, ErrorCode.ERR_AnonymousTypeDuplicatePropertyName, argumentSyntax.NameColon.Name);
+                    }
+                }
+                
+                // add the name to the list
                 // names would typically all be there or none at all
                 // but in case we need to handle this in error cases
                 if (elementNames != null)
@@ -663,15 +686,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                var boundArgument = BindExpression(argumentSyntax.Expression, diagnostics);
+                var boundArgument = BindValue(argumentSyntax.Expression, diagnostics, BindValueKind.RValue);
                 boundArguments.Add(boundArgument);
-                elementTypes.Add(boundArgument.Type);
+
+                // PROTOTYPE: need to report distinc errors for tuples
+                var elementType = GetAnonymousTypeFieldType(boundArgument, argumentSyntax, diagnostics, ref hasErrors);
+                elementTypes.Add(elementType);
             }
 
             var type = new TupleTypeSymbol(
                 elementTypes.ToImmutableAndFree(),
                 elementNames == null ?
-                                ImmutableArray<string>.Empty :
+                                default(ImmutableArray<string>) :
                                 elementNames.ToImmutableAndFree(),
                 node,
                 this,
@@ -680,7 +706,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             //PROTOTYPE: should be a wellknown member?
             var ctor = type.UnderlyingTupleType?.InstanceConstructors.FirstOrDefault();
 
-            return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type);
+            return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type, hasErrors);
         }
 
         private BoundExpression BindRefValue(RefValueExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -187,10 +187,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     this.LookupMembersInClass(result, type, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
                     break;
 
-                case TypeKind.Tuple:
-                    useSiteDiagnostics = LookupMembersInTuple(result, type, name, arity, basesBeingResolved, options, originalBinder, diagnose, useSiteDiagnostics);
-                    break;
-
                 case TypeKind.Submission:
                     this.LookupMembersInSubmissions(result, type, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
                     break;
@@ -210,12 +206,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // TODO: Diagnose ambiguity problems here, and conflicts between non-method and method? Or is that
             // done in the caller?
-        }
-
-        private HashSet<DiagnosticInfo> LookupMembersInTuple(LookupResult result, TypeSymbol type, string name, int arity, ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, HashSet<DiagnosticInfo> useSiteDiagnostics)
-        {
-            this.LookupMembersInClass(result, type, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
-            return useSiteDiagnostics;
         }
 
         private void LookupMembersInErrorType(LookupResult result, ErrorTypeSymbol errorType, string name, int arity, ConsList<Symbol> basesBeingResolved, LookupOptions options, Binder originalBinder, bool diagnose, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -728,7 +718,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // PROTOTYPE consider taking this out of the loop. tuples are always at the end of hierarchy
                 // PROTOTYPE match this in other lookups
                 var tuple = currentType as TupleTypeSymbol;
-                if (tuple != null)
+                if ((object)tuple != null)
                 {
                     currentType = tuple.UnderlyingTupleType;
                     continue;
@@ -1541,6 +1531,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case TypeKind.Dynamic:
                     this.AddMemberLookupSymbolsInfoInClass(result, type, options, originalBinder, type);
                     break;
+
+                    //PROTOTYPE: add special handling for tuple types - we need to collect both tuple members and from the underlying.
 
                 case TypeKind.Submission:
                     this.AddMemberLookupSymbolsInfoInSubmissions(result, type, options, originalBinder);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -184,6 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case TypeKind.Delegate:
                 case TypeKind.Array:
                 case TypeKind.Dynamic:
+                case TypeKind.Tuple:
                     this.LookupMembersInClass(result, type, name, arity, basesBeingResolved, options, originalBinder, diagnose, ref useSiteDiagnostics);
                     break;
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
@@ -99,9 +99,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolKind.NamedType:
                     return IsNamedTypeAccessible((NamedTypeSymbol)symbol, within, ref useSiteDiagnostics, basesBeingResolved);
 
-                case SymbolKind.TupleType:
-                    return IsNamedTypeAccessible(((TupleTypeSymbol)symbol).UnderlyingTupleType, within, ref useSiteDiagnostics, basesBeingResolved);
-
                 case SymbolKind.ErrorType:
                     // Always assume that error types are accessible.
                     return true;
@@ -223,11 +220,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)containingType != null);
 
             failedThroughTypeCheck = false;
-
-            // for tuples consider the underlying type as a true container for visibility puroposes.
-            containingType = 
-                (containingType as TupleTypeSymbol)?.UnderlyingTupleType ?? 
-                containingType;
 
             // easy case - members of containing type are accessible.
             if ((object)containingType == (object)within)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
@@ -99,6 +99,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SymbolKind.NamedType:
                     return IsNamedTypeAccessible((NamedTypeSymbol)symbol, within, ref useSiteDiagnostics, basesBeingResolved);
 
+                case SymbolKind.TupleType:
+                    return IsNamedTypeAccessible(((TupleTypeSymbol)symbol).UnderlyingTupleType, within, ref useSiteDiagnostics, basesBeingResolved);
+
                 case SymbolKind.ErrorType:
                     // Always assume that error types are accessible.
                     return true;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/AccessCheck.cs
@@ -224,6 +224,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             failedThroughTypeCheck = false;
 
+            // for tuples consider the underlying type as a true container for visibility puroposes.
+            containingType = 
+                (containingType as TupleTypeSymbol)?.UnderlyingTupleType ?? 
+                containingType;
+
             // easy case - members of containing type are accessible.
             if ((object)containingType == (object)within)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1143,6 +1143,7 @@
     <Node Name="BoundTupleCreationExpression" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <!-- The constructor of the underlying tuple type -->
     <Field Name="Constructor" Type="MethodSymbol" Null="disallow"/>
     <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1140,6 +1140,12 @@
     <Field Name="InitializerExpressionOpt" Type="BoundExpression" Null="allow"/>
   </Node>
   
+    <Node Name="BoundTupleCreationExpression" Base="BoundExpression">
+    <!-- Non-null type is required for this node kind -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
+    <Field Name="Constructor" Type="MethodSymbol" Null="disallow"/>
+    <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
+  </Node>
   
   <Node Name="BoundDynamicObjectCreationExpression" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1779,6 +1779,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    internal partial class BoundTupleCreationExpression
+    {
+        protected override OperationKind ExpressionKind => OperationKind.None;
+
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitNoneOperation(this);
+        }
+
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitNoneOperation(this, argument);
+        }
+    }
+
     internal partial class BoundDynamicInvocation
     {
         protected override OperationKind ExpressionKind => OperationKind.None;

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -433,6 +433,7 @@
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_IndexerAccess.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_IsOperator.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_LabeledStatement.cs" />
+    <Compile Include="Lowering\LocalRewriter\LocalRewriter_TupleCreationExpression.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_Literal.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_LocalDeclaration.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_LockStatement.cs" />

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -768,6 +768,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             {
                 namedTypeSymbol = AnonymousTypeManager.TranslateAnonymousTypeSymbol(namedTypeSymbol);
             }
+            else if (namedTypeSymbol.IsTupleType)
+            {
+                namedTypeSymbol = ((TupleTypeSymbol)namedTypeSymbol).UnderlyingTupleType;
+            }
 
             // Substitute error types with a special singleton object.
             // Unreported bad types can come through NoPia embedding, for example.
@@ -914,9 +918,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 case SymbolKind.TypeParameter:
                     return Translate((TypeParameterSymbol)typeSymbol);
-
-                case SymbolKind.TupleType:
-                    return Translate(((TupleTypeSymbol)typeSymbol).UnderlyingTupleType, syntaxNodeOpt, diagnostics);
             }
 
             throw ExceptionUtilities.UnexpectedValue(typeSymbol.Kind);
@@ -1089,6 +1090,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             if (container.IsAnonymousType)
             {
                 methodSymbol = AnonymousTypeManager.TranslateAnonymousTypeMethodSymbol(methodSymbol);
+            }
+            else if (container.IsTupleType)
+            {
+                container = ((TupleTypeSymbol)container).UnderlyingTupleType;
             }
 
             if (!methodSymbol.IsDefinition)

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -914,6 +914,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 case SymbolKind.TypeParameter:
                     return Translate((TypeParameterSymbol)typeSymbol);
+
+                case SymbolKind.TupleType:
+                    return Translate(((TupleTypeSymbol)typeSymbol).UnderlyingTupleType, syntaxNodeOpt, diagnostics);
             }
 
             throw ExceptionUtilities.UnexpectedValue(typeSymbol.Kind);

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -910,6 +910,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
+        public override BoundNode VisitTupleCreationExpression(BoundTupleCreationExpression node)
+        {
+            VisitArguments(node.Arguments, default(ImmutableArray<RefKind>), null);
+            if (_trackExceptions) NotePossibleException(node);
+            return null;
+        }
+
         public override BoundNode VisitDynamicObjectCreationExpression(BoundDynamicObjectCreationExpression node)
         {
             VisitArguments(node.Arguments, node.ArgumentRefKindsOpt, null);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
@@ -12,7 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression rewrittenReceiver = VisitExpression(node.ReceiverOpt);
 
-            return MakeFieldAccess(node.Syntax, rewrittenReceiver, node.FieldSymbol, node.ConstantValue, node.ResultKind, node.Type, node);
+            // field access of a tuple actually accesses the underlying field.
+            FieldSymbol field = (node.FieldSymbol as TupleFieldSymbol)?.UnderlyingTypleFieldSymbol ??
+                                node.FieldSymbol;
+
+            return MakeFieldAccess(node.Syntax, rewrittenReceiver, field, node.ConstantValue, node.ResultKind, node.Type, node);
         }
 
         private static BoundExpression MakeFieldAccess(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class LocalRewriter
+    {
+        public override BoundNode VisitTupleCreationExpression(BoundTupleCreationExpression node)
+        {
+            var rewrittenArguments = VisitList(node.Arguments);
+            return new BoundObjectCreationExpression(node.Syntax, node.Constructor, rewrittenArguments);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor_Minimal.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // TODO(cyrusn): This code needs to see if type is an attribute and if it can be shown 
             // in simplified form here.
 
-            if (!symbol.IsAnonymousType)
+            if (!(symbol.IsAnonymousType || symbol.IsTupleType))
             {
                 if (!NameBoundSuccessfullyToSameSymbol(symbol))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -634,15 +634,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds = false, bool ignoreDynamic = false)
         {
-            if (ReferenceEquals(this, t2)) return true;
+            if ((object)t2 ==  this) return true;
             if ((object)t2 == null) return false;
 
-            // if ignoring dynamic, then treat dynamic the same as the type 'object'
-            if (ignoreDynamic &&
-                t2.TypeKind == TypeKind.Dynamic &&
-                this.SpecialType == SpecialType.System_Object)
+            if (ignoreDynamic)
             {
-                return true;
+                if (t2.TypeKind == TypeKind.Dynamic)
+                {
+                    // if ignoring dynamic, then treat dynamic the same as the type 'object'
+                    if (this.SpecialType == SpecialType.System_Object)
+                    {
+                        return true;
+                    }
+                }
+
+                //PROTOTYPE: rename ignoreDynamic or introduce another "ignoreTuple" flag
+                // if ignoring dynamic, compare underlying tuple types
+                var tupleType = t2 as TupleTypeSymbol;
+                if (tupleType != null)
+                {
+                    t2 = tupleType.UnderlyingTupleType;
+                    if ((object)t2 == this) return true;
+                }
+
+                tupleType = this as TupleTypeSymbol;
+                if (tupleType != null)
+                {
+                    return tupleType.UnderlyingTupleType.Equals(t2, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+                }
             }
 
             NamedTypeSymbol other = t2 as NamedTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -634,7 +634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds = false, bool ignoreDynamic = false)
         {
-            if ((object)t2 ==  this) return true;
+            if ((object)t2 == this) return true;
             if ((object)t2 == null) return false;
 
             if (ignoreDynamic)
@@ -650,18 +650,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 //PROTOTYPE: rename ignoreDynamic or introduce another "ignoreTuple" flag
                 // if ignoring dynamic, compare underlying tuple types
-                var tupleType = t2 as TupleTypeSymbol;
-                if (tupleType != null)
+                if (t2.IsTupleType)
                 {
-                    t2 = tupleType.UnderlyingTupleType;
+                    t2 = ((TupleTypeSymbol)t2).UnderlyingTupleType;
                     if ((object)t2 == this) return true;
                 }
 
-                tupleType = this as TupleTypeSymbol;
-                if (tupleType != null)
-                {
-                    return tupleType.UnderlyingTupleType.Equals(t2, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
-                }
+                Debug.Assert(!this.IsTupleType);
             }
 
             NamedTypeSymbol other = t2 as NamedTypeSymbol;

--- a/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
@@ -560,10 +560,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public TupleFieldSymbol(string name, TupleTypeSymbol containingTuple, TypeSymbol type, FieldSymbol underlyingFieldOpt)
         {
-            this._name = name;
-            this._containingTuple = containingTuple;
-            this._type = type;
-            this._underlyingFieldOpt = underlyingFieldOpt;
+            _name = name;
+            _containingTuple = containingTuple;
+            _type = type;
+            _underlyingFieldOpt = underlyingFieldOpt;
+        }
+
+        public FieldSymbol UnderlyingTypleFieldSymbol
+        {
+            get
+            {
+                return _underlyingFieldOpt;
+            }
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _name;
+            }
         }
 
         public override Symbol AssociatedSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -554,6 +554,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Is this a symbol for a Tuple
+        /// </summary>
+        public virtual bool IsTupleType
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Is this type a managed type (false for everything but enum, pointer, and
         /// some struct types).
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -509,6 +509,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Interface:
                     case TypeKind.Enum:
                     case TypeKind.Delegate:
+                    case TypeKind.Tuple:
                         foreach (var typeArg in ((NamedTypeSymbol)current).TypeArgumentsNoUseSiteDiagnostics)
                         {
                             var result = typeArg.VisitType(predicate, arg);

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -509,7 +509,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     case TypeKind.Interface:
                     case TypeKind.Enum:
                     case TypeKind.Delegate:
-                    case TypeKind.Tuple:
                         foreach (var typeArg in ((NamedTypeSymbol)current).TypeArgumentsNoUseSiteDiagnostics)
                         {
                             var result = typeArg.VisitType(predicate, arg);

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -175,7 +175,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 default:
                     // Enums and delegates know their own base types
                     // intrinsically (and do not include interface lists)
-                    // so there is not the possibility of a cycle.
+                    // so there is no possibility of a cycle.
                     return type.BaseTypeNoUseSiteDiagnostics;
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -114,6 +114,7 @@
     <Compile Include="CodeGen\CodeGenTests.cs" />
     <Compile Include="CodeGen\CodeGenThrowTests.cs" />
     <Compile Include="CodeGen\CodeGenTryFinally.cs" />
+    <Compile Include="CodeGen\CodeGenTupleTest.cs" />
     <Compile Include="CodeGen\CodeGenTypeofTests.cs" />
     <Compile Include="CodeGen\CodeGenUsingStatementTests.cs" />
     <Compile Include="CodeGen\CompoundAssignmentForDelegate.cs" />

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class CodeGenTupleTests : CSharpTestBase
+    {
+
+
+        private static readonly string trivial2uple =
+                    @"
+
+// PROTOTYPE: put in correct namespace
+namespace System.Runtime.CompilerServices
+{
+    // struct with two values
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+
+        public override string ToString()
+        {
+            return '{' + Item1?.ToString() + "", "" + Item2.ToString() + '}';
+        }
+    }
+}
+
+            ";
+
+        [Fact]
+        public void SimpleTuple()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (1, 2);
+        System.Console.WriteLine(x.ToString());
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, int> V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  call       ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  constrained. ""System.Runtime.CompilerServices.ValueTuple<int, int>""
+  IL_0011:  callvirt   ""string object.ToString()""
+  IL_0016:  call       ""void System.Console.WriteLine(string)""
+  IL_001b:  ret
+}");
+        }
+
+        [Fact]
+        public void SimpleTupleNested()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (1, (2, (3, 4)).ToString());
+        System.Console.WriteLine(x.ToString());
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: "{1, {2, {3, 4}}}");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  5
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, string> V_0, //x
+                System.Runtime.CompilerServices.ValueTuple<int, > V_1)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  ldc.i4.4
+  IL_0006:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_000b:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, >..ctor(int, )""
+  IL_0010:  stloc.1
+  IL_0011:  ldloca.s   V_1
+  IL_0013:  constrained. ""System.Runtime.CompilerServices.ValueTuple<int, >""
+  IL_0019:  callvirt   ""string object.ToString()""
+  IL_001e:  call       ""System.Runtime.CompilerServices.ValueTuple<int, string>..ctor(int, string)""
+  IL_0023:  ldloca.s   V_0
+  IL_0025:  constrained. ""System.Runtime.CompilerServices.ValueTuple<int, string>""
+  IL_002b:  callvirt   ""string object.ToString()""
+  IL_0030:  call       ""void System.Console.WriteLine(string)""
+  IL_0035:  ret
+}");
+        }
+
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -162,6 +162,152 @@ class C
 ");
         }
 
+        [Fact]
+        public void TupleUnderlyingItemAccess01()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (a: 1, b: 2);
+        System.Console.WriteLine(x.Item2.ToString());
+        x.Item1 = 40;
+        System.Console.WriteLine(x.Item1 + x.Item2);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"2
+42");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, int> V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  call       ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldflda     ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_0010:  call       ""string int.ToString()""
+  IL_0015:  call       ""void System.Console.WriteLine(string)""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldc.i4.s   40
+  IL_001e:  stfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0029:  ldloc.0
+  IL_002a:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_002f:  add
+  IL_0030:  call       ""void System.Console.WriteLine(int)""
+  IL_0035:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TupleItemAccess()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (a: 1, b: 2);
+        System.Console.WriteLine(x.b.ToString());
+        x.a = 40;
+        System.Console.WriteLine(x.a + x.b);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"2
+42");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, int> V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  call       ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldflda     ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_0010:  call       ""string int.ToString()""
+  IL_0015:  call       ""void System.Console.WriteLine(string)""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldc.i4.s   40
+  IL_001e:  stfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0029:  ldloc.0
+  IL_002a:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_002f:  add
+  IL_0030:  call       ""void System.Console.WriteLine(int)""
+  IL_0035:  ret
+}
+");
+        }
+
+        [Fact]
+        public void TupleItemAccess01()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (a: 1, b: (c: 2, d: 3));
+        System.Console.WriteLine(x.b.c.ToString());
+        x.b.d = 39;
+        System.Console.WriteLine(x.a + x.b.c + x.b.d);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"2
+42");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       87 (0x57)
+  .maxstack  4
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, > V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  ldc.i4.3
+  IL_0005:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_000a:  call       ""System.Runtime.CompilerServices.ValueTuple<int, >..ctor(int, )""
+  IL_000f:  ldloca.s   V_0
+  IL_0011:  ldflda     "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_0016:  ldflda     ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_001b:  call       ""string int.ToString()""
+  IL_0020:  call       ""void System.Console.WriteLine(string)""
+  IL_0025:  ldloca.s   V_0
+  IL_0027:  ldflda     "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_002c:  ldc.i4.s   39
+  IL_002e:  stfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_0033:  ldloc.0
+  IL_0034:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, >.Item1""
+  IL_0039:  ldloc.0
+  IL_003a:  ldfld      "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_003f:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0044:  add
+  IL_0045:  ldloc.0
+  IL_0046:  ldfld      "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_004b:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_0050:  add
+  IL_0051:  call       ""void System.Console.WriteLine(int)""
+  IL_0056:  ret
+}
+");
+        }
 
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -116,5 +116,52 @@ class C
 }");
         }
 
+        [Fact]
+        public void TupleUnderlyingItemAccess()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (1, 2);
+        System.Console.WriteLine(x.Item2.ToString());
+        x.Item1 = 40;
+        System.Console.WriteLine(x.Item1 + x.Item2);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"2
+42");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       54 (0x36)
+  .maxstack  3
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, int> V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  call       ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  ldflda     ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_0010:  call       ""string int.ToString()""
+  IL_0015:  call       ""void System.Console.WriteLine(string)""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  ldc.i4.s   40
+  IL_001e:  stfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
+  IL_0029:  ldloc.0
+  IL_002a:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
+  IL_002f:  add
+  IL_0030:  call       ""void System.Console.WriteLine(int)""
+  IL_0035:  ret
+}
+");
+        }
+
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -12,8 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
     public class CodeGenTupleTests : CSharpTestBase
     {
-
-
         private static readonly string trivial2uple =
                     @"
 
@@ -95,17 +93,17 @@ class C
   // Code size       54 (0x36)
   .maxstack  5
   .locals init (System.Runtime.CompilerServices.ValueTuple<int, string> V_0, //x
-                System.Runtime.CompilerServices.ValueTuple<int, > V_1)
+                System.Runtime.CompilerServices.ValueTuple<int, <tuple: int Item1, int Item2>> V_1)
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.1
   IL_0003:  ldc.i4.2
   IL_0004:  ldc.i4.3
   IL_0005:  ldc.i4.4
   IL_0006:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
-  IL_000b:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, >..ctor(int, )""
+  IL_000b:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, <tuple: int Item1, int Item2>>..ctor(int, <tuple: int Item1, int Item2>)""
   IL_0010:  stloc.1
   IL_0011:  ldloca.s   V_1
-  IL_0013:  constrained. ""System.Runtime.CompilerServices.ValueTuple<int, >""
+  IL_0013:  constrained. ""System.Runtime.CompilerServices.ValueTuple<int, <tuple: int Item1, int Item2>>""
   IL_0019:  callvirt   ""string object.ToString()""
   IL_001e:  call       ""System.Runtime.CompilerServices.ValueTuple<int, string>..ctor(int, string)""
   IL_0023:  ldloca.s   V_0
@@ -277,30 +275,30 @@ class C
 {
   // Code size       87 (0x57)
   .maxstack  4
-  .locals init (System.Runtime.CompilerServices.ValueTuple<int, > V_0) //x
+  .locals init (System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>> V_0) //x
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.1
   IL_0003:  ldc.i4.2
   IL_0004:  ldc.i4.3
   IL_0005:  newobj     ""System.Runtime.CompilerServices.ValueTuple<int, int>..ctor(int, int)""
-  IL_000a:  call       ""System.Runtime.CompilerServices.ValueTuple<int, >..ctor(int, )""
+  IL_000a:  call       ""System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>..ctor(int, <tuple: int c, int d>)""
   IL_000f:  ldloca.s   V_0
-  IL_0011:  ldflda     "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_0011:  ldflda     ""<tuple: int c, int d> System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>.Item2""
   IL_0016:  ldflda     ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
   IL_001b:  call       ""string int.ToString()""
   IL_0020:  call       ""void System.Console.WriteLine(string)""
   IL_0025:  ldloca.s   V_0
-  IL_0027:  ldflda     "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_0027:  ldflda     ""<tuple: int c, int d> System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>.Item2""
   IL_002c:  ldc.i4.s   39
   IL_002e:  stfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
   IL_0033:  ldloc.0
-  IL_0034:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, >.Item1""
+  IL_0034:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>.Item1""
   IL_0039:  ldloc.0
-  IL_003a:  ldfld      "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_003a:  ldfld      ""<tuple: int c, int d> System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>.Item2""
   IL_003f:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item1""
   IL_0044:  add
   IL_0045:  ldloc.0
-  IL_0046:  ldfld      "" System.Runtime.CompilerServices.ValueTuple<int, >.Item2""
+  IL_0046:  ldfld      ""<tuple: int c, int d> System.Runtime.CompilerServices.ValueTuple<int, <tuple: int c, int d>>.Item2""
   IL_004b:  ldfld      ""int System.Runtime.CompilerServices.ValueTuple<int, int>.Item2""
   IL_0050:  add
   IL_0051:  call       ""void System.Console.WriteLine(int)""

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -68,6 +68,8 @@ Microsoft.CodeAnalysis.IOperation.Type.get -> Microsoft.CodeAnalysis.ITypeSymbol
 Microsoft.CodeAnalysis.IPropertySymbol.ReturnsByRef.get -> bool
 Microsoft.CodeAnalysis.ISkippedTokensTriviaSyntax
 Microsoft.CodeAnalysis.ISkippedTokensTriviaSyntax.Tokens.get -> Microsoft.CodeAnalysis.SyntaxTokenList
+Microsoft.CodeAnalysis.ITupleTypeSymbol
+Microsoft.CodeAnalysis.ITypeSymbol.IsTupleType.get -> bool
 Microsoft.CodeAnalysis.Metadata.Id.get -> Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.MethodKind.LocalFunction = 17 -> Microsoft.CodeAnalysis.MethodKind
@@ -935,9 +937,3 @@ virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.Vi
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitWhileUntilLoopStatement(Microsoft.CodeAnalysis.Semantics.IWhileUntilLoopStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitWithStatement(Microsoft.CodeAnalysis.Semantics.IWithStatement operation, TArgument argument) -> TResult
 virtual Microsoft.CodeAnalysis.Semantics.OperationVisitor<TArgument, TResult>.VisitYieldBreakStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation, TArgument argument) -> TResult
-Microsoft.CodeAnalysis.ITupleTypeSymbol
-Microsoft.CodeAnalysis.SymbolKind.TupleType = 19 -> Microsoft.CodeAnalysis.SymbolKind
-Microsoft.CodeAnalysis.TypeKind.Tuple = 13 -> Microsoft.CodeAnalysis.TypeKind
-virtual Microsoft.CodeAnalysis.SymbolVisitor.VisitTupleType(Microsoft.CodeAnalysis.ITupleTypeSymbol symbol) -> void
-virtual Microsoft.CodeAnalysis.SymbolVisitor<TResult>.VisitTupleType(Microsoft.CodeAnalysis.ITupleTypeSymbol symbol) -> TResult
-

--- a/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ITypeSymbol.cs
@@ -65,6 +65,11 @@ namespace Microsoft.CodeAnalysis
         bool IsAnonymousType { get; }
 
         /// <summary>
+        /// Is this a symbol for a tuple .
+        /// </summary>
+        bool IsTupleType { get; }
+
+        /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
         /// symbol by type substitution then <see cref="OriginalDefinition"/> gets the original symbol as it was defined in
         /// source or metadata.

--- a/src/Compilers/Core/Portable/Symbols/SymbolKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolKind.cs
@@ -101,10 +101,5 @@ namespace Microsoft.CodeAnalysis
         /// Symbol is a preprocessing/conditional compilation constant.
         /// </summary>
         Preprocessing = 18,
-
-        /// <summary>
-        /// Symbol is a tuple type.
-        /// </summary>
-        TupleType = 19,
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/SymbolVisitor.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolVisitor.cs
@@ -23,11 +23,6 @@ namespace Microsoft.CodeAnalysis
             DefaultVisit(symbol);
         }
 
-        public virtual void VisitTupleType(ITupleTypeSymbol symbol)
-        {
-            DefaultVisit(symbol);
-        }
-
         public virtual void VisitAssembly(IAssemblySymbol symbol)
         {
             DefaultVisit(symbol);

--- a/src/Compilers/Core/Portable/Symbols/SymbolVisitor`1.cs
+++ b/src/Compilers/Core/Portable/Symbols/SymbolVisitor`1.cs
@@ -26,11 +26,6 @@ namespace Microsoft.CodeAnalysis
             return DefaultVisit(symbol);
         }
 
-        public virtual TResult VisitTupleType(ITupleTypeSymbol symbol)
-        {
-            return DefaultVisit(symbol);
-        }
-
         public virtual TResult VisitAssembly(IAssemblySymbol symbol)
         {
             return DefaultVisit(symbol);

--- a/src/Compilers/Core/Portable/Symbols/TypeKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeKind.cs
@@ -79,10 +79,5 @@ namespace Microsoft.CodeAnalysis
         /// Type is an interactive submission.
         /// </summary>
         Submission = 12,
-
-        /// <summary>
-        /// Type is a tuple.
-        /// </summary>
-        Tuple = 13,
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbol.vb
@@ -452,6 +452,13 @@ Done:
             End Get
         End Property
 
+        Private ReadOnly Property ITypeSymbol_IsTupleSymbol As Boolean Implements ITypeSymbol.IsTupleType
+            Get
+                ' PROTOTYPE: VB does not yet support tuples.
+                Return False
+            End Get
+        End Property
+
         Private ReadOnly Property ITypeSymbol_TypeKind As TypeKind Implements ITypeSymbol.TypeKind
             Get
                 Return Me.TypeKind.ToCommon()

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedNamedTypeSymbol.cs
@@ -243,6 +243,14 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
+            public bool IsTupleType
+            {
+                get
+                {
+                    return _symbol.IsTupleType;
+                }
+            }
+
             ITypeSymbol ITypeSymbol.OriginalDefinition
             {
                 get

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationTypeSymbol.cs
@@ -74,6 +74,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             }
         }
 
+        public bool IsTupleType
+        {
+            get
+            {
+                return false;
+            }
+        }
+
         public new ITypeSymbol OriginalDefinition
         {
             get


### PR DESCRIPTION
Some very simple scenarios now work e2e from parsing to codegen.
There are some "PROTOTYPE" comments, but I feel we need to sync up, since this change opens many test scenarios.