### PR TITLE
Tuples: binding tuple type declaration; symbol support for tuples 3-7

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -635,7 +635,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var args = arguments.Count == 1 ?
                     new BoundExpression[] { BindValue(arguments[0].Expression, diagnostics, BindValueKind.RValue) } :
                     SpecializedCollections.EmptyArray<BoundExpression>();
-                    
+
                 return BadExpression(node, args);
             }
 
@@ -647,6 +647,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
             var elementTypes = ArrayBuilder<TypeSymbol>.GetInstance(arguments.Count);
             ArrayBuilder<string> elementNames = null;
+            var countOfExplicitNames = 0;
 
             for (int i = 0, l = arguments.Count; i < l; i++)
             {
@@ -656,22 +657,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // validate name if we have one
                 if (name != null)
                 {
-                    // PROTOTYPE: check for a case "ItemX" where X is not i
+                    countOfExplicitNames++;
 
-                    if (!uniqueFieldNames.Add(name))
+                    if (TupleTypeSymbol.IsMemberNameReserved(name) && name != TupleTypeSymbol.UnderlyingMemberName(i))
                     {
                         hasErrors = true;
-                        // PROTOTYPE: need specific duplicate name error for tuples
-                        Error(diagnostics, ErrorCode.ERR_AnonymousTypeDuplicatePropertyName, argumentSyntax.NameColon.Name);
+                        Error(diagnostics, ErrorCode.ERR_TupleReservedMemberName, argumentSyntax.NameColon.Name, name, i + 1);
+                    }
+                    else if (!uniqueFieldNames.Add(name))
+                    {
+                        hasErrors = true;
+                        Error(diagnostics, ErrorCode.ERR_TupleDuplicateMemberName, argumentSyntax.NameColon.Name);
                     }
                 }
-                
+
                 // add the name to the list
                 // names would typically all be there or none at all
                 // but in case we need to handle this in error cases
                 if (elementNames != null)
                 {
-                    elementNames.Add(name ?? "Item" + i);
+                    elementNames.Add(name ?? TupleTypeSymbol.UnderlyingMemberName(i));
                 }
                 else
                 {
@@ -680,7 +685,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         elementNames = ArrayBuilder<string>.GetInstance(arguments.Count);
                         for (int j = 0; j < i; j++)
                         {
-                            elementNames.Add(name ?? "Item" + j);
+                            elementNames.Add(TupleTypeSymbol.UnderlyingMemberName(j));
                         }
                         elementNames.Add(name);
                     }
@@ -694,8 +699,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 elementTypes.Add(elementType);
             }
 
+            if (countOfExplicitNames != 0 && countOfExplicitNames != elementTypes.Count)
+            {
+                hasErrors = true;
+                Error(diagnostics, ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, node);
+            }
+            var elements = elementTypes.ToImmutableAndFree();
+            if (elements.Length < 2 || elements.Length > 7)
+            {
+                // PROTOTYPE
+                diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, node.Location);
+                return BadExpression(node);
+            }
+
             var type = new TupleTypeSymbol(
-                elementTypes.ToImmutableAndFree(),
+                elements,
                 elementNames == null ?
                                 default(ImmutableArray<string>) :
                                 elementNames.ToImmutableAndFree(),
@@ -705,7 +723,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             //PROTOTYPE: should be a wellknown member?
             var ctor = type.UnderlyingTupleType?.InstanceConstructors.FirstOrDefault();
-
+            if ((object)ctor == null)
+            {
+                // PROTOTYPE
+                diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, node.Location);
+                return BadExpression(node);
+            }
             return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type, hasErrors);
         }
 
@@ -1174,7 +1197,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Captured in a lambda.
                     return containingMethod.MethodKind == MethodKind.AnonymousFunction || containingMethod.MethodKind == MethodKind.LocalFunction; // false in EE evaluation method
-            }
+                }
             }
             return false;
         }
@@ -1328,9 +1351,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var parameter = (ParameterSymbol)symbol;
                         if (IsBadLocalOrParameterCapture(parameter, parameter.RefKind))
-                                {
-                                    Error(diagnostics, ErrorCode.ERR_AnonDelegateCantUse, node, parameter.Name);
-                                }
+                        {
+                            Error(diagnostics, ErrorCode.ERR_AnonDelegateCantUse, node, parameter.Name);
+                        }
                         return new BoundParameter(node, parameter, hasErrors: isError);
                     }
 

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7397,6 +7397,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to PROTOTYPE This is not supported yet..
+        /// </summary>
+        internal static string ERR_PrototypeNotYetImplemented {
+            get {
+                return ResourceManager.GetString("ERR_PrototypeNotYetImplemented", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The * or -&gt; operator must be applied to a pointer.
         /// </summary>
         internal static string ERR_PtrExpected {
@@ -8608,6 +8617,33 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_TrailingWhitespaceInFormatSpecifier {
             get {
                 return ResourceManager.GetString("ERR_TrailingWhitespaceInFormatSpecifier", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tuple member names must be unique..
+        /// </summary>
+        internal static string ERR_TupleDuplicateMemberName {
+            get {
+                return ResourceManager.GetString("ERR_TupleDuplicateMemberName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tuple member names must all be provided, if any one is provided..
+        /// </summary>
+        internal static string ERR_TupleExplicitNamesOnAllMembersOrNone {
+            get {
+                return ResourceManager.GetString("ERR_TupleExplicitNamesOnAllMembersOrNone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tuple member name &apos;{0}&apos; is disallowed at position {1}..
+        /// </summary>
+        internal static string ERR_TupleReservedMemberName {
+            get {
+                return ResourceManager.GetString("ERR_TupleReservedMemberName", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4857,4 +4857,16 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_PeWritingFailure" xml:space="preserve">
     <value>An error occurred while writing the output file: {0}</value>
   </data>
+  <data name="ERR_TupleDuplicateMemberName" xml:space="preserve">
+    <value>Tuple member names must be unique.</value>
+  </data>
+  <data name="ERR_TupleExplicitNamesOnAllMembersOrNone" xml:space="preserve">
+    <value>Tuple member names must all be provided, if any one is provided.</value>
+  </data>
+  <data name="ERR_TupleReservedMemberName" xml:space="preserve">
+    <value>Tuple member name '{0}' is disallowed at position {1}.</value>
+  </data>
+  <data name="ERR_PrototypeNotYetImplemented" xml:space="preserve">
+    <value>PROTOTYPE This is not supported yet.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1377,5 +1377,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_BadAsyncLocalType = 8942,
         ERR_RefReturningCallAndAwait = 8943,
         ERR_TupleTooFewElements = 8200,
+        ERR_TupleReservedMemberName = 8201,
+        ERR_TupleDuplicateMemberName = 8202,
+        ERR_TupleExplicitNamesOnAllMembersOrNone = 8203,
+
+        ERR_PrototypeNotYetImplemented = 8204,
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7189,6 +7189,18 @@ class A
     // (7,10): error CS0246: The type or namespace name 'a' could not be found (are you missing a using directive or an assembly reference?)
     //         (a, b) =>
     Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "a").WithArguments("a").WithLocation(7, 10),
+    // (7,13): error CS0246: The type or namespace name 'b' could not be found (are you missing a using directive or an assembly reference?)
+    //         (a, b) =>
+    Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "b").WithArguments("b").WithLocation(7, 13),
+    // (7,9): error CS0518: Predefined type 'System.Runtime.CompilerServices.ValueTuple`2' is not defined or imported
+    //         (a, b) =>
+    Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(a, b)").WithArguments("System.Runtime.CompilerServices.ValueTuple`2").WithLocation(7, 9),
+    // (7,9): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.ValueTuple`2.Item1'
+    //         (a, b) =>
+    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(a, b)").WithArguments("System.Runtime.CompilerServices.ValueTuple`2", "Item1").WithLocation(7, 9),
+    // (7,9): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.ValueTuple`2.Item2'
+    //         (a, b) =>
+    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(a, b)").WithArguments("System.Runtime.CompilerServices.ValueTuple`2", "Item2").WithLocation(7, 9),
     // (11,9): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
     //         x + y; x == 1;
     Diagnostic(ErrorCode.ERR_IllegalStatement, "x + y").WithLocation(11, 9),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -267,7 +267,7 @@ class C
             var source = @"
 class A
 {
-    const delegate void D(); 
+    const delegate void D();
     protected virtual void Finalize const () { }
 }
 ";
@@ -275,21 +275,21 @@ class A
             // CONSIDER: Roslyn's cascading errors are much uglier than Dev10's.
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
     // (4,11): error CS1031: Type expected
-    //     const delegate void D(); 
+    //     const delegate void D();
     Diagnostic(ErrorCode.ERR_TypeExpected, "delegate").WithLocation(4, 11),
     // (4,11): error CS1001: Identifier expected
-    //     const delegate void D(); 
+    //     const delegate void D();
     Diagnostic(ErrorCode.ERR_IdentifierExpected, "delegate").WithLocation(4, 11),
     // (4,11): error CS0145: A const field requires a value to be provided
-    //     const delegate void D(); 
+    //     const delegate void D();
     Diagnostic(ErrorCode.ERR_ConstValueRequired, "delegate").WithLocation(4, 11),
     // (4,11): error CS1002: ; expected
-    //     const delegate void D(); 
+    //     const delegate void D();
     Diagnostic(ErrorCode.ERR_SemicolonExpected, "delegate").WithLocation(4, 11),
     // (5,37): error CS1002: ; expected
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_SemicolonExpected, "const").WithLocation(5, 37),
-    // (5,43): error CS8096: Tuple must contain at least two elements.
+    // (5,43): error CS8200: Tuple must contain at least two elements.
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
     // (5,46): error CS1001: Identifier expected
@@ -313,6 +313,9 @@ class A
     // (5,46): error CS0102: The type 'A' already contains a definition for ''
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("A", "").WithLocation(5, 46),
+    // (5,43): error CS8204: PROTOTYPE This is not supported yet.
+    //     protected virtual void Finalize const () { }
+    Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "()").WithLocation(5, 43),
     // (5,23): error CS0670: Field cannot have void type
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_FieldCantHaveVoidType, "void").WithLocation(5, 23),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1053,7 +1053,7 @@ class C
     // (5,15): error CS1003: Syntax error, ',' expected
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments(",", "(").WithLocation(5, 15),
-    // (5,15): error CS8096: Tuple must contain at least two elements.
+    // (5,15): error CS8200: Tuple must contain at least two elements.
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
     // (5,18): error CS1001: Identifier expected
@@ -1062,9 +1062,12 @@ class C
     // (5,18): error CS1026: ) expected
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(5, 18),
-    // (5,9): error CS0161: 'C.F<>(int, ())': not all code paths return a value
+    // (5,15): error CS8204: PROTOTYPE This is not supported yet.
     //     int F<int>() { }  // CS0081
-    Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, ())").WithLocation(5, 9)
+    Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "()").WithLocation(5, 15),
+    // (5,9): error CS0161: 'C.F<>(int, ?)': not all code paths return a value
+    //     int F<int>() { }  // CS0081
+    Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, ?)").WithLocation(5, 9)
     );
         }
 


### PR DESCRIPTION
Allow binding of tuple type declarations such as `(int, a) = ...` or `(int, string) M() { ... }`.

Also TupleTypeSymbol previously only supported 2-tuples. This adds support for tuples 3 through 7. Above 7 will come later.

Please advise whether the arrays of well-known types could be done better (lazy init?).
