### PR TITLE
Test/fix scoping rules for pattern locals declared within a fixed statement.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -29,6 +29,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (VariableDeclaratorSyntax declarator in _syntax.Declaration.Variables)
                 {
                     locals.Add(MakeLocal(RefKind.None, _syntax.Declaration, declarator, LocalDeclarationKind.FixedVariable));
+
+                    if (declarator.Initializer != null)
+                    {
+                        BuildAndAddPatternVariables(locals, declarator.Initializer.Value);
+                    }
                 }
 
                 return locals.ToImmutable();

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -284,7 +284,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitFixedStatement(FixedStatementSyntax node)
         {
             Debug.Assert((object)_method == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new PatternVariableBinder(node, node.Declaration.Variables, _enclosing);
             var binder = new FixedStatementBinder(_enclosing, node);
             AddToMap(node, binder);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1509,16 +1509,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (LocalSymbol local in localsOpt)
             {
-                if (local.DeclarationKind == LocalDeclarationKind.RegularVariable)
+                switch (local.DeclarationKind)
                 {
-                    ReportIfUnused(local, assigned: true);
-                }
-                else
-                {
-                    NoteRead(local); // At the end of the statement, there's an implied read when the local is disposed
+                    case LocalDeclarationKind.RegularVariable:
+                        ReportIfUnused(local, assigned: true);
+                        break;
+
+                    case LocalDeclarationKind.UsingVariable:
+                        NoteRead(local); // At the end of the statement, there's an implied read when the local is disposed
+                        break;
                 }
             }
-            Debug.Assert(localsOpt.All(_usedVariables.Contains));
+
+            // PROTOTYPE: Should the filter for pattern variables stay?
+            Debug.Assert(localsOpt.Where(l => l.DeclarationKind != LocalDeclarationKind.PatternVariable).All(_usedVariables.Contains));
 
             return result;
         }
@@ -1527,14 +1531,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (LocalSymbol local in node.Locals)
             {
-                if (local.DeclarationKind == LocalDeclarationKind.RegularVariable)
+                switch(local.DeclarationKind)
                 {
-                    DeclareVariable(local);
-                }
-                else
-                {
-                    Debug.Assert(local.DeclarationKind == LocalDeclarationKind.FixedVariable);
-                    // TODO: should something be done about this local?
+                    case LocalDeclarationKind.RegularVariable:
+                    case LocalDeclarationKind.PatternVariable:
+                        DeclareVariable(local);
+                        break;
+
+                    default:
+                        Debug.Assert(local.DeclarationKind == LocalDeclarationKind.FixedVariable);
+                        break;
                 }
             }
 


### PR DESCRIPTION
Related to #8817.

@gafter, @agocke, @dotnet/roslyn-compiler Please review.  