### PR TITLE
Fix instrumentation issues with => methods and multi-declarator local declarations

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -22,6 +22,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 MethodSymbol flushPayload = GetFlushPayload(compilation, methodBody.Syntax, diagnostics);
 
                 // Do not instrument the instrumentation helpers if they are part of the current compilation (which occurs only during testing). GetCreatePayload will fail with an infinite recursion if it is instrumented.
+                // PROTOTYPE (https://github.com/dotnet/roslyn/issues/10266): It is not correct to always skip implict methods, because that will miss field initializers.
                 if ((object)createPayload != null && (object)flushPayload != null && !method.IsImplicitlyDeclared && !method.Equals(createPayload) && !method.Equals(flushPayload))
                 {
                     // Create the symbol for the instrumentation payload.

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -190,7 +190,7 @@ True
         }
 
         [Fact]
-        public void ArrowPropertyCoverage()
+        public void ImplicitBlockMethodsCoverage()
         {
             string source = @"
 using System;
@@ -205,11 +205,21 @@ public class Program
     static void TestMain()
     {
         int x = Count;
+        x += Prop;
+        Prop = x;
+        Lambda(x, (y) => y + 1);
     }
 
     static int Function(int x) => x;
 
     static int Count => Function(44);
+
+    static int Prop { get; set; }
+
+    static int Lambda(int x, Func<int, int> l)
+    {
+        return l(x);
+    }
 }
 ";
             string expectedOutput = @"Flushing
@@ -217,9 +227,18 @@ public class Program
 True
 2
 True
+True
+True
+True
 3
 True
 4
+True
+5
+True
+6
+True
+7
 True
 ";
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -190,6 +190,104 @@ True
         }
 
         [Fact]
+        public void ArrowPropertyCoverage()
+        {
+            string source = @"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        TestMain();
+    }
+
+    static void TestMain()
+    {
+        int x = Count;
+    }
+
+    static int Function(int x) => x;
+
+    static int Count => Function(44);
+}
+";
+            string expectedOutput = @"Flushing
+1
+True
+2
+True
+3
+True
+4
+True
+";
+
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+        }
+
+        [Fact]
+        public void MultipleDeclarationsCoverage()
+        {
+            string source = @"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        TestMain();
+    }
+
+    static void TestMain()
+    {
+        DoubleDeclaration(5);
+        DoubleForDeclaration(5);
+    }
+
+    static int DoubleDeclaration(int x)
+    {
+        int c = x;
+        int a, b;
+        a = b = c;
+        int d = a, e = b;
+        return d + e;
+    }
+
+    static int DoubleForDeclaration(int x)
+    {
+        for(int a = x, b = x; a + b < 10; a++)
+        {
+            x++;
+        }
+
+        return x;
+    }
+}
+";
+            string expectedOutput = @"Flushing
+1
+True
+2
+True
+True
+3
+True
+True
+True
+True
+True
+4
+True
+False
+False
+True
+";
+
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+        }
+
+        [Fact]
         public void ManyStatementsCoverage()
         {
             string source = @"


### PR DESCRIPTION
Dynamic analysis instrumentation was producing malformed bound trees for methods defined with => bodies rather than { } bodies, and for local declarations that declare more than one variable.

@jcouv @AlekseyTs @VSadov @jaredpar @drognanar @amcasey @ManishJayaswal 