### PR TITLE
Stop creating local function nodes w/o flag

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -84,7 +84,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             languageVersion: other.LanguageVersion,
             documentationMode: other.DocumentationMode,
             kind: other.Kind,
-            preprocessorSymbols: other.PreprocessorSymbols)
+            preprocessorSymbols: other.PreprocessorSymbols,
+            features: other.Features.ToImmutableDictionary())
         {
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8232,6 +8232,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             SyntaxToken refTokenOpt,
             out LocalFunctionStatementSyntax localFunction)
         {
+            allowLocalFunctions = allowLocalFunctions && IsFeatureEnabled(MessageID.IDS_FeatureLocalFunctions);
+
             type = allowLocalFunctions ? ParseReturnType() : this.ParseType(false);
 
             VariableFlags flags = VariableFlags.Local;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8454,7 +8454,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 semicolon);
 
             decl = CheckForBlockAndExpressionBody(blockBody, expressionBody, decl);
-            decl = CheckFeatureAvailability(decl, MessageID.IDS_FeatureLocalFunctions);
             return decl;
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2839,19 +2839,33 @@ class Program
 }
 ";
             CreateCompilationWithMscorlib(source).VerifyDiagnostics(
-    // (6,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
-    //         void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "void f() { if () const int i = 0; }").WithArguments("local functions", "localFunctions").WithLocation(6, 9),
-    // (6,24): error CS1525: Invalid expression term ')'
-    //         void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 24),
-    // (6,26): error CS1023: Embedded statement cannot be a declaration or labeled statement
-    //         void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(6, 26),
-    // (6,14): warning CS0168: The variable 'f' is declared but never used
-    //         void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(6, 14)
-                );
+                // (6,9): error CS1547: Keyword 'void' cannot be used in this context
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(6, 9),
+                // (6,15): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_BadVarDecl, "() ").WithLocation(6, 15),
+                // (6,15): error CS1003: Syntax error, '[' expected
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "(").WithLocation(6, 15),
+                // (6,16): error CS1525: Invalid expression term ')'
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 16),
+                // (6,18): error CS1003: Syntax error, ']' expected
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_SyntaxError, "{").WithArguments("]", "{").WithLocation(6, 18),
+                // (6,18): error CS1002: ; expected
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "{").WithLocation(6, 18),
+                // (6,24): error CS1525: Invalid expression term ')'
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 24),
+                // (6,26): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(6, 26),
+                // (6,14): warning CS0168: The variable 'f' is declared but never used
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(6, 14));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3667,12 +3667,31 @@ class Program
 ";
             var option = TestOptions.ReleaseExe;
             CreateCompilationWithMscorlib(source, options: option, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)).VerifyDiagnostics(
-    // (6,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
-    //         void Local()
-    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, @"void Local()
-        {
-        }").WithArguments("local functions", "localFunctions").WithLocation(6, 9)
-                );
+                // (6,9): error CS1547: Keyword 'void' cannot be used in this context
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_NoVoidHere, "void").WithLocation(6, 9),
+                // (6,19): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_BadVarDecl, @"()
+").WithLocation(6, 19),
+                // (6,19): error CS1003: Syntax error, '[' expected
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "(").WithLocation(6, 19),
+                // (6,20): error CS1525: Invalid expression term ')'
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 20),
+                // (6,21): error CS1003: Syntax error, ']' expected
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_SyntaxError, "").WithArguments("]", "{").WithLocation(6, 21),
+                // (6,21): error CS1002: ; expected
+                //         void Local()
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "").WithLocation(6, 21),
+                // (9,9): error CS0149: Method name expected
+                //         Local();
+                Diagnostic(ErrorCode.ERR_MethodNameExpected, "Local").WithLocation(9, 9),
+                // (9,9): error CS0165: Use of unassigned local variable 'Local'
+                //         Local();
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "Local").WithArguments("Local").WithLocation(9, 9));
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -31,7 +31,10 @@ public class Vec
         object o = ""Pass"";
         int i1 = 0b001010; // binary literals
         int i2 = 23_554; // digit separators
-        int f() => 2; // local functions
+        // local functions
+        // Note: due to complexity and cost of parsing local functions we
+        // don't try to parse if the feature isn't enabled
+        int f() => 2;
         ref int i3 = ref i1; // ref locals
         string s = o is string k ? k : null; // pattern matching
         let var i4 = 3; // let
@@ -51,90 +54,96 @@ public class Vec
                 // (8,18): error CS8058: Feature 'digit separators' is experimental and unsupported; use '/features:digitSeparators' to enable.
                 //         int i2 = 23_554; // digit separators
                 Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "").WithArguments("digit separators", "digitSeparators").WithLocation(8, 18),
-                // (9,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
-                //         int f() => 2; // local functions
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "int f() => 2;").WithArguments("local functions", "localFunctions").WithLocation(9, 9),
-                // (9,22): error CS1513: } expected
-                //         int f() => 2; // local functions
-                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(9, 22),
-                // (10,22): error CS1525: Invalid expression term 'ref'
+                // (12,14): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
+                //         int f() => 2;
+                Diagnostic(ErrorCode.ERR_BadVarDecl, "() => 2").WithLocation(12, 14),
+                // (12,14): error CS1003: Syntax error, '[' expected
+                //         int f() => 2;
+                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "(").WithLocation(12, 14),
+                // (12,21): error CS1003: Syntax error, ']' expected
+                //         int f() => 2;
+                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments("]", ";").WithLocation(12, 21),
+                // (12,22): error CS1513: } expected
+                //         int f() => 2;
+                Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(12, 22),
+                // (13,22): error CS1525: Invalid expression term 'ref'
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(10, 22),
-                // (10,22): error CS1003: Syntax error, ',' expected
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "ref").WithArguments("ref").WithLocation(13, 22),
+                // (13,22): error CS1003: Syntax error, ',' expected
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",", "ref").WithLocation(10, 22),
-                // (10,26): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_SyntaxError, "ref").WithArguments(",", "ref").WithLocation(13, 22),
+                // (13,26): error CS1002: ; expected
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i1").WithLocation(10, 26),
-                // (11,20): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i1").WithLocation(13, 26),
+                // (14,20): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
                 //         string s = o is string k ? k : null; // pattern matching
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o is string k").WithArguments("pattern matching", "patterns").WithLocation(11, 20),
-                // (12,17): error CS1002: ; expected
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o is string k").WithArguments("pattern matching", "patterns").WithLocation(14, 20),
+                // (15,17): error CS1002: ; expected
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i4").WithLocation(12, 17),
-                // (13,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i4").WithLocation(15, 17),
+                // (16,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
                 //         int i5 = o match (case * : 7); // match
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o match (case * : 7)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(13, 18),
-                // (14,21): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o match (case * : 7)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(16, 18),
+                // (17,21): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
                 //         object q = (o is null) ? o : throw null; // throw expressions
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o is null").WithArguments("pattern matching", "patterns").WithLocation(14, 21),
-                // (14,38): error CS1525: Invalid expression term 'throw'
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o is null").WithArguments("pattern matching", "patterns").WithLocation(17, 21),
+                // (17,38): error CS1525: Invalid expression term 'throw'
                 //         object q = (o is null) ? o : throw null; // throw expressions
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "throw null").WithArguments("throw").WithLocation(14, 38),
-                // (15,13): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "throw null").WithArguments("throw").WithLocation(17, 38),
+                // (18,13): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
                 //         if (q is Vec(3)) {} // recursive pattern
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "q is Vec(3)").WithArguments("pattern matching", "patterns").WithLocation(15, 13),
-                // (15,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "q is Vec(3)").WithArguments("pattern matching", "patterns").WithLocation(18, 13),
+                // (18,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
                 //         if (q is Vec(3)) {} // recursive pattern
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "Vec(3)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(15, 18),
-                // (10,26): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "Vec(3)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(18, 18),
+                // (13,26): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_IllegalStatement, "i1").WithLocation(10, 26),
-                // (12,9): error CS0246: The type or namespace name 'let' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_IllegalStatement, "i1").WithLocation(13, 26),
+                // (15,9): error CS0246: The type or namespace name 'let' could not be found (are you missing a using directive or an assembly reference?)
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "let").WithArguments("let").WithLocation(12, 9),
-                // (12,17): error CS0103: The name 'i4' does not exist in the current context
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "let").WithArguments("let").WithLocation(15, 9),
+                // (15,17): error CS0103: The name 'i4' does not exist in the current context
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "i4").WithArguments("i4").WithLocation(12, 17),
-                // (12,13): warning CS0168: The variable 'var' is declared but never used
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "i4").WithArguments("i4").WithLocation(15, 17),
+                // (12,13): warning CS0168: The variable 'f' is declared but never used
+                //         int f() => 2;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13),
+                // (15,13): warning CS0168: The variable 'var' is declared but never used
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "var").WithArguments("var").WithLocation(12, 13),
-                // (9,13): warning CS0168: The variable 'f' is declared but never used
-                //         int f() => 2; // local functions
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(9, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "var").WithArguments("var").WithLocation(15, 13)
                 );
 
             // enables binary literals, digit separators, local functions, ref locals, pattern matching
             var demoParseOptions = regularParseOptions
                 .WithPreprocessorSymbols(new[] { "__DEMO__" });
             CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: demoParseOptions).VerifyDiagnostics(
-                // (12,17): error CS1002: ; expected
+                // (15,17): error CS1002: ; expected
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i4").WithLocation(12, 17),
-                // (13,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "i4").WithLocation(15, 17),
+                // (16,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
                 //         int i5 = o match (case * : 7); // match
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o match (case * : 7)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(13, 18),
-                // (14,38): error CS1525: Invalid expression term 'throw'
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o match (case * : 7)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(16, 18),
+                // (17,38): error CS1525: Invalid expression term 'throw'
                 //         object q = (o is null) ? o : throw null; // throw expressions
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "throw null").WithArguments("throw").WithLocation(14, 38),
-                // (15,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "throw null").WithArguments("throw").WithLocation(17, 38),
+                // (18,18): error CS8058: Feature 'pattern matching experimental features' is experimental and unsupported; use '/features:patternsExperimental' to enable.
                 //         if (q is Vec(3)) {} // recursive pattern
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "Vec(3)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(15, 18),
-                // (12,9): error CS0246: The type or namespace name 'let' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "Vec(3)").WithArguments("pattern matching experimental features", "patternsExperimental").WithLocation(18, 18),
+                // (15,9): error CS0246: The type or namespace name 'let' could not be found (are you missing a using directive or an assembly reference?)
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "let").WithArguments("let").WithLocation(12, 9),
-                // (12,17): error CS0103: The name 'i4' does not exist in the current context
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "let").WithArguments("let").WithLocation(15, 9),
+                // (15,17): error CS0103: The name 'i4' does not exist in the current context
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "i4").WithArguments("i4").WithLocation(12, 17),
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "i4").WithArguments("i4").WithLocation(15, 17),
                 // (8,13): warning CS0219: The variable 'i2' is assigned but its value is never used
                 //         int i2 = 23_554; // digit separators
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i2").WithArguments("i2").WithLocation(8, 13),
-                // (12,13): warning CS0168: The variable 'var' is declared but never used
+                // (15,13): warning CS0168: The variable 'var' is declared but never used
                 //         let var i4 = 3; // let
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "var").WithArguments("var").WithLocation(12, 13),
-                // (9,13): warning CS0168: The variable 'f' is declared but never used
-                //         int f() => 2; // local functions
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(9, 13)
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "var").WithArguments("var").WithLocation(15, 13),
+                // (12,13): warning CS0168: The variable 'f' is declared but never used
+                //         int f() => 2;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
                 );
 
             // additionally enables let, match, throw, and recursive patterns
@@ -144,9 +153,9 @@ public class Vec
                 // (8,13): warning CS0219: The variable 'i2' is assigned but its value is never used
                 //         int i2 = 23_554; // digit separators
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i2").WithArguments("i2").WithLocation(8, 13),
-                // (9,13): warning CS0168: The variable 'f' is declared but never used
-                //         int f() => 2; // local functions
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(9, 13)
+                // (12,13): warning CS0168: The variable 'f' is declared but never used
+                //         int f() => 2;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
-    public abstract class ParsingTests
+    public abstract class ParsingTests : CSharpTestBase
     {
         private IEnumerator<SyntaxNodeOrToken> _treeEnumerator;
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
             syntaxKindsPatterns.Add(SyntaxKind.CasePatternSwitchLabel);
 
             var analyzer = new CSharpTrackingDiagnosticAnalyzer();
-            using (var workspace = await TestWorkspace.CreateCSharpAsync(source, TestOptions.Regular))
+            using (var workspace = await TestWorkspace.CreateCSharpAsync(source, TestOptions.ExperimentalParseOptions))
             {
                 var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
                 AccessSupportedDiagnostics(analyzer);


### PR DESCRIPTION
When the experimental features flag is not enabled we should create only
C#6 nodes to prevent legacy consumers from being given parse nodes they
can't understand.

Fixes #9940 

@jaredpar @VSadov @dotnet/roslyn-compiler Please review