### PR TITLE
Repair dynamic analysis instrumentation for using and fixed statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -209,17 +209,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return visited;
                             }
 
+                            // A statement that represents the declarations in a using or fixed statement should not be treated as a separate statement.
                             switch (declarationSyntax.Parent.Kind())
                             {
                                 case SyntaxKind.UsingStatement:
+                                    if (declarationSyntax == ((UsingStatementSyntax)declarationSyntax.Parent).Declaration)
+                                    {
+                                        return visited;
+                                    }
+                                    break;
                                 case SyntaxKind.FixedStatement:
-                                    // Using and Fixed statements include a MultipleLocalDeclarations node even when they contain only one declaration,
-                                    // so this declaration should not be treated as a separate statement.
-                                    return visited;
+                                    if (declarationSyntax == ((FixedStatementSyntax)declarationSyntax.Parent).Declaration)
+                                    {
+                                        return visited;
+                                    }
+                                    break;
                             }
                         }
                         break;
                     case BoundKind.MultipleLocalDeclarations:
+                        // Using and fixed statements have a multiple local declarations node even if they contain only one declaration.
                         switch (statement.Syntax.Parent.Kind())
                         {
                             case SyntaxKind.UsingStatement:

--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -168,6 +168,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundStatement statement = node as BoundStatement;
             if (statement != null)
             {
+                // The default behavior is to instrument a statement unless it is compiler generated.
+                // Filter out statements that are not to be instrumented, and force instrumentation of some compiler-generated statements.
                 switch (statement.Kind)
                 {
                     case BoundKind.SwitchSection:

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -307,6 +307,61 @@ True
         }
 
         [Fact]
+        public void UsingAndFixedCoverage()
+        {
+            string source = @"
+using System;
+using System.IO;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        TestMain();
+    }
+
+    static void TestMain()
+    {
+        using (var memoryStream = new MemoryStream())
+        {
+            ;
+        }
+
+        var otherStream = new MemoryStream();
+        using (otherStream)
+        {
+            ;
+        }
+
+        unsafe
+        {
+            double[] a = { 1, 2, 3 };
+            fixed(double* p = a)
+            {
+                ;
+            }
+        }
+    }
+}
+";
+            string expectedOutput = @"Flushing
+1
+True
+2
+True
+True
+True
+True
+True
+True
+True
+True
+";
+           
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.UnsafeDebugExe,  emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+        }
+
+        [Fact]
         public void ManyStatementsCoverage()
         {
             string source = @"
@@ -580,9 +635,9 @@ True
             CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
-        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null)
+        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)
         {
-            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_asyncRefs, emitOptions: emitOptions);
+            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_asyncRefs, options: options, emitOptions: emitOptions);
         }
 
         private static readonly MetadataReference[] s_asyncRefs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -271,6 +271,7 @@ public class Program
         int c = x;
         int a, b;
         int f;
+
         a = b = f = c;
         int d = a, e = b;
         return d + e + f;

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -327,6 +327,11 @@ public class Program
             ;
         }
 
+        using (MemoryStream s1 = new MemoryStream(), s2 = new MemoryStream())
+        {
+            ;
+        }
+
         var otherStream = new MemoryStream();
         using (otherStream)
         {
@@ -340,6 +345,10 @@ public class Program
             {
                 ;
             }
+            fixed(double* q = a, r = a)
+            {
+                ;
+            }
         }
     }
 }
@@ -348,6 +357,10 @@ public class Program
 1
 True
 2
+True
+True
+True
+True
 True
 True
 True

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -336,6 +336,7 @@ public class Program
         TestMain();
     }
 
+    [Xunit.Fact]
     static void TestMain()
     {
         using (var memoryStream = new MemoryStream())
@@ -387,7 +388,7 @@ True
 True
 ";
            
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.UnsafeDebugExe,  emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, options: TestOptions.UnsafeDebugExe,  emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -260,6 +260,8 @@ public class Program
 
     static void TestMain()
     {
+        int x;
+        int a, b;
         DoubleDeclaration(5);
         DoubleForDeclaration(5);
     }
@@ -268,9 +270,10 @@ public class Program
     {
         int c = x;
         int a, b;
-        a = b = c;
+        int f;
+        a = b = f = c;
         int d = a, e = b;
-        return d + e;
+        return d + e + f;
     }
 
     static int DoubleForDeclaration(int x)
@@ -291,7 +294,6 @@ True
 True
 True
 3
-True
 True
 True
 True
@@ -613,7 +615,7 @@ public class Program
 
     async static Task<string> Second(string s)
     {
-        string doubled;
+        string doubled = """";
         if (s.Length > 2)
             doubled = s + s;
         else


### PR DESCRIPTION
Dynamic analysis instrumentation for using and fixed statements was failing due to incorrect treatment of the declarations of locals in these statements.

@jcouv @AlekseyTs @jaredpar @drognanar @ManishJayaswal @genlu are actively solicited. @amcasey might consider reviewing this out of kindness.