### PR TITLE
Verification abstraction

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -135,22 +135,22 @@ Global
 		src\Test\Utilities\Shared\TestUtilities.projitems*{6ff42825-5464-4151-ac55-ed828168c192}*SharedItemsImports = 13
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{ad6f474e-e6d4-4217-91f3-b7af1be31ccc}*SharedItemsImports = 13
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{d0bc9be7-24f6-40ca-8dc6-fcb93bd44b34}*SharedItemsImports = 13
-		src\Compilers\Server\ServerShared\ServerShared.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
+		src\Compilers\Server\ServerShared\ServerShared.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{e58ee9d7-1239-4961-a0c1-f9ec3952c4c1}*SharedItemsImports = 4
-		src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
+		src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
-		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
-		src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
+		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
+		src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{7ad4fe65-9a30-41a6-8004-aa8f89bcb7f3}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
-		src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{d874349c-8bb3-4bdc-8535-2d52ccca1198}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{d874349c-8bb3-4bdc-8535-2d52ccca1198}*SharedItemsImports = 4
+		src\Compilers\Core\MSBuildTask\Shared\MSBuildTask.Shared.projitems*{d874349c-8bb3-4bdc-8535-2d52ccca1198}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{e3cd2895-76a8-4d11-a316-ea67cb5ea42c}*SharedItemsImports = 4
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Compilers.sln
+++ b/Compilers.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CodeAnalysisTest", "src\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj", "{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}"
 EndProject

--- a/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             public void Emit(string expectedOutput, IEnumerable<ResourceDescription> manifestResources, bool peVerify, SignatureDescription[] expectedSignatures)
             {
-                using (var testEnvironment = RuntimeUtilityFactory.NewInstance(_dependencies))
+                using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
                 {
                     string mainModuleName = Emit(testEnvironment, manifestResources);
                     _allModuleData = testEnvironment.GetAllModuleData();
@@ -115,7 +115,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             // Replace bool verify parameter with string[] expectedPeVerifyOutput. If null, no verification. If empty verify have to succeed. Otherwise compare errors.
             public void EmitAndVerify(params string[] expectedPeVerifyOutput)
             {
-                using (var testEnvironment = RuntimeUtilityFactory.NewInstance(_dependencies))
+                using (var testEnvironment = RuntimeEnvironmentFactory.Create(_dependencies))
                 {
                     string mainModuleName = Emit(testEnvironment, null);
                     string[] actualOutput = testEnvironment.PeVerifyModules(new[] { mainModuleName }, throwOnError: false);
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
             }
 
-            private string Emit(IRuntimeUtility testEnvironment, IEnumerable<ResourceDescription> manifestResources)
+            private string Emit(IRuntimeEnvironment testEnvironment, IEnumerable<ResourceDescription> manifestResources)
             {
                 testEnvironment.Emit(_compilation, manifestResources);
 

--- a/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _diagnostics = testEnvironment.GetDiagnostics();
                 EmittedAssemblyData = testEnvironment.GetMainImage();
                 EmittedAssemblyPdb = testEnvironment.GetMainPdb();
-                _testData = ((IInternalRuntimeUtility) testEnvironment).GetCompilationTestData();
+                _testData = ((IInternalRuntimeEnvironment) testEnvironment).GetCompilationTestData();
 
                 return _compilation.Assembly.Identity.GetDisplayName();
             }

--- a/src/Test/Utilities/Desktop/Exceptions.cs
+++ b/src/Test/Utilities/Desktop/Exceptions.cs
@@ -1,20 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeGen;
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Utilities;
+using static Roslyn.Test.Utilities.ExceptionHelper; 
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -23,84 +12,35 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
     {
         public IEnumerable<Diagnostic> Diagnostics { get; }
 
-        protected EmitException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        protected EmitException(SerializationInfo info, StreamingContext context) 
+            : base(info, context) { }
 
         public EmitException(IEnumerable<Diagnostic> diagnostics, string directory)
             : base(GetMessageFromResult(diagnostics, directory))
         {
             this.Diagnostics = diagnostics;
         }
-
-        private static string GetMessageFromResult(IEnumerable<Diagnostic> diagnostics, string directory)
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine("Emit Failed, binaries saved to: ");
-            sb.AppendLine(directory);
-            foreach (var d in diagnostics)
-            {
-                sb.AppendLine(d.ToString());
-            }
-            return sb.ToString();
-        }
     }
 
     [Serializable]
     public class PeVerifyException : Exception
     {
-        protected PeVerifyException(SerializationInfo info, StreamingContext context) : base(info, context) { }
+        protected PeVerifyException(SerializationInfo info, StreamingContext context) 
+            : base(info, context) { }
 
-        public PeVerifyException(string output, string exePath) : base(GetMessageFromResult(output, exePath)) { }
+        public PeVerifyException(string output, string exePath) 
+            : base(GetMessageFromResult(output, exePath)) { }
 
-        private static string GetMessageFromResult(string output, string exePath)
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine();
-            sb.Append("PeVerify failed for assembly '");
-            sb.Append(exePath);
-            sb.AppendLine("':");
-            sb.AppendLine(output);
-            return sb.ToString();
-        }
     }
 
     [Serializable]
     public class ExecutionException : Exception
     {
-        public ExecutionException(string expectedOutput, string actualOutput, string exePath) : base(GetMessageFromResult(expectedOutput, actualOutput, exePath)) { }
+        public ExecutionException(string expectedOutput, string actualOutput, string exePath) 
+            : base(GetMessageFromResult(expectedOutput, actualOutput, exePath)) { }
 
-        public ExecutionException(Exception innerException, string exePath) : base(GetMessageFromException(innerException, exePath), innerException) { }
+        public ExecutionException(Exception innerException, string exePath) 
+            : base(GetMessageFromException(innerException, exePath), innerException) { }
 
-        private static string GetMessageFromException(Exception executionException, string exePath)
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine();
-            sb.Append("Execution failed for assembly '");
-            sb.Append(exePath);
-            sb.AppendLine("'.");
-            sb.Append("Exception: " + executionException);
-            return sb.ToString();
-        }
-
-        private static string GetMessageFromResult(string expectedOutput, string actualOutput, string exePath)
-        {
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine();
-            sb.Append("Execution failed for assembly '");
-            sb.Append(exePath);
-            sb.AppendLine("'.");
-            if (expectedOutput != null)
-            {
-                sb.Append("Expected: ");
-                sb.AppendLine(expectedOutput);
-                sb.Append("Actual:   ");
-                sb.AppendLine(actualOutput);
-            }
-            else
-            {
-                sb.Append("Output: ");
-                sb.AppendLine(actualOutput);
-            }
-            return sb.ToString();
-        }
     }
 }

--- a/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
@@ -12,10 +12,11 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
 using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
+using static Roslyn.Test.Utilities.RuntimeUtilities; 
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public sealed class HostedRuntimeEnvironment : IDisposable, IRuntimeEnvironment, IInternalRuntimeUtility
+    public sealed class HostedRuntimeEnvironment : IDisposable, IRuntimeEnvironment, IInternalRuntimeEnvironment
     {
         private sealed class RuntimeData : IDisposable
         {
@@ -194,7 +195,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             var diagnostics = DiagnosticBag.GetInstance();
             var dependencies = new List<ModuleData>();
-            var mainOutput = RuntimeUtilities.EmitCompilation(mainCompilation, manifestResources, dependencies, diagnostics, _testData);
+            var mainOutput = EmitCompilation(mainCompilation, manifestResources, dependencies, diagnostics, _testData);
 
             _emitData = new EmitData();
             _emitData.Diagnostics = diagnostics.ToReadOnlyAndFree();
@@ -221,7 +222,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             else
             {
                 string dumpDir;
-                RuntimeAssemblyManager.DumpAssemblyData(dependencies, out dumpDir);
+                DumpAssemblyData(dependencies, out dumpDir);
 
                 // This method MUST throw if compilation did not succeed.  If compilation succeeded and there were errors, that is bad.
                 // Please see KevinH if you intend to change this behavior as many tests expect the Exception to indicate failure.
@@ -345,7 +346,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _disposed = true;
         }
 
-        CompilationTestData IInternalRuntimeUtility.GetCompilationTestData()
+        CompilationTestData IInternalRuntimeEnvironment.GetCompilationTestData()
         {
             if (_testData.Module == null)
             {

--- a/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
@@ -15,7 +15,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public sealed class HostedRuntimeEnvironment : IDisposable, IRuntimeUtility, IInternalRuntimeUtility
+    public sealed class HostedRuntimeEnvironment : IDisposable, IRuntimeEnvironment, IInternalRuntimeUtility
     {
         private sealed class RuntimeData : IDisposable
         {

--- a/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Desktop/HostedRuntimeEnvironment.cs
@@ -1,24 +1,21 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
-using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public sealed class HostedRuntimeEnvironment : IDisposable
+    public sealed class HostedRuntimeEnvironment : IDisposable, IRuntimeUtility, IInternalRuntimeUtility
     {
         private sealed class RuntimeData : IDisposable
         {
@@ -52,18 +49,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 }
 
                 Disposed = true;
-            }
-        }
-
-        private struct EmitOutput
-        {
-            internal ImmutableArray<byte> Assembly { get; }
-            internal ImmutableArray<byte> Pdb { get; }
-
-            internal EmitOutput(ImmutableArray<byte> assembly, ImmutableArray<byte> pdb)
-            {
-                Assembly = assembly;
-                Pdb = pdb;
             }
         }
 
@@ -200,200 +185,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             }
         }
 
-        /// <summary>
-        /// Find all of the <see cref="Compilation"/> values reachable from this instance.
-        /// </summary>
-        /// <param name="compilation"></param>
-        /// <returns></returns>
-        private static List<Compilation> FindReferencedCompilations(Compilation original)
-        {
-            var list = new List<Compilation>();
-            var toVisit = new Queue<Compilation>(FindDirectReferencedCompilations(original));
-
-            while (toVisit.Count > 0)
-            {
-                var current = toVisit.Dequeue();
-                if (list.Contains(current))
-                {
-                    continue;
-                }
-
-                list.Add(current);
-
-                foreach (var other in FindDirectReferencedCompilations(current))
-                {
-                    toVisit.Enqueue(other);
-                }
-            }
-
-            return list;
-        }
-
-        private static List<Compilation> FindDirectReferencedCompilations(Compilation compilation)
-        {
-            var list = new List<Compilation>();
-            var previousCompilation = compilation.ScriptCompilationInfo?.PreviousScriptCompilation;
-            if (previousCompilation != null)
-            {
-                list.Add(previousCompilation);
-            }
-
-            foreach (var reference in compilation.References.OfType<CompilationReference>())
-            {
-                list.Add(reference.Compilation);
-            }
-
-            return list;
-        }
-
-        /// <summary>
-        /// Emit all of the references which are not directly or indirectly a <see cref="Compilation"/> value.
-        /// </summary>
-        private static void EmitReferences(Compilation compilation, HashSet<string> fullNameSet, List<ModuleData> dependencies, DiagnosticBag diagnostics)
-        {
-            // NOTE: specifically don't need to consider previous submissions since they will always be compilations.
-            foreach (var metadataReference in compilation.References)
-            {
-                if (metadataReference is CompilationReference)
-                {
-                    continue;
-                }
-
-                var peRef = (PortableExecutableReference)metadataReference;
-                var metadata = peRef.GetMetadata();
-                var isManifestModule = peRef.Properties.Kind == MetadataImageKind.Assembly;
-                var identity = isManifestModule
-                    ? ((AssemblyMetadata)metadata).GetAssembly().Identity
-                    : null;
-
-                // If this is an indirect reference to a Compilation then it is already been emitted 
-                // so no more work to be done.
-                if (isManifestModule && fullNameSet.Contains(identity.GetDisplayName()))
-                {
-                    continue;
-                }
-
-                foreach (var module in EnumerateModules(metadata))
-                {
-                    ImmutableArray<byte> bytes = module.Module.PEReaderOpt.GetEntireImage().GetContent();
-                    ModuleData moduleData;
-                    if (isManifestModule)
-                    {
-                        fullNameSet.Add(identity.GetDisplayName());
-                        moduleData = new ModuleData(identity,
-                                                    OutputKind.DynamicallyLinkedLibrary,
-                                                    bytes,
-                                                    pdb: default(ImmutableArray<byte>),
-                                                    inMemoryModule: true);
-                    }
-                    else
-                    {
-                        moduleData = new ModuleData(module.Name,
-                                                    bytes,
-                                                    pdb: default(ImmutableArray<byte>),
-                                                    inMemoryModule: true);
-                    }
-
-                    dependencies.Add(moduleData);
-                    isManifestModule = false;
-                }
-            }
-        }
-
-        private static IEnumerable<ModuleMetadata> EnumerateModules(Metadata metadata)
-        {
-            return (metadata.Kind == MetadataImageKind.Assembly) ? ((AssemblyMetadata)metadata).GetModules().AsEnumerable() : SpecializedCollections.SingletonEnumerable((ModuleMetadata)metadata);
-        }
-
-        private static EmitOutput? EmitCompilation(
-            Compilation compilation,
-            IEnumerable<ResourceDescription> manifestResources,
-            List<ModuleData> dependencies,
-            DiagnosticBag diagnostics,
-            CompilationTestData testData
-        )
-        {
-            // A Compilation can appear multiple times in a depnedency graph as both a Compilation and as a MetadataReference
-            // value.  Iterate the Compilations eagerly so they are always emitted directly and later references can re-use 
-            // the value.  This gives better, and consistent, diagostic information.
-            var referencedCompilations = FindReferencedCompilations(compilation);
-            var fullNameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-            foreach (var referencedCompilation in referencedCompilations)
-            {
-                var emitData = EmitCompilationCore(referencedCompilation, null, diagnostics, null);
-                if (emitData.HasValue)
-                {
-                    var moduleData = new ModuleData(referencedCompilation.Assembly.Identity,
-                                                    OutputKind.DynamicallyLinkedLibrary,
-                                                    emitData.Value.Assembly,
-                                                    pdb: default(ImmutableArray<byte>),
-                                                    inMemoryModule: true);
-                    fullNameSet.Add(moduleData.Id.FullName);
-                    dependencies.Add(moduleData);
-                }
-            }
-
-            // Now that the Compilation values have been emitted, emit the non-compilation references
-            foreach (var current in (new[] { compilation }).Concat(referencedCompilations))
-            {
-                EmitReferences(current, fullNameSet, dependencies, diagnostics);
-            }
-
-            return EmitCompilationCore(compilation, manifestResources, diagnostics, testData);
-        }
-
-        private static EmitOutput? EmitCompilationCore(
-            Compilation compilation,
-            IEnumerable<ResourceDescription> manifestResources,
-            DiagnosticBag diagnostics,
-            CompilationTestData testData
-        )
-        {
-            using (var executableStream = new MemoryStream())
-            {
-                var pdb = default(ImmutableArray<byte>);
-                var assembly = default(ImmutableArray<byte>);
-                var pdbStream = MonoHelpers.IsRunningOnMono()
-                    ? null
-                    : new MemoryStream();
-
-                EmitResult result;
-                try
-                {
-                    result = compilation.Emit(
-                        executableStream,
-                        pdbStream: pdbStream,
-                        xmlDocumentationStream: null,
-                        win32Resources: null,
-                        manifestResources: manifestResources,
-                        options: EmitOptions.Default,
-                        debugEntryPoint: null,
-                        testData: testData,
-                        getHostDiagnostics: null,
-                        cancellationToken: default(CancellationToken));
-                }
-                finally
-                {
-                    if (pdbStream != null)
-                    {
-                        pdb = pdbStream.ToImmutable();
-                        pdbStream.Dispose();
-                    }
-                }
-
-                diagnostics.AddRange(result.Diagnostics);
-                assembly = executableStream.ToImmutable();
-
-                if (result.Success)
-                {
-                    return new EmitOutput(assembly, pdb);
-                }
-
-                return null;
-            }
-        }
-
         public void Emit(
             Compilation mainCompilation,
             IEnumerable<ResourceDescription> manifestResources,
@@ -403,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             var diagnostics = DiagnosticBag.GetInstance();
             var dependencies = new List<ModuleData>();
-            var mainOutput = EmitCompilation(mainCompilation, manifestResources, dependencies, diagnostics, _testData);
+            var mainOutput = RuntimeUtilities.EmitCompilation(mainCompilation, manifestResources, dependencies, diagnostics, _testData);
 
             _emitData = new EmitData();
             _emitData.Diagnostics = diagnostics.ToReadOnlyAndFree();
@@ -484,7 +275,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return _emitData;
         }
 
-        internal ImmutableArray<Diagnostic> GetDiagnostics()
+        public ImmutableArray<Diagnostic> GetDiagnostics()
         {
             return GetEmitData().Diagnostics;
         }
@@ -499,7 +290,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return GetEmitData().MainModulePdb;
         }
 
-        internal IList<ModuleData> GetAllModuleData()
+        public IList<ModuleData> GetAllModuleData()
         {
             return GetEmitData().AllModuleData;
         }
@@ -511,14 +302,14 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             emitData.Manager.PeVerifyModules(new[] { emitData.MainModule.FullName });
         }
 
-        internal string[] PeVerifyModules(string[] modulesToVerify, bool throwOnError = true)
+        public string[] PeVerifyModules(string[] modulesToVerify, bool throwOnError = true)
         {
             var emitData = GetEmitData();
             emitData.RuntimeData.PeverifyRequested = true;
             return emitData.Manager.PeVerifyModules(modulesToVerify, throwOnError);
         }
 
-        internal SortedSet<string> GetMemberSignaturesFromMetadata(string fullyQualifiedTypeName, string memberName)
+        public SortedSet<string> GetMemberSignaturesFromMetadata(string fullyQualifiedTypeName, string memberName)
         {
             var emitData = GetEmitData();
             var searchIds = emitData.AllModuleData.Select(x => x.Id).ToList();
@@ -554,7 +345,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             _disposed = true;
         }
 
-        internal CompilationTestData GetCompilationTestData()
+        CompilationTestData IInternalRuntimeUtility.GetCompilationTestData()
         {
             if (_testData.Module == null)
             {

--- a/src/Test/Utilities/Desktop/MetadataSignatureUnitTestHelper.cs
+++ b/src/Test/Utilities/Desktop/MetadataSignatureUnitTestHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <param name="appDomainHost">Unit test AppDomain host</param>
         /// <param name="expectedSignatures">Baseline signatures - use the Signature() factory method to create instances of SignatureDescription</param>
         internal static void VerifyMemberSignatures(
-            IRuntimeUtility appDomainHost, params SignatureDescription[] expectedSignatures)
+            IRuntimeEnvironment appDomainHost, params SignatureDescription[] expectedSignatures)
         {
             Assert.NotNull(expectedSignatures);
             Assert.NotEmpty(expectedSignatures);
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <param name="actualSignatures">List of found signatures matching member name</param>
         /// <returns>True if a matching member signature was found, false otherwise</returns>
         private static bool VerifyMemberSignatureHelper(
-            IRuntimeUtility appDomainHost, string fullyQualifiedTypeName, string memberName,
+            IRuntimeEnvironment appDomainHost, string fullyQualifiedTypeName, string memberName,
             ref string expectedSignature, out List<string> actualSignatures)
         {
             Assert.False(string.IsNullOrWhiteSpace(fullyQualifiedTypeName), "'fullyQualifiedTypeName' can't be null or empty");

--- a/src/Test/Utilities/Desktop/MetadataSignatureUnitTestHelper.cs
+++ b/src/Test/Utilities/Desktop/MetadataSignatureUnitTestHelper.cs
@@ -15,15 +15,15 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         public string ExpectedSignature { get; set; }
     }
 
-    public class MetadataSignatureUnitTestHelper
+    internal class MetadataSignatureUnitTestHelper
     {
         /// <summary>
         /// Uses Reflection to verify that the specified member signatures are present in emitted metadata
         /// </summary>
         /// <param name="appDomainHost">Unit test AppDomain host</param>
         /// <param name="expectedSignatures">Baseline signatures - use the Signature() factory method to create instances of SignatureDescription</param>
-        public static void VerifyMemberSignatures(
-            HostedRuntimeEnvironment appDomainHost, params SignatureDescription[] expectedSignatures)
+        internal static void VerifyMemberSignatures(
+            IRuntimeUtility appDomainHost, params SignatureDescription[] expectedSignatures)
         {
             Assert.NotNull(expectedSignatures);
             Assert.NotEmpty(expectedSignatures);
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         /// <param name="actualSignatures">List of found signatures matching member name</param>
         /// <returns>True if a matching member signature was found, false otherwise</returns>
         private static bool VerifyMemberSignatureHelper(
-            HostedRuntimeEnvironment appDomainHost, string fullyQualifiedTypeName, string memberName,
+            IRuntimeUtility appDomainHost, string fullyQualifiedTypeName, string memberName,
             ref string expectedSignature, out List<string> actualSignatures)
         {
             Assert.False(string.IsNullOrWhiteSpace(fullyQualifiedTypeName), "'fullyQualifiedTypeName' can't be null or empty");

--- a/src/Test/Utilities/Desktop/RuntimeAssemblyManager.cs
+++ b/src/Test/Utilities/Desktop/RuntimeAssemblyManager.cs
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                     if (dumpDirectory == null)
                     {
-                        var assemblyLocation = typeof(IRuntimeUtility).Assembly.Location;
+                        var assemblyLocation = typeof(IRuntimeEnvironment).Assembly.Location;
                         dumpDirectory = Path.Combine(
                             Path.GetDirectoryName(assemblyLocation),
                             "Dumps");

--- a/src/Test/Utilities/Desktop/RuntimeAssemblyManager.cs
+++ b/src/Test/Utilities/Desktop/RuntimeAssemblyManager.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
+using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
@@ -455,7 +456,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
                     if (dumpDirectory == null)
                     {
-                        var assemblyLocation = typeof(HostedRuntimeEnvironment).Assembly.Location;
+                        var assemblyLocation = typeof(IRuntimeUtility).Assembly.Location;
                         dumpDirectory = Path.Combine(
                             Path.GetDirectoryName(assemblyLocation),
                             "Dumps");

--- a/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
@@ -4,10 +4,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
 using Roslyn.Test.Utilities;
+using static Roslyn.Test.Utilities.RuntimeUtilities; 
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public class CoreCLRRuntimeEnvironment : IRuntimeEnvironment, IInternalRuntimeUtility
+    public class CoreCLRRuntimeEnvironment : IRuntimeEnvironment, IInternalRuntimeEnvironment
     {
         private IEnumerable<ModuleData> _additionalDependencies;
         private CompilationTestData _testData = new CompilationTestData();
@@ -38,7 +39,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _mainImage = default(ImmutableArray<byte>);
                 _pdb = default(ImmutableArray<byte>);
                 _diagnostics = default(ImmutableArray<Diagnostic>);
-                throw new EmitException(diagnostics.ToReadOnly(), null);
+
+                string dumpDir;
+                DumpAssemblyData(dependencies, out dumpDir);
+                throw new EmitException(diagnostics.ToReadOnly(), dumpDir);
             }
         }
 
@@ -71,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             throw new NotImplementedException();
         }
 
-        CompilationTestData IInternalRuntimeUtility.GetCompilationTestData()
+        CompilationTestData IInternalRuntimeEnvironment.GetCompilationTestData()
         {
             return _testData;
         }

--- a/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeGen;
@@ -6,7 +7,7 @@ using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    class CoreCLRRuntimeEnvironment : IRuntimeUtility, IInternalRuntimeUtility
+    public class CoreCLRRuntimeEnvironment : IRuntimeEnvironment, IInternalRuntimeUtility
     {
         private IEnumerable<ModuleData> _additionalDependencies;
         private CompilationTestData _testData = new CompilationTestData();
@@ -75,39 +76,10 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
             return _testData;
         }
 
-        #region IDisposable Support
-        private bool disposedValue = false; // To detect redundant calls
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposedValue)
-            {
-                if (disposing)
-                {
-                    // TODO: dispose managed state (managed objects).
-                }
-
-                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-                // TODO: set large fields to null.
-
-                disposedValue = true;
-            }
-        }
-
-        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
-        // ~CoreCLRRuntimeEnvironment() {
-        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-        //   Dispose(false);
-        // }
-
-        // This code added to correctly implement the disposable pattern.
         public void Dispose()
         {
-            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-            Dispose(true);
-            // TODO: uncomment the following line if the finalizer is overridden above.
-            // GC.SuppressFinalize(this);
+            // We need Dispose to satisfy the IRuntimeEnvironment interface, but 
+            // we don't really need it.
         }
-        #endregion
     }
 }

--- a/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Portable/CoreCLRRuntimeEnvironment.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.CodeGen;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    class CoreCLRRuntimeEnvironment : IRuntimeUtility, IInternalRuntimeUtility
+    {
+        private IEnumerable<ModuleData> _additionalDependencies;
+        private CompilationTestData _testData = new CompilationTestData();
+        private ImmutableArray<byte> _mainImage;
+        private ImmutableArray<byte> _pdb;
+        private ImmutableArray<Diagnostic> _diagnostics;
+
+        public CoreCLRRuntimeEnvironment(IEnumerable<ModuleData> additionalDependencies = null)
+        {
+            _additionalDependencies = additionalDependencies;
+        }
+
+        public void Emit(Compilation mainCompilation, IEnumerable<ResourceDescription> manifestResources, bool usePdbForDebugging = false)
+        {
+            _testData.Methods.Clear();
+            var diagnostics = DiagnosticBag.GetInstance();
+            var dependencies = new List<ModuleData>();
+            var mainOutput = RuntimeUtilities.EmitCompilation(mainCompilation, manifestResources, dependencies, diagnostics, _testData);
+
+            if (mainOutput.HasValue)
+            {
+                _diagnostics = diagnostics.ToReadOnly();
+                _mainImage = mainOutput.Value.Assembly;
+                _pdb = mainOutput.Value.Pdb;
+            }
+            else
+            {
+                _mainImage = default(ImmutableArray<byte>);
+                _pdb = default(ImmutableArray<byte>);
+                _diagnostics = default(ImmutableArray<Diagnostic>);
+                throw new EmitException(diagnostics.ToReadOnly(), null);
+            }
+        }
+
+        public int Execute(string moduleName, string expectedOutput)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IList<ModuleData> GetAllModuleData()
+        {
+            throw new NotImplementedException();
+        }
+
+        public ImmutableArray<Diagnostic> GetDiagnostics() => _diagnostics;
+        public ImmutableArray<byte> GetMainImage() => _mainImage;
+        public ImmutableArray<byte> GetMainPdb() => _pdb;
+
+        public SortedSet<string> GetMemberSignaturesFromMetadata(string fullyQualifiedTypeName, string memberName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void PeVerify()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string[] PeVerifyModules(string[] modulesToVerify, bool throwOnError = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        CompilationTestData IInternalRuntimeUtility.GetCompilationTestData()
+        {
+            return _testData;
+        }
+
+        #region IDisposable Support
+        private bool disposedValue = false; // To detect redundant calls
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    // TODO: dispose managed state (managed objects).
+                }
+
+                // TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+                // TODO: set large fields to null.
+
+                disposedValue = true;
+            }
+        }
+
+        // TODO: override a finalizer only if Dispose(bool disposing) above has code to free unmanaged resources.
+        // ~CoreCLRRuntimeEnvironment() {
+        //   // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+        //   Dispose(false);
+        // }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
+            Dispose(true);
+            // TODO: uncomment the following line if the finalizer is overridden above.
+            // GC.SuppressFinalize(this);
+        }
+        #endregion
+    }
+}

--- a/src/Test/Utilities/Portable/Exceptions.cs
+++ b/src/Test/Utilities/Portable/Exceptions.cs
@@ -6,26 +6,26 @@ using static Roslyn.Test.Utilities.ExceptionHelper;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
-    public class EmitException : Exception
+    public sealed class EmitException : Exception
     {
         public IEnumerable<Diagnostic> Diagnostics { get; }
 
-        public EmitException(IEnumerable<Diagnostic> diagnostics, string directory)
+        internal EmitException(IEnumerable<Diagnostic> diagnostics, string directory)
             : base(GetMessageFromResult(diagnostics, directory))
         {
             this.Diagnostics = diagnostics;
         }
     }
 
-    public class PeVerifyException : Exception
+    public sealed class PeVerifyException : Exception
     {
-        public PeVerifyException(string output, string exePath) : base(GetMessageFromResult(output, exePath)) { }
+        internal PeVerifyException(string output, string exePath) : base(GetMessageFromResult(output, exePath)) { }
     }
 
-    public class ExecutionException : Exception
+    public sealed class ExecutionException : Exception
     {
-        public ExecutionException(string expectedOutput, string actualOutput, string exePath) : base(GetMessageFromResult(expectedOutput, actualOutput, exePath)) { }
+        internal ExecutionException(string expectedOutput, string actualOutput, string exePath) : base(GetMessageFromResult(expectedOutput, actualOutput, exePath)) { }
 
-        public ExecutionException(Exception innerException, string exePath) : base(GetMessageFromException(innerException, exePath), innerException) { }
+        internal ExecutionException(Exception innerException, string exePath) : base(GetMessageFromException(innerException, exePath), innerException) { }
     }
 }

--- a/src/Test/Utilities/Portable/Exceptions.cs
+++ b/src/Test/Utilities/Portable/Exceptions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using static Roslyn.Test.Utilities.ExceptionHelper; 
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    public class EmitException : Exception
+    {
+        public IEnumerable<Diagnostic> Diagnostics { get; }
+
+        public EmitException(IEnumerable<Diagnostic> diagnostics, string directory)
+            : base(GetMessageFromResult(diagnostics, directory))
+        {
+            this.Diagnostics = diagnostics;
+        }
+    }
+
+    public class PeVerifyException : Exception
+    {
+        public PeVerifyException(string output, string exePath) : base(GetMessageFromResult(output, exePath)) { }
+    }
+
+    public class ExecutionException : Exception
+    {
+        public ExecutionException(string expectedOutput, string actualOutput, string exePath) : base(GetMessageFromResult(expectedOutput, actualOutput, exePath)) { }
+
+        public ExecutionException(Exception innerException, string exePath) : base(GetMessageFromException(innerException, exePath), innerException) { }
+    }
+}

--- a/src/Test/Utilities/Portable/TestUtilities.csproj
+++ b/src/Test/Utilities/Portable/TestUtilities.csproj
@@ -115,6 +115,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommonTestBase.cs" />
+    <Compile Include="CoreCLRRuntimeEnvironment.cs" />
+    <Compile Include="Exceptions.cs" />
     <Compile Include="ICompilationVerifier.cs" />
     <Compile Include="MetadataSignatureUnitTestHelper.cs" />
     <Compile Include="ModuleData.cs" />

--- a/src/Test/Utilities/Shared/Compilation/IRuntimeEnvironment.cs
+++ b/src/Test/Utilities/Shared/Compilation/IRuntimeEnvironment.cs
@@ -1,4 +1,4 @@
-﻿
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -13,9 +13,9 @@ using Roslyn.Utilities;
 
 namespace Roslyn.Test.Utilities
 {
-    public class  RuntimeUtilityFactory
+    public class RuntimeEnvironmentFactory
     {
-        internal static IRuntimeUtility NewInstance(IEnumerable<ModuleData> additionalDependencies = null)
+        internal static IRuntimeEnvironment Create(IEnumerable<ModuleData> additionalDependencies = null)
     {
 
 #if DNX
@@ -98,6 +98,7 @@ namespace Roslyn.Test.Utilities
                 }
             }
         }
+
         /// <summary>
         /// Find all of the <see cref="Compilation"/> values reachable from this instance.
         /// </summary>
@@ -143,6 +144,7 @@ namespace Roslyn.Test.Utilities
 
             return list;
         }
+
         internal static EmitOutput? EmitCompilation(
             Compilation compilation,
             IEnumerable<ResourceDescription> manifestResources,
@@ -233,7 +235,7 @@ namespace Roslyn.Test.Utilities
         }
     }
 
-    public interface IRuntimeUtility: System.IDisposable
+    public interface IRuntimeEnvironment : IDisposable
     {
         void Emit(Microsoft.CodeAnalysis.Compilation mainCompilation, IEnumerable<ResourceDescription> manifestResources, bool usePdbForDebugging = false);
         int Execute(string moduleName, string expectedOutput);

--- a/src/Test/Utilities/Shared/Compilation/IRuntimeUtility.cs
+++ b/src/Test/Utilities/Shared/Compilation/IRuntimeUtility.cs
@@ -1,0 +1,253 @@
+﻿
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Utilities;
+
+namespace Roslyn.Test.Utilities
+{
+    public class  RuntimeUtilityFactory
+    {
+        internal static IRuntimeUtility NewInstance(IEnumerable<ModuleData> additionalDependencies = null)
+    {
+
+#if DNX
+            return new CoreCLRRuntimeEnvironment(additionalDependencies);
+#else
+            return new HostedRuntimeEnvironment(additionalDependencies);
+#endif
+        }
+    }
+
+    internal struct EmitOutput
+    {
+        internal ImmutableArray<byte> Assembly { get; }
+        internal ImmutableArray<byte> Pdb { get; }
+
+        internal EmitOutput(ImmutableArray<byte> assembly, ImmutableArray<byte> pdb)
+        {
+            Assembly = assembly;
+            Pdb = pdb;
+        }
+    }
+
+    internal static class RuntimeUtilities
+    {
+        private static IEnumerable<ModuleMetadata> EnumerateModules(Metadata metadata)
+        {
+            return (metadata.Kind == MetadataImageKind.Assembly) ? ((AssemblyMetadata)metadata).GetModules().AsEnumerable() : SpecializedCollections.SingletonEnumerable((ModuleMetadata)metadata);
+        }
+
+        /// <summary>
+        /// Emit all of the references which are not directly or indirectly a <see cref="Compilation"/> value.
+        /// </summary>
+        internal static void EmitReferences(Compilation compilation, HashSet<string> fullNameSet, List<ModuleData> dependencies, DiagnosticBag diagnostics)
+        {
+            // NOTE: specifically don't need to consider previous submissions since they will always be compilations.
+            foreach (var metadataReference in compilation.References)
+            {
+                if (metadataReference is CompilationReference)
+                {
+                    continue;
+                }
+
+                var peRef = (PortableExecutableReference)metadataReference;
+                var metadata = peRef.GetMetadata();
+                var isManifestModule = peRef.Properties.Kind == MetadataImageKind.Assembly;
+                var identity = isManifestModule
+                    ? ((AssemblyMetadata)metadata).GetAssembly().Identity
+                    : null;
+
+                // If this is an indirect reference to a Compilation then it is already been emitted 
+                // so no more work to be done.
+                if (isManifestModule && fullNameSet.Contains(identity.GetDisplayName()))
+                {
+                    continue;
+                }
+
+                foreach (var module in EnumerateModules(metadata))
+                {
+                    ImmutableArray<byte> bytes = module.Module.PEReaderOpt.GetEntireImage().GetContent();
+                    ModuleData moduleData;
+                    if (isManifestModule)
+                    {
+                        fullNameSet.Add(identity.GetDisplayName());
+                        moduleData = new ModuleData(identity,
+                                                    OutputKind.DynamicallyLinkedLibrary,
+                                                    bytes,
+                                                    pdb: default(ImmutableArray<byte>),
+                                                    inMemoryModule: true);
+                    }
+                    else
+                    {
+                        moduleData = new ModuleData(module.Name,
+                                                    bytes,
+                                                    pdb: default(ImmutableArray<byte>),
+                                                    inMemoryModule: true);
+                    }
+
+                    dependencies.Add(moduleData);
+                    isManifestModule = false;
+                }
+            }
+        }
+        /// <summary>
+        /// Find all of the <see cref="Compilation"/> values reachable from this instance.
+        /// </summary>
+        /// <param name="compilation"></param>
+        /// <returns></returns>
+        private static List<Compilation> FindReferencedCompilations(Compilation original)
+        {
+            var list = new List<Compilation>();
+            var toVisit = new Queue<Compilation>(FindDirectReferencedCompilations(original));
+
+            while (toVisit.Count > 0)
+            {
+                var current = toVisit.Dequeue();
+                if (list.Contains(current))
+                {
+                    continue;
+                }
+
+                list.Add(current);
+
+                foreach (var other in FindDirectReferencedCompilations(current))
+                {
+                    toVisit.Enqueue(other);
+                }
+            }
+
+            return list;
+        }
+
+        private static List<Compilation> FindDirectReferencedCompilations(Compilation compilation)
+        {
+            var list = new List<Compilation>();
+            var previousCompilation = compilation.ScriptCompilationInfo?.PreviousScriptCompilation;
+            if (previousCompilation != null)
+            {
+                list.Add(previousCompilation);
+            }
+
+            foreach (var reference in compilation.References.OfType<CompilationReference>())
+            {
+                list.Add(reference.Compilation);
+            }
+
+            return list;
+        }
+        internal static EmitOutput? EmitCompilation(
+            Compilation compilation,
+            IEnumerable<ResourceDescription> manifestResources,
+            List<ModuleData> dependencies,
+            DiagnosticBag diagnostics,
+            CompilationTestData testData
+        )
+        {
+            // A Compilation can appear multiple times in a depnedency graph as both a Compilation and as a MetadataReference
+            // value.  Iterate the Compilations eagerly so they are always emitted directly and later references can re-use 
+            // the value.  This gives better, and consistent, diagostic information.
+            var referencedCompilations = FindReferencedCompilations(compilation);
+            var fullNameSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var referencedCompilation in referencedCompilations)
+            {
+                var emitData = RuntimeUtilities.EmitCompilationCore(referencedCompilation, null, diagnostics, null);
+                if (emitData.HasValue)
+                {
+                    var moduleData = new ModuleData(referencedCompilation.Assembly.Identity,
+                                                    OutputKind.DynamicallyLinkedLibrary,
+                                                    emitData.Value.Assembly,
+                                                    pdb: default(ImmutableArray<byte>),
+                                                    inMemoryModule: true);
+                    fullNameSet.Add(moduleData.Id.FullName);
+                    dependencies.Add(moduleData);
+                }
+            }
+
+            // Now that the Compilation values have been emitted, emit the non-compilation references
+            foreach (var current in (new[] { compilation }).Concat(referencedCompilations))
+            {
+                EmitReferences(current, fullNameSet, dependencies, diagnostics);
+            }
+
+            return RuntimeUtilities.EmitCompilationCore(compilation, manifestResources, diagnostics, testData);
+        }
+
+        internal static EmitOutput? EmitCompilationCore(
+            Compilation compilation,
+            IEnumerable<ResourceDescription> manifestResources,
+            DiagnosticBag diagnostics,
+            CompilationTestData testData
+        )
+        {
+            using (var executableStream = new MemoryStream())
+            {
+                var pdb = default(ImmutableArray<byte>);
+                var assembly = default(ImmutableArray<byte>);
+                var pdbStream = MonoHelpers.IsRunningOnMono()
+                    ? null
+                    : new MemoryStream();
+
+                EmitResult result;
+                try
+                {
+                    result = compilation.Emit(
+                        executableStream,
+                        pdbStream: pdbStream,
+                        xmlDocumentationStream: null,
+                        win32Resources: null,
+                        manifestResources: manifestResources,
+                        options: EmitOptions.Default,
+                        debugEntryPoint: null,
+                        testData: testData,
+                        getHostDiagnostics: null,
+                        cancellationToken: default(CancellationToken));
+                }
+                finally
+                {
+                    if (pdbStream != null)
+                    {
+                        pdb = pdbStream.ToImmutable();
+                        pdbStream.Dispose();
+                    }
+                }
+
+                diagnostics.AddRange(result.Diagnostics);
+                assembly = executableStream.ToImmutable();
+
+                if (result.Success)
+                {
+                    return new EmitOutput(assembly, pdb);
+                }
+
+                return null;
+            }
+        }
+    }
+
+    public interface IRuntimeUtility: System.IDisposable
+    {
+        void Emit(Microsoft.CodeAnalysis.Compilation mainCompilation, IEnumerable<ResourceDescription> manifestResources, bool usePdbForDebugging = false);
+        int Execute(string moduleName, string expectedOutput);
+        ImmutableArray<byte> GetMainImage();
+        ImmutableArray<byte> GetMainPdb();
+        ImmutableArray<Diagnostic> GetDiagnostics();
+        SortedSet<string> GetMemberSignaturesFromMetadata(string fullyQualifiedTypeName, string memberName);
+        IList<ModuleData> GetAllModuleData();
+        void PeVerify();
+        string[] PeVerifyModules(string[] modulesToVerify, bool throwOnError = true);
+    }
+
+    internal interface IInternalRuntimeUtility
+    {
+        CompilationTestData GetCompilationTestData();
+    }
+}

--- a/src/Test/Utilities/Shared/ExceptionHelper.cs
+++ b/src/Test/Utilities/Shared/ExceptionHelper.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.CodeAnalysis;

--- a/src/Test/Utilities/Shared/ExceptionHelper.cs
+++ b/src/Test/Utilities/Shared/ExceptionHelper.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Roslyn.Test.Utilities
+{
+    internal static class ExceptionHelper
+    {
+        internal static string GetMessageFromResult(IEnumerable<Diagnostic> diagnostics, string directory)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine("Emit Failed, binaries saved to: ");
+            sb.AppendLine(directory);
+            foreach (var d in diagnostics)
+            {
+                sb.AppendLine(d.ToString());
+            }
+            return sb.ToString();
+        }
+
+        internal static string GetMessageFromResult(string output, string exePath)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine();
+            sb.Append("PeVerify failed for assembly '");
+            sb.Append(exePath);
+            sb.AppendLine("':");
+            sb.AppendLine(output);
+            return sb.ToString();
+        }
+
+        internal static string GetMessageFromException(Exception executionException, string exePath)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine();
+            sb.Append("Execution failed for assembly '");
+            sb.Append(exePath);
+            sb.AppendLine("'.");
+            sb.Append("Exception: " + executionException);
+            return sb.ToString();
+        }
+
+        internal static string GetMessageFromResult(string expectedOutput, string actualOutput, string exePath)
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.AppendLine();
+            sb.Append("Execution failed for assembly '");
+            sb.Append(exePath);
+            sb.AppendLine("'.");
+            if (expectedOutput != null)
+            {
+                sb.Append("Expected: ");
+                sb.AppendLine(expectedOutput);
+                sb.Append("Actual:   ");
+                sb.AppendLine(actualOutput);
+            }
+            else
+            {
+                sb.Append("Output: ");
+                sb.AppendLine(actualOutput);
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -25,7 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationOutputFiles.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationTestDataExtensions.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Compilation\IRuntimeUtility.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Compilation\IRuntimeEnvironment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\SpeculativeSemanticModelTestsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\TestOperationWalker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\VersionTestHelpers.cs" />

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -25,6 +25,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationOutputFiles.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationTestDataExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Compilation\IRuntimeUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\SpeculativeSemanticModelTestsBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\TestOperationWalker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\VersionTestHelpers.cs" />
@@ -36,6 +37,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\TestDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\ThrowingDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\TrackingDiagnosticAnalyzer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExceptionHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\ConsoleOutput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\CultureHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\DirectoryHelper.cs" />


### PR DESCRIPTION
Creates an IRuntimeUtility interface that exposes all the functionality native to a specific runtime for emitting, running, and verifying compiled code.

@dotnet/roslyn-compiler Ping for review; review by commit, nuget barfed all over the diff.

Also, should I implement this interface for portable code right now or should that come in a followup commit?