### PR TITLE
Bail in GetDependenceChain if typesymbol isn't found

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -2103,6 +2103,19 @@ class C
 
         [Fact()]
         [WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")]
+        public void GetDependenceChainRegression_10211_working()
+        {
+            var compilation = CreateCompilation(@"
+class Parent {}
+class Child : Parent {}
+");
+            var semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees[0]);
+            // Ensure that we don't crash here.
+            semanticModel.GetMethodBodyDiagnostics();
+        }
+
+        [Fact()]
+        [WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")]
         public void GetDependenceChainRegression_10211()
         {
             var compilation = CreateCompilation(@"
@@ -2110,6 +2123,7 @@ class Child : Parent {}
 class Parent {}
 ");
             var semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees[0]);
+            // Ensure that we don't crash here.
             semanticModel.GetMethodBodyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -2101,6 +2101,18 @@ class C
             VerifySpeculativeSemanticModelForMethodBody(blockStatement, speculativeModel);
         }
 
+        [Fact()]
+        [WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")]
+        public void GetDependenceChainRegression_10211()
+        {
+            var compilation = CreateCompilation(@"
+class Child : Parent {}
+class Parent {}
+");
+            var semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees[0]);
+            semanticModel.GetMethodBodyDiagnostics();
+        }
+
         private static void VerifySpeculativeSemanticModelForMethodBody(BlockSyntax blockStatement, SemanticModel speculativeModel)
         {
             var localDecl = (LocalDeclarationStatementSyntax)blockStatement.Statements[0];

--- a/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
@@ -187,10 +187,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private Function GetDependenceChain(visited As HashSet(Of Symbol),
                                                root As SourceNamedTypeSymbol,
                                                current As TypeSymbol) As ConsList(Of DependencyDesc)
-
             Debug.Assert(root.OriginalDefinition = root, "root must not be a substitution")
 
-            If current Is Nothing Then
+            If current Is Nothing Or current.Kind = SymbolKind.ErrorType Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/BaseTypeAnalysis.vb
@@ -189,7 +189,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                current As TypeSymbol) As ConsList(Of DependencyDesc)
             Debug.Assert(root.OriginalDefinition = root, "root must not be a substitution")
 
-            If current Is Nothing Or current.Kind = SymbolKind.ErrorType Then
+            If current Is Nothing OrElse current.Kind = SymbolKind.ErrorType Then
                 Return Nothing
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -2230,8 +2230,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return True
             End If
 
+            ' We can not get the relative order of a declaration without a source location
+            If typeToTest.Locations.IsEmpty Then
+                Return True
+            End If
+
             ' We use simple comparison based on source location 
-            Debug.Assert(typeToTest.Locations.Length > 0)
             Dim typeToTestLocation = typeToTest.Locations(0)
 
             Debug.Assert(Me.Locations.Length > 0)

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -4061,6 +4061,25 @@ End Class
             Assert.Equal(2, treeErrs.Length())
         End Sub
 
+        <Fact()>
+        <WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")>
+        Public Sub GetDependenceChainRegression_10211()
+            Dim source = <compilation>
+                             <file name="a.vb"><![CDATA[
+                                Public Class Child
+                                    Inherits Parent
+                                End Class
+
+                                Public Class Parent
+                                End Class
+                            ]]></file>
+                         </compilation>
+
+            Dim compilation = CreateCompilationWithoutReferences(source)
+            Dim semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees(0))
+            Dim diagnostics = semanticModel.GetMethodBodyDiagnostics()
+        End Sub
+
         <WorkItem(859721, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/859721")>
         <Fact()>
         Public Sub TestMethodBodyDiagnostics()

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -4063,6 +4063,27 @@ End Class
 
         <Fact()>
         <WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")>
+        Public Sub GetDependenceChainRegression_10211_working()
+            Dim source = <compilation>
+                             <file name="a.vb"><![CDATA[
+                                Public Class Parent
+                                End Class
+
+                                Public Class Child
+                                    Inherits Parent
+                                End Class
+                            ]]></file>
+                         </compilation>
+
+            Dim compilation = CreateCompilationWithoutReferences(source)
+            Dim semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees(0))
+
+            ' Ensuring that this doesn't throw
+            semanticModel.GetMethodBodyDiagnostics()
+        End Sub
+
+        <Fact()>
+        <WorkItem(10211, "https://github.com/dotnet/roslyn/issues/10211")>
         Public Sub GetDependenceChainRegression_10211()
             Dim source = <compilation>
                              <file name="a.vb"><![CDATA[

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelAPITests.vb
@@ -4077,7 +4077,9 @@ End Class
 
             Dim compilation = CreateCompilationWithoutReferences(source)
             Dim semanticModel = compilation.GetSemanticModel(compilation.SyntaxTrees(0))
-            Dim diagnostics = semanticModel.GetMethodBodyDiagnostics()
+
+            ' Ensuring that this doesn't throw
+            semanticModel.GetMethodBodyDiagnostics()
         End Sub
 
         <WorkItem(859721, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/859721")>


### PR DESCRIPTION
closes #10211

Very simple change, please review @dotnet/roslyn-compiler.

Also I'd like advice on how to add unit tests that cover this.