### PR TITLE
Tuples: adding tests for OHI

### DIFF
--- a/docs/features/tuples.work.md
+++ b/docs/features/tuples.work.md
@@ -16,12 +16,13 @@ This is the TODO list for the development of the tuples language feature for C# 
 
 - [ ] Control/data flow (mostly testing)
 - [ ] Validation with other C# features (evaluation order, dynamic, unsafe code/pointers, optional parameter constants, nullable)
+- [ ] Generating and loading metadata for user-defined member names
 - [ ] Semantic info and other IDE stuff
     - [ ] Debugger / watch window / expression evaluation / EnC
 - [x] Update well-known tuple types to TN naming convention
 - [ ] Generating and loading metadata for user-defined member names
 - [ ] Figure out full behavior for reserved member names
-- [ ] Support tuples 8+
+- [x] Support tuples 8+
 - [ ] Interop with System.Tuple, KeyValuePair
 - [ ] XML docs
 - [ ] Debugger bugs

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -61,17 +61,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
-            // NOTE: overrides can differ by object/dynamic.  If they do, we'll need to tweak newType before
-            // we can use it in place of this.Type.  We do so by computing the dynamic transform flags that
-            // code gen uses and then passing them to the dynamic type decoder that metadata reading uses.
+            if (sourceType.IsTupleType)
+            {
+                // PROTOTYPE(tuples) this check/case should be removed once tuple metadata encoding is implemented
+                ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
+                TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
-            ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
-            TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
+                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
+                return resultType;
+            }
+            else
+            {
+                // NOTE: overrides can differ by object/dynamic.  If they do, we'll need to tweak newType before
+                // we can use it in place of this.Type.  We do so by computing the dynamic transform flags that
+                // code gen uses and then passing them to the dynamic type decoder that metadata reading uses.
+                ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
+                TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
-            Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
-            Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false)); // Same object/dynamic as destination type.
-
-            return resultType;
+                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
+                Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false)); // Same object/dynamic as destination type.
+                return resultType;
+            }
         }
 
         internal static ImmutableArray<ParameterSymbol> CopyParameterCustomModifiers(ImmutableArray<ParameterSymbol> sourceParameters, ImmutableArray<ParameterSymbol> destinationParameters, bool alsoCopyParamsModifier)

--- a/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (numElements <= 1)
             {
                 throw ExceptionUtilities.Unreachable;
-        }
+            }
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, binder, diagnostics);
 
             return new TupleTypeSymbol(underlyingType, elementNames, binder.Compilation.Assembly);
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             var fieldsBuilder = ArrayBuilder<TupleFieldSymbol>.GetInstance(originalTuple._fields.Length);
             var originalFields = originalTuple._fields;
-            
+
             for (int i = 0; i < originalFields.Length; i++)
             {
                 fieldsBuilder.Add(originalFields[i].WithName(this, GetFieldNameFromArrayOrDefaultName(newElementNames, i)));
@@ -753,7 +753,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _fields.Length;
+                return 0;
             }
         }
 


### PR DESCRIPTION
This PR contains mostly tests. This uncovered two issues:

- A minor one which is fixed along, regarding the arity of the TupleTypeSymbol (should be zero). 
- The other one is more significant, regarding the treatment of flags (like dynamic or tuple names) during inheritance. A temporary workaround was put in place, which we'll address once we get to generating this sort of metadata.