### PR TITLE
Enc: async/iterator editing regression fix

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -7856,6 +7856,76 @@ class C
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [Fact]
+        public void AsyncMethodEdit_Semantics()
+        {
+            string src1 = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static async Task<int> F()
+    {
+        Console.WriteLine(1);
+        return await Task.FromResult(1);
+    }
+}
+";
+            string src2 = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static async Task<int> F()
+    {
+        Console.WriteLine(2);
+        return await Task.FromResult(1);
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
+        [Fact]
+        public void IteratorMethodEdit_Semantics()
+        {
+            string src1 = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    static IEnumerable<int> F()
+    {
+        Console.WriteLine(1);
+        yield return 1;
+    }
+}
+";
+            string src2 = @"
+using System;
+using System.Collections.Generic;
+
+class C
+{
+    static IEnumerable<int> F()
+    {
+        Console.WriteLine(2);
+        yield return 2;
+    }
+}
+";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifySemanticDiagnostics();
+        }
+
         #endregion
 
         #region Misplaced AS 

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -2312,7 +2312,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                             {
                                 var updatedMember = updatedMembers[updatedMemberIndex];
 
-                                ReportStateMachineRudeEdits(updatedMember, oldSymbol, diagnostics);
+                                ReportStateMachineRudeEdits(oldModel.Compilation, updatedMember, oldSymbol, diagnostics);
 
                                 bool newBodyHasLambdas;
                                 ReportLambdaAndClosureRudeEdits(
@@ -3703,6 +3703,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         #region State Machines
 
         private void ReportStateMachineRudeEdits(
+            Compilation oldCompilation,
             UpdatedMemberInfo updatedInfo, 
             ISymbol oldMember, 
             List<RudeEditDiagnostic> diagnostics)
@@ -3719,7 +3720,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
             // We assume that the attributes, if exist, are well formed.
             // If not an error will be reported during EnC delta emit.
-            if (oldMember.ContainingAssembly.GetTypeByMetadataName(stateMachineAttributeQualifiedName) == null)
+            if (oldCompilation.GetTypeByMetadataName(stateMachineAttributeQualifiedName) == null)
             {
                 diagnostics.Add(new RudeEditDiagnostic(
                     RudeEditKind.UpdatingStateMachineMethodMissingAttribute,


### PR DESCRIPTION
Fixes regression introduced in afec3b7

The change reported rude edit when Async/IteratorStateMachineAttribute was not present to avoid a crash. The check for presence of the attribute was wrong however, we looked for the attribute only in the assembly containing the edited method instead of the entire compilation.

Fixes internal bug 205522