### PR TITLE
[msbuild]: Csc/Vbc tasks should use mcs.exe and vbnc.exe when running on

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
@@ -178,7 +178,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             get
             {
-                return "csc.exe";
+                return MonoHelpers.IsRunningOnMono() ? "mcs.exe" : "csc.exe";
             }
         }
 

--- a/src/Compilers/Core/MSBuildTask/Shared/MSBuildTask.Shared.projitems
+++ b/src/Compilers/Core/MSBuildTask/Shared/MSBuildTask.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)InteractiveCompiler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IVbcHostObject6.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ManagedCompiler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MonoHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PropertyDictionary.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RCWForCurrentContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utilities.cs" />

--- a/src/Compilers/Core/MSBuildTask/Shared/MonoHelpers.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/MonoHelpers.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis.BuildTasks
+{
+    internal static class MonoHelpers
+    {
+        public static bool IsRunningOnMono()
+        {
+            return Type.GetType("Mono.Runtime") != null;
+        }
+    }
+}

--- a/src/Compilers/Core/MSBuildTask/Shared/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/Vbc.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             get
             {
-                return "vbc.exe";
+                return MonoHelpers.IsRunningOnMono() ? "vbnc.exe" : "vbc.exe";
             }
         }
 


### PR DESCRIPTION
.. Mono. This will allow not requiring `CscToolExe` to be overridden on
Mono. A wrapper script could completely skip overriding `CscToolExe` and
`CscToolPath`, if they wish to use mcs compiler. Same for Vbc.

Copied `src/Test/Utilities/Shared/FX/MonoHelpers.cs` to
`src/Compilers/Core/MSBuildTask/Shared/MonoHelpers.cs` for this.