### PR TITLE
Add an instrumentation component that can be used to instrument certain statements and expressions during lowering.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -3464,7 +3464,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             boundFilter = patternBinder.WrapWithVariablesIfAny(boundFilter);
-            boundFilter = new BoundSequencePointExpression(filter, boundFilter, boundFilter.Type);
             return boundFilter;
         }
 

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -378,6 +378,9 @@
     <Compile Include="Lowering\DiagnosticsPass_Warnings.cs" />
     <Compile Include="Lowering\Extensions.cs" />
     <Compile Include="Lowering\InitializerRewriter.cs" />
+    <Compile Include="Lowering\Instrumentation\CompoundInstrumenter.cs" />
+    <Compile Include="Lowering\Instrumentation\DebugInfoInjector.cs" />
+    <Compile Include="Lowering\Instrumentation\Instrumenter.cs" />
     <Compile Include="Lowering\IteratorRewriter\IteratorConstructor.cs" />
     <Compile Include="Lowering\IteratorRewriter\IteratorFinallyMethodSymbol.cs" />
     <Compile Include="Lowering\IteratorRewriter\IteratorMethodToStateMachineRewriter.IteratorFinallyFrame.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -380,6 +380,7 @@
     <Compile Include="Lowering\InitializerRewriter.cs" />
     <Compile Include="Lowering\Instrumentation\CompoundInstrumenter.cs" />
     <Compile Include="Lowering\Instrumentation\DebugInfoInjector.cs" />
+    <Compile Include="Lowering\Instrumentation\DebugInfoInjector_SequencePoints.cs" />
     <Compile Include="Lowering\Instrumentation\Instrumenter.cs" />
     <Compile Include="Lowering\IteratorRewriter\IteratorConstructor.cs" />
     <Compile Include="Lowering\IteratorRewriter\IteratorFinallyMethodSymbol.cs" />
@@ -439,7 +440,6 @@
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_PropertyAccess.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_Query.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_ReturnStatement.cs" />
-    <Compile Include="Lowering\LocalRewriter\LocalRewriter_SequencePoints.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_StackAlloc.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_StringConcat.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter_StringInterpolation.cs" />

--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -51,14 +51,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     BoundExpression payloadNullTest = factory.Binary(BinaryOperatorKind.ObjectEqual, boolType, factory.Field(null, payloadField), factory.Null(payloadType));
                     BoundStatement payloadIf = factory.If(payloadNullTest, createPayloadCall);
 
-                    // Methods defined without block syntax won't naturally get a sequence point for the entry of the method.
                     // It is a requirement that there be a sequence point before any executable code. A sequence point
                     // won't be generated automatically for the synthesized if statement because the if statement is compiler generated, so
                     // force the generation of a sequence point for the if statement.
-                    if (!methodHasExplicitBlock)
-                    {
-                        payloadIf = factory.SequencePoint(payloadIf.Syntax, payloadIf);
-                    }
+                    payloadIf = factory.SequencePoint(payloadIf.Syntax, payloadIf);
 
                     ImmutableArray<BoundStatement> newStatements = newMethodBody.Statements.Insert(0, payloadIf);
                     newMethodBody = newMethodBody.Update(newMethodBody.Locals, newMethodBody.LocalFunctions, newStatements);

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1595,8 +1595,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (body != null)
                 {
-                        return body;
-                    }
+                    return body;
+                }
+
                 statements = ImmutableArray<BoundStatement>.Empty;
             }
             else if (body == null)
@@ -1629,7 +1630,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                         compilationState.ReportCtorInitializerCycles(method, ctorCall.Method, ctorCall.Syntax, diagnostics);
                     }
 
-                    var constructorInitializer = new BoundExpressionStatement(initializerInvocation.Syntax, initializerInvocation) { WasCompilerGenerated = true };
+                    //  Base WasCompilerGenerated state off of whether constructor is implicitly declared, this will ensure proper instrumentation.
+                    var constructorInitializer = new BoundExpressionStatement(initializerInvocation.Syntax, initializerInvocation) { WasCompilerGenerated = method.IsImplicitlyDeclared };
                     Debug.Assert(initializerInvocation.HasAnyErrors || constructorInitializer.IsConstructorInitializer(), "Please keep this bound node in sync with BoundNodeExtensions.IsConstructorInitializer.");
                     return constructorInitializer;
                 }

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -118,18 +118,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ? (BoundStatement)BoundYieldBreakStatement.Synthesized(syntax)
                 : BoundReturnStatement.Synthesized(syntax, RefKind.None, null);
 
-            // Implicitly added return for async method does not need sequence points since lowering would add one.
-            if (syntax.IsKind(SyntaxKind.Block) && !method.IsAsync)
-            {
-                var blockSyntax = (BlockSyntax)syntax;
-
-                ret = new BoundSequencePointWithSpan(
-                    blockSyntax,
-                    ret,
-                    blockSyntax.CloseBraceToken.Span)
-                { WasCompilerGenerated = true };
-            }
-
             return body.Update(body.Locals, body.LocalFunctions, body.Statements.Add(ret));
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/InitializerRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/InitializerRewriter.cs
@@ -87,7 +87,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var boundReceiver = fieldInit.Field.IsStatic ? null :
                                         new BoundThisReference(syntax, fieldInit.Field.ContainingType);
 
-            // Mark this as CompilerGenerated so that the local rewriter doesn't add a sequence point.
             BoundStatement boundStatement =
                 new BoundExpressionStatement(syntax,
                     new BoundAssignmentOperator(syntax,
@@ -98,26 +97,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         fieldInit.InitialValue,
                         fieldInit.Field.Type)
                     { WasCompilerGenerated = true })
-                { WasCompilerGenerated = true };
+                { WasCompilerGenerated = fieldInit.WasCompilerGenerated };
 
-            Debug.Assert(syntax is ExpressionSyntax); // Should be the initial value.
-            Debug.Assert(syntax.Parent.Kind() == SyntaxKind.EqualsValueClause);
-            switch (syntax.Parent.Parent.Kind())
-            {
-                case SyntaxKind.VariableDeclarator:
-                    var declaratorSyntax = (VariableDeclaratorSyntax)syntax.Parent.Parent;
-                    boundStatement = LocalRewriter.AddSequencePoint(declaratorSyntax, boundStatement);
-                    break;
-
-                case SyntaxKind.PropertyDeclaration:
-                    var declaration = (PropertyDeclarationSyntax)syntax.Parent.Parent;
-                    boundStatement = LocalRewriter.AddSequencePoint(declaration, boundStatement);
-                    break;
-
-                default:
-                    throw ExceptionUtilities.UnexpectedValue(syntax.Parent.Parent.Kind());
-            }
-
+            Debug.Assert(LocalRewriter.IsFieldOrPropertyInitializer(boundStatement)); 
             return boundStatement;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -5,6 +5,14 @@ using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
+    /// <summary>
+    /// Utility class, provides a convenient way of combining various <see cref="Instrumenter"/>s in a chain,
+    /// allowing each of them to apply specific instrumentations in particular order.
+    /// 
+    /// Default implementation of all APIs delegates to the "previous" <see cref="Instrumenter"/> passed as a parameter
+    /// to the constructor of this class. Usually, derived types are going to let the base (this class) to do its work first
+    /// and then operate on the result they get back.
+    /// </summary>
     internal class CompoundInstrumenter : Instrumenter
     {
         public CompoundInstrumenter(Instrumenter previous)
@@ -48,6 +56,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundStatement InstrumentExpressionStatement(BoundExpressionStatement original, BoundStatement rewritten)
         {
             return Previous.InstrumentExpressionStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentFieldOrPropertyInitializer(BoundExpressionStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentFieldOrPropertyInitializer(original, rewritten);
         }
 
         public override BoundStatement InstrumentBreakStatement(BoundBreakStatement original, BoundStatement rewritten)
@@ -173,6 +186,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
         {
             return Previous.InstrumentForEachStatementGotoContinue(original, gotoContinue);
+        }
+
+        public override BoundExpression InstrumentCatchClauseFilter(BoundCatchBlock original, BoundExpression rewrittenFilter, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentCatchClauseFilter(original, rewrittenFilter, factory);
+        }
+
+        public override BoundExpression InstrumentSwitchStatementExpression(BoundSwitchStatement original, BoundExpression rewrittenExpression, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentSwitchStatementExpression(original, rewrittenExpression, factory);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -1,0 +1,178 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal class CompoundInstrumenter : Instrumenter
+    {
+        public CompoundInstrumenter(Instrumenter previous)
+        {
+            Debug.Assert(previous != null);
+            Previous = previous;
+        }
+
+        public Instrumenter Previous { get; }
+
+        public override BoundStatement InstrumentNoOpStatement(BoundNoOpStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentNoOpStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentYieldBreakStatement(BoundYieldBreakStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentYieldBreakStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentYieldReturnStatement(BoundYieldReturnStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentYieldReturnStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentThrowStatement(BoundThrowStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentThrowStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentContinueStatement(BoundContinueStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentContinueStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentGotoStatement(BoundGotoStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentGotoStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentExpressionStatement(BoundExpressionStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentExpressionStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentBreakStatement(BoundBreakStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentBreakStatement(original, rewritten);
+        }
+
+        public override BoundStatement CreateBlockPrologue(BoundBlock original)
+        {
+            return Previous.CreateBlockPrologue(original);
+        }
+
+        public override BoundStatement CreateBlockEpilogue(BoundBlock original)
+        {
+            return Previous.CreateBlockEpilogue(original);
+        }
+
+        public override BoundExpression InstrumentDoStatementCondition(BoundDoStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentDoStatementCondition(original, rewrittenCondition, factory);
+        }
+
+        public override BoundStatement InstrumentDoStatementConditionalGotoStart(BoundDoStatement original, BoundStatement ifConditionGotoStart)
+        {
+            return Previous.InstrumentDoStatementConditionalGotoStart(original, ifConditionGotoStart);
+        }
+
+        public override BoundStatement InstrumentForEachStatementCollectionVarDeclaration(BoundForEachStatement original, BoundStatement collectionVarDecl)
+        {
+            return Previous.InstrumentForEachStatementCollectionVarDeclaration(original, collectionVarDecl);
+        }
+
+        public override BoundStatement InstrumentForEachStatement(BoundForEachStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentForEachStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentForEachStatementIterationVarDeclaration(BoundForEachStatement original, BoundStatement iterationVarDecl)
+        {
+            return Previous.InstrumentForEachStatementIterationVarDeclaration(original, iterationVarDecl);
+        }
+
+        public override BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
+        {
+            return Previous.InstrumentForStatementGotoEnd(original, gotoEnd);
+        }
+
+        public override BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
+        {
+            return Previous.InstrumentForEachStatementGotoEnd(original, gotoEnd);
+        }
+
+        public override BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
+        {
+            return Previous.InstrumentForStatementConditionalGotoStart(original, branchBack);
+        }
+
+        public override BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)
+        {
+            return Previous.InstrumentForEachStatementConditionalGotoStart(original, branchBack);
+        }
+
+        public override BoundExpression InstrumentForStatementCondition(BoundForStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentForStatementCondition(original, rewrittenCondition, factory);
+        }
+
+        public override BoundStatement InstrumentIfStatement(BoundIfStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentIfStatement(original, rewritten);
+        }
+
+        public override BoundExpression InstrumentIfStatementCondition(BoundIfStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentIfStatementCondition(original, rewrittenCondition, factory);
+        }
+
+        public override BoundStatement InstrumentLabelStatement(BoundLabeledStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentLabelStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentLocalInitialization(BoundLocalDeclaration original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentLocalInitialization(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentLockTargetCapture(BoundLockStatement original, BoundStatement lockTargetCapture)
+        {
+            return Previous.InstrumentLockTargetCapture(original, lockTargetCapture);
+        }
+
+        public override BoundStatement InstrumentReturnStatement(BoundReturnStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentReturnStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
+        {
+            return Previous.InstrumentSwitchStatement(original, rewritten);
+        }
+
+        public override BoundStatement InstrumentUsingTargetCapture(BoundUsingStatement original, BoundStatement usingTargetCapture)
+        {
+            return Previous.InstrumentUsingTargetCapture(original, usingTargetCapture);
+        }
+
+        public override BoundExpression InstrumentWhileStatementCondition(BoundWhileStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            return Previous.InstrumentWhileStatementCondition(original, rewrittenCondition, factory);
+        }
+
+        public override BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        {
+            return Previous.InstrumentWhileStatementConditionalGotoStart(original, ifConditionGotoStart);
+        }
+
+        public override BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
+        {
+            return Previous.InstrumentWhileStatementGotoContinue(original, gotoContinue);
+        }
+
+        public override BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
+        {
+            return Previous.InstrumentForEachStatementGotoContinue(original, gotoContinue);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -1,0 +1,322 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal class DebugInfoInjector : CompoundInstrumenter
+    {
+        public static readonly DebugInfoInjector Singleton = new DebugInfoInjector(Instrumenter.NoOp);
+
+        public DebugInfoInjector(Instrumenter previous)
+            : base (previous)
+        {
+        }
+
+        private BoundStatement AddSequencePoint(BoundStatement node)
+        {
+            return new BoundSequencePoint(node.Syntax, node);
+        }
+
+        public override BoundStatement InstrumentNoOpStatement(BoundNoOpStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentNoOpStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentBreakStatement(BoundBreakStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentBreakStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentContinueStatement(BoundContinueStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentContinueStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentExpressionStatement(BoundExpressionStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentExpressionStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentGotoStatement(BoundGotoStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentGotoStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentThrowStatement(BoundThrowStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentThrowStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentYieldBreakStatement(BoundYieldBreakStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentYieldBreakStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentYieldReturnStatement(BoundYieldReturnStatement original, BoundStatement rewritten)
+        {
+            return AddSequencePoint(base.InstrumentYieldReturnStatement(original, rewritten));
+        }
+
+        public override BoundStatement CreateBlockPrologue(BoundBlock original)
+        {
+            var oBspan = ((BlockSyntax)original.Syntax).OpenBraceToken.Span;
+            return new BoundSequencePointWithSpan(original.Syntax, base.CreateBlockPrologue(original), oBspan);
+        }
+
+        public override BoundStatement CreateBlockEpilogue(BoundBlock original)
+        {
+            var previous = base.CreateBlockEpilogue(original);
+
+            // no need to mark "}" on the outermost block
+            // as it cannot leave it normally. The block will have "return" at the end.
+            CSharpSyntaxNode parent = original.Syntax.Parent;
+            if (parent == null || !(parent.IsAnonymousFunction() || parent is BaseMethodDeclarationSyntax))
+            {
+                var cBspan = ((BlockSyntax)original.Syntax).CloseBraceToken.Span;
+                return new BoundSequencePointWithSpan(original.Syntax, previous, cBspan);
+            }
+
+            return previous;
+        }
+
+        public override BoundExpression InstrumentDoStatementCondition(BoundDoStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            // EnC: We need to insert a hidden sequence point to handle function remapping in case 
+            // the containing method is edited while methods invoked in the condition are being executed.
+            return AddConditionSequencePoint(base.InstrumentDoStatementCondition(original, rewrittenCondition, factory), original.Syntax, factory);
+        }
+
+        public override BoundExpression InstrumentWhileStatementCondition(BoundWhileStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            // EnC: We need to insert a hidden sequence point to handle function remapping in case 
+            // the containing method is edited while methods invoked in the condition are being executed.
+            return AddConditionSequencePoint(base.InstrumentWhileStatementCondition(original, rewrittenCondition, factory), original.Syntax, factory);
+        }
+
+        public override BoundStatement InstrumentDoStatementConditionalGotoStart(BoundDoStatement original, BoundStatement ifConditionGotoStart)
+        {
+            var doSyntax = (DoStatementSyntax)original.Syntax;
+            var span = TextSpan.FromBounds(
+                doSyntax.WhileKeyword.SpanStart,
+                doSyntax.SemicolonToken.Span.End);
+
+            return new BoundSequencePointWithSpan(doSyntax, base.InstrumentDoStatementConditionalGotoStart(original, ifConditionGotoStart), span);
+        }
+
+        public override BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        {
+            WhileStatementSyntax whileSyntax = (WhileStatementSyntax)original.Syntax;
+            TextSpan conditionSequencePointSpan = TextSpan.FromBounds(
+                whileSyntax.WhileKeyword.SpanStart,
+                whileSyntax.CloseParenToken.Span.End);
+
+            return new BoundSequencePointWithSpan(whileSyntax, base.InstrumentWhileStatementConditionalGotoStart(original, ifConditionGotoStart), conditionSequencePointSpan);
+        }
+
+        private static BoundExpression AddConditionSequencePoint(BoundExpression condition, BoundStatement containingStatement, SyntheticBoundNodeFactory factory)
+        {
+            return AddConditionSequencePoint(condition, containingStatement.Syntax, factory);
+        }
+
+        private static BoundExpression AddConditionSequencePoint(BoundExpression condition, SyntaxNode synthesizedVariableSyntax, SyntheticBoundNodeFactory factory)
+        {
+            if (!factory.Compilation.Options.EnableEditAndContinue)
+            {
+                return condition;
+            }
+
+            // The local has to be associated with a syntax that is tracked by EnC source mapping.
+            // At most one ConditionalBranchDiscriminator variable shall be associated with any given EnC tracked syntax node.
+            var local = factory.SynthesizedLocal(condition.Type, synthesizedVariableSyntax, kind: SynthesizedLocalKind.ConditionalBranchDiscriminator);
+
+            // Add hidden sequence point unless the condition is a constant expression.
+            // Constant expression must stay a const to not invalidate results of control flow analysis.
+            var valueExpression = (condition.ConstantValue == null) ?
+                new BoundSequencePointExpression(syntax: null, expression: factory.Local(local), type: condition.Type) :
+                condition;
+
+            return new BoundSequence(
+                condition.Syntax,
+                ImmutableArray.Create(local),
+                ImmutableArray.Create<BoundExpression>(factory.AssignmentExpression(factory.Local(local), condition)),
+                valueExpression,
+                condition.Type);
+        }
+
+        /// <summary>
+        /// Add sequence point |here|:
+        /// 
+        /// foreach (Type var in |expr|) { }
+        /// </summary>
+        /// <remarks>
+        /// Hit once, before looping begins.
+        /// </remarks>
+        public override BoundStatement InstrumentForEachStatementCollectionVarDeclaration(BoundForEachStatement original, BoundStatement collectionVarDecl)
+        {
+            // NOTE: This is slightly different from Dev10.  In Dev10, when you stop the debugger
+            // on the collection expression, you can see the (uninitialized) iteration variable.
+            // In Roslyn, you cannot because the iteration variable is re-declared in each iteration
+            // of the loop and is, therefore, not yet in scope.
+            return new BoundSequencePoint(((ForEachStatementSyntax)original.Syntax).Expression,
+                                          base.InstrumentForEachStatementCollectionVarDeclaration(original, collectionVarDecl));
+        }
+
+        /// <summary>
+        /// Add sequence point |here|:
+        /// 
+        /// |foreach| (Type var in expr) { }
+        /// </summary>
+        /// <remarks>
+        /// Hit once, before looping begins.
+        /// </remarks>
+        public override BoundStatement InstrumentForEachStatement(BoundForEachStatement original, BoundStatement rewritten)
+        {
+            var forEachSyntax = (ForEachStatementSyntax)original.Syntax;
+            BoundSequencePointWithSpan foreachKeywordSequencePoint = new BoundSequencePointWithSpan(forEachSyntax, null, forEachSyntax.ForEachKeyword.Span);
+            return new BoundStatementList(forEachSyntax, 
+                                            ImmutableArray.Create<BoundStatement>(foreachKeywordSequencePoint,
+                                                                                base.InstrumentForEachStatement(original, rewritten)));
+        }
+
+        /// <summary>
+        /// Add sequence point |here|:
+        /// 
+        /// foreach (|Type var| in expr) { }
+        /// </summary>
+        /// <remarks>
+        /// Hit every iteration.
+        /// </remarks>
+        public override BoundStatement InstrumentForEachStatementIterationVarDeclaration(BoundForEachStatement original, BoundStatement iterationVarDecl)
+        {
+            var forEachSyntax = (ForEachStatementSyntax)original.Syntax;
+            TextSpan iterationVarDeclSpan = TextSpan.FromBounds(forEachSyntax.Type.SpanStart, forEachSyntax.Identifier.Span.End);
+            return new BoundSequencePointWithSpan(forEachSyntax, 
+                                                  base.InstrumentForEachStatementIterationVarDeclaration(original, iterationVarDecl), 
+                                                  iterationVarDeclSpan);
+        }
+
+        public override BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
+        {
+            return ForStatementCreateGotoEndSequencePoint(base.InstrumentForEachStatementGotoEnd(original, gotoEnd));
+        }
+
+        public override BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
+        {
+            return ForStatementCreateGotoEndSequencePoint(base.InstrumentForStatementGotoEnd(original, gotoEnd));
+        }
+
+        private static BoundStatement ForStatementCreateGotoEndSequencePoint(BoundStatement gotoEnd)
+        {
+            // Mark the initial jump as hidden.
+            // We do it to tell that this is not a part of previous statement.
+            // This jump may be a target of another jump (for example if loops are nested) and that will make 
+            // impression of the previous statement being re-executed
+            return new BoundSequencePoint(null, gotoEnd);
+        }
+
+        public override BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
+        {
+            // hidden sequence point if there is no condition
+            return new BoundSequencePoint(original.Condition?.Syntax, 
+                                          base.InstrumentForStatementConditionalGotoStart(original, branchBack));
+        }
+
+        public override BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)
+        {
+            var syntax = (ForEachStatementSyntax)original.Syntax;
+            return new BoundSequencePointWithSpan(syntax, 
+                                                  base.InstrumentForEachStatementConditionalGotoStart(original, branchBack),
+                                                  syntax.InKeyword.Span);
+        }
+
+        public override BoundExpression InstrumentForStatementCondition(BoundForStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            // EnC: We need to insert a hidden sequence point to handle function remapping in case 
+            // the containing method is edited while methods invoked in the condition are being executed.
+            return AddConditionSequencePoint(base.InstrumentForStatementCondition(original, rewrittenCondition, factory), original.Syntax, factory);
+        }
+
+        public override BoundStatement InstrumentIfStatement(BoundIfStatement original, BoundStatement rewritten)
+        {
+            var syntax = (IfStatementSyntax)original.Syntax;
+            return new BoundSequencePointWithSpan(
+                syntax,
+                base.InstrumentIfStatement(original, rewritten),
+                TextSpan.FromBounds(
+                    syntax.IfKeyword.SpanStart,
+                    syntax.CloseParenToken.Span.End),
+                original.HasErrors);
+        }
+
+        public override BoundExpression InstrumentIfStatementCondition(BoundIfStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            // EnC: We need to insert a hidden sequence point to handle function remapping in case 
+            // the containing method is edited while methods invoked in the condition are being executed.
+            return AddConditionSequencePoint(base.InstrumentIfStatementCondition(original, rewrittenCondition, factory), original.Syntax, factory);
+        }
+
+        public override BoundStatement InstrumentLabelStatement(BoundLabeledStatement original, BoundStatement rewritten)
+        {
+            var labeledSyntax = (LabeledStatementSyntax)original.Syntax;
+            var span = TextSpan.FromBounds(labeledSyntax.Identifier.SpanStart, labeledSyntax.ColonToken.Span.End);
+            return new BoundSequencePointWithSpan(labeledSyntax,
+                                                  base.InstrumentLabelStatement(original, rewritten), 
+                                                  span);
+        }
+
+        public override BoundStatement InstrumentLocalInitialization(BoundLocalDeclaration original, BoundStatement rewritten)
+        {
+            return LocalRewriter.AddSequencePoint(original.Syntax.Kind() == SyntaxKind.VariableDeclarator ?
+                                        (VariableDeclaratorSyntax)original.Syntax :
+                                        ((LocalDeclarationStatementSyntax)original.Syntax).Declaration.Variables.First(), 
+                                    base.InstrumentLocalInitialization(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentLockTargetCapture(BoundLockStatement original, BoundStatement lockTargetCapture)
+        {
+            LockStatementSyntax lockSyntax = (LockStatementSyntax)original.Syntax;
+            return new BoundSequencePointWithSpan(lockSyntax,
+                                                  base.InstrumentLockTargetCapture(original, lockTargetCapture), 
+                                                  TextSpan.FromBounds(lockSyntax.LockKeyword.SpanStart, lockSyntax.CloseParenToken.Span.End));
+        }
+
+        public override BoundStatement InstrumentReturnStatement(BoundReturnStatement original, BoundStatement rewritten)
+        {
+            return new BoundSequencePoint(original.Syntax,
+                                          base.InstrumentReturnStatement(original, rewritten));
+        }
+
+        public override BoundStatement InstrumentSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
+        {
+            SwitchStatementSyntax switchSyntax = (SwitchStatementSyntax)original.Syntax;
+            TextSpan switchSequencePointSpan = TextSpan.FromBounds(
+                switchSyntax.SwitchKeyword.SpanStart,
+                switchSyntax.CloseParenToken.Span.End);
+
+            return new BoundSequencePointWithSpan(
+                syntax: switchSyntax,
+                statementOpt: base.InstrumentSwitchStatement(original, rewritten),
+                span: switchSequencePointSpan,
+                hasErrors: false);
+        }
+
+        public override BoundStatement InstrumentUsingTargetCapture(BoundUsingStatement original, BoundStatement usingTargetCapture)
+        {
+            return LocalRewriter.AddSequencePoint((UsingStatementSyntax)original.Syntax, 
+                                    base.InstrumentUsingTargetCapture(original, usingTargetCapture));
+        }
+
+        public override BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
+        {
+            return new BoundSequencePoint(null, base.InstrumentForEachStatementGotoContinue(original, gotoContinue));
+        }
+
+        public override BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
+        {
+            return new BoundSequencePoint(null, base.InstrumentWhileStatementGotoContinue(original, gotoContinue));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -11,6 +11,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// This type is responsible for adding debugging sequence points for the executable code.
     /// It can be combined with other <see cref="Instrumenter"/>s. Usually, this class should be 
     /// the root of the chain in order to ensure sound debugging experience for the instrumented code.
+    /// In other words, sequence points are typically applied after all other changes.
     /// </summary>
     internal partial class DebugInfoInjector : CompoundInstrumenter
     {

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Diagnostics;
+using System;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal class Instrumenter
+    {
+        public static readonly Instrumenter NoOp = new Instrumenter();
+
+        public Instrumenter()
+        {
+        }
+
+        private static BoundStatement InstrumentStatement(BoundStatement original, BoundStatement rewritten)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            return rewritten;
+        }
+
+        public virtual BoundStatement InstrumentNoOpStatement(BoundNoOpStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+
+        public virtual BoundStatement InstrumentYieldBreakStatement(BoundYieldBreakStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentYieldReturnStatement(BoundYieldReturnStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        /// <summary>
+        /// Return a node that is associated with open brace of the block. Ok to return null.
+        /// </summary>
+        public virtual BoundStatement CreateBlockPrologue(BoundBlock original)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.Block);
+            return null;
+        }
+
+        /// <summary>
+        /// Return a node that is associated with close brace of the block. Ok to return null.
+        /// </summary>
+        public virtual BoundStatement CreateBlockEpilogue(BoundBlock original)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.Block);
+            return null;
+        }
+
+        public virtual BoundStatement InstrumentThrowStatement(BoundThrowStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentContinueStatement(BoundContinueStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentGotoStatement(BoundGotoStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentExpressionStatement(BoundExpressionStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentBreakStatement(BoundBreakStatement original, BoundStatement rewritten)
+        {
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundExpression InstrumentDoStatementCondition(BoundDoStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.DoStatement);
+            Debug.Assert(factory != null);
+            return rewrittenCondition;
+        }
+
+        public virtual BoundExpression InstrumentWhileStatementCondition(BoundWhileStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.WhileStatement);
+            Debug.Assert(factory != null);
+            return rewrittenCondition;
+        }
+
+        public virtual BoundStatement InstrumentDoStatementConditionalGotoStart(BoundDoStatement original, BoundStatement ifConditionGotoStart)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.DoStatement);
+            return ifConditionGotoStart; 
+        }
+
+        public virtual BoundStatement InstrumentWhileStatementConditionalGotoStart(BoundWhileStatement original, BoundStatement ifConditionGotoStart)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.WhileStatement);
+            return ifConditionGotoStart;
+        }
+
+        public virtual BoundStatement InstrumentForEachStatementCollectionVarDeclaration(BoundForEachStatement original, BoundStatement collectionVarDecl)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return collectionVarDecl;
+        }
+
+        public virtual BoundStatement InstrumentForEachStatement(BoundForEachStatement original, BoundStatement rewritten)
+        {
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentForEachStatementIterationVarDeclaration(BoundForEachStatement original, BoundStatement iterationVarDecl)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return iterationVarDecl;
+        }
+
+        public virtual BoundStatement InstrumentForStatementGotoEnd(BoundForStatement original, BoundStatement gotoEnd)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForStatement);
+            return gotoEnd;
+        }
+
+        public virtual BoundStatement InstrumentForEachStatementGotoEnd(BoundForEachStatement original, BoundStatement gotoEnd)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return gotoEnd;
+        }
+
+        public virtual BoundStatement InstrumentForEachStatementConditionalGotoStart(BoundForEachStatement original, BoundStatement branchBack)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return branchBack;
+        }
+
+        public virtual BoundStatement InstrumentForStatementConditionalGotoStart(BoundForStatement original, BoundStatement branchBack)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForStatement);
+            return branchBack;
+        }
+
+        public virtual BoundExpression InstrumentForStatementCondition(BoundForStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForStatement);
+            Debug.Assert(factory != null);
+            return rewrittenCondition;
+        }
+
+        public virtual BoundStatement InstrumentIfStatement(BoundIfStatement original, BoundStatement rewritten)
+        {
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.IfStatement);
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundExpression InstrumentIfStatementCondition(BoundIfStatement original, BoundExpression rewrittenCondition, SyntheticBoundNodeFactory factory)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.IfStatement);
+            Debug.Assert(factory != null);
+            return rewrittenCondition;
+        }
+
+        public virtual BoundStatement InstrumentLabelStatement(BoundLabeledStatement original, BoundStatement rewritten)
+        {
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.LabeledStatement);
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentLocalInitialization(BoundLocalDeclaration original, BoundStatement rewritten)
+        {
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.VariableDeclarator ||
+                         (original.Syntax.Kind() == SyntaxKind.LocalDeclarationStatement &&
+                                ((LocalDeclarationStatementSyntax)original.Syntax).Declaration.Variables.Count == 1));
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentLockTargetCapture(BoundLockStatement original, BoundStatement lockTargetCapture)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.LockStatement);
+            return lockTargetCapture;
+        }
+
+        public virtual BoundStatement InstrumentReturnStatement(BoundReturnStatement original, BoundStatement rewritten)
+        {
+            return rewritten;
+        }
+
+        public virtual BoundStatement InstrumentSwitchStatement(BoundSwitchStatement original, BoundStatement rewritten)
+        {
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.SwitchStatement);
+            return InstrumentStatement(original, rewritten);
+        }
+
+        public virtual BoundStatement InstrumentUsingTargetCapture(BoundUsingStatement original, BoundStatement usingTargetCapture)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.UsingStatement);
+            return usingTargetCapture;
+        }
+
+        public virtual BoundStatement InstrumentWhileStatementGotoContinue(BoundWhileStatement original, BoundStatement gotoContinue)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.WhileStatement);
+            return gotoContinue;
+        }
+
+        public virtual BoundStatement InstrumentForEachStatementGotoContinue(BoundForEachStatement original, BoundStatement gotoContinue)
+        {
+            Debug.Assert(!original.WasCompilerGenerated);
+            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            return gotoContinue;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -39,7 +39,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return InstrumentStatement(original, rewritten);
         }
 
-
         public virtual BoundStatement InstrumentYieldBreakStatement(BoundYieldBreakStatement original, BoundStatement rewritten)
         {
             Debug.Assert(!original.WasCompilerGenerated || original.Syntax.Kind() == SyntaxKind.Block);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BreakStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_BreakStatement.cs
@@ -10,8 +10,13 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitBreakStatement(BoundBreakStatement node)
         {
-            var result = new BoundGotoStatement(node.Syntax, node.Label, node.HasErrors);
-            return AddSequencePoint(result);
+            BoundStatement result = new BoundGotoStatement(node.Syntax, node.Label, node.HasErrors);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentBreakStatement(node, result);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ContinueStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ContinueStatement.cs
@@ -10,8 +10,13 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitContinueStatement(BoundContinueStatement node)
         {
-            var result = new BoundGotoStatement(node.Syntax, node.Label, node.HasErrors);
-            return AddSequencePoint(result);
+            BoundStatement result = new BoundGotoStatement(node.Syntax, node.Label, node.HasErrors);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentContinueStatement(node, result);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
@@ -22,7 +22,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                return AddSequencePoint(node.Update(loweredExpression));
+                BoundStatement result = node.Update(loweredExpression);
+                if (this.Instrument && !node.WasCompilerGenerated)
+                {
+                    result = _instrumenter.InstrumentExpressionStatement(node, result);
+                }
+
+                return result;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ExpressionStatement.cs
@@ -11,19 +11,23 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitExpressionStatement(BoundExpressionStatement node)
         {
-            var syntax = node.Syntax;
+            // NOTE: not using a BoundNoOpStatement, since we don't want a nop to be emitted.
+            // CONSIDER: could use a BoundNoOpStatement (DevDiv #12943).
+            return RewriteExpressionStatement(node) ?? BoundStatementList.Synthesized(node.Syntax);
+        }
+
+        private BoundStatement RewriteExpressionStatement(BoundExpressionStatement node, bool suppressInstrumentation = false)
+        {
             var loweredExpression = VisitUnusedExpression(node.Expression);
 
             if (loweredExpression == null)
             {
-                // NOTE: not using a BoundNoOpStatement, since we don't want a nop to be emitted.
-                // CONSIDER: could use a BoundNoOpStatement (DevDiv #12943).
-                return BoundStatementList.Synthesized(syntax);
+                return null;
             }
             else
             {
                 BoundStatement result = node.Update(loweredExpression);
-                if (this.Instrument && !node.WasCompilerGenerated)
+                if (!suppressInstrumentation && this.Instrument && !node.WasCompilerGenerated)
                 {
                     result = _instrumenter.InstrumentExpressionStatement(node, result);
                 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -199,25 +199,26 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (fixedInitializer.Expression.Type.SpecialType == SpecialType.System_String)
                 {
-                    return InitializeFixedStatementStringLocal(localSymbol, fixedInitializer, factory, out temp, out localToClear);
+                    return InitializeFixedStatementStringLocal(localDecl, localSymbol, fixedInitializer, factory, out temp, out localToClear);
                 }
                 else
                 {
                     Debug.Assert(fixedInitializer.Expression.Type.IsArray());
 
                     localToClear = localSymbol;
-                    return InitializeFixedStatementArrayLocal(localSymbol, fixedInitializer, factory, out temp);
+                    return InitializeFixedStatementArrayLocal(localDecl, localSymbol, fixedInitializer, factory, out temp);
                 }
             }
             else
             {
                 temp = null;
                 localToClear = localSymbol;
-                return RewriteLocalDeclaration(localDecl.Syntax, localSymbol, VisitExpression(initializer));
+                return RewriteLocalDeclaration(localDecl, localDecl.Syntax, localSymbol, VisitExpression(initializer));
             }
         }
 
         private BoundStatement InitializeFixedStatementStringLocal(
+            BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
             BoundFixedLocalCollectionInitializer fixedInitializer,
             SyntheticBoundNodeFactory factory,
@@ -245,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 factory.Local(stringTemp),
                 fixedInitializer.ElementPointerTypeConversion);
 
-            BoundStatement localInit = AddLocalDeclarationSequencePointIfNecessary(declarator, localSymbol,
+            BoundStatement localInit = AddLocalDeclarationSequencePointIfNecessary(localDecl, localSymbol,
                 factory.Assignment(factory.Local(localSymbol), convertedStringTemp));
 
             BoundExpression notNullCheck = MakeNullCheck(factory.Syntax, factory.Local(localSymbol), BinaryOperatorKind.NotEqual);
@@ -269,6 +270,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private BoundStatement InitializeFixedStatementArrayLocal(
+            BoundLocalDeclaration localDecl,
             LocalSymbol localSymbol,
             BoundFixedLocalCollectionInitializer fixedInitializer,
             SyntheticBoundNodeFactory factory,
@@ -347,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement localInit = factory.ExpressionStatement(
                 new BoundConditionalOperator(factory.Syntax, condition, consequenceAssignment, alternativeAssignment, ConstantValue.NotAvailable, localType));
 
-            return AddLocalDeclarationSequencePointIfNecessary(fixedInitializer.Syntax.Parent.Parent, localSymbol, localInit);
+            return AddLocalDeclarationSequencePointIfNecessary(localDecl, localSymbol, localInit);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_FixedStatement.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 factory.Local(stringTemp),
                 fixedInitializer.ElementPointerTypeConversion);
 
-            BoundStatement localInit = AddLocalDeclarationSequencePointIfNecessary(localDecl, localSymbol,
+            BoundStatement localInit = InstrumentLocalDeclarationIfNecessary(localDecl, localSymbol,
                 factory.Assignment(factory.Local(localSymbol), convertedStringTemp));
 
             BoundExpression notNullCheck = MakeNullCheck(factory.Syntax, factory.Local(localSymbol), BinaryOperatorKind.NotEqual);
@@ -349,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement localInit = factory.ExpressionStatement(
                 new BoundConditionalOperator(factory.Syntax, condition, consequenceAssignment, alternativeAssignment, ConstantValue.NotAvailable, localType));
 
-            return AddLocalDeclarationSequencePointIfNecessary(localDecl, localSymbol, localInit);
+            return InstrumentLocalDeclarationIfNecessary(localDecl, localSymbol, localInit);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_GotoStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_GotoStatement.cs
@@ -19,8 +19,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // for the emit phase. It is even doing harm to e.g. the stack depth calculation because this expression
             // would not need to be pushed to the stack.
             BoundLabel labelExpressionOpt = null;
+            BoundStatement result = node.Update(node.Label, caseExpressionOpt, labelExpressionOpt);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentGotoStatement(node, result);
+            }
 
-            return AddSequencePoint(node.Update(node.Label, caseExpressionOpt, labelExpressionOpt));
+            return result;
         }
 
         public override BoundNode VisitLabel(BoundLabel node)

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LabeledStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LabeledStatement.cs
@@ -17,13 +17,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             BoundStatement labelStatement = new BoundLabelStatement(node.Syntax, node.Label);
 
-            if (this.GenerateDebugInfo)
+            if (this.Instrument)
             {
                 var labeledSyntax = node.Syntax as LabeledStatementSyntax;
                 if (labeledSyntax != null)
                 {
-                    var span = TextSpan.FromBounds(labeledSyntax.Identifier.SpanStart, labeledSyntax.ColonToken.Span.End);
-                    labelStatement = _factory.SequencePointWithSpan(labeledSyntax, span, labelStatement);
+                    labelStatement = _instrumenter.InstrumentLabelStatement(node, labelStatement); 
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LocalDeclaration.cs
@@ -66,10 +66,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     localSymbol.RefKind),
                 hasErrors);
 
-            return AddLocalDeclarationSequencePointIfNecessary(originalOpt, localSymbol, rewrittenLocalDeclaration);
+            return InstrumentLocalDeclarationIfNecessary(originalOpt, localSymbol, rewrittenLocalDeclaration);
         }
 
-        private BoundStatement AddLocalDeclarationSequencePointIfNecessary(BoundLocalDeclaration originalOpt, LocalSymbol localSymbol, BoundStatement rewrittenLocalDeclaration)
+        private BoundStatement InstrumentLocalDeclarationIfNecessary(BoundLocalDeclaration originalOpt, LocalSymbol localSymbol, BoundStatement rewrittenLocalDeclaration)
         {
             // Add sequence points, if necessary.
             if (this.Instrument && originalOpt?.WasCompilerGenerated == false && !localSymbol.IsConst && 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_LockStatement.cs
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableArray.Create(boundLockTemp.LocalSymbol, boundLockTakenTemp.LocalSymbol),
                     ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create(
-                        MakeInitialLockSequencePoint(boundLockTempInit, lockSyntax),
+                        InstrumentLockTargetCapture(node, boundLockTempInit),
                         boundLockTakenTempInit,
                         new BoundTryStatement(
                             lockSyntax,
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableArray.Create(boundLockTemp.LocalSymbol),
                     ImmutableArray<LocalFunctionSymbol>.Empty,
                     ImmutableArray.Create(
-                        MakeInitialLockSequencePoint(boundLockTempInit, lockSyntax),
+                        InstrumentLockTargetCapture(node, boundLockTempInit),
                         enterCall,
                         new BoundTryStatement(
                             lockSyntax,
@@ -183,11 +183,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundStatement MakeInitialLockSequencePoint(BoundStatement statement, LockStatementSyntax lockSyntax)
+        private BoundStatement InstrumentLockTargetCapture(BoundLockStatement original, BoundStatement lockTargetCapture)
         {
-            return this.GenerateDebugInfo ?
-                new BoundSequencePointWithSpan(lockSyntax, statement, TextSpan.FromBounds(lockSyntax.LockKeyword.SpanStart, lockSyntax.CloseParenToken.Span.End)) :
-                statement;
+            return this.Instrument ?
+                _instrumenter.InstrumentLockTargetCapture(original, lockTargetCapture) :
+                lockTargetCapture;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
@@ -17,12 +17,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or if they are expression-bodied properties.
             // We do this to ensure that expression lambdas and expression-bodied
             // properties have sequence points.
-            if (this.GenerateDebugInfo &&
+            if (this.Instrument &&
                 (!rewritten.WasCompilerGenerated ||
                  (node.ExpressionOpt != null && IsLambdaOrExpressionBodiedMember)))
             {
-                // We're not calling AddSequencePoint since it ignores compiler-generated nodes.
-                return new BoundSequencePoint(rewritten.Syntax, rewritten);
+                rewritten = _instrumenter.InstrumentReturnStatement(node, rewritten);
             }
 
             return rewritten;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
@@ -17,9 +17,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             // or if they are expression-bodied properties.
             // We do this to ensure that expression lambdas and expression-bodied
             // properties have sequence points.
+            // We also add sequence points for the implicit "return" statement at the end of the method body
+            // (added by FlowAnalysisPass.AppendImplicitReturn). Implicitly added return for async method 
+            // does not need sequence points added here since it would be done later (presumably during Async rewrite).
             if (this.Instrument &&
-                (!rewritten.WasCompilerGenerated ||
-                 (node.ExpressionOpt != null && IsLambdaOrExpressionBodiedMember)))
+                (!node.WasCompilerGenerated ||
+                 (node.ExpressionOpt != null ? 
+                        IsLambdaOrExpressionBodiedMember :
+                        (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentMethod?.IsAsync == false))))
             {
                 rewritten = _instrumenter.InstrumentReturnStatement(node, rewritten);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
@@ -52,18 +52,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // Create the sequence point if generating debug info and
             // node is not compiler generated
-            if (this.GenerateDebugInfo && !node.WasCompilerGenerated)
+            if (this.Instrument && !node.WasCompilerGenerated)
             {
-                SwitchStatementSyntax switchSyntax = (SwitchStatementSyntax)syntax;
-                TextSpan switchSequencePointSpan = TextSpan.FromBounds(
-                    switchSyntax.SwitchKeyword.SpanStart,
-                    switchSyntax.CloseParenToken.Span.End);
-
-                return new BoundSequencePointWithSpan(
-                    syntax: syntax,
-                    statementOpt: rewrittenStatement,
-                    span: switchSequencePointSpan,
-                    hasErrors: false);
+                rewrittenStatement = _instrumenter.InstrumentSwitchStatement(node, rewrittenStatement);
             }
 
             return rewrittenStatement;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_SwitchStatement.cs
@@ -48,7 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // EnC: We need to insert a hidden sequence point to handle function remapping in case 
             // the containing method is edited while methods invoked in the expression are being executed.
-            var rewrittenStatement = MakeSwitchStatement(syntax, AddConditionSequencePoint(rewrittenExpression, node), rewrittenSections, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, node.BreakLabel, node);
+            if (!node.WasCompilerGenerated && this.Instrument)
+            {
+                rewrittenExpression = _instrumenter.InstrumentSwitchStatementExpression(node, rewrittenExpression, _factory);
+            }
+
+            var rewrittenStatement = MakeSwitchStatement(syntax, rewrittenExpression, rewrittenSections, node.ConstantTargetOpt, node.InnerLocals, node.InnerLocalFunctions, node.BreakLabel, node);
 
             // Create the sequence point if generating debug info and
             // node is not compiler generated

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ThrowStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ThrowStatement.cs
@@ -10,7 +10,13 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitThrowStatement(BoundThrowStatement node)
         {
-            return AddSequencePoint((BoundStatement)base.VisitThrowStatement(node));
+            var result = (BoundStatement)base.VisitThrowStatement(node);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentThrowStatement(node, result);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TryStatement.cs
@@ -86,11 +86,16 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // EnC: We need to insert a hidden sequence point to handle function remapping in case 
             // the containing method is edited while methods invoked in the condition are being executed.
+            if (rewrittenFilter != null && !node.WasCompilerGenerated && this.Instrument)
+            {
+                rewrittenFilter = _instrumenter.InstrumentCatchClauseFilter(node, rewrittenFilter, _factory);
+            }
+
             return node.Update(
                 node.LocalOpt,
                 rewrittenExceptionSourceOpt,
                 rewrittenExceptionTypeOpt,
-                AddConditionSequencePoint(rewrittenFilter, node),
+                rewrittenFilter,
                 rewrittenBody,
                 node.IsSynthesizedAsyncCatchAll);
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_UsingStatement.cs
@@ -131,9 +131,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             BoundStatement expressionStatement = new BoundExpressionStatement(expressionSyntax, tempAssignment);
-            if (this.GenerateDebugInfo)
+            if (this.Instrument)
             {
-                expressionStatement = AddSequencePoint(usingSyntax, expressionStatement);
+                expressionStatement = _instrumenter.InstrumentUsingTargetCapture(node, expressionStatement);
             }
 
             BoundStatement tryFinally = RewriteUsingStatementTryFinally(usingSyntax, tryBlock, boundTemp);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
@@ -10,12 +10,24 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitYieldBreakStatement(BoundYieldBreakStatement node)
         {
-            return AddSequencePoint((BoundStatement)base.VisitYieldBreakStatement(node));
+            var result = (BoundStatement)base.VisitYieldBreakStatement(node);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentYieldBreakStatement(node, result);
+            }
+
+            return result;
         }
 
         public override BoundNode VisitYieldReturnStatement(BoundYieldReturnStatement node)
         {
-            return AddSequencePoint((BoundStatement)base.VisitYieldReturnStatement(node));
+            var result = (BoundStatement)base.VisitYieldReturnStatement(node);
+            if (this.Instrument && !node.WasCompilerGenerated)
+            {
+                result = _instrumenter.InstrumentYieldReturnStatement(node, result);
+            }
+
+            return result;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Yield.cs
@@ -11,7 +11,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitYieldBreakStatement(BoundYieldBreakStatement node)
         {
             var result = (BoundStatement)base.VisitYieldBreakStatement(node);
-            if (this.Instrument && !node.WasCompilerGenerated)
+
+            // We also add sequence points for the implicit "yield break" statement at the end of the method body
+            // (added by FlowAnalysisPass.AppendImplicitReturn). Implicitly added "yield break" for async method 
+            // does not need sequence points added here since it would be done later (presumably during Async rewrite).
+            if (this.Instrument && 
+                (!node.WasCompilerGenerated || (node.Syntax.Kind() == SyntaxKind.Block && _factory.CurrentMethod?.IsAsync == false)))
             {
                 result = _instrumenter.InstrumentYieldBreakStatement(node, result);
             }

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -254,6 +254,7 @@ Hello
 Flushing
 1
 True
+True
 2
 False
 True

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBLambdaTests.cs
@@ -543,6 +543,7 @@ class C : B
       </customDebugInfo>
       <sequencePoints>
         <entry offset=""0x0"" hidden=""true"" />
+        <entry offset=""0x14"" startLine=""13"" startColumn=""30"" endLine=""13"" endColumn=""43"" />
         <entry offset=""0x27"" hidden=""true"" />
         <entry offset=""0x2d"" startLine=""14"" startColumn=""5"" endLine=""14"" endColumn=""6"" />
         <entry offset=""0x2e"" startLine=""15"" startColumn=""9"" endLine=""15"" endColumn=""19"" />

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DynamicTests.cs
@@ -3186,7 +3186,6 @@ class C
                                     //-thisReference: C
                                     //-fieldAccess: dynamic
                                     //-unaryOperator: bool
-                                    //-sequencePointExpression: bool
         {
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -5333,7 +5333,10 @@ class Program
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
     // (11,25): warning CS7095: Filter expression is a constant, consider removing the filter
     //         catch (A) when (false) 
-    Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(11, 25)
+    Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(11, 25),
+    // (13,13): warning CS0162: Unreachable code detected
+    //             Console.WriteLine(1); 
+    Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(13, 13)
                 );
         }
 
@@ -5364,6 +5367,39 @@ class Program
     // (10,33): warning CS7095: Filter expression is a constant, consider removing the filter
     //         catch (Exception) when (false) 
     Diagnostic(ErrorCode.WRN_FilterIsConstant, "false").WithLocation(10, 33),
+    // (12,13): warning CS0162: Unreachable code detected
+    //             Console.WriteLine(x);
+    Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(12, 13)
+                );
+        }
+
+        [Fact]
+        public void CS0162WRN_UnreachableCode_Filter_ConstantCondition3()
+        {
+            var text = @"
+using System;
+
+class Program
+{
+    static void M()
+    {
+        int x;
+        try { }
+        catch (Exception) when (true) 
+        {
+            Console.WriteLine(x);
+        }
+    }
+}
+";
+            // Unlike an unreachable code in if statement block we don't allow using
+            // a variable that's not definitely assigned. The reason why we allow it in an if statement
+            // is to make conditional compilation easier. Such scenario doesn't apply to filters.
+
+            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+    // (10,33): warning CS7095: Filter expression is a constant, consider removing the filter
+    //         catch (Exception) when (true) 
+    Diagnostic(ErrorCode.WRN_FilterIsConstant, "true").WithLocation(10, 33),
     // (12,31): error CS0165: Use of unassigned local variable 'x'
     //             Console.WriteLine(x);
     Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(12, 31)

--- a/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
+++ b/src/Compilers/Core/SharedCollections/ArrayBuilder.cs
@@ -75,6 +75,10 @@ namespace Microsoft.CodeAnalysis
             {
                 return _builder.Count;
             }
+            set
+            {
+                _builder.Count = value;
+            }
         }
 
         public T this[int index]


### PR DESCRIPTION
Move sequence point injection from LocalRewriter to the instrumentation component.
Related to #9819.

Note, I haven't got rid of all places where LocalRewriter deals with sequence points yet. 

@JohnHamby, @dotnet/roslyn-compiler Please take a look. 