### PR TITLE
Make IDEDiagnosticIDs distinct

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -9,10 +9,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string RemoveQualificationDiagnosticId = "IDE0003";
         public const string RemoveUnnecessaryCastDiagnosticId = "IDE0004";
         public const string RemoveUnnecessaryImportsDiagnosticId = "IDE0005";
-        public const string AddQualificationDiagnosticId = "IDE0006";
+        public const string IntellisenseBuildFailedDiagnosticId = "IDE0006";
         public const string UseImplicitTypingDiagnosticId = "IDE0007";
         public const string UseExplicitTypingDiagnosticId = "IDE0008";
-        public const string IntellisenseBuildFailedDiagnosticId = "IDE0006";
+        public const string AddQualificationDiagnosticId = "IDE0009";
 
         // Analyzer error Ids
         public const string AnalyzerChangedId = "IDE1001";


### PR DESCRIPTION
Switch AddQualificationDiagnosticId to "IDE0009" to remove conflict with IntellisenseBuildFailedDiagnosticId ("IDE0006").