### PR TITLE
Modify netci.groovy to enable ProcessWatchdog

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -4,6 +4,8 @@
 import jobs.generation.Utilities;
 def project = GithubProject
 
+buildTimeLimit = 120
+
 static void addLogRotator(def myJob) {
   myJob.with {
     logRotator {
@@ -50,7 +52,7 @@ static void addWrappers(def myJob) {
   myJob.with {
     wrappers {
       timeout {
-        absolute(120)
+        absolute(buildTimeLimit)
         abortBuild()
       }
       timestamps()
@@ -225,7 +227,7 @@ def branchNames = []
                     batchFile("""set TEMP=%WORKSPACE%\\Binaries\\Temp
 mkdir %TEMP%
 set TMP=%TEMP%
-.\\cibuild.cmd ${(configuration == 'dbg') ? '/debug' : '/release'} ${(buildTarget == 'unit32') ? '/test32' : '/test64'}""")
+.\\cibuild.cmd ${(configuration == 'dbg') ? '/debug' : '/release'} ${(buildTarget == 'unit32') ? '/test32' : '/test64'} /buildTimeLimit ${buildTimeLimit}""")
                   }
                 }
                 Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto')


### PR DESCRIPTION
This will enable the ProcessWatchdog on the `master` and `future` branches, where `cibuild.cmd` has been modified to use the `buildTimeLimit` option to enable the ProcessWatchdog. It will not affect the `stabilization`, `future-stabilization`, and `hotfixes` branches, where `cibuild.cmd` has been modified to accept but ignore the `buildTimeLimit` option.

The change will take effect as soon as Jenkins picks up the change to `netci.groovy`.

@jaredpar @davkean @dotnet/roslyn-infrastructure @srivatsn @michaelcfanning 