### PR TITLE
Publish dependencies built from Roslyn repo

### DIFF
--- a/build/BuildNuGets.csx
+++ b/build/BuildNuGets.csx
@@ -38,23 +38,27 @@ var Authors = @"Microsoft";
 var ProjectURL = @"http://msdn.com/roslyn";
 var Tags = @"Roslyn CodeAnalysis Compiler CSharp VB VisualBasic Parser Scanner Lexer Emit CodeGeneration Metadata IL Compilation Scripting Syntax Semantics";
 
-string SystemCollectionsImmutableVersion;
-string SystemReflectionMetadataVersion;
-string CodeAnalysisAnalyzersVersion;
-
 // Read preceding variables from MSBuild file
 var doc = XDocument.Load(Path.Combine(SolutionRoot, "build/Targets/VSL.Versions.targets"));
 XNamespace ns = @"http://schemas.microsoft.com/developer/msbuild/2003";
-SystemCollectionsImmutableVersion = doc.Descendants(ns + nameof(SystemCollectionsImmutableVersion)).Single().Value;
-SystemReflectionMetadataVersion = doc.Descendants(ns + nameof(SystemReflectionMetadataVersion)).Single().Value;
-CodeAnalysisAnalyzersVersion = doc.Descendants(ns + nameof(CodeAnalysisAnalyzersVersion)).Single().Value;
+string SystemCollectionsImmutableVersion = doc.Descendants(ns + nameof(SystemCollectionsImmutableVersion)).Single().Value;
+string SystemReflectionMetadataVersion = doc.Descendants(ns + nameof(SystemReflectionMetadataVersion)).Single().Value;
+string CodeAnalysisAnalyzersVersion = doc.Descendants(ns + nameof(CodeAnalysisAnalyzersVersion)).Single().Value;
+
+string MicrosoftDiaSymReaderVersion = GetExistingPackageVersion("Microsoft.DiaSymReader");
+string MicrosoftDiaSymReaderPortablePdbVersion = GetExistingPackageVersion("Microsoft.DiaSymReader.PortablePdb");
+
+string GetExistingPackageVersion(string name)
+{
+    string path = Directory.Exists(OutDir) ? Directory.GetFiles(OutDir, name + ".*.nupkg").SingleOrDefault() : null;
+    return (path == null) ? null : Path.GetFileNameWithoutExtension(path).Substring(name.Length + 1);
+}
 
 #endregion
 
 var NuGetAdditionalFilesPath = Path.Combine(SolutionRoot, "build/NuGetAdditionalFiles");
 var ThirdPartyNoticesPath = Path.Combine(NuGetAdditionalFilesPath, "ThirdPartyNotices.rtf");
 var NetCompilersPropsPath = Path.Combine(NuGetAdditionalFilesPath, "Microsoft.Net.Compilers.props");
-var IsReleaseVersion = !BuildVersion.Contains('-');
 
 string[] RedistPackageNames = {
     "Microsoft.CodeAnalysis.BuildTask.Portable",
@@ -142,30 +146,60 @@ int PackFiles(string[] packageNames, string licenseUrl)
     return exit;
 }
 
-XDocument CreatePublishingConfigDoc(IEnumerable<string> packageNames)
+XElement MakePackageElement(string packageName, string version)
 {
-    var packages =
-        packageNames.Select(packageName =>
-            new XElement("package", new XAttribute("id", packageName), new XAttribute("version", BuildVersion.ToString())));
+    return new XElement("package", new XAttribute("id", packageName), new XAttribute("version", version));
+}
 
-    return new XDocument(new XElement("packages", packages.ToArray()));
+IEnumerable<XElement> MakeRoslynPackageElements(bool isRelease)
+{
+    var packageNames = RedistPackageNames.Concat(NonRedistPackageNames);
+
+    if (isRelease)
+    {
+        packageNames = packageNames.Where(pn => !PreReleaseOnlyPackages.Contains(pn));
+    }
+
+    return packageNames.Select(packageName => MakePackageElement(packageName, BuildVersion));
+}
+
+void GeneratePublishingConfig(string fileName, IEnumerable<XElement> packages)
+{
+    var doc = new XDocument(new XElement("packages", packages.ToArray()));
+    doc.Save(Path.Combine(OutDir, fileName));
+}
+
+// Currently we publish some of the Roslyn dependencies. Remove this once they are moved to a separate repo.
+IEnumerable<XElement> MakePackageElementsForPublishedDependencies(bool isRelease)
+{
+    if (MicrosoftDiaSymReaderVersion != null && isRelease == IsReleaseVersion(MicrosoftDiaSymReaderVersion))
+    {
+        yield return MakePackageElement("Microsoft.DiaSymReader", MicrosoftDiaSymReaderVersion);
+    }
+
+    if (MicrosoftDiaSymReaderPortablePdbVersion != null && isRelease == IsReleaseVersion(MicrosoftDiaSymReaderPortablePdbVersion))
+    {
+        yield return MakePackageElement("Microsoft.DiaSymReader.PortablePdb", MicrosoftDiaSymReaderPortablePdbVersion);
+    }
 }
 
 void GeneratePublishingConfig()
 {
-    if (IsReleaseVersion)
+    if (IsReleaseVersion(BuildVersion))
     {
         // nuget:
-        var nuget = CreatePublishingConfigDoc(RedistPackageNames.Concat(NonRedistPackageNames).Where(pn => !PreReleaseOnlyPackages.Contains(pn)));
-        nuget.Save(Path.Combine(OutDir, "nuget_org-packages.config"));
+        var packages = MakeRoslynPackageElements(isRelease: true).Concat(MakePackageElementsForPublishedDependencies(isRelease: true));
+        GeneratePublishingConfig("nuget_org-packages.config", packages);
     }
     else
     {
         // myget:
-        var myget = CreatePublishingConfigDoc(RedistPackageNames.Concat(NonRedistPackageNames));
-        myget.Save(Path.Combine(OutDir, "myget_org-packages.config"));
+        var packages = MakeRoslynPackageElements(isRelease: false).Concat(MakePackageElementsForPublishedDependencies(isRelease: false));
+        GeneratePublishingConfig("myget_org-packages.config", packages);
     }
 }
+
+bool IsReleaseVersion(string version) => !version.Contains('-');
 
 Directory.CreateDirectory(OutDir);
 


### PR DESCRIPTION
Auto-publish Microsoft.DiaSymReader and Microsoft.DiaSymReader.PortablePdb to myget. These are built from Roslyn repo. This can be removed once we moved them to separate repos.