### PR TITLE
Tuples: adding support for tuples 8 and up

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Collections;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -628,11 +629,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression BindTupleExpression(TupleExpressionSyntax node, DiagnosticBag diagnostics)
         {
-            var arguments = node.Arguments;
-            if (arguments.Count < 2)
+            SeparatedSyntaxList<ArgumentSyntax> arguments = node.Arguments;
+            int numElements = arguments.Count;
+
+            if (numElements < 2)
             {
                 // this should be a parse error already.
-                var args = arguments.Count == 1 ?
+                var args = numElements == 1 ?
                     new BoundExpression[] { BindValue(arguments[0].Expression, diagnostics, BindValueKind.RValue) } :
                     SpecializedCollections.EmptyArray<BoundExpression>();
 
@@ -641,97 +644,59 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bool hasErrors = false;
 
-            // set of names already used
-            HashSet<string> uniqueFieldNames = new HashSet<string>();
-
             var boundArguments = ArrayBuilder<BoundExpression>.GetInstance(arguments.Count);
             var elementTypes = ArrayBuilder<TypeSymbol>.GetInstance(arguments.Count);
-            ArrayBuilder<string> elementNames = null;
-            var countOfExplicitNames = 0;
 
-            for (int i = 0, l = arguments.Count; i < l; i++)
+            // set of names already used
+            var uniqueFieldNames = PooledHashSet<string>.GetInstance();
+
+            ArrayBuilder<string> elementNames = null;
+            int countOfExplicitNames = 0;
+
+            // prepare and check element names and types
+            for (int i = 0, l = numElements; i < l; i++)
             {
-                var argumentSyntax = arguments[i];
-                var name = argumentSyntax.NameColon?.Name?.Identifier.ValueText;
+                ArgumentSyntax argumentSyntax = arguments[i];
+                string name = argumentSyntax.NameColon?.Name?.Identifier.ValueText;
 
                 // validate name if we have one
                 if (name != null)
                 {
                     countOfExplicitNames++;
-
-                    if (TupleTypeSymbol.IsMemberNameReserved(name) && name != TupleTypeSymbol.UnderlyingMemberName(i))
+                    if (!CheckTupleMemberName(name, i, argumentSyntax.NameColon.Name, diagnostics, uniqueFieldNames))
                     {
                         hasErrors = true;
-                        Error(diagnostics, ErrorCode.ERR_TupleReservedMemberName, argumentSyntax.NameColon.Name, name, i + 1);
-                    }
-                    else if (!uniqueFieldNames.Add(name))
-                    {
-                        hasErrors = true;
-                        Error(diagnostics, ErrorCode.ERR_TupleDuplicateMemberName, argumentSyntax.NameColon.Name);
                     }
                 }
+                CollectTupleFieldMemberNames(name, i + 1, numElements, ref elementNames);
 
-                // add the name to the list
-                // names would typically all be there or none at all
-                // but in case we need to handle this in error cases
-                if (elementNames != null)
-                {
-                    elementNames.Add(name ?? TupleTypeSymbol.UnderlyingMemberName(i));
-                }
-                else
-                {
-                    if (name != null)
-                    {
-                        elementNames = ArrayBuilder<string>.GetInstance(arguments.Count);
-                        for (int j = 0; j < i; j++)
-                        {
-                            elementNames.Add(TupleTypeSymbol.UnderlyingMemberName(j));
-                        }
-                        elementNames.Add(name);
-                    }
-                }
-
-                var boundArgument = BindValue(argumentSyntax.Expression, diagnostics, BindValueKind.RValue);
+                BoundExpression boundArgument = BindValue(argumentSyntax.Expression, diagnostics, BindValueKind.RValue);
                 boundArguments.Add(boundArgument);
 
                 // PROTOTYPE(tuples): need to report distinc errors for tuples
-                var elementType = GetAnonymousTypeFieldType(boundArgument, argumentSyntax, diagnostics, ref hasErrors);
+                TypeSymbol elementType = GetAnonymousTypeFieldType(boundArgument, argumentSyntax, diagnostics, ref hasErrors);
                 elementTypes.Add(elementType);
             }
+            uniqueFieldNames.Free();
 
             if (countOfExplicitNames != 0 && countOfExplicitNames != elementTypes.Count)
             {
                 hasErrors = true;
                 Error(diagnostics, ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, node);
             }
-            var elements = elementTypes.ToImmutableAndFree();
-            if (elements.Length < 2 || elements.Length > 7)
-            {
-                // PROTOTYPE(tuples)
-                diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, node.Location);
-                return BadExpression(node);
-            }
+
+            ImmutableArray<TypeSymbol> elements = elementTypes.ToImmutableAndFree();
 
             var type = new TupleTypeSymbol(
                 elements,
                 elementNames == null ?
-                                default(ImmutableArray<string>) :
-                                elementNames.ToImmutableAndFree(),
+                    default(ImmutableArray<string>) :
+                    elementNames.ToImmutableAndFree(),
                 node,
                 this,
                 diagnostics);
 
-            var ctor = (MethodSymbol)GetWellKnownTypeMember(this.Compilation, TupleTypeSymbol.GetTupleCtor(elements.Length), diagnostics, syntax: node);
-            if ((object)ctor != null)
-            {
-                ctor = ctor.AsMember(type.UnderlyingTupleType);
-            }
-            else
-            {
-                hasErrors = true;
-            }
-
-            return new BoundTupleCreationExpression(node, ctor, boundArguments.ToImmutableAndFree(), type, hasErrors);
+            return new BoundTupleCreationExpression(node, boundArguments.ToImmutableAndFree(), type, hasErrors);
         }
 
         private BoundExpression BindRefValue(RefValueExpressionSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1144,8 +1144,6 @@
     <Node Name="BoundTupleCreationExpression" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
-    <!-- The constructor of the underlying tuple type -->
-    <Field Name="ConstructorOpt" Type="MethodSymbol" Null="allow"/>
     <Field Name="Arguments" Type="ImmutableArray&lt;BoundExpression&gt;"/>
   </Node>
   

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -511,6 +511,7 @@
     <Compile Include="Symbols\AnonymousTypes\SynthesizedSymbols\AnonymousType.TemplateSymbol.cs" />
     <Compile Include="Symbols\AnonymousTypes\SynthesizedSymbols\AnonymousType.ToStringMethodSymbol.cs" />
     <Compile Include="Symbols\AnonymousTypes\SynthesizedSymbols\AnonymousType.TypeParameterSymbol.cs" />
+    <Compile Include="Symbols\TupleFieldSymbol.cs" />
     <Compile Include="Symbols\TupleTypeSymbol.cs" />
     <Compile Include="Symbols\ArrayTypeSymbol.cs" />
     <Compile Include="Symbols\AssemblySymbol.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8639,11 +8639,20 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tuple member name &apos;{0}&apos; is disallowed at position {1}..
+        ///   Looks up a localized string similar to Tuple member name &apos;{0}&apos; is only allowed at position {1}..
         /// </summary>
         internal static string ERR_TupleReservedMemberName {
             get {
                 return ResourceManager.GetString("ERR_TupleReservedMemberName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tuple membername &apos;{0}&apos; is disallowed at any position..
+        /// </summary>
+        internal static string ERR_TupleReservedMemberNameAnyPosition {
+            get {
+                return ResourceManager.GetString("ERR_TupleReservedMemberNameAnyPosition", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4864,9 +4864,12 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Tuple member names must all be provided, if any one is provided.</value>
   </data>
   <data name="ERR_TupleReservedMemberName" xml:space="preserve">
-    <value>Tuple member name '{0}' is disallowed at position {1}.</value>
+    <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>
   <data name="ERR_PrototypeNotYetImplemented" xml:space="preserve">
     <value>PROTOTYPE This is not supported yet.</value>
+  </data>
+  <data name="ERR_TupleReservedMemberNameAnyPosition" xml:space="preserve">
+    <value>Tuple membername '{0}' is disallowed at any position.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1378,8 +1378,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefReturningCallAndAwait = 8943,
         ERR_TupleTooFewElements = 8200,
         ERR_TupleReservedMemberName = 8201,
-        ERR_TupleDuplicateMemberName = 8202,
-        ERR_TupleExplicitNamesOnAllMembersOrNone = 8203,
+        ERR_TupleReservedMemberNameAnyPosition = 8202,
+        ERR_TupleDuplicateMemberName = 8203,
+        ERR_TupleExplicitNamesOnAllMembersOrNone = 8204,
 
         ERR_PrototypeNotYetImplemented = 8204,
     }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -12,11 +11,65 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             BoundExpression rewrittenReceiver = VisitExpression(node.ReceiverOpt);
 
-            // field access of a tuple actually accesses the underlying field.
-            FieldSymbol field = (node.FieldSymbol as TupleFieldSymbol)?.UnderlyingTypleFieldSymbol ??
-                                node.FieldSymbol;
+            var tupleField = node.FieldSymbol as TupleFieldSymbol;
+            if (tupleField != null)
+            {
+                return RewriteTupleFieldAccess(node, rewrittenReceiver);
+            }
+            else
+            {
+                return MakeFieldAccess(node.Syntax, rewrittenReceiver, node.FieldSymbol, node.ConstantValue, node.ResultKind, node.Type, node);
+            }
+        }
 
-            return MakeFieldAccess(node.Syntax, rewrittenReceiver, field, node.ConstantValue, node.ResultKind, node.Type, node);
+        /// <summary>
+        /// Converts access to a tuple instance into access into the underlying ValueTuple(s).
+        ///
+        /// For instance, tuple.Item8
+        /// produces fieldAccess(field=Item1, receiver=fieldAccess(field=Rest, receiver=ValueTuple for tuple))
+        /// </summary>
+        private BoundExpression RewriteTupleFieldAccess(BoundFieldAccess node, BoundExpression rewrittenReceiver)
+        {
+            var tupleField = (TupleFieldSymbol)node.FieldSymbol;
+            var tupleType = (TupleTypeSymbol)tupleField.ContainingSymbol;
+
+            int fieldRemainder;
+            int loop = TupleTypeSymbol.NumberOfValueTuples(tupleField.Position, out fieldRemainder);
+
+            NamedTypeSymbol currentLinkType = tupleType.UnderlyingTupleType;
+
+            if (loop > 1)
+            {
+                WellKnownMember wellKnownTupleRest = TupleTypeSymbol.GetTupleTypeMember(TupleTypeSymbol.RestPosition, TupleTypeSymbol.RestPosition);
+                var tupleRestField = (FieldSymbol)Binder.GetWellKnownTypeMember(_compilation, wellKnownTupleRest, _diagnostics, syntax: node.Syntax);
+                if ((object)tupleRestField == null)
+                {
+                    return node;
+                }
+
+                // make nested field accesses to Rest
+                do
+                {
+                    FieldSymbol nestedFieldSymbol = tupleRestField.AsMember(currentLinkType);
+
+                    currentLinkType = (NamedTypeSymbol)currentLinkType.TypeArgumentsNoUseSiteDiagnostics[TupleTypeSymbol.RestPosition - 1];
+                    rewrittenReceiver = new BoundFieldAccess(node.Syntax, rewrittenReceiver, nestedFieldSymbol, ConstantValue.NotAvailable, LookupResultKind.Viable, currentLinkType);
+                    loop--;
+                }
+                while (loop > 1);
+            }
+
+            // make a field access for the most local access
+            WellKnownMember wellKnownTypeMember = TupleTypeSymbol.GetTupleTypeMember(currentLinkType.Arity, fieldRemainder);
+            var linkField = (FieldSymbol)Binder.GetWellKnownTypeMember(_compilation, wellKnownTypeMember, _diagnostics, syntax: node.Syntax);
+            if ((object)linkField == null)
+            {
+                return node;
+            }
+
+            FieldSymbol lastFieldSymbol = linkField.AsMember(currentLinkType);
+
+            return new BoundFieldAccess(node.Syntax, rewrittenReceiver, lastFieldSymbol, node.ConstantValue, node.ResultKind, node.Type);
         }
 
         private static BoundExpression MakeFieldAccess(

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -1,11 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -13,8 +9,68 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitTupleCreationExpression(BoundTupleCreationExpression node)
         {
-            var rewrittenArguments = VisitList(node.Arguments);
-            return new BoundObjectCreationExpression(node.Syntax, node.ConstructorOpt, rewrittenArguments);
+            ImmutableArray<BoundExpression> rewrittenArguments = VisitList(node.Arguments);
+            return RewriteTupleCreationExpression(node, rewrittenArguments);
+        }
+
+        /// <summary>
+        /// Converts the expression for creating a tuple instance into an expression creating a ValueTuple (if short) or nested ValueTuples (if longer).
+        ///
+        /// For instance, for a long tuple we'll generate:
+        /// creationExpression(ctor=largestCtor, args=firstArgs+(nested creationExpression for remainder, with smaller ctor and next few args))
+        /// </summary>
+        private BoundNode RewriteTupleCreationExpression(BoundTupleCreationExpression node, ImmutableArray<BoundExpression> rewrittenArguments)
+        {
+            NamedTypeSymbol underlyingTupleType = ((TupleTypeSymbol)node.Type).UnderlyingTupleType;
+
+            ArrayBuilder<NamedTypeSymbol> underlyingTupleTypeChain = ArrayBuilder<NamedTypeSymbol>.GetInstance();
+            TupleTypeSymbol.GetUnderlyingTypeChain(underlyingTupleType, underlyingTupleTypeChain);
+
+            try
+            {
+                // make a creation expression for the smallest type
+                NamedTypeSymbol smallestType = underlyingTupleTypeChain.Pop();
+                ImmutableArray<BoundExpression> smallestCtorArguments = ImmutableArray.Create(rewrittenArguments,
+                                                                                              underlyingTupleTypeChain.Count * (TupleTypeSymbol.RestPosition - 1),
+                                                                                              smallestType.Arity);
+
+                var smallestCtor = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, TupleTypeSymbol.GetTupleCtor(smallestType.Arity), _diagnostics, syntax: node.Syntax);
+                if ((object)smallestCtor == null)
+                {
+                    return node;
+                }
+
+                MethodSymbol smallestConstructor = smallestCtor.AsMember(smallestType);
+                BoundObjectCreationExpression currentCreation = new BoundObjectCreationExpression(node.Syntax, smallestConstructor, smallestCtorArguments);
+
+                if (underlyingTupleTypeChain.Count > 0)
+                {
+                    var tuple8Ctor = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, TupleTypeSymbol.GetTupleCtor(TupleTypeSymbol.RestPosition), _diagnostics, syntax: node.Syntax);
+                    if ((object)tuple8Ctor == null)
+                    {
+                        return node;
+                    }
+
+                    // make successively larger creation expressions containing the previous one
+                    do
+                    {
+                        ImmutableArray<BoundExpression> ctorArguments = ImmutableArray.Create(rewrittenArguments,
+                                                                                              (underlyingTupleTypeChain.Count - 1) * (TupleTypeSymbol.RestPosition - 1),
+                                                                                              TupleTypeSymbol.RestPosition - 1)
+                                                                                      .Add(currentCreation);
+
+                        MethodSymbol constructor = tuple8Ctor.AsMember(underlyingTupleTypeChain.Pop());
+                        currentCreation = new BoundObjectCreationExpression(node.Syntax, constructor, ctorArguments);
+                    }
+                    while (underlyingTupleTypeChain.Count > 0);
+                }
+
+                return currentCreation;
+            }
+            finally
+            {
+                underlyingTupleTypeChain.Free();
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AbstractTypeMap.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 NamedTypeSymbol oldUnderlyingType = previousTuple.UnderlyingTupleType;
                 NamedTypeSymbol newUnderlyingType = (NamedTypeSymbol)SubstituteType(oldUnderlyingType).Type;
 
-                return ((object)newUnderlyingType == (object)oldUnderlyingType) ? previous : TupleTypeSymbol.ConstructTupleTypeSymbol(previousTuple, newUnderlyingType);
+                return ((object)newUnderlyingType == (object)oldUnderlyingType) ? previous : previousTuple.WithUnderlyingType(newUnderlyingType);
             }
 
             // TODO: we could construct the result's ConstructedFrom lazily by using a "deep"

--- a/src/Compilers/CSharp/Portable/Symbols/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleFieldSymbol.cs
@@ -1,0 +1,228 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
+using System.Collections.Immutable;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    /// <summary>
+    /// A TupleFieldSymbol represents the field of a tuple type, such as (int, byte).Item2 or (int a, long b).a
+    /// </summary>
+    internal sealed class TupleFieldSymbol : FieldSymbol
+    {
+        private readonly string _name;
+        private readonly TypeSymbol _type;
+        private readonly TupleTypeSymbol _containingTuple;
+        private readonly int _position;
+        private readonly FieldSymbol _underlyingFieldOpt;
+
+        /// <summary>
+        /// Missing underlying field is handled for error recovery
+        /// A tuple without backing fields is usable for binding purposes, since we know its name and type,
+        /// but caller is supposed to report some kind of error at declaration.
+        ///
+        /// position is 1 for Item1.
+        /// </summary>
+        internal TupleFieldSymbol(string name, TupleTypeSymbol containingTuple, TypeSymbol type, int position, FieldSymbol underlyingFieldOpt)
+        {
+            _name = name;
+            _containingTuple = containingTuple;
+            _underlyingFieldOpt = underlyingFieldOpt;
+            _type = type;
+            _position = position;
+        }
+
+        /// <summary>
+        /// Copy this tuple field, but modify it to use the new containing tuple, link type and field type.
+        /// </summary>
+        internal TupleFieldSymbol WithType(TupleTypeSymbol newContainingTuple, NamedTypeSymbol newlinkType, TypeSymbol newFieldType)
+        {
+            FieldSymbol newUnderlyingFieldOpt = _underlyingFieldOpt?.OriginalDefinition.AsMember(newlinkType);
+            Debug.Assert(newUnderlyingFieldOpt == null || newUnderlyingFieldOpt.Type == newFieldType);
+
+            return new TupleFieldSymbol(_name, newContainingTuple, newFieldType, _position, newUnderlyingFieldOpt);
+        }
+
+        internal static FieldSymbol GetUnderlyingField(int containingTupleArity, NamedTypeSymbol containingUnderlyingType, int fieldIndex, CSharpSyntaxNode syntax, Binder binder, DiagnosticBag diagnostics)
+        {
+            int tupleRemainder;
+            int tupleChainLength = TupleTypeSymbol.NumberOfValueTuples(containingTupleArity, out tupleRemainder);
+
+            int fieldRemainder;
+            int fieldChainLength = TupleTypeSymbol.NumberOfValueTuples(fieldIndex + 1, out fieldRemainder);
+
+            int containingLinkSize = TupleTypeSymbol.RestPosition;
+            if (fieldChainLength == tupleChainLength)
+            {
+                containingLinkSize = tupleRemainder;
+            }
+
+            // PROTOTYPE(tuples) Constructing a TupleTypeSymbol with TupleFieldSymbols should not produce diagnostics for missing well-known members and type members.
+            //                      The error handling should be shifted to lowering. This will help when we implement metadata loading.
+            WellKnownMember wellKnownTypeMember = TupleTypeSymbol.GetTupleTypeMember(containingLinkSize, fieldRemainder);
+            var linkField = (FieldSymbol)Binder.GetWellKnownTypeMember(binder.Compilation, wellKnownTypeMember, diagnostics, syntax: syntax);
+            if ((object)linkField == null)
+            {
+                return null;
+            }
+
+            NamedTypeSymbol linkType = TupleTypeSymbol.GetNestedTupleType(containingUnderlyingType, fieldChainLength - 1);
+
+            return linkField.AsMember(linkType);
+        }
+
+        public override string Name
+        {
+            get
+            {
+                return _name;
+            }
+        }
+
+        /// <summary>
+        /// Returns the position of this field within the tuple.
+        /// For instance, the position for Item1 is 1.
+        /// </summary>
+        public int Position => _position;
+
+        public override Symbol AssociatedSymbol
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public override Symbol ContainingSymbol
+        {
+            get
+            {
+                return _containingTuple;
+            }
+        }
+
+        public override ImmutableArray<CustomModifier> CustomModifiers
+        {
+            get
+            {
+                return _underlyingFieldOpt?.CustomModifiers ?? ImmutableArray<CustomModifier>.Empty;
+            }
+        }
+
+        public override Accessibility DeclaredAccessibility
+        {
+            get
+            {
+                return _underlyingFieldOpt?.DeclaredAccessibility ?? Accessibility.Public;
+            }
+        }
+
+        public override bool IsConst
+        {
+            get
+            {
+                return _underlyingFieldOpt?.IsConst ?? false;
+            }
+        }
+
+        public override bool IsReadOnly
+        {
+            get
+            {
+                return _underlyingFieldOpt?.IsReadOnly ?? false;
+            }
+        }
+
+        public override bool IsStatic
+        {
+            get
+            {
+                return _underlyingFieldOpt?.IsStatic ?? false;
+            }
+        }
+
+        public override bool IsVolatile
+        {
+            get
+            {
+                return _underlyingFieldOpt?.IsVolatile ?? false;
+            }
+        }
+
+        public override ImmutableArray<Location> Locations
+        {
+            get
+            {
+                return ImmutableArray<Location>.Empty;
+            }
+        }
+
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
+        {
+            get
+            {
+                return ImmutableArray<SyntaxReference>.Empty;
+            }
+        }
+
+        internal override bool HasRuntimeSpecialName
+        {
+            get
+            {
+                return _underlyingFieldOpt?.HasRuntimeSpecialName ?? false;
+            }
+        }
+
+        internal override bool HasSpecialName
+        {
+            get
+            {
+                return _underlyingFieldOpt?.HasSpecialName ?? false;
+            }
+        }
+
+        internal override bool IsNotSerialized
+        {
+            get
+            {
+                return _underlyingFieldOpt?.IsNotSerialized ?? false;
+            }
+        }
+
+        internal override MarshalPseudoCustomAttributeData MarshallingInformation
+        {
+            get
+            {
+                return _underlyingFieldOpt?.MarshallingInformation;
+            }
+        }
+
+        internal override ObsoleteAttributeData ObsoleteAttributeData
+        {
+            get
+            {
+                // PROTOTYPE: need to figure what is the right behavior when underlying is obsolete
+                return null;
+            }
+        }
+
+        internal override int? TypeLayoutOffset
+        {
+            get
+            {
+                return _underlyingFieldOpt?.TypeLayoutOffset;
+            }
+        }
+
+        internal override ConstantValue GetConstantValue(ConstantFieldsInProgress inProgress, bool earlyDecodingWellKnownAttributes)
+        {
+            return _underlyingFieldOpt?.GetConstantValue(inProgress, earlyDecodingWellKnownAttributes);
+        }
+
+        internal override TypeSymbol GetFieldType(ConsList<FieldSymbol> fieldsBeingBound)
+        {
+            return _type;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Test.Utilities;
-using Roslyn.Test.Utilities;
-using Xunit;
+using System;
 using System.Linq;
 using System.Text;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
 {
@@ -67,6 +65,125 @@ namespace System
     }
         ";
 
+        private static readonly string trivalRemainingTuples = @"
+namespace System
+{
+    public struct ValueTuple<T1>
+    {
+        public T1 Item1;
+
+        public ValueTuple(T1 item1)
+        {
+            this.Item1 = item1;
+        }
+
+        public override string ToString()
+        {
+            return '{' + Item1?.ToString() + '}';
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+        public TRest Rest;
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+            Rest = rest;
+        }
+    }
+}
+";
         [Fact]
         public void SimpleTuple()
         {
@@ -378,6 +495,30 @@ class C
         }
 
         [Fact]
+        public void LongTupleTypeMismatch()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int, int, int, int, int, int, int, int) x = (""Alice"", 2, 3, 4, 5, 6, 7, 8);
+        (int, int, int, int, int, int, int, int) y = (1, 2, 3, 4, 5, 6, 7, 8, 9);
+    }
+}
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
+
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (6,54): error CS0029: Cannot implicitly convert type '<tuple: string Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>' to '<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>'
+                //         (int, int, int, int, int, int, int, int) x = ("Alice", 2, 3, 4, 5, 6, 7, 8);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, @"(""Alice"", 2, 3, 4, 5, 6, 7, 8)").WithArguments("<tuple: string Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>", "<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>").WithLocation(6, 54),
+                // (7,54): error CS0029: Cannot implicitly convert type '<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8, int Item9>' to '<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>'
+                //         (int, int, int, int, int, int, int, int) y = (1, 2, 3, 4, 5, 6, 7, 8, 9);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(1, 2, 3, 4, 5, 6, 7, 8, 9)").WithArguments("<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8, int Item9>", "<tuple: int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8>").WithLocation(7, 54)
+                );
+        }
+
+        [Fact]
         public void TupleTypeWithLateDiscoveredName()
         {
             var source = @"
@@ -393,9 +534,13 @@ class C
             var tree = Parse(source);
             var comp = CreateCompilationWithMscorlib(tree);
             comp.VerifyDiagnostics(
-                // (6,29): error CS8203: Tuple member names must all be provided, if any one is provided.
+                // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
                 //         (int, string a) x = (1, "hello", c: 2);
-                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(1, ""hello"", c: 2)").WithLocation(6, 29));
+                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, "(int, string a)").WithLocation(6, 9),
+                // (6,29): error CS8204: Tuple member names must all be provided, if any one is provided.
+                //         (int, string a) x = (1, "hello", c: 2);
+                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(1, ""hello"", c: 2)").WithLocation(6, 29)
+                );
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
@@ -439,11 +584,14 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            // PROTOTYPE(tuples) we also expect an error on the tuple type declaration
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (6,29): error CS8203: Tuple member names must all be provided, if any one is provided.
+                // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
                 //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(b: 1, ""hello"", 2)").WithLocation(6, 29));
+                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, "(int, string a)").WithLocation(6, 9),
+                // (6,29): error CS8204: Tuple member names must all be provided, if any one is provided.
+                //         (int, string a) x = (b: 1, "hello", 2);
+                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(b: 1, ""hello"", 2)").WithLocation(6, 29)
+                );
         }
 
         [Fact]
@@ -665,6 +813,35 @@ class C
         }
 
         [Fact]
+        public void LongTupleWithSubstitution()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    static void Main()
+    {
+        Console.WriteLine(Test(42).Result);
+    }
+
+    public static async Task<T> Test<T>(T a)
+    {
+        var x = (f1: 1, f2: 2, f3: 3, f4: 4, f5: 5, f6: 6, f7: 7, f8: a);
+
+        await Task.Yield();
+
+        return x.f8;
+    }
+}
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
+
+            var comp = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe);
+            CompileAndVerify(comp, expectedOutput: @"42");
+        }
+
+        [Fact]
         public void TupleUsageWithoutTupleLibrary()
         {
             var source = @"
@@ -679,6 +856,9 @@ class C
             // PROTOTYPE(tuples) those are not the final diagnostics
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
+                // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
+                //         (int, string a) x = (b: 1, "hello", 2);
+                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, "(int, string a)").WithLocation(6, 9),
                 // (6,9): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         (int, string a) x = (b: 1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(int, string a)").WithArguments("System.ValueTuple`2").WithLocation(6, 9),
@@ -688,7 +868,7 @@ class C
                 // (6,9): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
                 //         (int, string a) x = (b: 1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(int, string a)").WithArguments("System.ValueTuple`2", "Item2").WithLocation(6, 9),
-                // (6,29): error CS8203: Tuple member names must all be provided, if any one is provided.
+                // (6,29): error CS8204: Tuple member names must all be provided, if any one is provided.
                 //         (int, string a) x = (b: 1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(b: 1, ""hello"", 2)").WithLocation(6, 29),
                 // (6,29): error CS0518: Predefined type 'System.ValueTuple`3' is not defined or imported
@@ -702,10 +882,8 @@ class C
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item2").WithLocation(6, 29),
                 // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3.Item3'
                 //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item3").WithLocation(6, 29),
-                // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3..ctor'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", ".ctor").WithLocation(6, 29));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item3").WithLocation(6, 29)
+                );
         }
 
         [Fact]
@@ -721,15 +899,18 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            // PROTOTYPE(tuples) we expect similar errors on "a"
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (6,38): error CS8202: Tuple member names must be unique.
+                // (6,24): error CS8203: Tuple member names must be unique.
+                //         (int a, string a) x = (b: 1, b: "hello", b: 2);
+                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "a").WithLocation(6, 24),
+                // (6,38): error CS8203: Tuple member names must be unique.
                 //         (int a, string a) x = (b: 1, b: "hello", b: 2);
                 Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "b").WithLocation(6, 38),
-                // (6,50): error CS8202: Tuple member names must be unique.
+                // (6,50): error CS8203: Tuple member names must be unique.
                 //         (int a, string a) x = (b: 1, b: "hello", b: 2);
-                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "b").WithLocation(6, 50));
+                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "b").WithLocation(6, 50)
+               );
         }
 
         [Fact]
@@ -746,15 +927,48 @@ class C
 }
 " + trivial2uple;
 
-            // PROTOTYPE(tuples) we expect similar errors on the type declarations
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (6,50): error CS8201: Tuple member name 'Item1' is disallowed at position 2.
+                // (6,28): error CS8201: Tuple member name 'Item1' is only allowed at position 1.
                 //         (int Item1, string Item1) x = (Item1: 1, Item1: "hello");
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item1").WithArguments("Item1", "2").WithLocation(6, 50),
-                // (7,40): error CS8201: Tuple member name 'Item2' is disallowed at position 1.
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item1").WithArguments("Item1", "1").WithLocation(6, 28),
+                // (6,50): error CS8201: Tuple member name 'Item1' is only allowed at position 1.
+                //         (int Item1, string Item1) x = (Item1: 1, Item1: "hello");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item1").WithArguments("Item1", "1").WithLocation(6, 50),
+                // (7,14): error CS8201: Tuple member name 'Item2' is only allowed at position 2.
                 //         (int Item2, string Item2) y = (Item2: 1, Item2: "hello");
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "1").WithLocation(7, 40));
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "2").WithLocation(7, 14),
+                // (7,40): error CS8201: Tuple member name 'Item2' is only allowed at position 2.
+                //         (int Item2, string Item2) y = (Item2: 1, Item2: "hello");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "2").WithLocation(7, 40)
+                );
+        }
+
+        [Fact]
+        public void TupleWithNonReservedNames()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int Item1, int Item01, int Item10) x = (Item01: 1, Item1: 2, Item10: 3);
+    }
+}
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
+
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.VerifyDiagnostics(
+                // (6,37): error CS8201: Tuple member name 'Item10' is only allowed at position 10.
+                //         (int Item1, int Item01, int Item10) x = (Item01: 1, Item1: 2, Item10: 3);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item10").WithArguments("Item10", "10").WithLocation(6, 37),
+                // (6,61): error CS8201: Tuple member name 'Item1' is only allowed at position 1.
+                //         (int Item1, int Item01, int Item10) x = (Item01: 1, Item1: 2, Item10: 3);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item1").WithArguments("Item1", "1").WithLocation(6, 61),
+                // (6,71): error CS8201: Tuple member name 'Item10' is only allowed at position 10.
+                //         (int Item1, int Item01, int Item10) x = (Item01: 1, Item1: 2, Item10: 3);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item10").WithArguments("Item10", "10").WithLocation(6, 71)
+                );
         }
 
         [Fact]
@@ -790,12 +1004,15 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            // PROTOTYPE(tuples) we also expect duplicate member name error on the tuple type declaration
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (6,50): error CS8202: Tuple member names must be unique.
+                // (6,24): error CS8203: Tuple member names must be unique.
                 //         (int a, string a) x = (b: 1, c: "hello", b: 2);
-                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "b").WithLocation(6, 50));
+                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "a").WithLocation(6, 24),
+                // (6,50): error CS8203: Tuple member names must be unique.
+                //         (int a, string a) x = (b: 1, c: "hello", b: 2);
+                Diagnostic(ErrorCode.ERR_TupleDuplicateMemberName, "b").WithLocation(6, 50)
+                );
         }
 
         [Fact]
@@ -806,64 +1023,98 @@ class C
 {
     static void Main()
     {
-        (int Item1, string Item3) x = (Item2: 1, Item4: ""hello"", Item3: 2);
+        (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: ""bad"", Item4: ""bad"", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: ""bad"");
     }
 }
-" + trivial2uple + trivial3uple;
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            // PROTOTYPE(tuples) we also expect reserved member name error on the tuple type declaration
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (6,40): error CS8201: Tuple member name 'Item2' is disallowed at position 1.
-                //         (int Item1, string Item3) x = (Item2: 1, Item4: "hello", Item3: 2);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "1").WithLocation(6, 40),
-                // (6,50): error CS8201: Tuple member name 'Item4' is disallowed at position 2.
-                //         (int Item1, string Item3) x = (Item2: 1, Item4: "hello", Item3: 2);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item4").WithArguments("Item4", "2").WithLocation(6, 50));
+                // (6,28): error CS8201: Tuple member name 'Item3' is only allowed at position 3.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item3").WithArguments("Item3", "3").WithLocation(6, 28),
+                // (6,42): error CS8201: Tuple member name 'Item2' is only allowed at position 2.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "2").WithLocation(6, 42),
+                // (6,100): error CS8202: Tuple membername 'Rest' is disallowed at any position.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 100),
+                // (6,111): error CS8201: Tuple member name 'Item2' is only allowed at position 2.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "2").WithLocation(6, 111),
+                // (6,125): error CS8201: Tuple member name 'Item4' is only allowed at position 4.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item4").WithArguments("Item4", "4").WithLocation(6, 125),
+                // (6,189): error CS8202: Tuple membername 'Rest' is disallowed at any position.
+                //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 189)
+               );
         }
 
-        // PROTOTYPE(tuples) this test can be removed once tuple-8 and above are implemented
         [Fact]
-        public void LongTupleDeclarationDoesntCrash()
+        public void LongTupleDeclaration()
         {
             var source = @"
 class C
 {
     static void Main()
     {
-        (int, int, int, int, int, int, int, int, int, int, int, int) x;
+        (int, int, int, int, int, int, int, string, int, int, int, int) x = (1, 2, 3, 4, 5, 6, 7, ""Alice"", 2, 3, 4, 5);
+        System.Console.WriteLine($""{x.Item1} {x.Item2} {x.Item3} {x.Item4} {x.Item5} {x.Item6} {x.Item7} {x.Item8} {x.Item9} {x.Item10} {x.Item11} {x.Item12}"");
     }
 }
-" + trivial2uple;
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (6,9): error CS8204: PROTOTYPE This is not supported yet.
-                //         (int, int, int, int, int, int, int, int, int, int, int, int) x;
-                Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "(int, int, int, int, int, int, int, int, int, int, int, int)").WithLocation(6, 9),
-                // (6,70): warning CS0168: The variable 'x' is declared but never used
-                //         (int, int, int, int, int, int, int, int, int, int, int, int) x;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "x").WithArguments("x").WithLocation(6, 70));
+            Action<ModuleSymbol> validator = module =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var x = nodes.OfType<VariableDeclaratorSyntax>().First();
+
+                Assert.Equal("<tuple: System.Int32 Item1, System.Int32 Item2, System.Int32 Item3, System.Int32 Item4, System.Int32 Item5, System.Int32 Item6, System.Int32 Item7, "
+                    + "System.String Item8, System.Int32 Item9, System.Int32 Item10, System.Int32 Item11, System.Int32 Item12> x",
+                    model.GetDeclaredSymbol(x).ToTestDisplayString());
+            };
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            verifier.VerifyDiagnostics();
         }
 
-
-        // PROTOTYPE(tuples) this test can be removed once tuple-8 and above are implemented
         [Fact]
-        public void LongTupleCreationDoesntCrash()
+        public void LongTupleDeclarationWithNames()
         {
             var source = @"
 class C
 {
     static void Main()
     {
-        var x = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+        (int a, int b, int c, int d, int e, int f, int g, string h, int i, int j, int k, int l) x = (1, 2, 3, 4, 5, 6, 7, ""Alice"", 2, 3, 4, 5);
+        System.Console.WriteLine($""{x.a} {x.b} {x.c} {x.d} {x.e} {x.f} {x.g} {x.h} {x.i} {x.j} {x.k} {x.l}"");
     }
 }
-" + trivial2uple;
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-                // (6,17): error CS8204: PROTOTYPE This is not supported yet.
-                //         var x = (1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
-                Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)").WithLocation(6, 17));
+            Action<ModuleSymbol> validator = module =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var x = nodes.OfType<VariableDeclaratorSyntax>().First();
+
+                Assert.Equal("<tuple: System.Int32 a, System.Int32 b, System.Int32 c, System.Int32 d, System.Int32 e, System.Int32 f, System.Int32 g, "
+                    + "System.String h, System.Int32 i, System.Int32 j, System.Int32 k, System.Int32 l> x",
+                    model.GetDeclaredSymbol(x).ToTestDisplayString());
+            };
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -924,14 +1175,33 @@ class C
         System.Console.WriteLine($""{x.first} {x.second}"");
     }
 
-    (T1 first, T2 second) M<T1, T2>()
+    static (T1 first, T2 second) M<T1, T2>()
     {
         return (default(T1), default(T2));
     }
 }
 ";
-            // PROTOTYPE(tuples) this should not throw
-            Assert.Throws<NullReferenceException>(() => CompileAndVerify(source));
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.VerifyDiagnostics(
+                // (10,12): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //     static (T1 first, T2 second) M<T1, T2>()
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2").WithLocation(10, 12),
+                // (10,12): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
+                //     static (T1 first, T2 second) M<T1, T2>()
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2", "Item1").WithLocation(10, 12),
+                // (10,12): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
+                //     static (T1 first, T2 second) M<T1, T2>()
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2", "Item2").WithLocation(10, 12),
+                // (12,16): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         return (default(T1), default(T2));
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2").WithLocation(12, 16),
+                // (12,16): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
+                //         return (default(T1), default(T2));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2", "Item1").WithLocation(12, 16),
+                // (12,16): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
+                //         return (default(T1), default(T2));
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2", "Item2").WithLocation(12, 16)
+                );
         }
 
         [Fact]
@@ -956,24 +1226,37 @@ class C
         }
 
         [Fact]
-        public void MethodReturnsValueTuple()
+        public void LongTupleCreation()
         {
-            var source = @"
+            var source = trivial2uple + trivial3uple + trivalRemainingTuples + @"
 class C
 {
     static void Main()
     {
-        System.Console.WriteLine(M().ToString());
-    }
-
-    static (int, string) M()
-    {
-        return (1, ""hello"");
+        var x = (1, 2, 3, 4, 5, 6, 7, ""Alice"", 2, 3, 4, 5, 6, 7, ""Bob"", 2, 3);
+        System.Console.WriteLine($""{x.Item1} {x.Item2} {x.Item3} {x.Item4} {x.Item5} {x.Item6} {x.Item7} {x.Item8} {x.Item9} {x.Item10} {x.Item11} {x.Item12} {x.Item13} {x.Item14} {x.Item15} {x.Item16} {x.Item17}"");
     }
 }
-" + trivial2uple;
+";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"{1, hello}");
+            Action<ModuleSymbol> validator = module =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var node = nodes.OfType<TupleExpressionSyntax>().Single();
+
+                Assert.Equal("<tuple: System.Int32 Item1, System.Int32 Item2, System.Int32 Item3, System.Int32 Item4, System.Int32 Item5, System.Int32 Item6, System.Int32 Item7, "
+                     + "System.String Item8, System.Int32 Item9, System.Int32 Item10, System.Int32 Item11, System.Int32 Item12, System.Int32 Item13, System.Int32 Item14, "
+                     + "System.String Item15, System.Int32 Item16, System.Int32 Item17>",
+                     model.GetTypeInfo(node).Type.ToTestDisplayString());
+            };
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1088,89 +1371,117 @@ class C
         }
 
         [Fact]
-        public void Tuple2To7Members()
+        public void LongTupleCreationWithNames()
         {
-
-            var source = trivial2uple + trivial3uple + @"
-namespace System
+            var source = @"
+class C
 {
-    public struct ValueTuple<T1, T2, T3, T4>
+    static void Main()
     {
-        public T1 Item1;
-        public T2 Item2;
-        public T3 Item3;
-        public T4 Item4;
-
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4)
-        {
-            Item1 = item1;
-            Item2 = item2;
-            Item3 = item3;
-            Item4 = item4;
-        }
-    }
-
-    public struct ValueTuple<T1, T2, T3, T4, T5>
-    {
-        public T1 Item1;
-        public T2 Item2;
-        public T3 Item3;
-        public T4 Item4;
-        public T5 Item5;
-
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5)
-        {
-            Item1 = item1;
-            Item2 = item2;
-            Item3 = item3;
-            Item4 = item4;
-            Item5 = item5;
-        }
-    }
-
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6>
-    {
-        public T1 Item1;
-        public T2 Item2;
-        public T3 Item3;
-        public T4 Item4;
-        public T5 Item5;
-        public T6 Item6;
-
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6)
-        {
-            Item1 = item1;
-            Item2 = item2;
-            Item3 = item3;
-            Item4 = item4;
-            Item5 = item5;
-            Item6 = item6;
-        }
-    }
-
-    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7>
-    {
-        public T1 Item1;
-        public T2 Item2;
-        public T3 Item3;
-        public T4 Item4;
-        public T5 Item5;
-        public T6 Item6;
-        public T7 Item7;
-
-        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7)
-        {
-            Item1 = item1;
-            Item2 = item2;
-            Item3 = item3;
-            Item4 = item4;
-            Item5 = item5;
-            Item6 = item6;
-            Item7 = item7;
-        }
+        var x = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: ""Alice"", i: 2, j: 3, k: 4, l: 5, m: 6, n: 7, o: ""Bob"", p: 2, q: 3);
+        System.Console.WriteLine($""{x.a} {x.b} {x.c} {x.d} {x.e} {x.f} {x.g} {x.h} {x.i} {x.j} {x.k} {x.l} {x.m} {x.n} {x.o} {x.p} {x.q}"");
     }
 }
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
 
+            Action<ModuleSymbol> validator = module =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var node = nodes.OfType<TupleExpressionSyntax>().Single();
+
+                Assert.Equal("<tuple: System.Int32 a, System.Int32 b, System.Int32 c, System.Int32 d, System.Int32 e, System.Int32 f, System.Int32 g, "
+                     + "System.String h, System.Int32 i, System.Int32 j, System.Int32 k, System.Int32 l, System.Int32 m, System.Int32 n, "
+                     + "System.String o, System.Int32 p, System.Int32 q>",
+                     model.GetTypeInfo(node).Type.ToTestDisplayString());
+            };
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LongTupleWithArgumentEvaluation()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (a: PrintAndReturn(1), b: 2, c: 3, d: PrintAndReturn(4), e: 5, f: 6, g: PrintAndReturn(7), h: PrintAndReturn(""Alice""), i: 2, j: 3, k: 4, l: 5, m: 6, n: PrintAndReturn(7), o: PrintAndReturn(""Bob""), p: 2, q: PrintAndReturn(3));
+    }
+
+    static T PrintAndReturn<T>(T i)
+    {
+        System.Console.Write(i + "" "");
+        return i;
+    }
+}
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 4 7 Alice 7 Bob 3", additionalRefs: new[] { MscorlibRef });
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LongTupleGettingRest()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: ""Alice"", i: 1);
+        System.Console.WriteLine($""{x.Rest.Item1} {x.Rest.Item2}"");
+    }
+}
+" + trivial2uple + trivial3uple + trivalRemainingTuples;
+
+            Action<ModuleSymbol> validator = module =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+                var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                var node = nodes.OfType<MemberAccessExpressionSyntax>().Where(n => n.ToString() == "x.Rest").First();
+                Assert.Equal("System.ValueTuple<System.String, System.Int32>", model.GetTypeInfo(node).Type.ToTestDisplayString());
+            };
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"Alice 1", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator);
+            verifier.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void MethodReturnsValueTuple()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        System.Console.WriteLine(M().ToString());
+    }
+
+    static (int, string) M()
+    {
+        return (1, ""hello"");
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"{1, hello}");
+        }
+
+        [Fact]
+        public void Tuple2To8Members()
+        {
+            var source = trivial2uple + trivial3uple + trivalRemainingTuples + @"
 class C
 {
     static void Main()
@@ -1202,11 +1513,19 @@ class C
         System.Console.Write((1, 2, 3, 4, 5, 6, 7).Item5);
         System.Console.Write((1, 2, 3, 4, 5, 6, 7).Item6);
         System.Console.Write((1, 2, 3, 4, 5, 6, 7).Item7);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item1);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item2);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item3);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item4);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item5);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item6);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item7);
+        System.Console.Write((8, 9, 0, 1, 2, 3, 4, 5).Item8);
     }
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "123456789012345678901234567");
+            var comp = CompileAndVerify(source, expectedOutput: "12345678901234567890123456789012345");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -660,6 +660,7 @@ namespace System
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor:
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor:
                     case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor:
+                    case WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor:
 
                         // PROTOTYPE(tuples) tuples
                         // Not yet in the platform.

--- a/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/OneOrMany.cs
@@ -4,11 +4,12 @@ using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Text;
+using System.Diagnostics;
 
 namespace Roslyn.Utilities
 {
     /// <summary>
-    /// Represents a single item or many items. 
+    /// Represents a single item or many items.
     /// </summary>
     /// <remarks>
     /// Used when a collection usually contains a single item but sometimes might contain multiple.

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -405,6 +405,7 @@ namespace Microsoft.CodeAnalysis
         System_ValueTuple_T1_T2_T3_T4_T5__ctor,
         System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
         System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor,
+        System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor,
 
         System_String__Format_IFormatProvider,
         Count

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2798,7 +2798,7 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.GenericTypeParameter, 4,
                     (byte)SignatureTypeCode.GenericTypeParameter, 5,
 
-                 // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+                // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7,                                                 // DeclaringTypeId
                 0,                                                                                                          // Arity
@@ -2811,6 +2811,21 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.GenericTypeParameter, 4,
                     (byte)SignatureTypeCode.GenericTypeParameter, 5,
                     (byte)SignatureTypeCode.GenericTypeParameter, 6,
+
+                // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor
+                (byte)MemberFlags.Constructor,                                                                              // Flags
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest - WellKnownType.ExtSentinel),  // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    8,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 0,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 1,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 2,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 3,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 4,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 5,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 6,
+                    (byte)SignatureTypeCode.GenericTypeParameter, 7,
 
                 // System_String__Format_IFormatProvider
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
@@ -3170,6 +3185,7 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5__ctor
                 ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor
                 ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+                ".ctor",                                    // System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor
 
                 "Format",                                   // System_String__Format_IFormatProvider
             };

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -627,7 +627,8 @@ End Namespace
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
-                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor
 
                         ' PROTOTYPE(tuples)
                         ' Not available yet, but will be in upcoming release.
@@ -749,7 +750,8 @@ End Namespace
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4__ctor,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5__ctor,
                          WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6__ctor,
-                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7__ctor,
+                         WellKnownMember.System_ValueTuple_T1_T2_T3_T4_T5_T6_T7_TRest__ctor
 
                         ' PROTOTYPE(tuples)
                         ' Not available yet, but will be in upcoming release.


### PR DESCRIPTION
`TupleTypeSymbol` now holds a chain of underlying types, instead of just one. 
For instance, it will keep a chain such as `ValueTuple<....., ValueTuple<string>>` and `ValueTuple<string>` to represent the types underlying `(7x int, string)`.

Similarly, `TupleFieldSymbol` now holds a chain of underlying field symbols, instead of just one. 
This allows an access the string above using `(tuple).Item8` or the element's name to be converted to `ValueTuple.Rest.Item1`.

Because the common case is short tuples, those chains use `OneOrMany`.

The binder (`Binder_Expression.cs` and `Binder_Symbols.cs`) now allows binding the declaration and creation of a tuple type with more than 7 elements.

Local lowering (`LocalRewriter_Field.cs` and `LocalRewriter_TupleCreationExpression.cs`) rewrites tuple field access and tuple creation to match the nesting of `ValueTuple` types.

@dotnet/roslyn-compiler for review.
