### PR TITLE
Guarantee that method tokens used in dynamic analysis instrumentation are for definitions

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -443,8 +443,8 @@
   <Node Name="BoundTypeOfPrivateImplementationDetails" Base="BoundTypeOf">
   </Node>
 
-   <!-- Represents the raw metadata token value for a method. Dynamic instrumentation depends on tracking method tokens. -->
-  <Node Name="BoundMethodToken" Base="BoundExpression">
+   <!-- Represents the raw metadata token value for a method definition. Dynamic instrumentation depends on tracking method tokens. -->
+  <Node Name="BoundMethodDefinitionToken" Base="BoundExpression">
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
     <Field Name="Method" Type="MethodSymbol"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -1809,7 +1809,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundMethodToken
+    internal partial class BoundMethodDefinitionToken
     {
         protected override OperationKind ExpressionKind => OperationKind.None;
 

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -316,10 +316,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitTypeReferenceToken(_module.Translate(symbol, syntaxNode, _diagnostics), syntaxNode);
         }
 
-        private void EmitSymbolToken(MethodSymbol method, CSharpSyntaxNode syntaxNode, BoundArgListOperator optArgList, bool encodeAsRawToken = false)
+        private void EmitSymbolToken(MethodSymbol method, CSharpSyntaxNode syntaxNode, BoundArgListOperator optArgList, bool encodeAsRawDefinitionToken = false)
         {
-            _builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList, needDeclaration: encodeAsRawToken), syntaxNode, _diagnostics, encodeAsRawToken);
-            //_builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList), syntaxNode, _diagnostics, encodeAsRawToken);
+            _builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList, needDeclaration: encodeAsRawDefinitionToken), syntaxNode, _diagnostics, encodeAsRawDefinitionToken);
         }
 
         private void EmitSymbolToken(FieldSymbol symbol, CSharpSyntaxNode syntaxNode)

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -318,7 +318,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
         private void EmitSymbolToken(MethodSymbol method, CSharpSyntaxNode syntaxNode, BoundArgListOperator optArgList, bool encodeAsRawToken = false)
         {
-            _builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList), syntaxNode, _diagnostics, encodeAsRawToken);
+            _builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList, needDeclaration: encodeAsRawToken), syntaxNode, _diagnostics, encodeAsRawToken);
+            //_builder.EmitToken(_module.Translate(method, syntaxNode, _diagnostics, optArgList), syntaxNode, _diagnostics, encodeAsRawToken);
         }
 
         private void EmitSymbolToken(FieldSymbol symbol, CSharpSyntaxNode syntaxNode)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -220,10 +220,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitModuleVersionIdLoad((BoundModuleVersionId)expression);
                     break;
 
-                case BoundKind.MethodToken:
+                case BoundKind.MethodDefinitionToken:
                     if (used)
                     {
-                        EmitMethodTokenExpression((BoundMethodToken)expression);
+                        EmitMethodDefinitionTokenExpression((BoundMethodDefinitionToken)expression);
                     }
                     break;
 
@@ -2678,12 +2678,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             EmitSymbolToken(type, boundSizeOfOperator.SourceType.Syntax);
         }
 
-        private void EmitMethodTokenExpression(BoundMethodToken node)
+        private void EmitMethodDefinitionTokenExpression(BoundMethodDefinitionToken node)
         {
             Debug.Assert(node.Method.IsDefinition);
             Debug.Assert(node.Type.SpecialType == SpecialType.System_Int32);
             _builder.EmitOpCode(ILOpCode.Ldtoken);
-            EmitSymbolToken(node.Method, node.Syntax, null, encodeAsRawToken: true);
+            EmitSymbolToken(node.Method, node.Syntax, null, encodeAsRawDefinitionToken: true);
         }
 
         private void EmitModuleVersionIdLoad(BoundModuleVersionId node)

--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     
                     BoundExpression mvid = factory.ModuleVersionId();
 
-                    BoundExpression methodToken = factory.MethodToken(method);
+                    BoundExpression methodToken = factory.MethodDefinitionToken(method);
                     BoundStatement createPayloadCall = factory.ExpressionStatement(factory.Call(null, createPayload, mvid, methodToken, factory.Field(null, payloadField), factory.Literal(dynamicAnalysisSpans.Length)));
 
                     BoundExpression payloadNullTest = factory.Binary(BinaryOperatorKind.ObjectEqual, boolType, factory.Field(null, payloadField), factory.Null(payloadType));

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -1293,7 +1293,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        public override BoundNode VisitMethodToken(BoundMethodToken node)
+        public override BoundNode VisitMethodDefinitionToken(BoundMethodDefinitionToken node)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -977,9 +977,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             { WasCompilerGenerated = true };
         }
 
-        public BoundExpression MethodToken(MethodSymbol method)
+        public BoundExpression MethodDefinitionToken(MethodSymbol method)
         {
-            return new BoundMethodToken(
+            return new BoundMethodDefinitionToken(
                 Syntax,
                 method,
                 SpecialType(Microsoft.CodeAnalysis.SpecialType.System_Int32))


### PR DESCRIPTION
The fix is from @AlekseyTs by way of @drognanar and @amcasey .

Review requested from @AlekseyTs @jcouv @dotnet/roslyn-compiler @drognanar  @genlu @tmat 