### PR TITLE
Only run Naming Rules on "Ordinary" methods

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -183,6 +183,7 @@
     <Compile Include="CodeActions\Preview\PreviewTests.cs" />
     <Compile Include="CodeActions\ReplaceMethodWithProperty\ReplaceMethodWithPropertyTests.cs" />
     <Compile Include="Diagnostics\InvokeDelegateWithConditionalAccess\InvokeDelegateWithConditionalAccessTests.cs" />
+    <Compile Include="Diagnostics\NamingStyles\NamingStylesTests_OptionSets.cs" />
     <Compile Include="Diagnostics\QualifyMemberAccess\QualifyMemberAccessTests.cs" />
     <Compile Include="Diagnostics\Suppression\RemoveSuppressionTests.cs" />
     <Compile Include="Diagnostics\Suppression\SuppressionTest_FixMultipleTests.cs" />
@@ -211,8 +212,9 @@
     <Compile Include="Completion\ReferenceDirectiveCompletionProviderTests.cs" />
     <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseExplicitTypeTests.cs" />
     <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseExplicitTypeTests_FixAllTests.cs" />
-    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseImplicitTypeTests_FixAllTests.cs" />
     <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseImplicitTypeTests.cs" />
+    <Compile Include="Diagnostics\UseImplicitOrExplicitType\UseImplicitTypeTests_FixAllTests.cs" />
+    <Compile Include="Diagnostics\NamingStyles\NamingStylesTests.cs" />
     <Compile Include="GoToAdjacentMember\CSharpGoToAdjacentMemberTests.cs" />
     <Compile Include="Diagnostics\AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.NamingStyles;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyles
+{
+    public partial class NamingStylesTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace) =>
+            new Tuple<DiagnosticAnalyzer, CodeFixProvider>(new CSharpNamingStyleDiagnosticAnalyzer(), new CSharpNamingStyleCodeFixProvider());
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseClass_CorrectName()
+        {
+            await TestMissingAsync(
+                @"class [|C|] { }",
+                options: ClassNamesArePascalCase);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseClass_NameGetsCapitalized()
+        {
+            await TestAsync(
+                @"class [|c|] { }",
+                @"class C { }",
+                options: ClassNamesArePascalCase);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_CorrectName()
+        {
+            await TestMissingAsync(
+@"class C 
+{
+    void [|M|]() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_NameGetsCapitalized()
+        {
+            await TestAsync(
+@"class C 
+{
+    void [|m|]() { }
+}",
+@"class C 
+{
+    void M() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_ConstructorsAreIgnored()
+        {
+            await TestMissingAsync(
+@"class c
+{
+    public [|c|]() { }
+}",
+                options: MethodNamesArePascalCase);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        public async Task TestPascalCaseMethod_PropertyAccessorsAreIgnored()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    public int P { [|get|]; set; }
+}",
+                options: MethodNamesArePascalCase);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/NamingStyles/NamingStylesTests_OptionSets.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Simplification;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.NamingStyles
+{
+    public partial class NamingStylesTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        private IDictionary<OptionKey, object> ClassNamesArePascalCase =>
+            Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), ClassNamesArePascalCaseOptionString());
+
+        private IDictionary<OptionKey, object> MethodNamesArePascalCase =>
+            Options(new OptionKey(SimplificationOptions.NamingPreferences, LanguageNames.CSharp), MethodNamesArePascalCaseOptionString());
+
+        private IDictionary<OptionKey, object> Options(OptionKey option, object value)
+        {
+            var options = new Dictionary<OptionKey, object>();
+            options.Add(option, value);
+            return options;
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        private string ClassNamesArePascalCaseOptionString()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                Guid.NewGuid(), 
+                "Name", 
+                SpecializedCollections.SingletonEnumerable(new SymbolSpecification.SymbolKindOrTypeKind(TypeKind.Class)).ToList(),
+                SpecializedCollections.EmptyList<SymbolSpecification.AccessibilityKind>(),
+                SpecializedCollections.EmptyList<SymbolSpecification.ModifierKind>(),
+                SpecializedCollections.EmptyList<string>());
+
+            var namingStyle = new NamingStyle();
+            namingStyle.CapitalizationScheme = Capitalization.PascalCase;
+            namingStyle.Name = "Name";
+            namingStyle.Prefix = "";
+            namingStyle.Suffix = "";
+            namingStyle.WordSeparator = "";
+
+
+            var namingRule = new SerializableNamingRule();
+            namingRule.SymbolSpecificationID = symbolSpecification.ID;
+            namingRule.NamingStyleID = namingStyle.ID;
+            namingRule.EnforcementLevel = DiagnosticSeverity.Error;
+            namingRule.Title = "Title";
+
+            var info = new SerializableNamingStylePreferencesInfo();
+            info.SymbolSpecifications.Add(symbolSpecification);
+            info.NamingStyles.Add(namingStyle);
+            info.NamingRules.Add(namingRule);
+
+            return info.CreateXElement().ToString();
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.NamingStyle)]
+        private string MethodNamesArePascalCaseOptionString()
+        {
+            var symbolSpecification = new SymbolSpecification(
+                Guid.NewGuid(),
+                "Name",
+                SpecializedCollections.SingletonEnumerable(new SymbolSpecification.SymbolKindOrTypeKind(SymbolKind.Method)).ToList(),
+                SpecializedCollections.EmptyList<SymbolSpecification.AccessibilityKind>(),
+                SpecializedCollections.EmptyList<SymbolSpecification.ModifierKind>(),
+                SpecializedCollections.EmptyList<string>());
+
+            var namingStyle = new NamingStyle();
+            namingStyle.CapitalizationScheme = Capitalization.PascalCase;
+            namingStyle.Name = "Name";
+            namingStyle.Prefix = "";
+            namingStyle.Suffix = "";
+            namingStyle.WordSeparator = "";
+
+
+            var namingRule = new SerializableNamingRule();
+            namingRule.SymbolSpecificationID = symbolSpecification.ID;
+            namingRule.NamingStyleID = namingStyle.ID;
+            namingRule.EnforcementLevel = DiagnosticSeverity.Error;
+            namingRule.Title = "Title";
+
+            var info = new SerializableNamingStylePreferencesInfo();
+            info.SymbolSpecifications.Add(symbolSpecification);
+            info.NamingStyles.Add(namingStyle);
+            info.NamingRules.Add(namingRule);
+
+            return info.CreateXElement().ToString();
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/NamingStylePreferencesInfo.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/NamingStylePreferencesInfo.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.SymbolCategorization;
@@ -23,6 +24,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
                 return false;
             }
 
+            if (!IsSymbolNameAnalyzable(symbol))
+            {
+                applicableRule = null;
+                return false;
+            }
+
             var matchingRule = NamingRules.FirstOrDefault(r => r.AppliesTo(symbol, categorizationService));
             if (matchingRule == null)
             {
@@ -31,6 +38,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }
 
             applicableRule = matchingRule.GetBestMatchingRule(symbol, categorizationService);
+            return true;
+        }
+
+        private bool IsSymbolNameAnalyzable(ISymbol symbol)
+        {
+            var methodSymbol = symbol as IMethodSymbol;
+            if (methodSymbol != null && methodSymbol.MethodKind != MethodKind.Ordinary)
+            {
+                return false;
+            }
+
             return true;
         }
     }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/Serialization/SymbolSpecification.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/Serialization/SymbolSpecification.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
     {
         public Guid ID { get; private set; }
         public string Name { get; private set; }
-        public List<SymbolKindOrTypeKind> ApplicableSymbolKindList { get; private set; }
-        public List<AccessibilityKind> ApplicableAccessibilityList { get; private set; }
-        public List<ModifierKind> RequiredModifierList { get; private set; }
-        public List<string> RequiredCustomTagList { get; private set; }
+        public IList<SymbolKindOrTypeKind> ApplicableSymbolKindList { get; private set; }
+        public IList<AccessibilityKind> ApplicableAccessibilityList { get; private set; }
+        public IList<ModifierKind> RequiredModifierList { get; private set; }
+        public IList<string> RequiredCustomTagList { get; private set; }
 
         internal SymbolSpecification()
         {
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             RequiredCustomTagList = new List<string>();
         }
 
-        public SymbolSpecification(Guid id, string symbolSpecName, List<SymbolKindOrTypeKind> symbolKindList, List<AccessibilityKind> accessibilityKindList, List<ModifierKind> modifierList, List<string> customTagList)
+        public SymbolSpecification(Guid id, string symbolSpecName, IList<SymbolKindOrTypeKind> symbolKindList, IList<AccessibilityKind> accessibilityKindList, IList<ModifierKind> modifierList, IList<string> customTagList)
         {
             ID = id;
             Name = symbolSpecName;


### PR DESCRIPTION
Fixes #9710, Fixes #9711 