### PR TITLE
Make compiler VSIX extension aware of VS versions

### DIFF
--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -48,6 +48,9 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Microsoft.Build, Version=$(VisualStudioReferenceAssemblyVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>false</Private>
     </Reference>


### PR DESCRIPTION
The compiler was hard coding the version of MSBuild to be 14.0.  This works on Dev14 but fails in Dev15 where MSBuild is 15.0.  This changes the extension to pick the MSBuild version based on the current version of Visual Studio.