### PR TITLE
explicitly dump entire XML fragments to help with debugging

### DIFF
--- a/src/VisualStudio/Core/Test/Progression/ProgressionTestHelpers.vb
+++ b/src/VisualStudio/Core/Test/Progression/ProgressionTestHelpers.vb
@@ -36,10 +36,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Progression
 
         Public Sub AssertSimplifiedGraphIs(graph As Graph, xml As XElement)
             Dim graphXml = graph.ToSimplifiedXDocument()
-            If Not XNode.DeepEquals(graphXml, xml) Then
+            If Not XNode.DeepEquals(graphXml.Root, xml) Then
                 ' They aren't equal, so therefore the text representations definitely aren't equal.
                 ' We'll Assert.Equal those, so that way xunit will show nice before/after text
-                Assert.Equal(xml.ToString(), graphXml.ToString())
+                'Assert.Equal(xml.ToString(), graphXml.ToString())
+
+                ' In an attempt to diagnose some flaky tests, the whole contents of both objects will be output
+                Throw New Exception($"Graph XML was not equal, check for out-of-order elements.
+Expected:
+{xml.ToString()}
+
+Actual:
+{graphXml.ToString()}
+")
             End If
         End Sub
     End Module


### PR DESCRIPTION
This is to potentially help diagnose #9653, where it's expected that the resultant XML fragment is 'correct', but out of order.