### PR TITLE
Integrate ProcessWatchdog into cibuild.cmd and BuildAndTest.proj

### DIFF
--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -9,7 +9,6 @@
     <RoslynSolution Condition="'$(RoslynSolution)' == ''">$(MSBuildThisFileDirectory)Roslyn.sln</RoslynSolution>
     <SamplesSolution>$(MSBuildThisFileDirectory)src\Samples\Samples.sln</SamplesSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
-    <RunTestArgs>$(RunTestArgs) -nocache</RunTestArgs>
     <RunTestArgs Condition="'$(ManualTest)' == ''">$(RunTestArgs) -xml</RunTestArgs>
     <RunTestArgs Condition="'$(Test64)' == 'true'">$(RunTestArgs) -test64</RunTestArgs>
     <RunTestArgs Condition="'$(Trait)' != ''">$(RunTestArgs) -trait:$(Trait)</RunTestArgs>

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -112,7 +112,7 @@
 
       <!--
       The time reserved for the process watchdog to kill all test processes and obtain crash
-      dumps from them, measure in seconds. Ignored if $(RunProcessWatchdog) is not true.
+      dumps from them, measure in seconds.
       -->
       <BufferTime>300</BufferTime>
 
@@ -120,7 +120,7 @@
       The fully constructed command line which runs a PowerShell script that runs both the
       Core CLR unit tests and the desktop unit tests under the control of the process watchdog.
       -->
-      <RunProcessWatchdogScriptCommand>PowerShell.exe -ExecutionPolicy RemoteSigned .\build\scripts\Run-TestsWithProcessWatchdog.ps1 -ProcessWatchDogExe $(ProcessWatchDogExe) -ProcessWatchdogOutputDirectory $(ProcessWatchdogOutputDirectory) -ProcDumpExe $(ProcDumpExe) -CoreRunExe '$(CoreRunExe)' -CoreRunArgs '$(CoreRunArgs)' -RunTestsExe '$(RunTestsExe)' -RunTestsArgs '$(RunTestsArgs)' -BuildStartTime $(BuildStartTime) -BuildTimeLimit $(BuildTimeLimit) -BufferTime $(BufferTime)</RunProcessWatchdogScriptCommand>
+      <RunProcessWatchdogScriptCommand>PowerShell.exe -ExecutionPolicy RemoteSigned -NoProfile .\build\scripts\Run-TestsWithProcessWatchdog.ps1 -ProcessWatchDogExe $(ProcessWatchDogExe) -ProcessWatchdogOutputDirectory $(ProcessWatchdogOutputDirectory) -ProcDumpExe $(ProcDumpExe) -CoreRunExe '$(CoreRunExe)' -CoreRunArgs '$(CoreRunArgs)' -RunTestsExe '$(RunTestsExe)' -RunTestsArgs '$(RunTestsArgs)' -BuildStartTime $(BuildStartTime) -BuildTimeLimit $(BuildTimeLimit) -BufferTime $(BufferTime)</RunProcessWatchdogScriptCommand>
     </PropertyGroup>
 
     <Exec Condition="'$(RunProcessWatchdog)' == 'true'" Command="$(RunProcessWatchdogScriptCommand)" />

--- a/BuildAndTest.proj
+++ b/BuildAndTest.proj
@@ -9,6 +9,7 @@
     <RoslynSolution Condition="'$(RoslynSolution)' == ''">$(MSBuildThisFileDirectory)Roslyn.sln</RoslynSolution>
     <SamplesSolution>$(MSBuildThisFileDirectory)src\Samples\Samples.sln</SamplesSolution>
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <RunTestArgs>$(RunTestArgs) -nocache</RunTestArgs>
     <RunTestArgs Condition="'$(ManualTest)' == ''">$(RunTestArgs) -xml</RunTestArgs>
     <RunTestArgs Condition="'$(Test64)' == 'true'">$(RunTestArgs) -test64</RunTestArgs>
     <RunTestArgs Condition="'$(Trait)' != ''">$(RunTestArgs) -trait:$(Trait)</RunTestArgs>
@@ -94,9 +95,36 @@
         Text="Found test assemblies outside a well-known test directory: 
 @(MisplacedTestAssemblies, '%0a')" />
 
-    <Exec Command="$(CoreClrTestDirectory)\CoreRun.exe $(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\xUnitResults\TestResults.xml" />
+    <PropertyGroup>
+      <CoreRunExe>$(CoreClrTestDirectory)\CoreRun.exe</CoreRunExe>
+      <CoreRunArgs>$(CoreClrTestDirectory)\xunit.console.netcore.exe @(CoreTestAssemblies, ' ') -parallel all -xml $(CoreClrTestDirectory)\xUnitResults\TestResults.xml</CoreRunArgs>
+      <RunTestsExe>Binaries\$(Configuration)\RunTests\RunTests.exe</RunTestsExe>
+      <RunTestsArgs>$(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools $(RunTestArgs) @(TestAssemblies, ' ')</RunTestsArgs>
+    </PropertyGroup>
+    
+    <Exec Condition="'$(RunProcessWatchdog)' != 'true'" Command="&quot;$(CoreRunExe)&quot; $(CoreRunArgs)" />
 
-    <Exec Command="Binaries\$(Configuration)\RunTests\RunTests.exe &quot;$(NuGetPackageRoot)\xunit.runner.console\$(XunitVersion)\tools&quot; $(RunTestArgs) @(TestAssemblies, ' ')" />
+    <Exec Condition="'$(RunProcessWatchdog)' != 'true'" Command="&quot;$(RunTestsExe)&quot; $(RunTestsArgs)" />
+
+    <PropertyGroup Condition="'$(RunProcessWatchdog)' == 'true'">
+      <ProcessWatchDogExe>$(OutputDirectory)\ProcessWatchdog\ProcessWatchdog.exe</ProcessWatchDogExe>
+      <ProcessWatchdogOutputDirectory Condition="'$(ProcessWatchdogOutputDirectory)' == ''">$(OutputDirectory)\ProcessWatchdogOutput</ProcessWatchdogOutputDirectory>
+      <ProcDumpExe Condition="'$(ProcDumpExe)' == ''">C:\Sysinternals\Procdump.exe</ProcDumpExe>
+
+      <!--
+      The time reserved for the process watchdog to kill all test processes and obtain crash
+      dumps from them, measure in seconds. Ignored if $(RunProcessWatchdog) is not true.
+      -->
+      <BufferTime>300</BufferTime>
+
+      <!--
+      The fully constructed command line which runs a PowerShell script that runs both the
+      Core CLR unit tests and the desktop unit tests under the control of the process watchdog.
+      -->
+      <RunProcessWatchdogScriptCommand>PowerShell.exe -ExecutionPolicy RemoteSigned .\build\scripts\Run-TestsWithProcessWatchdog.ps1 -ProcessWatchDogExe $(ProcessWatchDogExe) -ProcessWatchdogOutputDirectory $(ProcessWatchdogOutputDirectory) -ProcDumpExe $(ProcDumpExe) -CoreRunExe '$(CoreRunExe)' -CoreRunArgs '$(CoreRunArgs)' -RunTestsExe '$(RunTestsExe)' -RunTestsArgs '$(RunTestsArgs)' -BuildStartTime $(BuildStartTime) -BuildTimeLimit $(BuildTimeLimit) -BufferTime $(BufferTime)</RunProcessWatchdogScriptCommand>
+    </PropertyGroup>
+
+    <Exec Condition="'$(RunProcessWatchdog)' == 'true'" Command="$(RunProcessWatchdogScriptCommand)" />
 
   </Target>
 

--- a/build/scripts/Run-TestsWithProcessWatchdog.ps1
+++ b/build/scripts/Run-TestsWithProcessWatchdog.ps1
@@ -19,9 +19,6 @@ The directory into which ProcessWatchdog.exe should write memory dumps and scree
 .PARAMETER ProcDumpExe
 The path to the SysInternals executable ProcDump.exe, which produces memory dumps.
 
-.PARAMETER CoreRunArgs
-The arguments to be passed to CoreRun.exe.
-
 .PARAMETER CoreRunExe
 The path to the executable CoreRun.exe, which runs the Core CLR unit tests.
 
@@ -36,16 +33,13 @@ The arguments to be passed to RunTests.exe.
 
 .PARAMETER BuildStartTime
 The time the Jenkins build started, in the ISO 8601-compatible format YYYY-MM-DDThh:mm:ss.
-Ignored if $RunProcessWatchdog is not $true.
 
 .PARAMETER BuildTimeLimit
 The total time allowed for the Jenkins build, measured in minutes.
-Ignored if $RunProcessWatchdog is not $true.
 
 .PARAMETER BufferTime
 The time reserved for the process watchdog to kill all test processes and obtain crash
 dumps from them, measure in seconds. 
-Ignored if $RunProcessWatchdog is not $true.
 #>
 
 [CmdletBinding()]
@@ -75,7 +69,6 @@ function Check-TimeRemaining($testGroupName)
 }
 
 function Get-TimeRemaining() {
-    
     $secondsSinceStart = ([DateTime]::Now - [DateTime]::Parse($BuildStartTime)).TotalSeconds
     [Math]::Truncate($BuildTimeLimit * 60 - $secondsSinceStart - $BufferTime)
 }

--- a/build/scripts/Run-TestsWithProcessWatchdog.ps1
+++ b/build/scripts/Run-TestsWithProcessWatchdog.ps1
@@ -1,0 +1,89 @@
+<#
+.SYNOPSIS
+Run the unit tests under the control of the process watchdog.
+
+.DESCRIPTION
+This script runs the unit tests under the control of the process watchdog.
+The process watchdog allows the unit tests a certain amount of time to
+run. If they don't complete in the allotted time, then the watchdog
+obtains memory dumps from the test process and all its descendant processes,
+takes a screen shot, and kills the processes.
+
+.PARAMETER ProcessWatchdogExe
+The path to the executable ProcessWatchdog.exe, which sets time limits on
+the unit tests.
+
+.PARAMETER ProcessWatchdogOutputDirectory
+The directory into which ProcessWatchdog.exe should write memory dumps and screen shots.
+
+.PARAMETER ProcDumpExe
+The path to the SysInternals executable ProcDump.exe, which produces memory dumps.
+
+.PARAMETER CoreRunArgs
+The arguments to be passed to CoreRun.exe.
+
+.PARAMETER CoreRunExe
+The path to the executable CoreRun.exe, which runs the Core CLR unit tests.
+
+.PARAMETER CoreRunArgs
+The arguments to be passed to CoreRun.exe.
+
+.PARAMETER RunTestsExe
+The path to the executable RunTests.exe, which runs the desktop unit tests.
+
+.PARAMETER RunTestsArgs
+The arguments to be passed to RunTests.exe.
+
+.PARAMETER BuildStartTime
+The time the Jenkins build started, in the ISO 8601-compatible format YYYY-MM-DDThh:mm:ss.
+Ignored if $RunProcessWatchdog is not $true.
+
+.PARAMETER BuildTimeLimit
+The total time allowed for the Jenkins build, measured in minutes.
+Ignored if $RunProcessWatchdog is not $true.
+
+.PARAMETER BufferTime
+The time reserved for the process watchdog to kill all test processes and obtain crash
+dumps from them, measure in seconds. 
+Ignored if $RunProcessWatchdog is not $true.
+#>
+
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory=$true)] [string] $ProcessWatchdogExe,
+    [Parameter(Mandatory=$true)] [string] $ProcessWatchdogOutputDirectory,
+    [Parameter(Mandatory=$true)] [string] $ProcDumpExe,
+    [Parameter(Mandatory=$true)] [string] $CoreRunExe,
+    [Parameter(Mandatory=$true)] [string] $CoreRunArgs,
+    [Parameter(Mandatory=$true)] [string] $RunTestsExe,
+    [Parameter(Mandatory=$true)] [string] $RunTestsArgs,
+    [Parameter(Mandatory=$true)] [string] $BuildStartTime,
+    [Parameter(Mandatory=$true)] [int] $BuildTimeLimit,
+    [Parameter(Mandatory=$true)] [int] $BufferTime
+)
+
+function Check-TimeRemaining($testGroupName)
+{
+    $timeRemaining = Get-TimeRemaining
+    if ($timeRemaining -gt 0) {
+        Write-Host "$timeRemaining seconds remain to run the $testGroupName unit tests."
+        $timeRemaining
+    } else {
+        Write-Host "There is no time remaining to run the $testGroupName unit tests."
+        exit 1;
+    }
+}
+
+function Get-TimeRemaining() {
+    
+    $secondsSinceStart = ([DateTime]::Now - [DateTime]::Parse($BuildStartTime)).TotalSeconds
+    [Math]::Truncate($BuildTimeLimit * 60 - $secondsSinceStart - $BufferTime)
+}
+
+$timeRemaining = Check-TimeRemaining "Core CLR"
+
+& $ProcessWatchdogExe --executable $CoreRunExe --arguments "$CoreRunArgs" --time-limit $timeRemaining --output-folder "$ProcessWatchdogOutputDirectory" --screenshot --procdump-path "$ProcDumpExe"
+
+$timeRemaining = Check-TimeRemaining "desktop"
+
+& $ProcessWatchdogExe --executable $RunTestsExe --arguments "$RunTestsArgs" --time-limit $timeRemaining --output-folder "$ProcessWatchdogOutputDirectory" --screenshot --procdump-path "$ProcDumpExe"

--- a/build/scripts/Run-TestsWithProcessWatchdog.ps1
+++ b/build/scripts/Run-TestsWithProcessWatchdog.ps1
@@ -56,6 +56,11 @@ Param(
     [Parameter(Mandatory=$true)] [int] $BufferTime
 )
 
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+$BuildStartSeconds = [DateTime]::ParseExact($BuildStartTime, "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ff", [CultureInfo]::InvariantCulture)
+
 function Check-TimeRemaining($testGroupName)
 {
     $timeRemaining = Get-TimeRemaining
@@ -69,7 +74,7 @@ function Check-TimeRemaining($testGroupName)
 }
 
 function Get-TimeRemaining() {
-    $secondsSinceStart = ([DateTime]::Now - [DateTime]::Parse($BuildStartTime)).TotalSeconds
+    $secondsSinceStart = ([DateTime]::Now - $BuildStartSeconds).TotalSeconds
     [Math]::Truncate($BuildTimeLimit * 60 - $secondsSinceStart - $BufferTime)
 }
 

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -36,7 +36,6 @@ REM and so the tests will not run under the ProcessWatchdog.
 if not "%BuildTimeLimit%" == "" (
     set CurrentDate=%date%
     set CurrentTime=%time: =0%
-	set Current
     set BuildStartTime=!CurrentDate:~-4!-!CurrentDate:~-10,2!-!CurrentDate:~-7,2!T!CurrentTime!
     set RunProcessWatchdog=true
 ) else (

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -35,14 +35,13 @@ REM Developers building from the command line will presumably not pass /buildTim
 REM and so the tests will not run under the ProcessWatchdog.
 if not "%BuildTimeLimit%" == "" (
     set CurrentDate=%date%
-    set CurrentTime=%time%
+    set CurrentTime=%time: =0%
+	set Current
     set BuildStartTime=!CurrentDate:~-4!-!CurrentDate:~-10,2!-!CurrentDate:~-7,2!T!CurrentTime!
     set RunProcessWatchdog=true
 ) else (
     set RunProcessWatchdog=false
 )
-
-echo %BuildStartTime%
     
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" || goto :BuildFailed
 

--- a/src/Tools/ProcessWatchdog/ConsoleUtils.cs
+++ b/src/Tools/ProcessWatchdog/ConsoleUtils.cs
@@ -13,14 +13,20 @@ namespace ProcessWatchdog
                 string.Format(CultureInfo.CurrentCulture, format, args));
         }
 
-        internal static void LogError(string messageFormat, params object[] args)
+        internal static void LogError(ErrorCode errorCode, string messageFormat, params object[] args)
         {
             string fullMessage = string.Format(
-                CultureInfo.CurrentCulture,
+                CultureInfo.InvariantCulture,
                 Resources.ErrorFormat,
+                FormatErrorCode(errorCode),
                 string.Format(CultureInfo.CurrentCulture, messageFormat, args));
 
             Console.Error.WriteLine(fullMessage);
+        }
+
+        private static string FormatErrorCode(ErrorCode errorCode)
+        {
+            return string.Format(CultureInfo.InvariantCulture, "PW{0:D4}", (int)errorCode);
         }
     }
 }

--- a/src/Tools/ProcessWatchdog/ErrorCode.cs
+++ b/src/Tools/ProcessWatchdog/ErrorCode.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace ProcessWatchdog
+{
+    internal enum ErrorCode
+    {
+        None = 0,
+        ProcessTimedOut = 1,
+        InvalidTimeLimit = 2,
+        InvalidPollingInterval = 3,
+        ProcDumpNotFound = 4,
+        CannotTakeScreenShotNoConsoleSession = 5,
+        CannotTakeScreenShotUnexpectedError = 6
+    }
+}

--- a/src/Tools/ProcessWatchdog/ProcessTracker.cs
+++ b/src/Tools/ProcessWatchdog/ProcessTracker.cs
@@ -114,9 +114,11 @@ namespace ProcessWatchdog
         {
             var descendants = new List<Process>();
 
+            // Don't include procdump itself in the descendants, because
+            // we don't want to kill procdump.
             string query = string.Format(
                 CultureInfo.InvariantCulture,
-                "SELECT * FROM Win32_Process WHERE ParentProcessId={0}",
+                "SELECT * FROM Win32_Process WHERE ParentProcessId = {0} AND Name <> \"procdump.exe\"",
                 processId);
             var searcher = new ManagementObjectSearcher(query);
 

--- a/src/Tools/ProcessWatchdog/ProcessWatchdog.csproj
+++ b/src/Tools/ProcessWatchdog/ProcessWatchdog.csproj
@@ -30,6 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConsoleUtils.cs" />
+    <Compile Include="ErrorCode.cs" />
     <Compile Include="ProcDump.cs" />
     <Compile Include="Options.cs" />
     <Compile Include="ProcessTracker.cs" />

--- a/src/Tools/ProcessWatchdog/Resources.Designer.cs
+++ b/src/Tools/ProcessWatchdog/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace ProcessWatchdog {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error: {0}.
+        ///   Looks up a localized string similar to Error {0}: {1}.
         /// </summary>
         internal static string ErrorFormat {
             get {

--- a/src/Tools/ProcessWatchdog/Resources.resx
+++ b/src/Tools/ProcessWatchdog/Resources.resx
@@ -130,7 +130,7 @@
     <value>Could not take screenshot for process {0}.</value>
   </data>
   <data name="ErrorFormat" xml:space="preserve">
-    <value>Error: {0}</value>
+    <value>Error {0}: {1}</value>
   </data>
   <data name="ErrorInvalidPollingInterval" xml:space="preserve">
     <value>The value {0} is not a valid polling interval. Please specify the polling interval as a positive number of milliseconds.</value>

--- a/src/Tools/ProcessWatchdog/ScreenShotSaver.cs
+++ b/src/Tools/ProcessWatchdog/ScreenShotSaver.cs
@@ -24,12 +24,12 @@ namespace ProcessWatchdog
                 // System.ComponentModel.Win32Exception (0x80004005): The handle is invalid. This
                 // means we're not running in a console session, hence there's no UI to take a
                 // screenshot of. This is perfectly normal on the server.
-                ConsoleUtils.LogError(Resources.ErrorCannotTakeScreenshotNoConsoleSession, ex);
+                ConsoleUtils.LogError(ErrorCode.CannotTakeScreenShotNoConsoleSession, Resources.ErrorCannotTakeScreenshotNoConsoleSession, ex);
             }
             catch (Exception ex)
             {
                 // This is something else, we'd better know about this.
-                ConsoleUtils.LogError(Resources.ErrorCannotTakeScreenshotUnexpectedError, ex);
+                ConsoleUtils.LogError(ErrorCode.CannotTakeScreenShotUnexpectedError, Resources.ErrorCannotTakeScreenshotUnexpectedError, ex);
             }
         }
 


### PR DESCRIPTION
... but it's not yet enabled, because we haven't changed netci.groovy to pass the /buildTimeLimit parameter to cibuild.cmd.

@davkean @jaredpar @tannergooding @jasonmalinowski @srivatsn @michaelcfanning 