### PR TITLE
Make MS.VS.ProjectSystem.Managed build deterministically

### DIFF
--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -8,11 +8,7 @@ $ErrorActionPreference="Stop"
 
 # List of binary names that should be skipped because they have a known issue that
 # makes them non-deterministic.  
-$script:skipList = @(
-
-    # https://github.com/dotnet/roslyn/issues/8739
-    "Microsoft.VisualStudio.ProjectSystem.Managed.dll"
-)
+$script:skipList = @()
 
 # Holds the determinism data checked on every build.
 $script:dataMap = @{}

--- a/src/ProjectSystem/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
+++ b/src/ProjectSystem/Microsoft.VisualStudio.ProjectSystem.Managed/Microsoft.VisualStudio.ProjectSystem.Managed.csproj
@@ -66,26 +66,32 @@
     <XamlPropertyRule Include="ProjectSystem\Rules\CSharp.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\General.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ProjectReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedAssemblyReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedCOMReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
     <XamlPropertyRule Include="ProjectSystem\Rules\ResolvedProjectReference.xaml">
       <Generator>MSBuild:GenerateRuleSourceFromXaml</Generator>
       <SubType>Designer</SubType>
+      <CreateFallbackRule>false</CreateFallbackRule>
     </XamlPropertyRule>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The code generated for the fallback rule member contained use of `Guid::NewGuid()`.  This made the build of the output source naturally non-deterministic.  At a glance there doesn't seem to be a reason for using a fallback member hence I disabled it.

I'm following up with @davkean to get a bug filed to fix this code generation path to be deterministic.

closes #8739