### PR TITLE
Build the correct name for paths

### DIFF
--- a/src/Tools/Source/RunTests/Cache/ContentUtil.cs
+++ b/src/Tools/Source/RunTests/Cache/ContentUtil.cs
@@ -83,7 +83,7 @@ namespace RunTests.Cache
 
                 try
                 {
-                    var currentPath = Path.Combine(binariesPath, Path.ChangeExtension(current.Name, "dll"));
+                    var currentPath = Path.Combine(binariesPath, $"{current.Name}.dll");
                     var currentAssembly = File.Exists(currentPath)
                         ? Assembly.ReflectionOnlyLoadFrom(currentPath)
                         : Assembly.ReflectionOnlyLoad(current.FullName);


### PR DESCRIPTION
The code for building names for dependencies was using ChangeExtension instead of just appending
the .dll extension.  This allowed for entries like MS.CA and MS.CA.CSharp to have the same
hash in specific cases.