### PR TITLE
Properly format usings that are added inside a namespace.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddUsing/AddUsingTests.cs
@@ -2145,6 +2145,45 @@ namespace Namespace2
 }");
         }
 
+        [WorkItem(5499, "https://github.com/dotnet/roslyn/issues/5499")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddUsing)]
+        public async Task TestFormattingForNamespaceUsings()
+        {
+            await TestAsync(
+@"namespace N
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+
+    class Program
+    {
+        void Main()
+        {
+            [|Task<int>|]
+        }
+    }
+}",
+@"namespace N
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    class Program
+    {
+        void Main()
+        {
+            Task<int>
+        }
+    }
+}",
+compareTokens: false);
+        }
+
         public partial class AddUsingTestsWithAddImportDiagnosticProvider : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -494,7 +494,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                 {
                     // It does not matter if it is fully qualified or simple so lets return the simple name.
                     return root.AddUsingDirective(
-                        simplifiedUsing.WithoutTrivia().WithoutAnnotations(), contextNode, placeSystemNamespaceFirst,
+                        simplifiedUsing.WithoutAnnotations(), contextNode, placeSystemNamespaceFirst,
                         Formatter.Annotation);
                 }
             }


### PR DESCRIPTION
We were erroneously stripping elastic trivia from the "using directive" we wanted to add.  Because of this, the formatter wasn't appropriate ensuring two newlines between the last using and the next construct.

Fixes: https://github.com/dotnet/roslyn/issues/5499
Fixes: https://github.com/dotnet/roslyn/issues/9236