### PR TITLE
Tuples: lookup well-known ValueTuple members relative to given type

### DIFF
--- a/docs/features/tuples.work.md
+++ b/docs/features/tuples.work.md
@@ -8,6 +8,12 @@ This is the TODO list for the development of the tuples language feature for C# 
     - [ ] `(byte, float) x = (1, 2)` should work
     - [ ] `return (null, null)` should work in `(object, object) M()`
 - [ ] OHI validation / fixing
+- [ ] Write spec
+- [ ] Honor feature flag
+- [ ] Publish short-term nuget package for tuples library
+- [ ] Get tuples library into corefx
+- [ ] Add warning for re-using member names out of position
+
 - [ ] Control/data flow (mostly testing)
 - [ ] Validation with other C# features (evaluation order, dynamic, unsafe code/pointers, optional parameter constants, nullable)
 - [ ] Semantic info and other IDE stuff
@@ -17,8 +23,6 @@ This is the TODO list for the development of the tuples language feature for C# 
 - [ ] Figure out full behavior for reserved member names
 - [ ] Support tuples 8+
 - [ ] Interop with System.Tuple, KeyValuePair
-- [ ] Publish short-term nuget package for tuples library
-- [ ] Get tuples library into corefx
 - [ ] XML docs
 - [ ] Debugger bugs
     - [ ] Tuple debug display is {(1, 2)} because ValueTuple.ToString() returns "(1, 2)"

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -687,14 +687,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             ImmutableArray<TypeSymbol> elements = elementTypes.ToImmutableAndFree();
 
-            var type = new TupleTypeSymbol(
-                elements,
-                elementNames == null ?
-                    default(ImmutableArray<string>) :
-                    elementNames.ToImmutableAndFree(),
-                node,
-                this,
-                diagnostics);
+            var type = TupleTypeSymbol.Create(
+                                        elements,
+                                        elementNames == null ?
+                                            default(ImmutableArray<string>) :
+                                            elementNames.ToImmutableAndFree(),
+                                        node,
+                                        this,
+                                        diagnostics);
 
             return new BoundTupleCreationExpression(node, boundArguments.ToImmutableAndFree(), type, hasErrors);
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -436,16 +436,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, syntax.Location));
             }
 
-            var tuple = new TupleTypeSymbol(
-                typesArray,
-                elementNames == null ?
-                    default(ImmutableArray<string>) :
-                    elementNames.ToImmutableAndFree(),
-                syntax,
-                this,
-                diagnostics);
-
-            return tuple;
+            return TupleTypeSymbol.Create(
+                                            typesArray,
+                                            elementNames == null ?
+                                                default(ImmutableArray<string>) :
+                                                elementNames.ToImmutableAndFree(),
+                                            syntax,
+                                            this,
+                                            diagnostics);
         }
 
         private static void CollectTupleFieldMemberNames(string name, int position, int tupleSize, ref ArrayBuilder<string> elementNames)

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7316,6 +7316,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Member &apos;{0}&apos; was not found on type &apos;{1}&apos; from assembly &apos;{2}&apos;..
+        /// </summary>
+        internal static string ERR_PredefinedTypeMemberNotFoundInAssembly {
+            get {
+                return ResourceManager.GetString("ERR_PredefinedTypeMemberNotFoundInAssembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Predefined type &apos;{0}&apos; is not defined or imported.
         /// </summary>
         internal static string ERR_PredefinedTypeNotFound {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4872,4 +4872,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TupleReservedMemberNameAnyPosition" xml:space="preserve">
     <value>Tuple membername '{0}' is disallowed at any position.</value>
   </data>
+  <data name="ERR_PredefinedTypeMemberNotFoundInAssembly" xml:space="preserve">
+    <value>Member '{0}' was not found on type '{1}' from assembly '{2}'.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1382,6 +1382,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleDuplicateMemberName = 8203,
         ERR_TupleExplicitNamesOnAllMembersOrNone = 8204,
 
-        ERR_PrototypeNotYetImplemented = 8204,
+        ERR_PredefinedTypeMemberNotFoundInAssembly = 8205,
+
+        ERR_PrototypeNotYetImplemented = 9000,
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Field.cs
@@ -41,7 +41,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (loop > 1)
             {
                 WellKnownMember wellKnownTupleRest = TupleTypeSymbol.GetTupleTypeMember(TupleTypeSymbol.RestPosition, TupleTypeSymbol.RestPosition);
-                var tupleRestField = (FieldSymbol)Binder.GetWellKnownTypeMember(_compilation, wellKnownTupleRest, _diagnostics, syntax: node.Syntax);
+                var tupleRestField = (FieldSymbol)TupleTypeSymbol.GetWellKnownMemberInType(currentLinkType.OriginalDefinition, wellKnownTupleRest, _compilation.Assembly, _diagnostics, node.Syntax);
+
                 if ((object)tupleRestField == null)
                 {
                     return node;
@@ -61,7 +62,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // make a field access for the most local access
             WellKnownMember wellKnownTypeMember = TupleTypeSymbol.GetTupleTypeMember(currentLinkType.Arity, fieldRemainder);
-            var linkField = (FieldSymbol)Binder.GetWellKnownTypeMember(_compilation, wellKnownTypeMember, _diagnostics, syntax: node.Syntax);
+            var linkField = (FieldSymbol)TupleTypeSymbol.GetWellKnownMemberInType(currentLinkType.OriginalDefinition, wellKnownTypeMember, _compilation.Assembly, _diagnostics, node.Syntax);
+
             if ((object)linkField == null)
             {
                 return node;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_TupleCreationExpression.cs
@@ -33,8 +33,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray<BoundExpression> smallestCtorArguments = ImmutableArray.Create(rewrittenArguments,
                                                                                               underlyingTupleTypeChain.Count * (TupleTypeSymbol.RestPosition - 1),
                                                                                               smallestType.Arity);
-
-                var smallestCtor = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, TupleTypeSymbol.GetTupleCtor(smallestType.Arity), _diagnostics, syntax: node.Syntax);
+                var smallestCtor = (MethodSymbol)TupleTypeSymbol.GetWellKnownMemberInType(smallestType.OriginalDefinition,
+                                                                                            TupleTypeSymbol.GetTupleCtor(smallestType.Arity),
+                                                                                            _compilation.Assembly,
+                                                                                            _diagnostics,
+                                                                                            node.Syntax);
                 if ((object)smallestCtor == null)
                 {
                     return node;
@@ -45,7 +48,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (underlyingTupleTypeChain.Count > 0)
                 {
-                    var tuple8Ctor = (MethodSymbol)Binder.GetWellKnownTypeMember(_compilation, TupleTypeSymbol.GetTupleCtor(TupleTypeSymbol.RestPosition), _diagnostics, syntax: node.Syntax);
+                    NamedTypeSymbol tuple8Type = underlyingTupleTypeChain.Peek();
+                    var tuple8Ctor = (MethodSymbol)TupleTypeSymbol.GetWellKnownMemberInType(tuple8Type.OriginalDefinition,
+                                                                                            TupleTypeSymbol.GetTupleCtor(TupleTypeSymbol.RestPosition),
+                                                                                            _compilation.Assembly,
+                                                                                            _diagnostics,
+                                                                                            node.Syntax);
                     if ((object)tuple8Ctor == null)
                     {
                         return node;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -849,41 +849,44 @@ class C
 {
     static void Main()
     {
-        (int, string a) x = (b: 1, ""hello"", 2);
+        (int, string) x = (1, ""hello"");
     }
 }
 ";
-            // PROTOTYPE(tuples) those are not the final diagnostics
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
-                // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, "(int, string a)").WithLocation(6, 9),
                 // (6,9): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(int, string a)").WithArguments("System.ValueTuple`2").WithLocation(6, 9),
-                // (6,9): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(int, string a)").WithArguments("System.ValueTuple`2", "Item1").WithLocation(6, 9),
-                // (6,9): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(int, string a)").WithArguments("System.ValueTuple`2", "Item2").WithLocation(6, 9),
-                // (6,29): error CS8204: Tuple member names must all be provided, if any one is provided.
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, @"(b: 1, ""hello"", 2)").WithLocation(6, 29),
-                // (6,29): error CS0518: Predefined type 'System.ValueTuple`3' is not defined or imported
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3").WithLocation(6, 29),
-                // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3.Item1'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item1").WithLocation(6, 29),
-                // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3.Item2'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item2").WithLocation(6, 29),
-                // (6,29): error CS0656: Missing compiler required member 'System.ValueTuple`3.Item3'
-                //         (int, string a) x = (b: 1, "hello", 2);
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, @"(b: 1, ""hello"", 2)").WithArguments("System.ValueTuple`3", "Item3").WithLocation(6, 29)
-                );
+                //         (int, string) x = (1, "hello");
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(int, string)").WithArguments("System.ValueTuple`2").WithLocation(6, 9),
+                // (6,27): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         (int, string) x = (1, "hello");
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, @"(1, ""hello"")").WithArguments("System.ValueTuple`2").WithLocation(6, 27)
+                               );
+        }
+
+        [Fact]
+        public void TupleUsageWithMissingTupleMembers()
+        {
+            var source = @"
+namespace System
+{
+    public struct ValueTuple<T1, T2> { }
+}
+
+class C
+{
+    static void Main()
+    {
+        (int, int) x = (1, 2);
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp");
+            comp.VerifyEmitDiagnostics(
+                // (11,24): error CS8205: Member '.ctor' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
+                //         (int, int) x = (1, 2);
+                Diagnostic(ErrorCode.ERR_PredefinedTypeMemberNotFoundInAssembly, "(1, 2)").WithArguments(".ctor", "System.ValueTuple<T1, T2>", "comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(11, 24)
+                               );
         }
 
         [Fact]
@@ -1186,22 +1189,10 @@ class C
                 // (10,12): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //     static (T1 first, T2 second) M<T1, T2>()
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2").WithLocation(10, 12),
-                // (10,12): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
-                //     static (T1 first, T2 second) M<T1, T2>()
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2", "Item1").WithLocation(10, 12),
-                // (10,12): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
-                //     static (T1 first, T2 second) M<T1, T2>()
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(T1 first, T2 second)").WithArguments("System.ValueTuple`2", "Item2").WithLocation(10, 12),
                 // (12,16): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         return (default(T1), default(T2));
-                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2").WithLocation(12, 16),
-                // (12,16): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
-                //         return (default(T1), default(T2));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2", "Item1").WithLocation(12, 16),
-                // (12,16): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
-                //         return (default(T1), default(T2));
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2", "Item2").WithLocation(12, 16)
-                );
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(default(T1), default(T2))").WithArguments("System.ValueTuple`2").WithLocation(12, 16)
+                                );
         }
 
         [Fact]
@@ -1476,6 +1467,188 @@ class C
 " + trivial2uple;
 
             var comp = CompileAndVerify(source, expectedOutput: @"{1, hello}");
+        }
+
+        [Fact]
+        public void DistinctTupleTypesInCompilation()
+        {
+            var source1 = @"
+public class C1
+{
+    public static (int a, int b) M()
+    {
+        return (1, 2);
+    }
+}
+" + trivial2uple;
+
+            var source2 = @"
+public class C2
+{
+    public static (int c, int d) M()
+    {
+        return (3, 4);
+    }
+}
+" + trivial2uple;
+
+            var source = @"
+class C3
+{
+    public static void Main()
+    {
+        System.Console.Write(C1.M().Item1 + "" "");
+        System.Console.Write(C1.M().a + "" "");
+        System.Console.Write(C1.M().Item2 + "" "");
+        System.Console.Write(C1.M().b + "" "");
+        System.Console.Write(C2.M().Item1 + "" "");
+        System.Console.Write(C2.M().c + "" "");
+        System.Console.Write(C2.M().Item2 + "" "");
+        System.Console.Write(C2.M().d);
+    }
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(source1);
+            var comp2 = CreateCompilationWithMscorlib(source2);
+            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) });
+        }
+
+        [Fact]
+        public void DistinctTupleTypesInCompilationCannotAssign()
+        {
+            var source1 = @"
+public class C1
+{
+    public static (int a, int b) M()
+    {
+        return (1, 2);
+    }
+}
+" + trivial2uple;
+
+            var source2 = @"
+public class C2
+{
+    public static (int c, int d) M()
+    {
+        return (3, 4);
+    }
+}
+" + trivial2uple;
+
+            var source = @"
+class C3
+{
+    public static void Main()
+    {
+        var x = C1.M();
+        x = C2.M();
+    }
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(source1);
+            var comp2 = CreateCompilationWithMscorlib(source2);
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) });
+
+            // PROTOTYPE(tuples) this error is misleading or worse.
+            comp.VerifyDiagnostics(
+                // (7,13): error CS0029: Cannot implicitly convert type '<tuple: int c, int d>' to '<tuple: int a, int b>'
+                //         x = C2.M();
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "C2.M()").WithArguments("<tuple: int c, int d>", "<tuple: int a, int b>").WithLocation(7, 13)
+                );
+        }
+
+        [Fact]
+        public void AmbiguousTupleTypesForCreation()
+        {
+            var source = @"
+class C3
+{
+    public static void Main()
+    {
+        var x = (1, 1);
+    }
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1");
+            var comp2 = CreateCompilationWithMscorlib(trivial2uple);
+
+            var comp = CompileAndVerify(source, additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) });
+            comp.VerifyDiagnostics(
+                // warning CS1685: The predefined type 'ValueTuple<T1, T2>' is defined in multiple assemblies in the global alias; using definition from 'comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.ValueTuple<T1, T2>", "comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                                );
+        }
+
+        [Fact]
+        public void AmbiguousTupleTypesForDeclaration()
+        {
+            var source = @"
+class C3
+{
+    public void M((int, int) x) { }
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1");
+            var comp2 = CreateCompilationWithMscorlib(trivial2uple);
+
+            var comp = CompileAndVerify(source, additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) });
+            comp.VerifyDiagnostics(
+                // warning CS1685: The predefined type 'ValueTuple<T1, T2>' is defined in multiple assemblies in the global alias; using definition from 'comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'
+                Diagnostic(ErrorCode.WRN_MultiplePredefTypes).WithArguments("System.ValueTuple<T1, T2>", "comp1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(1, 1)
+                                );
+        }
+
+        [Fact]
+        public void LocalTupleTypeWinsWhenTupleTypesInCompilation()
+        {
+            var source1 = @"
+public class C1
+{
+    public static (int a, int b) M()
+    {
+        return (1, 2);
+    }
+}
+" + trivial2uple;
+
+            var source2 = @"
+public class C2
+{
+    public static (int c, int d) M()
+    {
+        return (3, 4);
+    }
+}
+" + trivial2uple;
+
+            var source = @"
+class C3
+{
+    public static void Main()
+    {
+        System.Console.Write(C1.M().Item1 + "" "");
+        System.Console.Write(C1.M().a + "" "");
+        System.Console.Write(C1.M().Item2 + "" "");
+        System.Console.Write(C1.M().b + "" "");
+        System.Console.Write(C2.M().Item1 + "" "");
+        System.Console.Write(C2.M().c + "" "");
+        System.Console.Write(C2.M().Item2 + "" "");
+        System.Console.Write(C2.M().d + "" "");
+
+        var x = (e: 5, f: 6);
+        System.Console.Write(x.Item1 + "" "");
+        System.Console.Write(x.e + "" "");
+        System.Console.Write(x.Item2 + "" "");
+        System.Console.Write(x.f + "" "");
+        System.Console.Write(x.GetType().Assembly == typeof(C3).Assembly);
+    }
+}
+" + trivial2uple;
+
+            var comp1 = CreateCompilationWithMscorlib(source1);
+            var comp2 = CreateCompilationWithMscorlib(source2);
+            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4 5 5 6 6 True", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) });
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7195,12 +7195,6 @@ class A
     // (7,9): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
     //         (a, b) =>
     Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(a, b)").WithArguments("System.ValueTuple`2").WithLocation(7, 9),
-    // (7,9): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item1'
-    //         (a, b) =>
-    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(a, b)").WithArguments("System.ValueTuple`2", "Item1").WithLocation(7, 9),
-    // (7,9): error CS0656: Missing compiler required member 'System.ValueTuple`2.Item2'
-    //         (a, b) =>
-    Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "(a, b)").WithArguments("System.ValueTuple`2", "Item2").WithLocation(7, 9),
     // (11,9): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
     //         x + y; x == 1;
     Diagnostic(ErrorCode.ERR_IllegalStatement, "x + y").WithLocation(11, 9),


### PR DESCRIPTION
Changing member lookups to rely on the tuple's underlying type rather than the well-known type. This is in preparation for metadata generation and loading work.