### PR TITLE
Test/fix scoping rules for pattern locals declared within a match expression.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.QueryUnboundLambdaState.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class Binder
     {
-        private delegate BoundBlock LambdaBodyFactory(LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics);
+        private delegate BoundBlock LambdaBodyFactory(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics);
 
         private class QueryUnboundLambdaState : UnboundLambdaState
         {
@@ -47,9 +47,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new WithQueryLambdaParametersBinder(lambdaSymbol, _rangeVariableMap, binder);
             }
 
-            protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics)
+            protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics)
             {
-                return _bodyFactory(lambdaSymbol, ref lambdaBodyBinder, diagnostics);
+                return _bodyFactory(lambdaSymbol, lambdaBodyBinder, diagnostics);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -756,12 +756,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #endif
         
-        internal Binder WithPatternVariablesIfAny(ExpressionSyntax scopeOpt)
-        {
-            Debug.Assert(Locals.Length == 0);
-            return new PatternVariableBinder(scopeOpt, scopeOpt, this);
-        }
-
         internal void BuildAndAddPatternVariables(
             ArrayBuilder<LocalSymbol> builder,
             CSharpSyntaxNode node = null,

--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -762,18 +762,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new PatternVariableBinder(scopeOpt, scopeOpt, this);
         }
 
-        internal Binder WithPatternVariablesIfAny(ArgumentListSyntax initializerArgumentListOpt)
-        {
-            Debug.Assert(Locals.Length == 0);
-
-            if (initializerArgumentListOpt == null || initializerArgumentListOpt.Arguments.Count == 0)
-            {
-                return this;
-            }
-
-            return new PatternVariableBinder(initializerArgumentListOpt, initializerArgumentListOpt.Arguments, this);
-        }
-
         internal void BuildAndAddPatternVariables(
             ArrayBuilder<LocalSymbol> builder,
             CSharpSyntaxNode node = null,
@@ -788,11 +776,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             patterns.Free();
         }
 
-        internal BoundExpression WrapWithVariablesIfAny(BoundExpression expression)
+        internal BoundExpression WrapWithVariablesIfAny(CSharpSyntaxNode node, BoundExpression expression)
         {
             return (Locals.Length == 0)
                 ? expression
-                : new BoundSequence(expression.Syntax, Locals, ImmutableArray<BoundExpression>.Empty, expression, expression.Type) { WasCompilerGenerated = true };
+                : new BoundSequence(node, Locals, ImmutableArray<BoundExpression>.Empty, expression, expression.Type) { WasCompilerGenerated = true };
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Initializers.cs
@@ -267,10 +267,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 initializerDiagnostics = diagnostics;
             }
 
-            var collisionDetector = new LocalScopeBinder(binder);
-            var patternBinder = new PatternVariableBinder(equalsValueClauseNode, equalsValueClauseNode.Value, collisionDetector);
-            var boundInitValue = patternBinder.BindVariableOrAutoPropInitializer(equalsValueClauseNode, RefKind.None, fieldSymbol.GetFieldType(fieldsBeingBound), initializerDiagnostics);
-            boundInitValue = patternBinder.WrapWithVariablesIfAny(boundInitValue);
+            binder = new ExecutableCodeBinder(equalsValueClauseNode, fieldSymbol, new LocalScopeBinder(binder));
+            var boundInitValue = binder.BindVariableOrAutoPropInitializer(equalsValueClauseNode, RefKind.None, fieldSymbol.GetFieldType(fieldsBeingBound), initializerDiagnostics);
 
             if (isImplicitlyTypedField)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -717,6 +717,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var section in node.Sections)
             {
                 var sectionBinder = this.GetBinder(section); // each section has its own locals.
+                Debug.Assert(sectionBinder != null);
+
                 var pattern = sectionBinder.BindPattern(section.Pattern, expression, expression.Type, section.HasErrors, diagnostics);
                 var guard = (section.WhenClause != null) ? sectionBinder.BindBooleanExpression(section.WhenClause.Condition, diagnostics) : null;
                 var e = sectionBinder.BindExpression(section.Expression, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -716,7 +716,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var sectionBuilder = ArrayBuilder<BoundMatchCase>.GetInstance(node.Sections.Count);
             foreach (var section in node.Sections)
             {
-                var sectionBinder = new PatternVariableBinder(section, this); // each section has its own locals.
+                var sectionBinder = this.GetBinder(section); // each section has its own locals.
                 var pattern = sectionBinder.BindPattern(section.Pattern, expression, expression.Type, section.HasErrors, diagnostics);
                 var guard = (section.WhenClause != null) ? sectionBinder.BindBooleanExpression(section.WhenClause.Condition, diagnostics) : null;
                 var e = sectionBinder.BindExpression(section.Expression, diagnostics);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -562,7 +562,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var xExpression = new BoundParameter(let, lambdaSymbol.Parameters[0]) { WasCompilerGenerated = true };
 
-                lambdaBodyBinder = lambdaBodyBinder.WithPatternVariablesIfAny(let.Expression);
+                lambdaBodyBinder = lambdaBodyBinder.GetBinder(let.Expression);
+                Debug.Assert(lambdaBodyBinder != null);
 
                 var yExpression = lambdaBodyBinder.BindValue(let.Expression, d, BindValueKind.RValue);
                 SourceLocation errorLocation = new SourceLocation(let.SyntaxTree, new TextSpan(let.Identifier.SpanStart, let.Expression.Span.End - let.Identifier.SpanStart));
@@ -647,7 +648,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             return MakeQueryUnboundLambda(expression, new QueryUnboundLambdaState(this, qvm, parameters, (LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics) =>
             {
-                lambdaBodyBinder = lambdaBodyBinder.WithPatternVariablesIfAny(expression);
                 return lambdaBodyBinder.BindLambdaExpressionAsBlock(RefKind.None, expression, diagnostics);
             }));
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -524,7 +524,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(LambdaUtilities.IsQueryPairLambda(node));
 
-            LambdaBodyFactory bodyFactory = (LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag d) =>
+            LambdaBodyFactory bodyFactory = (LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag d) =>
             {
                 var x1Expression = new BoundParameter(node, lambdaSymbol.Parameters[0]) { WasCompilerGenerated = true };
                 var x2Expression = new BoundParameter(node, lambdaSymbol.Parameters[1]) { WasCompilerGenerated = true };
@@ -558,7 +558,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // are accessed as TRID.Item1 (or members of that), and y is accessed
             // as TRID.Item2, where TRID is the compiler-generated identifier used
             // to represent the transparent identifier in the result.
-            LambdaBodyFactory bodyFactory = (LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag d) =>
+            LambdaBodyFactory bodyFactory = (LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag d) =>
             {
                 var xExpression = new BoundParameter(let, lambdaSymbol.Parameters[0]) { WasCompilerGenerated = true };
 
@@ -646,7 +646,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private UnboundLambda MakeQueryUnboundLambda(RangeVariableMap qvm, ImmutableArray<RangeVariableSymbol> parameters, ExpressionSyntax expression)
         {
-            return MakeQueryUnboundLambda(expression, new QueryUnboundLambdaState(this, qvm, parameters, (LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics) =>
+            return MakeQueryUnboundLambda(expression, new QueryUnboundLambdaState(this, qvm, parameters, (LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics) =>
             {
                 return lambdaBodyBinder.BindLambdaExpressionAsBlock(RefKind.None, expression, diagnostics);
             }));
@@ -654,8 +654,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private UnboundLambda MakeQueryUnboundLambdaWithCast(RangeVariableMap qvm, RangeVariableSymbol parameter, ExpressionSyntax expression, TypeSyntax castTypeSyntax, TypeSymbol castType)
         {
-            return MakeQueryUnboundLambda(expression, new QueryUnboundLambdaState(this, qvm, ImmutableArray.Create(parameter), (LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics) =>
+            return MakeQueryUnboundLambda(expression, new QueryUnboundLambdaState(this, qvm, ImmutableArray.Create(parameter), (LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics) =>
             {
+                lambdaBodyBinder = lambdaBodyBinder.GetBinder(expression);
+                Debug.Assert(lambdaBodyBinder != null);
+
                 BoundExpression boundExpression = lambdaBodyBinder.BindValue(expression, diagnostics, BindValueKind.RValue);
 
                 // We transform the expression from "expr" to "expr.Cast<castTypeOpt>()".

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -457,7 +457,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (node.ExpressionBody != null)
                 {
-                    block = binder.GetBinder(node.ExpressionBody).BindExpressionBodyAsBlock(node.ExpressionBody, diagnostics);
+                    block = binder.BindExpressionBodyAsBlock(node.ExpressionBody, diagnostics);
                 }
                 else
                 {
@@ -3558,9 +3558,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal BoundBlock BindExpressionBodyAsBlock(ArrowExpressionClauseSyntax expressionBody,
                                                       DiagnosticBag diagnostics)
         {
+            Binder bodyBinder = this.GetBinder(expressionBody);
+            Debug.Assert(bodyBinder != null);
+
             RefKind refKind = expressionBody.RefKeyword.Kind().GetRefKind();
-            BoundExpression expression = BindValue(expressionBody.Expression, diagnostics, refKind != RefKind.None ? BindValueKind.RefReturn : BindValueKind.RValue);
-            return CreateBlockFromExpression(expressionBody, this.Locals, refKind, expression, expressionBody.Expression, diagnostics);
+            BoundExpression expression = bodyBinder.BindValue(expressionBody.Expression, diagnostics, refKind != RefKind.None ? BindValueKind.RefReturn : BindValueKind.RValue);
+            return bodyBinder.CreateBlockFromExpression(expressionBody, bodyBinder.Locals, refKind, expression, expressionBody.Expression, diagnostics);
         }
 
         /// <summary>
@@ -3568,8 +3571,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public BoundBlock BindLambdaExpressionAsBlock(RefKind refKind, ExpressionSyntax body, DiagnosticBag diagnostics)
         {
-            BoundExpression expression = BindValue(body, diagnostics, refKind != RefKind.None ? BindValueKind.RefReturn : BindValueKind.RValue);
-            return CreateBlockFromExpression(body, this.Locals, refKind, expression, body, diagnostics);
+            Binder bodyBinder = this.GetBinder(body);
+            Debug.Assert(bodyBinder != null);
+
+            BoundExpression expression = bodyBinder.BindValue(body, diagnostics, refKind != RefKind.None ? BindValueKind.RefReturn : BindValueKind.RValue);
+            return bodyBinder.CreateBlockFromExpression(body, bodyBinder.Locals, refKind, expression, body, diagnostics);
         }
 
         internal virtual ImmutableArray<LocalSymbol> Locals

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -65,6 +66,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Binder binder;
                     if (map.TryGetValue(methodWithYield, out binder))
                     {
+                        Symbol containing = binder.ContainingMemberOrLambda;
+
                         // get the closest inclosing InMethodBinder and make it an iterator
                         InMethodBinder inMethod = null;
                         while (binder != null)
@@ -74,14 +77,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 break;
                             binder = binder.Next;
                         }
-                        if (inMethod != null)
+                        if (inMethod != null && (object)inMethod.ContainingMemberOrLambda == containing)
                         {
                             inMethod.MakeIterator();
                             symbolsWithYield.Add((MethodSymbol)inMethod.ContainingMemberOrLambda);
                         }
                         else
                         {
-                            Debug.Assert(false);
+                            Debug.Assert(methodWithYield == _root && methodWithYield is ExpressionSyntax);
                         }
                     }
                     else

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -637,6 +637,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
                 AddToMap(node, patternBinder);
+                Visit(node.Expression, patternBinder);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
@@ -48,14 +48,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Variables declared in [in] expressions of top level from clause and 
             // join clauses are in scope 
             Visit(node.FromClause.Expression);
+            Visit(node.Body);
+        }
 
-            foreach (var clause in node.Body.Clauses)
+        public override void VisitQueryBody(QueryBodySyntax node)
+        {
+            // Variables declared in [in] expressions of top level from clause and 
+            // join clauses are in scope 
+            foreach (var clause in node.Clauses)
             {
                 if (clause.Kind() == SyntaxKind.JoinClause)
                 {
                     Visit(((JoinClauseSyntax)clause).InExpression);
                 }
             }
+
+            Visit(node.Continuation);
         }
 
         public override void VisitBinaryExpression(BinaryExpressionSyntax node)

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -844,7 +844,8 @@
     Empty if the catch syntax doesn't declare a local variable.
     
     In the initial bound tree the first variable is the exception variable (if present).
-    After the node is lowered it might be another variable.
+    After the node is lowered the exception variable might become a field and will be removed from 
+    the array, otherwise it will stay at the first position.
     -->
     <Field Name="Locals" Type="ImmutableArray&lt;LocalSymbol&gt;"/>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -297,7 +297,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public abstract TypeSymbol ParameterType(int index);
         //public abstract SyntaxToken ParameterIdentifier(int index);
         public abstract RefKind RefKind(int index);
-        protected abstract BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics);
+        protected abstract BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics);
 
         public virtual void GenerateAnonymousFunctionConversionError(DiagnosticBag diagnostics, TypeSymbol targetType)
         {
@@ -409,7 +409,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var parameters = DelegateParameters(delegateType);
             lambdaSymbol = new LambdaSymbol(binder.Compilation, binder.ContainingMemberOrLambda, _unboundLambda, parameters, refKind, returnType);
             lambdaBodyBinder = new ExecutableCodeBinder(_unboundLambda.Syntax, lambdaSymbol, ParameterBinder(lambdaSymbol, binder));
-            block = BindLambdaBody(lambdaSymbol, ref lambdaBodyBinder, diagnostics);
+            block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
             ValidateUnsafeParameters(diagnostics, parameters);
 
         haveLambdaBodyAndBinders:
@@ -484,7 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var parameters = DelegateParameters(delegateType);
             var lambdaSymbol = new LambdaSymbol(binder.Compilation, binder.ContainingMemberOrLambda, _unboundLambda, parameters, refKind: Microsoft.CodeAnalysis.RefKind.None, returnType: null);
             Binder lambdaBodyBinder = new ExecutableCodeBinder(_unboundLambda.Syntax, lambdaSymbol, ParameterBinder(lambdaSymbol, binder));
-            var block = BindLambdaBody(lambdaSymbol, ref lambdaBodyBinder, diagnostics);
+            var block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
 
             var result = new BoundLambda(_unboundLambda.Syntax, block, diagnostics.ToReadOnlyAndFree(), lambdaBodyBinder, delegateType, inferReturnType: true)
             { WasCompilerGenerated = _unboundLambda.WasCompilerGenerated };
@@ -860,7 +860,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _parameterTypes[index];
         }
 
-        protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, ref Binder lambdaBodyBinder, DiagnosticBag diagnostics)
+        protected override BoundBlock BindLambdaBody(LambdaSymbol lambdaSymbol, Binder lambdaBodyBinder, DiagnosticBag diagnostics)
         {
             if (this.IsExpressionLambda)
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -866,7 +866,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var refKind = this.ExpressionRefKind;
                 var body = (ExpressionSyntax)this.Body;
-                lambdaBodyBinder = lambdaBodyBinder.WithPatternVariablesIfAny(body);
                 return lambdaBodyBinder.BindLambdaExpressionAsBlock(refKind, body, diagnostics);
             }
             else

--- a/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/AttributeSemanticModel.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private readonly AliasSymbol _aliasOpt;
 
         private AttributeSemanticModel(CSharpCompilation compilation, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Binder rootBinder, SyntaxTreeSemanticModel parentSemanticModelOpt = null, int speculatedPosition = 0)
-            : base(compilation, syntax, attributeType, rootBinder, parentSemanticModelOpt, speculatedPosition)
+            : base(compilation, syntax, attributeType, new ExecutableCodeBinder(syntax, rootBinder.ContainingMember(), rootBinder), parentSemanticModelOpt, speculatedPosition)
         {
             Debug.Assert(syntax != null);
             _aliasOpt = aliasOpt;
@@ -27,8 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         public static AttributeSemanticModel Create(CSharpCompilation compilation, AttributeSyntax syntax, NamedTypeSymbol attributeType, AliasSymbol aliasOpt, Binder rootBinder)
         {
-            var executableBinder = new ExecutableCodeBinder(syntax, attributeType, rootBinder);
-            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, new PatternVariableBinder(syntax, executableBinder));
+            return new AttributeSemanticModel(compilation, syntax, attributeType, aliasOpt, rootBinder);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -403,7 +403,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var diagnostics = DiagnosticBag.GetInstance();
             AliasSymbol aliasOpt; // not needed.
             NamedTypeSymbol attributeType = (NamedTypeSymbol)binder.BindType(attribute.Name, diagnostics, out aliasOpt);
-            var boundNode = binder.BindAttribute(attribute, attributeType, diagnostics);
+            var boundNode = new ExecutableCodeBinder(attribute, binder.ContainingMemberOrLambda, binder).BindAttribute(attribute, attributeType, diagnostics);
             diagnostics.Free();
 
             return boundNode;
@@ -720,6 +720,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (binder != null)
             {
                 var diagnostics = DiagnosticBag.GetInstance();
+
+                if (constructorInitializer.ArgumentList != null)
+                {
+                    binder = new ExecutableCodeBinder(constructorInitializer.ArgumentList, binder.ContainingMemberOrLambda, binder);
+                }
+
                 var bnode = memberModel.Bind(binder, constructorInitializer, diagnostics);
                 var binfo = memberModel.GetSymbolInfoForNode(SymbolInfoOptions.DefaultOptions, bnode, bnode, boundNodeForSyntacticParent: null, binderOpt: binder);
                 diagnostics.Free();

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -225,6 +225,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                         binder = rootBinder.GetBinder(current);
                     }
                 }
+                else if (current.Kind() == SyntaxKind.MatchSection)
+                {
+                    if (LookupPosition.IsInMatchSectionScope(position, (MatchSectionSyntax)current))
+                    {
+                        binder = rootBinder.GetBinder(current);
+                    }
+                }
                 else if (current.Kind() == SyntaxKind.ArrowExpressionClause && current.Parent?.Kind() == SyntaxKind.LocalFunctionStatement)
                 {
                     binder = rootBinder.GetBinder(current);

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -44,11 +44,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             _root = root;
             _memberSymbol = memberSymbol;
 
-            if (root.Kind() == SyntaxKind.ArrowExpressionClause)
-            {
-                rootBinder = rootBinder.WithPatternVariablesIfAny(((ArrowExpressionClauseSyntax)root).Expression);
-            }
-
             this.RootBinder = rootBinder.WithAdditionalFlags(GetSemanticModelBinderFlags());
             _parentSemanticModelOpt = parentSemanticModelOpt;
             _speculatedPosition = speculatedPosition;
@@ -148,8 +143,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node == root)
             {
-                return rootBinder;
+                return rootBinder.GetBinder(node) ?? rootBinder;
             }
+
+            Debug.Assert(root.Contains(node));
 
             ExpressionSyntax typeOfArgument = null;
             CSharpSyntaxNode unexpectedAnonymousFunction = null;
@@ -249,7 +246,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     binder = rootBinder.GetBinder(current);
                 }
-                else if (current.Kind() == SyntaxKind.ArrowExpressionClause && current.Parent?.Kind() == SyntaxKind.LocalFunctionStatement)
+                else if (current.Kind() == SyntaxKind.ArrowExpressionClause)
+                {
+                    binder = rootBinder.GetBinder(current);
+                }
+                else if (current is ExpressionSyntax && (current.Parent as LambdaExpressionSyntax)?.Body == current)
                 {
                     binder = rootBinder.GetBinder(current);
                 }
@@ -257,8 +258,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // If this ever breaks, make sure that all callers of
                     // CanHaveAssociatedLocalBinder are in sync.
-                    Debug.Assert(!current.CanHaveAssociatedLocalBinder() || 
-                                 (current == root && current.Kind() == SyntaxKind.ArrowExpressionClause));
+                    Debug.Assert(!current.CanHaveAssociatedLocalBinder());
                 }
 
                 if (current == root)
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            binder = binder ?? rootBinder;
+            binder = binder ?? rootBinder.GetBinder(root) ?? rootBinder;
             Debug.Assert(binder != null);
 
             if (typeOfArgument != null && !typeOfEncounteredBeforeUnexpectedAnonymousFunction)
@@ -1359,7 +1359,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     result = GetLambdaEnclosingBinder(position, node, innerLambda, ((BoundLambda)boundInnerLambda).Binder);
                     break;
                 case BoundKind.QueryClause:
-                    result = GetQueryEnclosingBinder(position, ((BoundQueryClause)boundInnerLambda));
+                    result = GetQueryEnclosingBinder(position, node, ((BoundQueryClause)boundInnerLambda));
                     break;
                 default:
                     return GetEnclosingBinder(node, position); // Known to return non-null with BinderFlags.SemanticModel.
@@ -1372,7 +1372,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <remarks>
         /// Returned binder doesn't need to have <see cref="BinderFlags.SemanticModel"/> set - the caller will add it.
         /// </remarks>
-        private static Binder GetQueryEnclosingBinder(int position, BoundQueryClause queryClause)
+        private static Binder GetQueryEnclosingBinder(int position, CSharpSyntaxNode startingNode, BoundQueryClause queryClause)
         {
             for (BoundNode n = queryClause.Value; n != null;)
             {
@@ -1384,29 +1384,70 @@ namespace Microsoft.CodeAnalysis.CSharp
                         continue;
                     case BoundKind.Call:
                         var call = (BoundCall)n;
-                        if (call == null || call.Arguments.Length == 0) return queryClause.Binder;
-                        // TODO: should we look for the "nearest" argument as a fallback?
-                        n = call.Arguments[call.Arguments.Length - 1];
                         foreach (var arg in call.Arguments)
                         {
-                            if (arg.Syntax.FullSpan.Contains(position)) n = arg;
+                            if (arg.Syntax.FullSpan.Contains(position) ||
+                                (arg as BoundQueryClause)?.Value.Syntax.FullSpan.Contains(position) == true)
+                            {
+                                n = arg;
+                                break;
+                            }
                         }
+
+                        if (n != call)
+                        {
+                            continue;
+                        }
+
+                        BoundExpression receiver = call.ReceiverOpt;
+
+                        // In some error scenarios, we end-up with a method group as the receiver,
+                        // let's get to real receiver.
+                        while (receiver?.Kind == BoundKind.MethodGroup)
+                        {
+                            receiver = ((BoundMethodGroup)receiver).ReceiverOpt;
+                        }
+
+                        if (receiver?.Syntax.FullSpan.Contains(position) == true ||
+                            (receiver as BoundQueryClause)?.Value.Syntax.FullSpan.Contains(position) == true)
+                        {
+                            n = receiver;
+                            continue;
+                        }
+
+                        // TODO: should we look for the "nearest" argument as a fallback?
+                        n = call.Arguments.LastOrDefault();
                         continue;
                     case BoundKind.Conversion:
                         n = ((BoundConversion)n).Operand;
                         continue;
                     case BoundKind.UnboundLambda:
-                        // NOTE: Calling GetLambdaEnclosingBinder would just return this binder.
-                        return ((UnboundLambda)n).BindForErrorRecovery().Binder;
+                        var unbound = (UnboundLambda)n;
+                        return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, unbound.Syntax),
+                                                  position, unbound.BindForErrorRecovery().Binder, unbound.Syntax);
                     case BoundKind.Lambda:
-                        // NOTE: Calling GetLambdaEnclosingBinder would just return this binder.
-                        return ((BoundLambda)n).Binder;
+                        var lambda = (BoundLambda)n;
+                        return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, lambda.Body.Syntax), 
+                                                  position, lambda.Binder, lambda.Body.Syntax);
                     default:
-                        return queryClause.Binder;
+                        goto done;
                 }
             }
 
-            return queryClause.Binder;
+done:
+            return GetEnclosingBinder(AdjustStartingNodeAccordingToNewRoot(startingNode, queryClause.Syntax),
+                                      position, queryClause.Binder, queryClause.Syntax);
+        }
+
+        private static CSharpSyntaxNode AdjustStartingNodeAccordingToNewRoot(CSharpSyntaxNode startingNode, CSharpSyntaxNode root)
+        {
+            CSharpSyntaxNode result = startingNode.Contains(root) ? root : startingNode;
+            if (result != root && !root.Contains(result))
+            {
+                result = root;
+            }
+
+            return result;
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -232,6 +232,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                         binder = rootBinder.GetBinder(current);
                     }
                 }
+                else if (current.Kind() == SyntaxKind.ArgumentList)
+                {
+                    var argList = (ArgumentListSyntax)current;
+
+                    if (LookupPosition.IsBetweenTokens(position, argList.OpenParenToken, argList.CloseParenToken))
+                    {
+                        binder = rootBinder.GetBinder(current);
+                    }
+                }
+                else if (current.Kind() == SyntaxKind.EqualsValueClause)
+                {
+                    binder = rootBinder.GetBinder(current);
+                }
+                else if (current.Kind() == SyntaxKind.Attribute)
+                {
+                    binder = rootBinder.GetBinder(current);
+                }
                 else if (current.Kind() == SyntaxKind.ArrowExpressionClause && current.Parent?.Kind() == SyntaxKind.LocalFunctionStatement)
                 {
                     binder = rootBinder.GetBinder(current);

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1550,7 +1550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     binder = new ExecutableCodeBinder(arrowExpression, sourceMethod, binder);
                     importChain = binder.ImportChain;
                     // Add locals
-                    return binder.WithPatternVariablesIfAny(arrowExpression.Expression).BindExpressionBodyAsBlock(arrowExpression, diagnostics);
+                    return binder.BindExpressionBodyAsBlock(arrowExpression, diagnostics);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1727,8 +1727,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // wrap in ConstructorInitializerBinder for appropriate errors
             // Handle scoping for possible pattern variables declared in the initializer
-            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor).
-                                       WithPatternVariablesIfAny(initializerArgumentListOpt);
+            Binder initializerBinder = outerBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.ConstructorInitializer, constructor);
+
+            if (initializerArgumentListOpt != null)
+            {
+                initializerBinder = new ExecutableCodeBinder(initializerArgumentListOpt, constructor, initializerBinder);
+            }
 
             return initializerBinder.BindConstructorInitializer(initializerArgumentListOpt, constructor, diagnostics);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstantValueUtils.cs
@@ -53,19 +53,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var enumConstant = fieldSymbol as SourceEnumConstantSymbol;
             Binder collisionDetector = new LocalScopeBinder(binder);
-            collisionDetector = collisionDetector.WithPatternVariablesIfAny(initializer.Value);
+            collisionDetector = new ExecutableCodeBinder(initializer, fieldSymbol, collisionDetector);
             BoundExpression result;
 
             if ((object)enumConstant != null)
             {
-                result = collisionDetector.BindEnumConstantInitializer(enumConstant, initializer.Value, diagnostics);
+                result = collisionDetector.BindEnumConstantInitializer(enumConstant, initializer, diagnostics);
             }
             else
             {
                 result = collisionDetector.BindVariableOrAutoPropInitializer(initializer, RefKind.None, fieldSymbol.Type, diagnostics);
             }
 
-            result = collisionDetector.WrapWithVariablesIfAny(result);
             return result;
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LambdaUtilities.cs
@@ -375,10 +375,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // With the introduction of pattern-matching, many nodes now contain top-level
                 // expressions that may introduce pattern variables.
                 case SyntaxKind.EqualsValueClause:
-                case SyntaxKind.CatchFilterClause:
+                case SyntaxKind.MatchSection:
                     return true;
 
                 // Due to pattern-matching, any statement that contains an expression may introduce a scope.
+                // PROTOTYPE(patterns): The set of statements below needs a clean-up. For example, checked
+                //                      statement doesn't introduce a scope. 
                 case SyntaxKind.CheckedStatement:
                 case SyntaxKind.DoStatement:
                 case SyntaxKind.ExpressionStatement:

--- a/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
@@ -244,6 +244,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         }
 
         /// <remarks>
+        /// Used to determine whether it would be appropriate to use the binder for the match section (if any).
+        /// Not used to determine whether the position is syntactically within the section.
+        /// </remarks>
+        internal static bool IsInMatchSectionScope(int position, MatchSectionSyntax section)
+        {
+            Debug.Assert(section != null);
+            return section.Span.Contains(position);
+        }
+
+        /// <remarks>
         /// Used to determine whether it would be appropriate to use the binder for the statement (if any).
         /// Not used to determine whether the position is syntactically within the statement.
         /// </remarks>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -66,6 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 (kind = syntax.Kind()) == SyntaxKind.CatchClause ||
                 kind == SyntaxKind.CatchFilterClause ||
                 kind == SyntaxKind.SwitchSection ||
+                kind == SyntaxKind.MatchSection ||
                 kind == SyntaxKind.ArrowExpressionClause;
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -67,6 +67,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind == SyntaxKind.CatchFilterClause ||
                 kind == SyntaxKind.SwitchSection ||
                 kind == SyntaxKind.MatchSection ||
+                kind == SyntaxKind.EqualsValueClause ||
+                kind == SyntaxKind.Attribute ||
+                kind == SyntaxKind.ArgumentList ||
                 kind == SyntaxKind.ArrowExpressionClause;
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -70,7 +70,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind == SyntaxKind.EqualsValueClause ||
                 kind == SyntaxKind.Attribute ||
                 kind == SyntaxKind.ArgumentList ||
-                kind == SyntaxKind.ArrowExpressionClause;
+                kind == SyntaxKind.ArrowExpressionClause ||
+                (syntax is ExpressionSyntax && (syntax.Parent as LambdaExpressionSyntax)?.Body == syntax);
         }
 
         /// <summary>


### PR DESCRIPTION
Related to #8817.

@gafter, @agocke, @dotnet/roslyn-compiler Please review.

Note, diff in PatternMatchingTests.cs can be reviewed in individual commits. The combined diff is too big for GitHub to handle.