### PR TITLE
More precisely control when we should include NuGet packages in VSIXes

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -181,11 +181,16 @@
 
   <!-- ====================================================================================
 
-         Force-include our NuGet-consumed assets into VSIX projects
+         Include some of our NuGet-consumed assets into VSIX projects
 
-         NOTE: this is a very specialized behavior we need for producing the Roslyn VSIXes.
-           It should not be copied into other projects without careful thought and
-           understanding of the VSSDK VSIX targets.
+         This exists for two reasons:
+
+         1) In some cases, we need to include the contents of a NuGet package that is otherwise
+            contained within the SuppressFromVsix list, because we're actually the component
+            inside Visual Studio that ships that component
+         
+         2) The SDK targets don't currently look at the ReferenceCopyLocalPaths produced
+            by the NuGet build task.
 
        ==================================================================================== -->
 
@@ -193,15 +198,19 @@
     <GetVsixSourceItemsDependsOn>$(GetVsixSourceItemsDependsOn);IncludeNuGetResolvedAssets</GetVsixSourceItemsDependsOn>
   </PropertyGroup>
 
-  <Target Name="IncludeNuGetResolvedAssets" DependsOnTargets="ResolveNuGetPackageAssets">
-    <ItemGroup Condition="'$(IncludeCopyLocalReferencesInVSIXContainer)' == 'true'">
-      <VSIXCopyLocalReferenceSourceItem Include="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''">
+  <Target Name="IncludeNuGetResolvedAssets" DependsOnTargets="ResolveNuGetPackageAssets" Condition="'@(NuGetPackageToIncludeInVsix)' != ''">
+    <ItemGroup>
+      <_ReferenceCopyLocalPathsWithPotentialInclusions Include="@(ReferenceCopyLocalPaths)">
+        <NuGetPackageToIncludeInVsix>%(NuGetPackageToIncludeInVsix.Identity)</NuGetPackageToIncludeInVsix>
+      </_ReferenceCopyLocalPathsWithPotentialInclusions>
+
+      <VSIXCopyLocalReferenceSourceItem Include="@(_ReferenceCopyLocalPathsWithPotentialInclusions)"
+       Condition="'%(_ReferenceCopyLocalPathsWithPotentialInclusions.NuGetPackageId)' == '%(_ReferenceCopyLocalPathsWithPotentialInclusions.NuGetPackageToIncludeInVsix)'">
         <ForceIncludeInVsix>true</ForceIncludeInVsix>
         <Private>true</Private>
       </VSIXCopyLocalReferenceSourceItem>
     </ItemGroup>
   </Target>
-
 
   <!-- ====================================================================================
 

--- a/src/Compilers/Extension/CompilerExtension.csproj
+++ b/src/Compilers/Extension/CompilerExtension.csproj
@@ -48,6 +48,12 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader.Native" />
+    <!-- Even though the VS process includes both of these, we need to also include them in the VSIX for the compiler processes -->
+    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
+    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+  </ItemGroup>
+  <ItemGroup>
     <Reference Include="envdte, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>false</Private>
     </Reference>

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -141,6 +141,14 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Telemetry" />
   </ItemGroup>
+  <ItemGroup>
+    <NuGetPackageToIncludeInVsix Include="ManagedEsent" />
+    <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.Elfie" />
+    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader" />
+    <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
+    <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
+    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+  </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>

--- a/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/VisualStudioInteractiveComponents.csproj
@@ -151,6 +151,14 @@
       </IncludeOutputGroupsInVSIXLocalOnly>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <!-- Even though the VS process includes these, we need to also include them in the VSIX for the interactive host processes -->
+    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
+    <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+    <!-- Other interactive host processes dependencies -->
+    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem" />
+    <NuGetPackageToIncludeInVsix Include="System.IO.FileSystem.Primitives" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Back in 84d7856e, I updated our targets to always include all dependencies from NuGet packages in our VSIXes. This was quick, but had a few problems:

1. we would force-include everything, including VS SDK assemblies
2. we would include the same assembly in multiple VSIXes, even when
   we really didn't need them.

This is mostly a change to address the former. Now you have to
explicitly state which NuGet packages you do want to bring in, and only
those will get brought in to your VSIX. The rest are excluded.

*Review:* @dotnet/roslyn-infrastructure for general oversight, and then @dotnet/roslyn-compiler, @dotnet/roslyn-ide, and @dotnet/roslyn-interactive to review their respective changes to each VSIX.