### PR TITLE
Fixes for the tuple e2e scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -721,14 +721,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 this,
                 diagnostics);
 
-            //PROTOTYPE: should be a wellknown member?
-            var ctor = type.UnderlyingTupleType?.InstanceConstructors.FirstOrDefault();
-            if ((object)ctor == null)
+            var ctor = (MethodSymbol)GetWellKnownTypeMember(this.Compilation, TupleTypeSymbol.GetTupleCtor(elements.Length), diagnostics, syntax: node);
+            if ((object)ctor != null)
             {
-                // PROTOTYPE
-                diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, node.Location);
-                return BadExpression(node);
+                ctor = ctor.AsMember(type.UnderlyingTupleType);
             }
+            else
+            {
+                hasErrors = true;
+            }
+
             return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type, hasErrors);
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1145,7 +1145,7 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <!-- The constructor of the underlying tuple type -->
-    <Field Name="Constructor" Type="MethodSymbol" Null="disallow"/>
+    <Field Name="ConstructorOpt" Type="MethodSymbol" Null="allow"/>
     <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
   </Node>
   

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitTupleCreationExpression(BoundTupleCreationExpression node)
         {
             var rewrittenArguments = VisitList(node.Arguments);
-            return new BoundObjectCreationExpression(node.Syntax, node.Constructor, rewrittenArguments);
+            return new BoundObjectCreationExpression(node.Syntax, node.ConstructorOpt, rewrittenArguments);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
@@ -125,6 +125,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                             WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7 };
 
         /// <summary>
+        /// Find the constructor for a well-known ValueTuple type of a given arity.
+        /// For example, for arity=2:
+        /// returns WellKnownMember.System_ValueTuple_T1_T2__ctor
+        /// </summary>
+        internal static WellKnownMember GetTupleCtor(int arity)
+        {
+            if (arity > 7)
+            {
+                // PROTOTYPE
+                arity = 1;
+            }
+            return tupleCtors[arity - 1];
+        }
+
+        private static readonly WellKnownMember[] tupleCtors = {
+                                                            WellKnownMember.System_ValueTuple_T1__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2_T3__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
+                                                            WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor };
+
+
+        /// <summary>
         /// Find the well-known members to the ValueTuple type of a given arity and index/position.
         /// For example, for arity=3 and position=0:
         /// returns WellKnownMember.System_ValueTuple_T1_T2_T3__Item1
@@ -256,7 +281,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal sealed override ObsoleteAttributeData ObsoleteAttributeData
         {
-            get { return _underlyingType.ObsoleteAttributeData; }
+            get
+            {
+                // PROTOTYPE: need to figure what is the right behavior when underlying is obsolete
+                return null;
+            }
         }
 
         public override ImmutableArray<Symbol> GetMembers()
@@ -812,7 +841,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _underlyingFieldOpt?.ObsoleteAttributeData;
+                // PROTOTYPE: need to figure what is the right behavior when underlying is obsolete
+                return null;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -703,9 +703,9 @@ class C
                 // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3.Item3'
                 //         (int, string a) x = (b: 1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item3").WithLocation(6, 29),
-                // (6,29): error CS8204: PROTOTYPE This is not supported yet.
+                // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3..ctor'
                 //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, @"(b: 1, ""hello"", 2)").WithLocation(6, 29));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", ".ctor").WithLocation(6, 29));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -652,6 +652,15 @@ namespace System
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item6:
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item7:
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest:
+
+                    case WellKnownMember.System_ValueTuple_T1__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor:
+
                         // PROTOTYPE tuples
                         // Not yet in the platform.
                         continue;

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -398,6 +398,14 @@ namespace Microsoft.CodeAnalysis
         System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item7,
         System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest,
 
+        System_ValueTuple_T1__ctor,
+        System_ValueTuple_T1_T2__ctor,
+        System_ValueTuple_T1_T2_T3__ctor,
+        System_ValueTuple_T1_T2_T3_T4__ctor,
+        System_ValueTuple_T1_T2_T3_T4_T5__ctor,
+        System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
+        System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor,
+
         System_String__Format_IFormatProvider,
         Count
     }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2735,6 +2735,83 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.GenericTypeParameter, 7,                                                        // Field Signature
 
+                // System_ValueTuple_T1__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1,                                                                   // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+
+                // System_ValueTuple_T1_T2__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2,                                                                // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    2,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+
+                // System_ValueTuple_T1_T2_T3__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2_T3,                                                             // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    3,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+
+                 // System_ValueTuple_T1_T2_T3_T4__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2_T3_T4,                                                          // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    4,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,
+
+                // System_ValueTuple_T_T2_T3_T4_T5__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5,                                                       // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    5,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,
+
+                // System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5_T6,                                                    // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    6,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 5,
+
+                 // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    7,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 5,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 6,
+
                 // System_String__Format_IFormatProvider
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)SpecialType.System_String,                                                                            // DeclaringTypeId
@@ -3085,6 +3162,14 @@ namespace Microsoft.CodeAnalysis
                 "Item6",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item6
                 "Item7",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item7
                 "Rest",                                     // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest
+
+                ".ctor",                                    // System_ValueTuple_T1__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
 
                 "Format",                                   // System_String__Format_IFormatProvider
             };

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -620,7 +620,15 @@ End Namespace
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item5,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item6,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item7,
-                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest,
+                         WellKnownMember.System_ValueTuple_T1__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+
                         ' PROTOTYPE tuples
                         ' Not available yet, but will be in upcoming release.
                         Continue For
@@ -734,7 +742,15 @@ End Namespace
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item5,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item6,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Item7,
-                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__Rest,
+                         WellKnownMember.System_ValueTuple_T1__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+
                         ' PROTOTYPE tuples
                         ' Not available yet, but will be in upcoming release.
                         Continue For


### PR DESCRIPTION
Made tuple ctors WellKnown members
Made ctors optional in the bound tuple creation nodes
ObsoleteAttributeData for tuple wrappers returns null (at least for now)