### PR TITLE
Fix naming in use var codestyle

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -5,21 +5,21 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitTyping
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitType
 {
     public partial class UseExplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace) =>
             new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
-                new CSharpUseExplicitTypingDiagnosticAnalyzer(), new UseExplicitTypingCodeFixProvider());
+                new CSharpUseExplicitTypeDiagnosticAnalyzer(), new UseExplicitTypeCodeFixProvider());
 
         private readonly SimpleCodeStyleOption onWithNone = new SimpleCodeStyleOption(true, NotificationOption.None);
         private readonly SimpleCodeStyleOption offWithNone = new SimpleCodeStyleOption(false, NotificationOption.None);
@@ -31,27 +31,27 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
         private readonly SimpleCodeStyleOption offWithError = new SimpleCodeStyleOption(false, NotificationOption.Error);
 
         // specify all options explicitly to override defaults.
-        private IDictionary<OptionKey, object> ExplicitTypingEverywhere() =>
+        private IDictionary<OptionKey, object> ExplicitTypeEverywhere() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
-        private IDictionary<OptionKey, object> ExplicitTypingExceptWhereApparent() =>
+        private IDictionary<OptionKey, object> ExplicitTypeExceptWhereApparent() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
-        private IDictionary<OptionKey, object> ExplicitTypingForBuiltInTypesOnly() =>
+        private IDictionary<OptionKey, object> ExplicitTypeForBuiltInTypesOnly() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
-        private IDictionary<OptionKey, object> ExplicitTypingEnforcements() =>
+        private IDictionary<OptionKey, object> ExplicitTypeEnforcements() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithWarning)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithError)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
-        private IDictionary<OptionKey, object> ExplicitTypingNoneEnforcement() =>
+        private IDictionary<OptionKey, object> ExplicitTypeNoneEnforcement() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithNone)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, offWithNone)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithNone);
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
 
         #region Error Cases
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnFieldDeclaration()
         {
             await TestMissingAsync(
@@ -73,10 +73,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicit
 class Program
 {
     [|var|] _myfield = 5;
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnFieldLikeEvents()
         {
             await TestMissingAsync(
@@ -84,10 +84,10 @@ class Program
 class Program
 {
     public event [|var|] _myevent;
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnAnonymousMethodExpression()
         {
             await TestMissingAsync(
@@ -100,10 +100,10 @@ class Program
             return value != ""0"";
         };
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnLambdaExpression()
         {
             await TestMissingAsync(
@@ -114,10 +114,10 @@ class Program
     {
         [|var|] x = y => y * y;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnDeclarationWithMultipleDeclarators()
         {
             await TestMissingAsync(
@@ -128,10 +128,10 @@ class Program
     {
         [|var|] x = 5, y = x;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnDeclarationWithoutInitializer()
         {
             await TestMissingAsync(
@@ -142,10 +142,10 @@ class Program
     {
         [|var|] x;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotDuringConflicts()
         {
             await TestMissingAsync(
@@ -161,10 +161,10 @@ class Program
     {
 
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotIfAlreadyExplicitlyTyped()
         {
             await TestMissingAsync(
@@ -175,10 +175,10 @@ class Program
     {
          [|Program|] p = new Program();
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnRHS()
         {
             await TestMissingAsync(
@@ -198,7 +198,7 @@ class var
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnErrorSymbol()
         {
             await TestMissingAsync(
@@ -209,12 +209,12 @@ class Program
     {
         [|var|] x = new Foo();
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
         #endregion
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnDynamic()
         {
             await TestMissingAsync(
@@ -225,10 +225,10 @@ class Program
     {
         [|dynamic|] x = 1;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnAnonymousType()
         {
             await TestMissingAsync(
@@ -239,10 +239,10 @@ class Program
     {
         [|var|] x = new { Amount = 108, Message = ""Hello"" };
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnArrayOfAnonymousType()
         {
             await TestMissingAsync(
@@ -253,10 +253,10 @@ class Program
     {
         [|var|] x = new[] { new { name = ""apple"", diam = 4 }, new { name = ""grape"", diam = 1 }};
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task NotOnEnumerableOfAnonymousTypeFromAQueryExpression()
         {
             await TestMissingAsync(
@@ -281,7 +281,7 @@ class Product
 ");
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnLocalWithIntrinsicTypeString()
         {
             await TestAsync(
@@ -300,10 +300,10 @@ class C
     {
         string s = ""hello"";
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnIntrinsicType()
         {
             await TestAsync(
@@ -322,10 +322,10 @@ class C
     {
         int s = 5;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnFrameworkType()
         {
             await TestAsync(
@@ -344,10 +344,10 @@ class C
     {
         List<int> c = new List<int>();
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnUserDefinedType()
         {
             await TestAsync(
@@ -366,10 +366,10 @@ class C
     {
         C c = new C();
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnGenericType()
         {
             await TestAsync(
@@ -388,10 +388,10 @@ class C<T>
     {
         C<int> c = new C<int>();
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnSingleDimensionalArrayTypeWithNewOperator()
         {
             await TestAsync(
@@ -410,10 +410,10 @@ class C
     {
         int[] n1 = new int[4] {2, 4, 6, 8};
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnSingleDimensionalArrayTypeWithNewOperator2()
         {
             await TestAsync(
@@ -432,10 +432,10 @@ class C
     {
         int[] n1 = new[] {2, 4, 6, 8};
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnSingleDimensionalJaggedArrayType()
         {
             await TestAsync(
@@ -462,10 +462,10 @@ class C
             new[]{5,6,7,8}
         };
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnDeclarationWithObjectInitializer()
         {
             await TestAsync(
@@ -492,10 +492,10 @@ class C
     {
         public string City { get; set; }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnDeclarationWithCollectionInitializer()
         {
             await TestAsync(
@@ -516,10 +516,10 @@ class C
     {
         List<int> digits = new List<int> { 1, 2, 3 };
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnDeclarationWithCollectionAndObjectInitializers()
         {
             await TestAsync(
@@ -554,10 +554,10 @@ class C
     {
         public string City { get; set; }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnForStatement()
         {
             await TestAsync(
@@ -582,10 +582,10 @@ class C
 
         }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnForeachStatement()
         {
             await TestAsync(
@@ -614,10 +614,10 @@ class C
 
         }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnQueryExpression()
         {
             await TestAsync(
@@ -660,10 +660,10 @@ class C
             public string City { get; set; }
         }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeInUsingStatement()
         {
             await TestAsync(
@@ -702,10 +702,10 @@ class C
             throw new NotImplementedException();
         }
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnInterpolatedString()
         {
             await TestAsync(
@@ -724,10 +724,10 @@ class Program
     {
         string s = $""Hello, {name}""
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnExplicitConversion()
         {
             await TestAsync(
@@ -748,10 +748,10 @@ class C
         double x = 1234.7;
         int a = (int)x;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
         public async Task SuggestExplicitTypeOnConditionalAccessExpression()
         {
             await TestAsync(
@@ -780,10 +780,10 @@ class C
     {
         return this;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInCheckedExpression()
         {
             await TestAsync(
@@ -804,10 +804,10 @@ class C
        long number1 = int.MaxValue + 20L;
        int intNumber = checked((int)number1);
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInAwaitExpression()
         {
             await TestAsync(
@@ -838,10 +838,10 @@ class C
     {
         return string.Empty;
     }
-}", options: ExplicitTypingEverywhere());
+}", options: ExplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInBuiltInNumericType()
         {
             await TestAsync(
@@ -860,10 +860,10 @@ class C
     {
         int text = 1;
     }
-}", options: ExplicitTypingForBuiltInTypesOnly());
+}", options: ExplicitTypeForBuiltInTypesOnly());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInBuiltInCharType()
         {
             await TestAsync(
@@ -886,10 +886,10 @@ class C
     }
 
     public char GetChar() => 'c';
-}", options: ExplicitTypingForBuiltInTypesOnly());
+}", options: ExplicitTypeForBuiltInTypesOnly());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInBuiltInType_string()
         {
             // though string isn't an intrinsic type per the compiler
@@ -910,10 +910,10 @@ class C
     {
         string text = string.Empty;
     }
-}", options: ExplicitTypingForBuiltInTypesOnly());
+}", options: ExplicitTypeForBuiltInTypesOnly());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeInBuiltInType_object()
         {
             // object isn't an intrinsic type per the compiler
@@ -936,10 +936,10 @@ class C
         object j = new C();
         object text = j;
     }
-}", options: ExplicitTypingForBuiltInTypesOnly());
+}", options: ExplicitTypeForBuiltInTypesOnly());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeNotificationLevelNone()
         {
             var source =
@@ -951,10 +951,10 @@ class C
         [|var|] n1 = new C();
     }
 }";
-            await TestMissingAsync(source, ExplicitTypingNoneEnforcement());
+            await TestMissingAsync(source, ExplicitTypeNoneEnforcement());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeNotificationLevelInfo()
         {
             var source =
@@ -967,13 +967,13 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source,
-                options: ExplicitTypingEnforcements(),
+                options: ExplicitTypeEnforcements(),
                 diagnosticCount: 1,
-                diagnosticId: IDEDiagnosticIds.UseExplicitTypingDiagnosticId,
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Info);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeNotificationLevelWarning()
         {
             var source =
@@ -986,13 +986,13 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source,
-                options: ExplicitTypingEnforcements(),
+                options: ExplicitTypeEnforcements(),
                 diagnosticCount: 1,
-                diagnosticId: IDEDiagnosticIds.UseExplicitTypingDiagnosticId,
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Warning);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestExplicitTypeNotificationLevelError()
         {
             var source =
@@ -1005,9 +1005,9 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source,
-                options: ExplicitTypingEnforcements(),
+                options: ExplicitTypeEnforcements(),
                 diagnosticCount: 1,
-                diagnosticId: IDEDiagnosticIds.UseExplicitTypingDiagnosticId,
+                diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Error);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests_FixAllTests.cs
@@ -5,14 +5,14 @@ using Microsoft.CodeAnalysis.CSharp;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitTyping
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseExplicitType
 {
     public partial class UseExplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         #region "Fix all occurrences tests"
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInDocumentScope_PreferExplicitTypeEverywhere()
         {
@@ -123,11 +123,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ExplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInProject_PreferExplicitTypeEverywhere()
         {
@@ -238,11 +238,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ExplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInSolution_PreferExplicitTypeEverywhere()
         {
@@ -353,11 +353,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ExplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ExplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInDocumentScope_PreferExplicitTypeExceptWhereApparent()
         {
@@ -404,7 +404,7 @@ class Program
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ExplicitTypingExceptWhereApparent(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ExplicitTypeExceptWhereApparent(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -6,21 +6,21 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
-using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles;
+using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitTyping
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType
 {
     public partial class UseImplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace) =>
             new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
-                new CSharpUseImplicitTypingDiagnosticAnalyzer(), new UseImplicitTypingCodeFixProvider());
+                new CSharpUseImplicitTypeDiagnosticAnalyzer(), new UseImplicitTypeCodeFixProvider());
 
         private readonly SimpleCodeStyleOption onWithNone = new SimpleCodeStyleOption(true, NotificationOption.None);
         private readonly SimpleCodeStyleOption offWithNone = new SimpleCodeStyleOption(false, NotificationOption.None);
@@ -32,32 +32,32 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicit
         private readonly SimpleCodeStyleOption offWithError = new SimpleCodeStyleOption(false, NotificationOption.Error);
 
         // specify all options explicitly to override defaults.
-        private IDictionary<OptionKey, object> ImplicitTypingEverywhere() => 
+        private IDictionary<OptionKey, object> ImplicitTypeEverywhere() => 
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
 
-        private IDictionary<OptionKey, object> ImplicitTypingWhereApparent() =>
+        private IDictionary<OptionKey, object> ImplicitTypeWhereApparent() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo);
 
-        private IDictionary<OptionKey, object> ImplicitTypingWhereApparentAndForIntrinsics() =>
+        private IDictionary<OptionKey, object> ImplicitTypeWhereApparentAndForIntrinsics() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
 
-        private IDictionary<OptionKey, object> ImplicitTypingButKeepIntrinsics() =>
+        private IDictionary<OptionKey, object> ImplicitTypeButKeepIntrinsics() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, offWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo);
 
-        private IDictionary<OptionKey, object> ImplicitTypingEnforcements() =>
+        private IDictionary<OptionKey, object> ImplicitTypeEnforcements() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithWarning)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithError)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
 
-        private IDictionary<OptionKey, object> ImplicitTypingNoneEnforcement() =>
+        private IDictionary<OptionKey, object> ImplicitTypeNoneEnforcement() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithNone)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithNone)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithNone);
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicit
             return options;
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnFieldDeclaration()
         {
             await TestMissingAsync(
@@ -77,10 +77,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicit
 class Program
 {
     [|int|] _myfield = 5;
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnFieldLikeEvents()
         {
             await TestMissingAsync(
@@ -88,10 +88,10 @@ class Program
 class Program
 {
     public event [|D|] _myevent;
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnConstants()
         {
             await TestMissingAsync(
@@ -102,10 +102,10 @@ class Program
     {
         const [|int|] x = 5;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnNullLiteral()
         {
             await TestMissingAsync(
@@ -116,10 +116,10 @@ class Program
     {
         [|Program|] x = null;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnDynamic()
         {
             await TestMissingAsync(
@@ -130,10 +130,10 @@ class Program
     {
         [|dynamic|] x = 1;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnAnonymousMethodExpression()
         {
             await TestMissingAsync(
@@ -146,10 +146,10 @@ class Program
             return value != ""0"";
         };
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnLambdaExpression()
         {
             await TestMissingAsync(
@@ -160,10 +160,10 @@ class Program
     {
         [|Func<int, int>|] x = y => y * y;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnMethodGroup()
         {
             await TestMissingAsync(
@@ -174,10 +174,10 @@ class Program
     {
         [|Func<string, string>|] copyStr = string.Copy;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnDeclarationWithMultipleDeclarators()
         {
             await TestMissingAsync(
@@ -188,10 +188,10 @@ class Program
     {
         [|int|] x = 5, y = x;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnDeclarationWithoutInitializer()
         {
             await TestMissingAsync(
@@ -202,10 +202,10 @@ class Program
     {
         [|Program|] x;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnIFormattable()
         {
             await TestMissingAsync(
@@ -216,10 +216,10 @@ class Program
     {
         [|IFormattable|] s = $""Hello, {name}""
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnFormattableString()
         {
             await TestMissingAsync(
@@ -230,10 +230,10 @@ class Program
     {
         [|FormattableString|] s = $""Hello, {name}""
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotInCatchDeclaration()
         {
             await TestMissingAsync(
@@ -252,10 +252,10 @@ class Program
             throw;
         }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotDuringConflicts()
         {
             await TestMissingAsync(
@@ -271,10 +271,10 @@ class Program
     {
 
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotIfAlreadyImplicitlyTyped()
         {
             await TestMissingAsync(
@@ -285,10 +285,10 @@ class Program
     {
          [|var|] p = new Program();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnImplicitConversion()
         {
             await TestMissingAsync(
@@ -300,10 +300,10 @@ class Program
         int i = int.MaxValue;
         [|long|] l = i;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnBoxingImplicitConversion()
         {
             await TestMissingAsync(
@@ -315,10 +315,10 @@ class Program
         int i = int.MaxValue;
         [|object|] o = i;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnRHS()
         {
             await TestMissingAsync(
@@ -329,10 +329,10 @@ class C
     {
         C c = new [|C|]();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnVariablesUsedInInitalizerExpression()
         {
             await TestMissingAsync(
@@ -343,10 +343,10 @@ class C
     {
         [|int|] i = (i = 20);
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnAssignmentToInterfaceType()
         {
             await TestMissingAsync(
@@ -365,10 +365,10 @@ class A : IInterface
 interface IInterface
 {
 
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task NotOnArrayInitializerWithoutNewKeyword()
         {
             await TestMissingAsync(
@@ -379,10 +379,10 @@ class C
     {
         [|int[]|] n1 = {2, 4, 6, 8};
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnLocalWithIntrinsicTypeString()
         {
             await TestAsync(
@@ -401,10 +401,10 @@ class C
     {
         var s = ""hello"";
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnIntrinsicType()
         {
             await TestAsync(
@@ -423,10 +423,10 @@ class C
     {
         var s = 5;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnFrameworkType()
         {
             await TestAsync(
@@ -445,10 +445,10 @@ class C
     {
         var c = new List<int>();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnUserDefinedType()
         {
             await TestAsync(
@@ -467,10 +467,10 @@ class C
     {
         var c = new C();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnGenericType()
         {
             await TestAsync(
@@ -489,10 +489,10 @@ class C<T>
     {
         var c = new C<int>();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnSeeminglyConflictingType()
         {
             await TestAsync(
@@ -511,10 +511,10 @@ class var<T>
     {
         var c = new var<int>();
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnSingleDimensionalArrayTypeWithNewOperator()
         {
             await TestAsync(
@@ -533,10 +533,10 @@ class C
     {
         var n1 = new int[4] {2, 4, 6, 8};
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnSingleDimensionalArrayTypeWithNewOperator2()
         {
             await TestAsync(
@@ -555,10 +555,10 @@ class C
     {
         var n1 = new[] {2, 4, 6, 8};
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnSingleDimensionalJaggedArrayType()
         {
             await TestAsync(
@@ -585,10 +585,10 @@ class C
             new[]{5,6,7,8}
         };
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnDeclarationWithObjectInitializer()
         {
             await TestAsync(
@@ -615,10 +615,10 @@ class C
     {
         public string City { get; set; }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnDeclarationWithCollectionInitializer()
         {
             await TestAsync(
@@ -639,10 +639,10 @@ class C
     {
         var digits = new List<int> { 1, 2, 3 };
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnDeclarationWithCollectionAndObjectInitializers()
         {
             await TestAsync(
@@ -677,10 +677,10 @@ class C
     {
         public string City { get; set; }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnForStatement()
         {
             await TestAsync(
@@ -705,10 +705,10 @@ class C
 
         }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnForeachStatement()
         {
             await TestAsync(
@@ -735,10 +735,10 @@ class C
 
         }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnQueryExpression()
         {
             await TestAsync(
@@ -781,10 +781,10 @@ class C
             public string City { get; set; }
         }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInUsingStatement()
         {
             await TestAsync(
@@ -823,10 +823,10 @@ class C
             throw new NotImplementedException();
         }
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnExplicitConversion()
         {
             await TestAsync(
@@ -847,10 +847,10 @@ class Program
         double x = 1234.7;
         var a = (int)x;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInConditionalAccessExpression()
         {
             await TestAsync(
@@ -879,10 +879,10 @@ class C
     {
         return this;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInCheckedExpression()
         {
             await TestAsync(
@@ -903,10 +903,10 @@ class C
        long number1 = int.MaxValue + 20L;
        var intNumber = checked((int)number1);
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInUnCheckedExpression()
         {
             await TestAsync(
@@ -927,10 +927,10 @@ class C
        long number1 = int.MaxValue + 20L;
        var intNumber = unchecked((int)number1);
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInAwaitExpression()
         {
             await TestAsync(
@@ -961,10 +961,10 @@ class C
     {
         return string.Empty;
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarInParenthesizedExpression()
         {
             await TestAsync(
@@ -983,10 +983,10 @@ class C
     {
         var text = (5);
     }
-}", options: ImplicitTypingEverywhere());
+}", options: ImplicitTypeEverywhere());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task DoNotSuggestVarOnBuiltInType_Literal_WithOption()
         {
             await TestMissingAsync(
@@ -997,10 +997,10 @@ class C
     {
         [|int|] s = 5;
     }
-}", options: ImplicitTypingButKeepIntrinsics());
+}", options: ImplicitTypeButKeepIntrinsics());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task DoNotSuggestVarOnBuiltInType_WithOption()
         {
             await TestMissingAsync(
@@ -1013,10 +1013,10 @@ class C
     {
         [|int|] s = (unchecked(maxValue + 10));
     }
-}", options: ImplicitTypingButKeepIntrinsics());
+}", options: ImplicitTypeButKeepIntrinsics());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarOnFrameworkTypeEquivalentToBuiltInType()
         {
             await TestAsync(
@@ -1039,11 +1039,11 @@ class C
     {
         var s = (unchecked(maxValue + 10));
     }
-}", options: ImplicitTypingButKeepIntrinsics());
+}", options: ImplicitTypeButKeepIntrinsics());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_DefaultExpression()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_DefaultExpression()
         {
             await TestAsync(
 @"using System;
@@ -1061,11 +1061,11 @@ class C
     {
         var text = default(C);
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_Literals()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_Literals()
         {
             await TestAsync(
 @"using System;
@@ -1083,11 +1083,11 @@ class C
     {
         var text = 5;
     }
-}", options: ImplicitTypingWhereApparentAndForIntrinsics());
+}", options: ImplicitTypeWhereApparentAndForIntrinsics());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task DoNotSuggestVarWhereTypingIsEvident_Literals()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task DoNotSuggestVarWhereTypeIsEvident_Literals()
         {
             await TestMissingAsync(
 @"using System;
@@ -1097,11 +1097,11 @@ class C
     {
         [|int|] text = 5;
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_ObjectCreationExpression()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_ObjectCreationExpression()
         {
             await TestAsync(
 @"using System;
@@ -1119,11 +1119,11 @@ class C
     {
         var c = new C();
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_CastExpression()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_CastExpression()
         {
             await TestAsync(
 @"using System;
@@ -1143,10 +1143,10 @@ class C
         object o = int.MaxValue;
         var i = (Int32)o;
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVar_BuiltInTypesRulePrecedesOverTypeIsApparentRule()
         {
             // The option settings here say 
@@ -1165,11 +1165,11 @@ class C
         object o = int.MaxValue;
         [|int|] i = (Int32)o;
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_IsExpression()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_IsExpression()
         {
             await TestAsync(
 @"using System;
@@ -1205,11 +1205,11 @@ class A : IInterface
 interface IInterface
 {
 
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_AsExpression()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_AsExpression()
         {
             await TestAsync(
 @"using System;
@@ -1245,11 +1245,11 @@ class A : IInterface
 interface IInterface
 {
 
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_ConversionHelpers()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_ConversionHelpers()
         {
             await TestAsync(
 @"using System;
@@ -1267,11 +1267,11 @@ class C
     {
         var a = int.Parse(""1"");
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_CreationHelpers()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_CreationHelpers()
         {
             await TestAsync(
 @"class C
@@ -1295,11 +1295,11 @@ class XElement
 class XElement
 {
     internal static XElement Load() => return null;
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_CreationHelpersWithInferredTypeArguments()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_CreationHelpersWithInferredTypeArguments()
         {
             await TestAsync(
 @"using System;
@@ -1317,11 +1317,11 @@ class C
     {
         var a = Tuple.Create(0, true);
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_ConvertToType()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_ConvertToType()
         {
             await TestAsync(
 @"using System;
@@ -1341,11 +1341,11 @@ class C
         int integralValue = 12534;
         var decimalValue = Convert.ToDecimal(integralValue);
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
-        public async Task SuggestVarWhereTypingIsEvident_IConvertibleToType()
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task SuggestVarWhereTypeIsEvident_IConvertibleToType()
         {
             await TestAsync(
 @"using System;
@@ -1367,10 +1367,10 @@ class C
         IConvertible iConv = codePoint;
         var ch = iConv.ToChar(null);
     }
-}", options: ImplicitTypingWhereApparent());
+}", options: ImplicitTypeWhereApparent());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarNotificationLevelNone()
         {
             var source =
@@ -1382,10 +1382,10 @@ class C
         [|C|] n1 = new C();
     }
 }";
-            await TestMissingAsync(source, ImplicitTypingNoneEnforcement());
+            await TestMissingAsync(source, ImplicitTypeNoneEnforcement());
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarNotificationLevelInfo()
         {
             var source =
@@ -1398,13 +1398,13 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source, 
-                options: ImplicitTypingEnforcements(), 
+                options: ImplicitTypeEnforcements(), 
                 diagnosticCount: 1, 
-                diagnosticId: IDEDiagnosticIds.UseImplicitTypingDiagnosticId, 
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId, 
                 diagnosticSeverity: DiagnosticSeverity.Info);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarNotificationLevelWarning()
         {
             var source =
@@ -1417,13 +1417,13 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source,
-                options: ImplicitTypingEnforcements(),
+                options: ImplicitTypeEnforcements(),
                 diagnosticCount: 1,
-                diagnosticId: IDEDiagnosticIds.UseImplicitTypingDiagnosticId,
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Warning);
         }
 
-        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         public async Task SuggestVarNotificationLevelError()
         {
             var source =
@@ -1436,9 +1436,9 @@ class C
     }
 }";
             await TestDiagnosticSeverityAndCountAsync(source,
-                options: ImplicitTypingEnforcements(),
+                options: ImplicitTypeEnforcements(),
                 diagnosticCount: 1,
-                diagnosticId: IDEDiagnosticIds.UseImplicitTypingDiagnosticId,
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Error);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests_FixAllTests.cs
@@ -5,14 +5,14 @@ using Microsoft.CodeAnalysis.CSharp;
 using Roslyn.Test.Utilities;
 using Xunit;
 
-namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitTyping
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicitType
 {
     public partial class UseImplicitTypeTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
     {
         #region "Fix all occurrences tests"
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInDocumentScope_PreferImplicitTypeEverywhere()
         {
@@ -123,11 +123,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ImplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInProject_PreferImplicitTypeEverywhere()
         {
@@ -238,11 +238,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ImplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInSolution_PreferImplicitTypeEverywhere()
         {
@@ -353,11 +353,11 @@ class Program2
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ImplicitTypingEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ImplicitTypeEverywhere(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         [Fact]
-        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitTyping)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
         [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
         public async Task TestFixAllInDocumentScope_PreferBuiltInTypes()
         {
@@ -404,7 +404,7 @@ class Program
     </Project>
 </Workspace>";
 
-            await TestAsync(input, expected, options: ImplicitTypingButKeepIntrinsics(), fixAllActionEquivalenceKey: fixAllActionId);
+            await TestAsync(input, expected, options: ImplicitTypeButKeepIntrinsics(), fixAllActionEquivalenceKey: fixAllActionId);
         }
 
         #endregion

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -74,8 +74,8 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsSpellcheck = "CodeActions.Spellcheck";
             public const string CodeActionsSuppression = "CodeActions.Suppression";
             public const string CodeActionsUseAutoProperty = "CodeActions.UseAutoProperty";
-            public const string CodeActionsUseImplicitTyping = "CodeActions.UseImplicitTyping";
-            public const string CodeActionsUseExplicitTyping = "CodeActions.UseExplicitTyping";
+            public const string CodeActionsUseImplicitType = "CodeActions.UseImplicitType";
+            public const string CodeActionsUseExplicitType = "CodeActions.UseExplicitType";
             public const string CodeGeneration = nameof(CodeGeneration);
             public const string CodeGenerationSortDeclarations = "CodeGeneration.SortDeclarations";
             public const string CodeModel = nameof(CodeModel);

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -88,8 +88,8 @@
     <Compile Include="CodeFixes\SimplifyTypeNames\SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.cs" />
     <Compile Include="CodeFixes\SimplifyTypeNames\SimplifyTypeNamesCodeFixProvider.cs" />
     <Compile Include="CodeFixes\Suppression\CSharpSuppressionCodeFixProvider.cs" />
-    <Compile Include="CodeFixes\UseImplicitTyping\UseExplicitTypingCodeFixProvider.cs" />
-    <Compile Include="CodeFixes\UseImplicitTyping\UseImplicitTypingCodeFixProvider.cs" />
+    <Compile Include="CodeFixes\TypeStyle\UseExplicitTypeCodeFixProvider.cs" />
+    <Compile Include="CodeFixes\TypeStyle\UseImplicitTypeCodeFixProvider.cs" />
     <Compile Include="CodeRefactorings\EncapsulateField\EncapsulateFieldCodeRefactoringProvider.cs" />
     <Compile Include="CodeRefactorings\ExtractInterface\ExtractInterfaceCodeRefactoringProvider.cs" />
     <Compile Include="CodeRefactorings\ExtractMethod\ExtractMethodCodeRefactoringProvider.cs" />
@@ -271,16 +271,16 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>CSharpFeaturesResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Diagnostics\Analyzers\CSharpTypingStyleDiagnosticAnalyzerBase.cs" />
-    <Compile Include="Diagnostics\Analyzers\CSharpTypingStyleDiagnosticAnalyzerBase.State.cs" />
+    <Compile Include="Diagnostics\Analyzers\CSharpTypeStyleDiagnosticAnalyzerBase.cs" />
+    <Compile Include="Diagnostics\Analyzers\CSharpTypeStyleDiagnosticAnalyzerBase.State.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpQualifyMemberAccessDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpNamingStyleDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpUnboundIdentifiersDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpRemoveUnnecessaryImportsDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\Analyzers\CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs" />
-    <Compile Include="Diagnostics\Analyzers\CSharpUseExplicitTypingDiagnosticAnalyzer.cs" />
-    <Compile Include="Diagnostics\Analyzers\CSharpUseImplicitTypingDiagnosticAnalyzer.cs" />
+    <Compile Include="Diagnostics\Analyzers\CSharpUseExplicitTypeDiagnosticAnalyzer.cs" />
+    <Compile Include="Diagnostics\Analyzers\CSharpUseImplicitTypeDiagnosticAnalyzer.cs" />
     <Compile Include="Diagnostics\CSharpAnalyzerDriverService.cs" />
     <Compile Include="DocumentationComments\CSharpDocumentationCommentFormattingService.cs" />
     <Compile Include="DocumentationComments\DocumentationCommentUtilities.cs" />

--- a/src/Features/CSharp/Portable/CodeFixes/TypeStyle/UseExplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/TypeStyle/UseExplicitTypeCodeFixProvider.cs
@@ -16,13 +16,13 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseExplicitType), Shared]
-    internal class UseExplicitTypingCodeFixProvider : CodeFixProvider
+    internal class UseExplicitTypeCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds =>
-            ImmutableArray.Create(IDEDiagnosticIds.UseExplicitTypingDiagnosticId);
+            ImmutableArray.Create(IDEDiagnosticIds.UseExplicitTypeDiagnosticId);
 
         public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
 

--- a/src/Features/CSharp/Portable/CodeFixes/TypeStyle/UseImplicitTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/TypeStyle/UseImplicitTypeCodeFixProvider.cs
@@ -12,13 +12,13 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 
-namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.UseImplicitTyping
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.UseImplicitType), Shared]
-    internal class UseImplicitTypingCodeFixProvider : CodeFixProvider
+    internal class UseImplicitTypeCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds =>
-            ImmutableArray.Create(IDEDiagnosticIds.UseImplicitTypingDiagnosticId);
+            ImmutableArray.Create(IDEDiagnosticIds.UseImplicitTypeDiagnosticId);
 
         public override FixAllProvider GetFixAllProvider() => BatchFixAllProvider.Instance;
 

--- a/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyle.cs
+++ b/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyle.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
 {
     [Flags]
-    internal enum TypeStyle
+    internal enum TypeStylePreference
     {
         None = 0,
         ImplicitTypeForIntrinsicTypes = 1 << 0,

--- a/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
+++ b/src/Features/CSharp/Portable/CodeStyle/TypeStyle/TypeStyleHelper.cs
@@ -48,16 +48,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
             CancellationToken cancellationToken) =>
                 semanticModel.GetTypeInfo(initializerExpression, cancellationToken).Type?.IsSpecialType() == true;
 
-        private static bool IsImplicitStylePreferred(TypeStyle stylePreferences,
+        private static bool IsImplicitStylePreferred(TypeStylePreference stylePreferences,
             bool isBuiltInTypeContext,
             bool isTypeApparentContext)
         {
 
             return isBuiltInTypeContext
-                    ? stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes)
+                    ? stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeForIntrinsicTypes)
                     : isTypeApparentContext
-                        ? stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent)
-                        : stylePreferences.HasFlag(TypeStyle.ImplicitTypeWherePossible);
+                        ? stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWhereApparent)
+                        : stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWherePossible);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
         /// Things (like analyzers) that do have a local declaration already, should pass this in.
         /// </remarks>
         public static bool IsTypeApparentInAssignmentExpression(
-            TypeStyle stylePreferences,
+            TypeStylePreference stylePreferences,
             ExpressionSyntax initializerExpression,
             SemanticModel semanticModel,
             CancellationToken cancellationToken,
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
             // literals, use var if options allow usage here.
             if (initializerExpression.IsAnyLiteralExpression())
             {
-                return stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
+                return stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeForIntrinsicTypes);
             }
 
             // constructor invocations cases:
@@ -226,9 +226,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
             return node;
         }
 
-        private static TypeStyle GetCurrentTypeStylePreferences(OptionSet optionSet)
+        private static TypeStylePreference GetCurrentTypeStylePreferences(OptionSet optionSet)
         {
-            var stylePreferences = TypeStyle.None;
+            var stylePreferences = TypeStylePreference.None;
 
             var styleForIntrinsicTypes = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
             var styleForApparent = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
@@ -236,17 +236,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle.TypeStyle
 
             if (styleForIntrinsicTypes.IsChecked)
             {
-                stylePreferences |= TypeStyle.ImplicitTypeForIntrinsicTypes;
+                stylePreferences |= TypeStylePreference.ImplicitTypeForIntrinsicTypes;
             }
 
             if (styleForApparent.IsChecked)
             {
-                stylePreferences |= TypeStyle.ImplicitTypeWhereApparent;
+                stylePreferences |= TypeStylePreference.ImplicitTypeWhereApparent;
             }
 
             if (styleForElsewhere.IsChecked)
             {
-                stylePreferences |= TypeStyle.ImplicitTypeWherePossible;
+                stylePreferences |= TypeStylePreference.ImplicitTypeWherePossible;
             }
 
             return stylePreferences;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
     {
         internal class State
         {
-            private readonly Dictionary<CodeStyle.TypeStyle.TypeStylePreference, DiagnosticSeverity> _styleToSeverityMap;
+            private readonly Dictionary<TypeStylePreference, DiagnosticSeverity> _styleToSeverityMap;
 
             public TypeStylePreference TypeStylePreference { get; private set; }
             public bool IsInIntrinsicTypeContext { get; private set; }
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             public State(bool isVariableDeclarationContext)
             {
                 this.IsInVariableDeclarationContext = isVariableDeclarationContext;
-                _styleToSeverityMap = new Dictionary<CodeStyle.TypeStyle.TypeStylePreference, DiagnosticSeverity>();
+                _styleToSeverityMap = new Dictionary<TypeStylePreference, DiagnosticSeverity>();
             }
 
             public static State Generate(SyntaxNode declaration, SemanticModel semanticModel, OptionSet optionSet, bool isVariableDeclarationContext, CancellationToken cancellationToken)
@@ -42,15 +42,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             {
                 if (IsInIntrinsicTypeContext)
                 {
-                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeForIntrinsicTypes];
+                    return _styleToSeverityMap[TypeStylePreference.ImplicitTypeForIntrinsicTypes];
                 }
                 else if (IsTypeApparentInContext)
                 {
-                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWhereApparent];
+                    return _styleToSeverityMap[TypeStylePreference.ImplicitTypeWhereApparent];
                 }
                 else
                 {
-                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWherePossible];
+                    return _styleToSeverityMap[TypeStylePreference.ImplicitTypeWherePossible];
                 }
             }
 
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             /// Returns true if type information could be gleaned by simply looking at the given statement.
             /// This typically means that the type name occurs in right hand side of an assignment.
             /// </summary>
-            private bool IsTypeApparentInDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CodeStyle.TypeStyle.TypeStylePreference stylePreferences, CancellationToken cancellationToken)
+            private bool IsTypeApparentInDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, TypeStylePreference stylePreferences, CancellationToken cancellationToken)
             {
                 var initializer = variableDeclaration.Variables.Single().Initializer;
                 var initializerExpression = GetInitializerExpression(initializer);
@@ -126,29 +126,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             private TypeStylePreference GetCurrentTypeStylePreferences(OptionSet optionSet)
             {
-                var stylePreferences = CodeStyle.TypeStyle.TypeStylePreference.None;
+                var stylePreferences = TypeStylePreference.None;
 
                 var styleForIntrinsicTypes = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
                 var styleForApparent = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
                 var styleForElsewhere = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible);
 
-                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeForIntrinsicTypes, styleForIntrinsicTypes.Notification.Value);
-                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWhereApparent, styleForApparent.Notification.Value);
-                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWherePossible, styleForElsewhere.Notification.Value);
+                _styleToSeverityMap.Add(TypeStylePreference.ImplicitTypeForIntrinsicTypes, styleForIntrinsicTypes.Notification.Value);
+                _styleToSeverityMap.Add(TypeStylePreference.ImplicitTypeWhereApparent, styleForApparent.Notification.Value);
+                _styleToSeverityMap.Add(TypeStylePreference.ImplicitTypeWherePossible, styleForElsewhere.Notification.Value);
 
                 if (styleForIntrinsicTypes.IsChecked)
                 {
-                    stylePreferences |= CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeForIntrinsicTypes;
+                    stylePreferences |= TypeStylePreference.ImplicitTypeForIntrinsicTypes;
                 }
 
                 if (styleForApparent.IsChecked)
                 {
-                    stylePreferences |= CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWhereApparent;
+                    stylePreferences |= TypeStylePreference.ImplicitTypeWhereApparent;
                 }
 
                 if (styleForElsewhere.IsChecked)
                 {
-                    stylePreferences |= CodeStyle.TypeStyle.TypeStylePreference.ImplicitTypeWherePossible;
+                    stylePreferences |= TypeStylePreference.ImplicitTypeWherePossible;
                 }
 
                 return stylePreferences;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -12,23 +12,23 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
-namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
-    internal partial class CSharpTypingStyleDiagnosticAnalyzerBase
+    internal partial class CSharpTypeStyleDiagnosticAnalyzerBase
     {
         internal class State
         {
-            private readonly Dictionary<TypeStyle, DiagnosticSeverity> _styleToSeverityMap;
+            private readonly Dictionary<CodeStyle.TypeStyle.TypeStyle, DiagnosticSeverity> _styleToSeverityMap;
 
             public TypeStyle TypeStyle { get; private set; }
             public bool IsInIntrinsicTypeContext { get; private set; }
-            public bool IsTypingApparentInContext { get; private set; }
+            public bool IsTypeApparentInContext { get; private set; }
             public bool IsInVariableDeclarationContext { get; }
 
             public State(bool isVariableDeclarationContext)
             {
                 this.IsInVariableDeclarationContext = isVariableDeclarationContext;
-                _styleToSeverityMap = new Dictionary<TypeStyle, DiagnosticSeverity>();
+                _styleToSeverityMap = new Dictionary<CodeStyle.TypeStyle.TypeStyle, DiagnosticSeverity>();
             }
 
             public static State Generate(SyntaxNode declaration, SemanticModel semanticModel, OptionSet optionSet, bool isVariableDeclarationContext, CancellationToken cancellationToken)
@@ -42,15 +42,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             {
                 if (IsInIntrinsicTypeContext)
                 {
-                    return _styleToSeverityMap[TypeStyle.ImplicitTypeForIntrinsicTypes];
+                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStyle.ImplicitTypeForIntrinsicTypes];
                 }
-                else if (IsTypingApparentInContext)
+                else if (IsTypeApparentInContext)
                 {
-                    return _styleToSeverityMap[TypeStyle.ImplicitTypeWhereApparent];
+                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWhereApparent];
                 }
                 else
                 {
-                    return _styleToSeverityMap[TypeStyle.ImplicitTypeWherePossible];
+                    return _styleToSeverityMap[CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWherePossible];
                 }
             }
 
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             {
                 this.TypeStyle = GetCurrentTypingStylePreferences(optionSet);
 
-                IsTypingApparentInContext =
+                IsTypeApparentInContext =
                         IsInVariableDeclarationContext
                      && IsTypeApparentInDeclaration((VariableDeclarationSyntax)declaration, semanticModel, TypeStyle, cancellationToken);
 
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             /// Returns true if type information could be gleaned by simply looking at the given statement.
             /// This typically means that the type name occurs in right hand side of an assignment.
             /// </summary>
-            private bool IsTypeApparentInDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, TypeStyle stylePreferences, CancellationToken cancellationToken)
+            private bool IsTypeApparentInDeclaration(VariableDeclarationSyntax variableDeclaration, SemanticModel semanticModel, CodeStyle.TypeStyle.TypeStyle stylePreferences, CancellationToken cancellationToken)
             {
                 var initializer = variableDeclaration.Variables.Single().Initializer;
                 var initializerExpression = GetInitializerExpression(initializer);
@@ -126,29 +126,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
 
             private TypeStyle GetCurrentTypingStylePreferences(OptionSet optionSet)
             {
-                var stylePreferences = TypeStyle.None;
+                var stylePreferences = CodeStyle.TypeStyle.TypeStyle.None;
 
                 var styleForIntrinsicTypes = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
                 var styleForApparent = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
                 var styleForElsewhere = optionSet.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible);
 
-                _styleToSeverityMap.Add(TypeStyle.ImplicitTypeForIntrinsicTypes, styleForIntrinsicTypes.Notification.Value);
-                _styleToSeverityMap.Add(TypeStyle.ImplicitTypeWhereApparent, styleForApparent.Notification.Value);
-                _styleToSeverityMap.Add(TypeStyle.ImplicitTypeWherePossible, styleForElsewhere.Notification.Value);
+                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStyle.ImplicitTypeForIntrinsicTypes, styleForIntrinsicTypes.Notification.Value);
+                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWhereApparent, styleForApparent.Notification.Value);
+                _styleToSeverityMap.Add(CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWherePossible, styleForElsewhere.Notification.Value);
 
                 if (styleForIntrinsicTypes.IsChecked)
                 {
-                    stylePreferences |= TypeStyle.ImplicitTypeForIntrinsicTypes;
+                    stylePreferences |= CodeStyle.TypeStyle.TypeStyle.ImplicitTypeForIntrinsicTypes;
                 }
 
                 if (styleForApparent.IsChecked)
                 {
-                    stylePreferences |= TypeStyle.ImplicitTypeWhereApparent;
+                    stylePreferences |= CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWhereApparent;
                 }
 
                 if (styleForElsewhere.IsChecked)
                 {
-                    stylePreferences |= TypeStyle.ImplicitTypeWherePossible;
+                    stylePreferences |= CodeStyle.TypeStyle.TypeStyle.ImplicitTypeWherePossible;
                 }
 
                 return stylePreferences;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -12,9 +12,9 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
-    internal abstract partial class CSharpTypingStyleDiagnosticAnalyzerBase : DiagnosticAnalyzer, IBuiltInAnalyzer
+    internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase : DiagnosticAnalyzer, IBuiltInAnalyzer
     {
         private readonly string _diagnosticId;
         private readonly LocalizableString _title;
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
         private readonly DiagnosticDescriptor _errorDiagnosticDescriptor;
         private readonly Dictionary<DiagnosticSeverity, DiagnosticDescriptor> _severityToDescriptorMap;
 
-        public CSharpTypingStyleDiagnosticAnalyzerBase(string diagnosticId, LocalizableString title, LocalizableString message)
+        public CSharpTypeStyleDiagnosticAnalyzerBase(string diagnosticId, LocalizableString title, LocalizableString message)
         {
             _diagnosticId = diagnosticId;
             _title = title;

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
-            var stylePreferences = state.TypeStyle;
+            var stylePreferences = state.TypeStylePreference;
             var shouldNotify = state.ShouldNotify();
 
             // If notification preference is None, don't offer the suggestion.
@@ -41,15 +41,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             if (state.IsInIntrinsicTypeContext)
             {
-                return !stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
+                return !stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeForIntrinsicTypes);
             }
             else if (state.IsTypeApparentInContext)
             {
-                return !stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent);
+                return !stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWhereApparent);
             }
             else
             {
-                return !stylePreferences.HasFlag(TypeStyle.ImplicitTypeWherePossible);
+                return !stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWherePossible);
             }
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseExplicitTypeDiagnosticAnalyzer.cs
@@ -10,10 +10,10 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class CSharpUseExplicitTypingDiagnosticAnalyzer : CSharpTypingStyleDiagnosticAnalyzerBase
+    internal sealed class CSharpUseExplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
     {
         private static readonly LocalizableString s_Title =
             new LocalizableResourceString(nameof(CSharpFeaturesResources.UseExplicitTypeDiagnosticTitle), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
@@ -21,8 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
         private static readonly LocalizableString s_Message =
             new LocalizableResourceString(nameof(CSharpFeaturesResources.UseExplicitType), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
 
-        public CSharpUseExplicitTypingDiagnosticAnalyzer()
-            : base(diagnosticId: IDEDiagnosticIds.UseExplicitTypingDiagnosticId,
+        public CSharpUseExplicitTypeDiagnosticAnalyzer()
+            : base(diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
                    title: s_Title,
                    message: s_Message)
         {
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             {
                 return !stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
             }
-            else if (state.IsTypingApparentInContext)
+            else if (state.IsTypeApparentInContext)
             {
                 return !stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent);
             }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
         protected override bool IsStylePreferred(SemanticModel semanticModel, OptionSet optionSet, State state, CancellationToken cancellationToken)
         {
-            var stylePreferences = state.TypeStyle;
+            var stylePreferences = state.TypeStylePreference;
             var shouldNotify = state.ShouldNotify();
 
             // If notification preference is None, don't offer the suggestion.
@@ -42,15 +42,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 
             if (state.IsInIntrinsicTypeContext)
             {
-                return stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
+                return stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeForIntrinsicTypes);
             }
             else if (state.IsTypeApparentInContext)
             {
-                return stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent);
+                return stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWhereApparent);
             }
             else
             {
-                return stylePreferences.HasFlag(TypeStyle.ImplicitTypeWherePossible);
+                return stylePreferences.HasFlag(TypeStylePreference.ImplicitTypeWherePossible);
             }
         }
 

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUseImplicitTypeDiagnosticAnalyzer.cs
@@ -11,10 +11,10 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 
-namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    internal sealed class CSharpUseImplicitTypingDiagnosticAnalyzer : CSharpTypingStyleDiagnosticAnalyzerBase
+    internal sealed class CSharpUseImplicitTypeDiagnosticAnalyzer : CSharpTypeStyleDiagnosticAnalyzerBase
     {
         private static readonly LocalizableString s_Title =
             new LocalizableResourceString(nameof(CSharpFeaturesResources.UseImplicitTypeDiagnosticTitle), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
@@ -22,8 +22,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
         private static readonly LocalizableString s_Message =
             new LocalizableResourceString(nameof(CSharpFeaturesResources.UseImplicitType), CSharpFeaturesResources.ResourceManager, typeof(CSharpFeaturesResources));
 
-        public CSharpUseImplicitTypingDiagnosticAnalyzer()
-            : base(diagnosticId: IDEDiagnosticIds.UseImplicitTypingDiagnosticId,
+        public CSharpUseImplicitTypeDiagnosticAnalyzer()
+            : base(diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                    title: s_Title,
                    message: s_Message)
         {
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypingStyles
             {
                 return stylePreferences.HasFlag(TypeStyle.ImplicitTypeForIntrinsicTypes);
             }
-            else if (state.IsTypingApparentInContext)
+            else if (state.IsTypeApparentInContext)
             {
                 return stylePreferences.HasFlag(TypeStyle.ImplicitTypeWhereApparent);
             }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string RemoveUnnecessaryCastDiagnosticId = "IDE0004";
         public const string RemoveUnnecessaryImportsDiagnosticId = "IDE0005";
         public const string IntellisenseBuildFailedDiagnosticId = "IDE0006";
-        public const string UseImplicitTypingDiagnosticId = "IDE0007";
-        public const string UseExplicitTypingDiagnosticId = "IDE0008";
+        public const string UseImplicitTypeDiagnosticId = "IDE0007";
+        public const string UseExplicitTypeDiagnosticId = "IDE0008";
         public const string AddQualificationDiagnosticId = "IDE0009";
 
         // Analyzer error Ids

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -1026,9 +1026,27 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         /// <summary>
         ///   Looks up a localized string similar to For built-in types.
         /// </summary>
-        internal static string UseVarForIntrinsicTypes {
+        internal static string UseImplicitTypeForIntrinsicTypes {
             get {
-                return ResourceManager.GetString("UseVarForIntrinsicTypes", resourceCulture);
+                return ResourceManager.GetString("UseImplicitTypeForIntrinsicTypes", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Elsewhere.
+        /// </summary>
+        internal static string UseImplicitTypeWhenPossible {
+            get {
+                return ResourceManager.GetString("UseImplicitTypeWhenPossible", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to When variable type is apparent.
+        /// </summary>
+        internal static string UseImplicitTypeWhenTypeIsApparent {
+            get {
+                return ResourceManager.GetString("UseImplicitTypeWhenTypeIsApparent", resourceCulture);
             }
         }
         
@@ -1038,24 +1056,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         internal static string UseVarWhenGeneratingLocals {
             get {
                 return ResourceManager.GetString("UseVarWhenGeneratingLocals", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Elsewhere.
-        /// </summary>
-        internal static string UseVarWhenPossible {
-            get {
-                return ResourceManager.GetString("UseVarWhenPossible", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to When variable type is apparent.
-        /// </summary>
-        internal static string UseVarWhenTypeIsApparent {
-            get {
-                return ResourceManager.GetString("UseVarWhenTypeIsApparent", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -411,13 +411,13 @@
   <data name="SetTypeInferencePreferences" xml:space="preserve">
     <value>Type Inference preferences:</value>
   </data>
-  <data name="UseVarForIntrinsicTypes" xml:space="preserve">
+  <data name="UseImplicitTypeForIntrinsicTypes" xml:space="preserve">
     <value>For built-in types</value>
   </data>
-  <data name="UseVarWhenPossible" xml:space="preserve">
+  <data name="UseImplicitTypeWhenPossible" xml:space="preserve">
     <value>Elsewhere</value>
   </data>
-  <data name="UseVarWhenTypeIsApparent" xml:space="preserve">
+  <data name="UseImplicitTypeWhenTypeIsApparent" xml:space="preserve">
     <value>When variable type is apparent</value>
   </data>
   <data name="QualifyEventAccessWithThis" xml:space="preserve">

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -492,7 +492,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(CSharpCodeStyleOptions.UseVarWhenDeclaringLocals, value); }
         }
 
-        public string Style_UseVarWherePossible
+        public string Style_UseImplicitTypeWherePossible
         {
             get
             {
@@ -505,7 +505,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             }
         }
 
-        public string Style_UseVarWhenTypeIsApparent
+        public string Style_UseImplicitTypeWhereApparent
         {
             get
             {
@@ -518,7 +518,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             }
         }
 
-        public string Style_UseVarForIntrinsicTypes
+        public string Style_UseImplicitTypeForIntrinsicTypes
         {
             get
             {

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
@@ -51,9 +51,9 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         private const string SpaceAroundBinaryOperator = nameof(AutomationObject.Space_AroundBinaryOperator);
         private const string UnindentLabels = nameof(AutomationObject.Indent_UnindentLabels);
         private const string FlushLabelsLeft = nameof(AutomationObject.Indent_FlushLabelsLeft);
-        private const string Style_UseVarForIntrinsicTypes = nameof(AutomationObject.Style_UseVarForIntrinsicTypes);
-        private const string Style_UseVarWhenTypeIsApparent = nameof(AutomationObject.Style_UseVarWhenTypeIsApparent);
-        private const string Style_UseVarWherePossible = nameof(AutomationObject.Style_UseVarWherePossible);
+        private const string Style_UseImplicitTypeForIntrinsicTypes = nameof(AutomationObject.Style_UseImplicitTypeForIntrinsicTypes);
+        private const string Style_UseImplicitTypeWhereApparent = nameof(AutomationObject.Style_UseImplicitTypeWhereApparent);
+        private const string Style_UseImplicitTypeWherePossible = nameof(AutomationObject.Style_UseImplicitTypeWherePossible);
 
         private KeyValuePair<string, IOption> GetOptionInfoForOnOffOptions(FieldInfo fieldInfo)
         {
@@ -206,18 +206,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             // code style: use var options.
             if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes)
             {
-                var useVarValue = this.Manager.GetValueOrDefault<string>(Style_UseVarForIntrinsicTypes);
-                return FetchUseVarOption(useVarValue, out value);
+                var typeStyleValue = this.Manager.GetValueOrDefault<string>(Style_UseImplicitTypeForIntrinsicTypes);
+                return FetchTypeStyleOption(typeStyleValue, out value);
             }
             else if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeWhereApparent)
             {
-                var useVarValue = this.Manager.GetValueOrDefault<string>(Style_UseVarWhenTypeIsApparent);
-                return FetchUseVarOption(useVarValue, out value);
+                var typeStyleValue = this.Manager.GetValueOrDefault<string>(Style_UseImplicitTypeWhereApparent);
+                return FetchTypeStyleOption(typeStyleValue, out value);
             }
             else if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeWherePossible)
             {
-                var useVarValue = this.Manager.GetValueOrDefault<string>(Style_UseVarWherePossible);
-                return FetchUseVarOption(useVarValue, out value);
+                var typeStyleValue = this.Manager.GetValueOrDefault<string>(Style_UseImplicitTypeWherePossible);
+                return FetchTypeStyleOption(typeStyleValue, out value);
             }
 
             return base.TryFetch(optionKey, out value);
@@ -292,36 +292,36 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             // code style: use var options.
             if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes)
             {
-                return PersistUseVarOption(Style_UseVarForIntrinsicTypes, value);
+                return PersistTypeStyleOption(Style_UseImplicitTypeForIntrinsicTypes, value);
             }
             else if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeWhereApparent)
             {
-                return PersistUseVarOption(Style_UseVarWhenTypeIsApparent, value);
+                return PersistTypeStyleOption(Style_UseImplicitTypeWhereApparent, value);
             }
             else if (optionKey.Option == CSharpCodeStyleOptions.UseImplicitTypeWherePossible)
             {
-                return PersistUseVarOption(Style_UseVarWherePossible, value);
+                return PersistTypeStyleOption(Style_UseImplicitTypeWherePossible, value);
             }
 
             return base.TryPersist(optionKey, value);
         }
 
-        private bool PersistUseVarOption(string option, object value)
+        private bool PersistTypeStyleOption(string option, object value)
         {
             var serializedValue = ((SimpleCodeStyleOption)value).ToXElement().ToString();
             this.Manager.SetValueAsync(option, value: serializedValue, isMachineLocal: false);
             return true;
         }
 
-        private static bool FetchUseVarOption(string useVarOptionValue, out object value)
+        private static bool FetchTypeStyleOption(string typeStyleOptionValue, out object value)
         {
-            if (string.IsNullOrEmpty(useVarOptionValue))
+            if (string.IsNullOrEmpty(typeStyleOptionValue))
             {
                 value = SimpleCodeStyleOption.Default;
             }
             else
             {
-                value = SimpleCodeStyleOption.FromXElement(XElement.Parse(useVarOptionValue));
+                value = SimpleCodeStyleOption.FromXElement(XElement.Parse(typeStyleOptionValue));
             }
 
             return true;

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/StyleViewModel.cs
@@ -253,7 +253,7 @@ class C{
                 new CodeStylePreference(CSharpVSResources.PreferFrameworkType, isChecked: false),
             };
 
-            var useVarPreferences = new List<CodeStylePreference>
+            var typeStylePreferences = new List<CodeStylePreference>
             {
                 new CodeStylePreference(CSharpVSResources.PreferVar, isChecked: true),
                 new CodeStylePreference(CSharpVSResources.PreferExplicitType, isChecked: false),
@@ -267,9 +267,9 @@ class C{
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, CSharpVSResources.PreferIntrinsicPredefinedTypeKeywordInDeclaration, s_intrinsicPreviewDeclarationTrue, s_intrinsicPreviewDeclarationFalse, this, optionSet, predefinedTypesGroupTitle, predefinedTypesPreferences));
             CodeStyleItems.Add(new BooleanCodeStyleOptionViewModel(SimplificationOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, CSharpVSResources.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, s_intrinsicPreviewMemberAccessTrue, s_intrinsicPreviewMemberAccessFalse, this, optionSet, predefinedTypesGroupTitle, predefinedTypesPreferences));
 
-            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CSharpVSResources.UseVarForIntrinsicTypes, s_varForIntrinsicsPreviewTrue, s_varForIntrinsicsPreviewFalse, this, optionSet, varGroupTitle, useVarPreferences));
-            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, CSharpVSResources.UseVarWhenTypeIsApparent, s_varWhereApparentPreviewTrue, s_varWhereApparentPreviewFalse, this, optionSet, varGroupTitle, useVarPreferences));
-            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CSharpVSResources.UseVarWhenPossible, s_varWherePossiblePreviewTrue, s_varWherePossiblePreviewFalse, this, optionSet, varGroupTitle, useVarPreferences));
+            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, CSharpVSResources.UseImplicitTypeForIntrinsicTypes, s_varForIntrinsicsPreviewTrue, s_varForIntrinsicsPreviewFalse, this, optionSet, varGroupTitle, typeStylePreferences));
+            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, CSharpVSResources.UseImplicitTypeWhenTypeIsApparent, s_varWhereApparentPreviewTrue, s_varWhereApparentPreviewFalse, this, optionSet, varGroupTitle, typeStylePreferences));
+            CodeStyleItems.Add(new SimpleCodeStyleOptionViewModel(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, CSharpVSResources.UseImplicitTypeWhenPossible, s_varWherePossiblePreviewTrue, s_varWherePossiblePreviewFalse, this, optionSet, varGroupTitle, typeStylePreferences));
         }
     }
 }


### PR DESCRIPTION
This is a boring PR with no functional changes. The only changes are some code clean ups suggested on the original implementation. The changes are as follows:

1. Rename typing to type
2. Rename useVar to useImplicitType to maintain consistency
3. Rename a type to not match its namespace.
4. simplify type names.

Part of https://github.com/dotnet/roslyn/issues/9155