### PR TITLE
Skip TestCrossLanguageParameterizedPropertyOverride test

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -1595,7 +1595,7 @@ End Module
         End Function
 
         <WorkItem(545661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545661")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/10132"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Async Function TestCrossLanguageParameterizedPropertyOverride() As Task
             Dim workspace =
 <Workspace>


### PR DESCRIPTION
It's now reliabily failing, we don't need people to hit this anymore.

Review: @dotnet/roslyn-ide and FYI to @brettfo and @dpoeschl.