### PR TITLE
Mark ParseOptions.CommonWithKind with attribute of EditorBrowsableState.Never

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
@@ -38,6 +38,9 @@ namespace Microsoft.CodeAnalysis
             return CommonWithKind(kind);
         }
 
+        // It was supposed to be a protected implementation detail. 
+        // The "pattern" we have for these is the public With* method is the only public callable one, 
+        // and that forwards to the protected Common* like all the other methods in the class (see PR #10304 comments by Jason Malinowski) 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public abstract ParseOptions CommonWithKind(SourceCodeKind kind);
 

--- a/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Roslyn.Utilities;
 
@@ -37,6 +38,7 @@ namespace Microsoft.CodeAnalysis
             return CommonWithKind(kind);
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public abstract ParseOptions CommonWithKind(SourceCodeKind kind);
 
         /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
+++ b/src/Compilers/Core/Portable/Compilation/ParseOptions.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis
 
         // It was supposed to be a protected implementation detail. 
         // The "pattern" we have for these is the public With* method is the only public callable one, 
-        // and that forwards to the protected Common* like all the other methods in the class (see PR #10304 comments by Jason Malinowski) 
+        // and that forwards to the protected Common* like all the other methods in the class. 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public abstract ParseOptions CommonWithKind(SourceCodeKind kind);
 


### PR DESCRIPTION
Mark ParseOptions.CommonWithKind with attribute of `EditorBrowsableState.Never` according to #8353