### PR TITLE
Introduce internalBootstrap.csx to bootstrap internal users

### DIFF
--- a/src/Test/Perf/bootstrap.bat
+++ b/src/Test/Perf/bootstrap.bat
@@ -6,4 +6,10 @@ set MSBuild=%ProgramFiles%\MSBuild\14.0\bin\msbuild.exe
 if not exist "%MSBuild%" set MSBuild=%ProgramFiles(x86)%\MSBuild\14.0\bin\msbuild.exe
 "%MSBuild%" "%~dp0..\..\Interactive\csi\csi.csproj" /p:Configuration=Release /p:OutDir="%~dp0infra\bin\\"
 
-
+if "%USERDNSDOMAIN%" == "REDMOND.CORP.MICROSOFT.COM" (
+    if exist "%SYSTEMDRIVE%/CPC" ( rd /s /q "%SYSTEMDRIVE%/CPC" )
+    robocopy \\mlangfs1\public\basoundr\CpcBinaries %SYSTEMDRIVE%\CPC /mir 
+    robocopy \\mlangfs1\public\basoundr\vibenchcsv2json %SYSTEMDRIVE%\CPC /s 
+) else (
+    echo "Machine not in Microsoft Corp Net Domain. Hence not downloading internal tools"
+)

--- a/src/Test/Perf/infra/run_and_report.csx
+++ b/src/Test/Perf/infra/run_and_report.csx
@@ -19,8 +19,8 @@ if (result)
     var elapsedTimeViBenchJsonFilePath = GetViBenchJsonFromCsv(elapsedTimeCsvFilePath, null, null);
     string jsonFileName = Path.GetFileName(elapsedTimeViBenchJsonFilePath);
 
-    Log("Copy the json file to the ViBench share");
     // Move the json file to a file-share
+    Log("Copy the json file to the share");
     File.Copy(elapsedTimeViBenchJsonFilePath, $@"\\vcbench-srv4\benchview\uploads\vibench\{jsonFileName}");
 }
 else


### PR DESCRIPTION
This change introduces a script that will be required to run apart from
Bootstrap.bat file that the users are expected to run before running the
tests on their machines

This script downloads the tools CPC and ViBenchToJson, which can give a
better metric results when tests are run rather than just the Wall run
time