### PR TITLE
Generate constructor should not be offered on simple names.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -766,5 +766,24 @@ class Derived : Base
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; abstract class Y { class X : Y { void M ( ) { new X ( new [|string|] ( ) ) ; } } } ",
 @"using System ; using System . Collections . Generic ; using System . Linq ; using System . Threading . Tasks ; abstract class Y { class X : Y { private string v ; public X ( string v ) { this . v = v ; } void M ( ) { new X ( new string ( ) ) ; } } } ");
         }
+
+        [WorkItem(9575, "https://github.com/dotnet/roslyn/issues/9575")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        public async Task TestMissingOnMethodCall()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    public C(int arg)
+    {
+    }
+
+    public bool M(string s, int i, bool b)
+    {
+        return [|M|](i, b);
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -598,5 +598,19 @@ Class X
     End Sub
 End Class")
         End Function
+
+        <WorkItem(9575, "https://github.com/dotnet/roslyn/issues/9575")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function TestMissingOnMethodCall() As Task
+            Await TestMissingAsync(
+"class C
+    public sub new(int arg)
+    end sub
+
+    public function M(s as string, i as integer, b as boolean) as boolean
+        return [|M|](i, b)
+    end function
+end class")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -38,8 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateConstructor
 
         protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
         {
-            if (node is SimpleNameSyntax ||
-                node is ObjectCreationExpressionSyntax ||
+            if (node is ObjectCreationExpressionSyntax ||
                 node is ConstructorInitializerSyntax ||
                 node is AttributeSyntax)
             {

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;
@@ -12,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateConstructor
 {
@@ -36,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateConstructor
             return service.GenerateConstructorAsync(document, node, cancellationToken);
         }
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             if (node is ObjectCreationExpressionSyntax ||
                 node is ConstructorInitializerSyntax ||
@@ -45,7 +47,19 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateConstructor
                 return true;
             }
 
-            return diagnostic.Id == CS7036 && node is ClassDeclarationSyntax;
+            return diagnostic.Id == CS7036 && 
+                node is ClassDeclarationSyntax && 
+                IsInClassDeclarationHeader((ClassDeclarationSyntax)node, token);
+        }
+
+        private bool IsInClassDeclarationHeader(ClassDeclarationSyntax node, SyntaxToken token)
+        {
+            var start = node.SpanStart;
+            var end = node.BaseList != null
+                ? node.BaseList.Span.End
+                : node.Identifier.Span.End;
+
+            return TextSpan.FromBounds(start, end).Contains(token.Span);
         }
 
         protected override SyntaxNode GetTargetNode(SyntaxNode node)

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateEnumMember
             return service.GenerateEnumMemberAsync(document, node, cancellationToken);
         }
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             return node is IdentifierNameSyntax;
         }

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateConversionCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateConversionCodeFixProvider.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod
             get { return ImmutableArray.Create(CS0029, CS0030); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             return node.IsKind(SyntaxKind.IdentifierName) ||
                    node.IsKind(SyntaxKind.MethodDeclaration) ||

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod
             get { return ImmutableArray.Create(CS0103, CS1061, CS0117, CS0122, CS0539, CS1501, CS1503, CS0305, CS0308, CS1660, CS1739, CS7036); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             return node.IsKind(SyntaxKind.IdentifierName) ||
                    node.IsKind(SyntaxKind.MethodDeclaration) ||

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateType
             get { return ImmutableArray.Create(CS0103, CS0117, CS0234, CS0246, CS0305, CS0308, CS0426, CS0616); }
         }
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             var qualified = node as QualifiedNameSyntax;
             if (qualified != null)

--- a/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable
         public override ImmutableArray<string> FixableDiagnosticIds =>
             ImmutableArray.Create(CS1061, CS0103, CS0117, CS0539, CS0246, CS0120);
 
-        protected override bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected override bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             return node is SimpleNameSyntax || node is PropertyDeclarationSyntax || node is MemberBindingExpressionSyntax;
         }

--- a/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/GenerateMember/AbstractGenerateMemberCodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
             return node;
         }
 
-        protected virtual bool IsCandidate(SyntaxNode node, Diagnostic diagnostic)
+        protected virtual bool IsCandidate(SyntaxNode node, SyntaxToken token, Diagnostic diagnostic)
         {
             return false;
         }
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.GenerateMember
                 yield break;
             }
 
-            var nodes = token.GetAncestors<SyntaxNode>().Where(n => IsCandidate(n, diagnostic));
+            var nodes = token.GetAncestors<SyntaxNode>().Where(n => IsCandidate(n, token, diagnostic));
             foreach (var node in nodes)
             {
                 var name = GetTargetNode(node);

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
@@ -54,14 +54,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
             Return node
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             If TypeOf node Is InvocationExpressionSyntax OrElse
                TypeOf node Is ObjectCreationExpressionSyntax OrElse
                TypeOf node Is AttributeSyntax Then
                 Return True
             End If
 
-            Return diagnostic.Id = BC30387 AndAlso TypeOf node Is ClassBlockSyntax
+            Return diagnostic.Id = BC30387 AndAlso
+                TypeOf node Is ClassBlockSyntax AndAlso
+                IsInClassDeclarationHeader(DirectCast(node, ClassBlockSyntax), token)
+        End Function
+
+        Private Function IsInClassDeclarationHeader(node As ClassBlockSyntax, token As SyntaxToken) As Boolean
+            Return node.ClassStatement.Span.Contains(token.Span)
         End Function
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateConstructor/GenerateConstructorCodeFixProvider.vb
@@ -55,7 +55,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateConstructor
         End Function
 
         Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
-            If TypeOf node Is SimpleNameSyntax OrElse TypeOf node Is InvocationExpressionSyntax OrElse TypeOf node Is ObjectCreationExpressionSyntax OrElse TypeOf node Is AttributeSyntax Then
+            If TypeOf node Is InvocationExpressionSyntax OrElse
+               TypeOf node Is ObjectCreationExpressionSyntax OrElse
+               TypeOf node Is AttributeSyntax Then
                 Return True
             End If
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEnumMember/GenerateEnumMemberCodeFixProvider.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEnumMember
             Return service.GenerateEnumMemberAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is MemberAccessExpressionSyntax
         End Function
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateConversionCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateConversionCodeFixProvider.vb
@@ -28,7 +28,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
             Return service.GenerateConversionAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is QualifiedNameSyntax OrElse
                 TypeOf node Is SimpleNameSyntax OrElse
                 TypeOf node Is MemberAccessExpressionSyntax OrElse

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -42,7 +42,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
             Return service.GenerateMethodAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             Return TypeOf node Is QualifiedNameSyntax OrElse
                 TypeOf node Is SimpleNameSyntax OrElse
                 TypeOf node Is MemberAccessExpressionSyntax OrElse

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateType/GenerateTypeCodeFixProvider.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateType
             Return service.GenerateTypeAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             Dim qualified = TryCast(node, QualifiedNameSyntax)
             If qualified IsNot Nothing Then
                 Return True

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateVariable/GenerateVariableCodeFixProvider.vb
@@ -31,7 +31,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateVariable
             Return service.GenerateVariableAsync(document, node, cancellationToken)
         End Function
 
-        Protected Overrides Function IsCandidate(node As SyntaxNode, diagnostic As Diagnostic) As Boolean
+        Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
             If TypeOf node Is QualifiedNameSyntax OrElse TypeOf node Is MemberAccessExpressionSyntax Then
                 Return True
             End If


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/9575