### PR TITLE
Add SupportsSyntaxTree checks to resolve NullReferenceExceptions in Salsa ContainedDocument scenarios

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -73,6 +73,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private async Task<IEnumerable<CompletionItem>> GetSnippetsForDocumentAsync(Document document, int position, Workspace workspace, CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+            {
+                return SpecializedCollections.EmptyEnumerable<CompletionItem>();
+            }
+
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             var semanticFacts = document.GetLanguageService<ISemanticFactsService>();

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -47,6 +47,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private async Task<bool> ShouldShowSpeculativeTCompletionItemAsync(Document document, int position, CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+            {
+                return false;
+            }
+
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             if (syntaxTree.IsInNonUserCode(position, cancellationToken) ||
                 syntaxTree.IsPreProcessorDirectiveContext(position, cancellationToken))

--- a/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -86,6 +86,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             int position,
             CancellationToken cancellationToken)
         {
+            if (!document.SupportsSyntaxTree)
+            {
+                return null;
+            }
+
             var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
             var syntaxFacts = document.GetLanguageService<ISyntaxFactsService>();
             if (syntaxFacts.IsInNonUserCode(syntaxTree, position, cancellationToken))

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -280,6 +280,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             foreach (var relatedDocumentId in relatedDocuments)
             {
                 var relatedDocument = document.Project.Solution.GetDocument(relatedDocumentId);
+                if (!relatedDocument.SupportsSyntaxTree)
+                {
+                    continue;
+                }
+
                 var context = await GetOrCreateContext(relatedDocument, position, cancellationToken).ConfigureAwait(false);
 
                 if (IsCandidateProject(context, cancellationToken))

--- a/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var linkedDocument = solution.GetDocument(linkedDocumentId);
                 if (!linkedDocument.SupportsSyntaxTree)
                 {
-                    return false;
+                    continue;
                 }
 
                 if (await contextChecker(linkedDocument, cancellationToken).ConfigureAwait(false))

--- a/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -52,6 +52,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             foreach (var linkedDocumentId in linkedDocumentIds)
             {
                 var linkedDocument = document.Project.Solution.GetDocument(linkedDocumentId);
+                if (!linkedDocument.SupportsSyntaxTree)
+                {
+                    continue;
+                }
+
                 var items = await getItemsWorker(linkedDocument, cancellationToken).ConfigureAwait(false);
                 if (items != null)
                 {
@@ -76,6 +81,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             foreach (var linkedDocumentId in document.GetLinkedDocumentIds())
             {
                 var linkedDocument = solution.GetDocument(linkedDocumentId);
+                if (!linkedDocument.SupportsSyntaxTree)
+                {
+                    return false;
+                }
+
                 if (await contextChecker(linkedDocument, cancellationToken).ConfigureAwait(false))
                 {
                     return true;
@@ -91,7 +101,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
             foreach (var linkedDocumentId in document.GetLinkedDocumentIds())
             {
-                yield return solution.GetDocument(linkedDocumentId);
+                var linkedDocument = solution.GetDocument(linkedDocumentId);
+                if (!linkedDocument.SupportsSyntaxTree)
+                {
+                    continue;
+                }
+
+                yield return linkedDocument;
             }
         }
     }

--- a/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -52,11 +52,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             foreach (var linkedDocumentId in linkedDocumentIds)
             {
                 var linkedDocument = document.Project.Solution.GetDocument(linkedDocumentId);
-                if (!linkedDocument.SupportsSyntaxTree)
-                {
-                    continue;
-                }
-
                 var items = await getItemsWorker(linkedDocument, cancellationToken).ConfigureAwait(false);
                 if (items != null)
                 {
@@ -81,11 +76,6 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             foreach (var linkedDocumentId in document.GetLinkedDocumentIds())
             {
                 var linkedDocument = solution.GetDocument(linkedDocumentId);
-                if (!linkedDocument.SupportsSyntaxTree)
-                {
-                    continue;
-                }
-
                 if (await contextChecker(linkedDocument, cancellationToken).ConfigureAwait(false))
                 {
                     return true;


### PR DESCRIPTION
A document can contain multiple ContainedDocuments if both Razor and JS script blocks are present.
When a linked or related document is retrieved a check is required to ensure it supports syntax trees.
Otherwise a NullReferenceException will be hit when there is an attempt to get the root of the syntax tree. @CyrusNajmabadi, @vladima
