### PR TITLE
Change Signature - Show ref returns in signature preview

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ChangeSignature/ChangeSignatureDialogViewModel.cs
@@ -164,7 +164,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ChangeSignature
                 SymbolDisplayMemberOptions.IncludeType |
                 SymbolDisplayMemberOptions.IncludeExplicitInterface |
                 SymbolDisplayMemberOptions.IncludeAccessibility |
-                SymbolDisplayMemberOptions.IncludeModifiers);
+                SymbolDisplayMemberOptions.IncludeModifiers |
+                SymbolDisplayMemberOptions.IncludeRef);
 
         private static SymbolDisplayFormat s_parameterDisplayFormat = new SymbolDisplayFormat(
             genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,

--- a/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
+++ b/src/VisualStudio/Core/Test/ChangeSignature/ChangeSignatureViewModelTests.vb
@@ -214,6 +214,26 @@ class MyClass
                 type:="int[,]")
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
+        <WorkItem(8437, "https://github.com/dotnet/roslyn/issues/8437")>
+        Public Async Function ChangeSignature_ParameterDisplay_RefReturns() As Tasks.Task
+            Dim markup = <Text><![CDATA[
+class MyClass
+{
+    public ref int $$M(int[,] x)
+    {
+    }
+}"]]></Text>
+
+            Dim viewModelTestState = Await GetViewModelTestStateAsync(markup, LanguageNames.CSharp)
+            Dim viewModel = viewModelTestState.ViewModel
+            VerifyOpeningState(viewModel, "public ref int M(int[,] x)")
+            VerifyParameterInfo(
+                viewModel,
+                parameterIndex:=0,
+                type:="int[,]")
+        End Function
+
         Private Sub VerifyAlteredState(
            viewModelTestState As ChangeSignatureViewModelTestState,
            Optional monitor As PropertyChangedTestMonitor = Nothing,
@@ -310,11 +330,13 @@ class MyClass
 
         End Sub
 
-        Private Async Function GetViewModelTestStateAsync(markup As XElement, languageName As String) As Tasks.Task(Of ChangeSignatureViewModelTestState)
+        Private Async Function GetViewModelTestStateAsync(
+            markup As XElement,
+            languageName As String) As Tasks.Task(Of ChangeSignatureViewModelTestState)
 
             Dim workspaceXml =
             <Workspace>
-                <Project Language=<%= languageName %> CommonReferences="true">
+                <Project Language=<%= languageName %> CommonReferences="true" Features="refLocalsAndReturns">
                     <Document><%= markup.NormalizedValue.Replace(vbCrLf, vbLf) %></Document>
                 </Project>
             </Workspace>


### PR DESCRIPTION
Fixes #8437

## Ask Mode Info

**Customer scenario**: The signature preview in Change Signature will now accurately reflect the ref return-ness of the method being updated.
**Bugs this fixes**: #8437
**Workarounds**: None
**Risk**: Very low, it's just consuming a simple new API in symbol display from the compiler.
**Performance impact**: None.
**Is this a regression from a previous update?**: No, this has been broken since we introduced ref returns.
**Root cause analysis**: It was not implemented as part of the original ref returns work.
**How was the bug found?**: Initial testing of ref returns.