### PR TITLE
Rationalize/clean-up usage of GetBinder/Locals/LocalFunction/Labels/Next with binders.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return CreateConversion(source.Syntax, source, conversion, isCast: false, destination: destination, diagnostics: diagnostics);
         }
 
-        protected BoundExpression CreateConversion(
+        internal BoundExpression CreateConversion(
             BoundExpression source,
             Conversion conversion,
             TypeSymbol destination,
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return CreateConversion(source.Syntax, source, conversion, isCast: false, destination: destination, diagnostics: diagnostics);
         }
 
-        protected BoundExpression CreateConversion(
+        internal BoundExpression CreateConversion(
             CSharpSyntaxNode syntax,
             BoundExpression source,
             Conversion conversion,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -722,7 +722,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var pattern = sectionBinder.BindPattern(section.Pattern, expression, expression.Type, section.HasErrors, diagnostics);
                 var guard = (section.WhenClause != null) ? sectionBinder.BindBooleanExpression(section.WhenClause.Condition, diagnostics) : null;
                 var e = sectionBinder.BindExpression(section.Expression, diagnostics);
-                sectionBuilder.Add(new BoundMatchCase(section, sectionBinder.Locals, pattern, guard, e, section.HasErrors));
+                sectionBuilder.Add(new BoundMatchCase(section, sectionBinder.GetDeclaredLocalsForScope(section), pattern, guard, e, section.HasErrors));
             }
 
             var resultType = BestType(node, sectionBuilder, diagnostics);
@@ -784,6 +784,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         private BoundStatement BindLetStatement(LetStatementSyntax node, DiagnosticBag diagnostics)
+        {
+            var letBinder = this.GetBinder(node);
+            Debug.Assert(letBinder != null);
+            return letBinder.WrapWithVariablesIfAny(node, letBinder.BindLetStatementParts(node, diagnostics));
+        }
+
+        private BoundStatement BindLetStatementParts(LetStatementSyntax node, DiagnosticBag diagnostics)
         {
             var expression = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
             // TODO: any constraints on the expression must be enforced here. For example,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Query.cs
@@ -582,7 +582,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // The bound block represents a closure scope for transparent identifiers captured in the let clause.
                 // Such closures shall be associated with the lambda body expression.
-                return lambdaBodyBinder.CreateBlockFromExpression(let.Expression, lambdaBodyBinder.Locals, RefKind.None, construction, null, d);
+                return lambdaBodyBinder.CreateBlockFromExpression(let.Expression, lambdaBodyBinder.GetDeclaredLocalsForScope(let.Expression), RefKind.None, construction, null, d);
             };
 
             var lambda = MakeQueryUnboundLambda(state.RangeVariableMap(), ImmutableArray.Create(x), let.Expression, bodyFactory);
@@ -664,7 +664,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // We transform the expression from "expr" to "expr.Cast<castTypeOpt>()".
                 boundExpression = lambdaBodyBinder.MakeQueryInvocation(expression, boundExpression, "Cast", castTypeSyntax, castType, diagnostics);
 
-                return lambdaBodyBinder.CreateBlockFromExpression(expression, lambdaBodyBinder.Locals, RefKind.None, boundExpression, expression, diagnostics);
+                return lambdaBodyBinder.CreateBlockFromExpression(expression, lambdaBodyBinder.GetDeclaredLocalsForScope(expression), RefKind.None, boundExpression, expression, diagnostics);
             }));
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BuckStopsHereBinder.cs
@@ -154,12 +154,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return null;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
         {
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
         {
             throw ExceptionUtilities.Unreachable;
         }
@@ -204,32 +204,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // There's supposed to be a LockBinder (or other overrider of this method) in the chain.
             throw ExceptionUtilities.Unreachable;
-        }
-
-        internal override ImmutableArray<LocalSymbol> Locals
-        {
-            get
-            {
-                return ImmutableArray<LocalSymbol>.Empty;
-            }
-        }
-
-        internal override ImmutableArray<LocalFunctionSymbol> LocalFunctions
-        {
-            get
-            {
-                // There's supposed to be a LocalScopeBinder (or other overrider of this method) in the chain.
-                throw ExceptionUtilities.Unreachable;
-            }
-        }
-
-        internal override ImmutableArray<LabelSymbol> Labels
-        {
-            get
-            {
-                // There's supposed to be a LocalScopeBinder (or other overrider of this method) in the chain.
-                throw ExceptionUtilities.Unreachable;
-            }
         }
 
         internal override ImmutableHashSet<Symbol> LockedOrDisposedVariables

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -37,14 +37,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return locals.ToImmutableAndFree();
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
         {
-            return this.Locals;
+            if (_syntax == scopeDesignator)
+            {
+                return this.Locals;
+            }
+
+            throw ExceptionUtilities.Unreachable;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
         {
-            return ImmutableArray<LocalFunctionSymbol>.Empty;
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -42,14 +42,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ImmutableArray<LocalSymbol>.Empty;
         }
 
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
         {
-            return this.Locals;
+            if (_syntax == scopeDesignator)
+            {
+                return this.Locals;
+            }
+
+            throw ExceptionUtilities.Unreachable;
         }
 
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
         {
-            return ImmutableArray<LocalFunctionSymbol>.Empty;
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -71,17 +71,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(node.Initializers.Count == 0);
                 ImmutableArray<BoundLocalDeclaration> unused;
-                initializer = this.BindForOrUsingOrFixedDeclarations(node.Declaration, LocalDeclarationKind.ForInitializerVariable, diagnostics, out unused);
+                initializer = originalBinder.BindForOrUsingOrFixedDeclarations(node.Declaration, LocalDeclarationKind.ForInitializerVariable, diagnostics, out unused);
             }
             else
             {
-                initializer = this.BindStatementExpressionList(node.Initializers, diagnostics);
+                initializer = originalBinder.BindStatementExpressionList(node.Initializers, diagnostics);
             }
 
-            var condition = (node.Condition != null) ? BindBooleanExpression(node.Condition, diagnostics) : null;
-            var increment = BindStatementExpressionList(node.Incrementors, diagnostics);
+            var condition = (node.Condition != null) ? originalBinder.BindBooleanExpression(node.Condition, diagnostics) : null;
+            var increment = originalBinder.BindStatementExpressionList(node.Incrementors, diagnostics);
             var body = originalBinder.BindPossibleEmbeddedStatement(node.Statement, diagnostics);
 
+            Debug.Assert(this.Locals == this.GetDeclaredLocalsForScope(node));
             return new BoundForStatement(node,
                                          this.Locals,
                                          initializer,
@@ -90,6 +91,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                                          body,
                                          this.BreakLabel,
                                          this.ContinueLabel);
+        }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            if (_syntax == scopeDesignator)
+            {
+                return this.Locals;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -472,15 +472,5 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
         }
-
-        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode node)
-        {
-            return ImmutableArray<LocalSymbol>.Empty;
-        }
-
-        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode node)
-        {
-            return ImmutableArray<LocalFunctionSymbol>.Empty;
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockBinder.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -31,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Allow method groups during binding and then rule them out when we check that the expression has
             // a reference type.
             ExpressionSyntax exprSyntax = TargetExpressionSyntax;
-            BoundExpression expr = BindTargetExpression(diagnostics);
+            BoundExpression expr = BindTargetExpression(diagnostics, originalBinder);
             TypeSymbol exprType = expr.Type;
 
             bool hasErrors = false;

--- a/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LockOrUsingBinder.cs
@@ -35,6 +35,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (targetExpressionSyntax != null)
                     {
+                        // We rely on this in the GetBinder call below.
+                        Debug.Assert(targetExpressionSyntax.Parent.Kind() == SyntaxKind.LockStatement ||
+                                     targetExpressionSyntax.Parent.Kind() == SyntaxKind.UsingStatement);
+
                         // For some reason, dev11 only warnings about locals and parameters.  If you do the same thing
                         // with a field of a local or parameter (e.g. lock(p.x)), there's no warning when you modify
                         // the local/parameter or its field.  We're going to take advantage of this restriction to break
@@ -44,7 +48,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // that require lvalue checks.
                         if (targetExpressionSyntax.Kind() == SyntaxKind.IdentifierName)
                         {
-                            BoundExpression expression = BindTargetExpression(diagnostics: null); // Diagnostics reported by BindUsingStatementParts.
+                            BoundExpression expression = BindTargetExpression(diagnostics: null, // Diagnostics reported by BindUsingStatementParts.
+                                                                              originalBinder: GetBinder(targetExpressionSyntax.Parent));
+
                             switch (expression.Kind)
                             {
                                 case BoundKind.Local:
@@ -64,13 +70,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected BoundExpression BindTargetExpression(DiagnosticBag diagnostics)
+        protected BoundExpression BindTargetExpression(DiagnosticBag diagnostics, Binder originalBinder)
         {
             if (_lazyExpressionAndDiagnostics == null)
             {
                 // Filter out method group in conversion.
                 DiagnosticBag expressionDiagnostics = DiagnosticBag.GetInstance();
-                BoundExpression boundExpression = this.BindValue(TargetExpressionSyntax, expressionDiagnostics, Binder.BindValueKind.RValueOrMethodGroup);
+                BoundExpression boundExpression = originalBinder.BindValue(TargetExpressionSyntax, expressionDiagnostics, Binder.BindValueKind.RValueOrMethodGroup);
                 Interlocked.CompareExchange(ref _lazyExpressionAndDiagnostics, new ExpressionAndDiagnostics(boundExpression, expressionDiagnostics.ToReadOnlyAndFree()), null);
             }
             Debug.Assert(_lazyExpressionAndDiagnostics != null);

--- a/src/Compilers/CSharp/Portable/Binder/ScriptLocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ScriptLocalScopeBinder.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -23,6 +24,24 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LabelSymbol> BuildLabels()
         {
             return _labels.GetLabels();
+        }
+        
+        internal override bool IsLabelsScopeBinder
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
 
         // Labels potentially shared across multiple ScriptLocalScopeBinder instances.

--- a/src/Compilers/CSharp/Portable/Binder/SimpleLocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SimpleLocalScopeBinder.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -20,6 +21,16 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
             return _locals;
+        }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -117,6 +117,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return builder.ToImmutableAndFree();
         }
 
+        internal override bool IsLocalFunctionsScopeBinder
+        {
+            get
+            {
+                return true;
+            }
+        }
+
         internal override GeneratedLabelSymbol BreakLabel
         {
             get
@@ -131,20 +139,28 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!IsPatternSwitch(_switchSyntax))
             {
-            foreach (var section in _switchSyntax.Sections)
-            {
-                // add switch case/default labels
-                BuildSwitchLabels(section.Labels, ref labels);
+                foreach (var section in _switchSyntax.Sections)
+                {
+                    // add switch case/default labels
+                    BuildSwitchLabels(section.Labels, GetBinder(section), ref labels);
 
-                // add regular labels from the statements in the switch section
-                base.BuildLabels(section.Statements, ref labels);
-            }
+                    // add regular labels from the statements in the switch section
+                    base.BuildLabels(section.Statements, ref labels);
+                }
             }
 
             return (labels != null) ? labels.ToImmutableAndFree() : ImmutableArray<LabelSymbol>.Empty;
         }
 
-        private void BuildSwitchLabels(SyntaxList<SwitchLabelSyntax> labelsSyntax, ref ArrayBuilder<LabelSymbol> labels)
+        internal override bool IsLabelsScopeBinder
+        {
+            get
+            {
+                return true;
+            }
+        }
+
+        private void BuildSwitchLabels(SyntaxList<SwitchLabelSyntax> labelsSyntax, Binder sectionBinder, ref ArrayBuilder<LabelSymbol> labels)
         {
             TypeSymbol switchGoverningType = null;
 
@@ -161,14 +177,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(caseLabel.Value != null);
                     DiagnosticBag tempDiagnosticBag = DiagnosticBag.GetInstance();
 
-                    var boundLabelExpression = BindValue(caseLabel.Value, tempDiagnosticBag, BindValueKind.RValue);
+                    var boundLabelExpression = sectionBinder.BindValue(caseLabel.Value, tempDiagnosticBag, BindValueKind.RValue);
 
                     if ((object)switchGoverningType == null)
                     {
-                        switchGoverningType = this.BindSwitchExpression(_switchSyntax.Expression, tempDiagnosticBag).Type;
+                        switchGoverningType = this.BindSwitchExpression(_switchSyntax.Expression, this, tempDiagnosticBag).Type;
                     }
 
-                    boundLabelExpression = ConvertCaseExpression(switchGoverningType, labelSyntax, boundLabelExpression, ref boundLabelConstantOpt, tempDiagnosticBag);
+                    boundLabelExpression = ConvertCaseExpression(switchGoverningType, labelSyntax, boundLabelExpression, sectionBinder, ref boundLabelConstantOpt, tempDiagnosticBag);
 
                     tempDiagnosticBag.Free();
                         break;
@@ -191,7 +207,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private BoundExpression ConvertCaseExpression(TypeSymbol switchGoverningType, CSharpSyntaxNode node, BoundExpression caseExpression, ref ConstantValue constantValueOpt, DiagnosticBag diagnostics, bool isGotoCaseExpr = false)
+        private BoundExpression ConvertCaseExpression(TypeSymbol switchGoverningType, CSharpSyntaxNode node, BoundExpression caseExpression, Binder sectionBinder, ref ConstantValue constantValueOpt, DiagnosticBag diagnostics, bool isGotoCaseExpr = false)
         {
             BoundExpression convertedCaseExpression;
             if (!isGotoCaseExpr)
@@ -199,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // NOTE: This will allow user-defined conversions, even though they're not allowed here.  This is acceptable
                 // because the result of a user-defined conversion does not have a ConstantValue and we'll report a diagnostic
                 // to that effect below (same error code as Dev10).
-                convertedCaseExpression = GenerateConversionForAssignment(switchGoverningType, caseExpression, diagnostics);
+                convertedCaseExpression = sectionBinder.GenerateConversionForAssignment(switchGoverningType, caseExpression, diagnostics);
             }
             else
             {
@@ -217,7 +233,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // CONSIDER: Should we introduce a breaking change and violate Dev10 compatibility and follow the spec?
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                Conversion conversion = Conversions.ClassifyConversionFromExpression(caseExpression, switchGoverningType, ref useSiteDiagnostics);
+                Conversion conversion = sectionBinder.Conversions.ClassifyConversionFromExpression(caseExpression, switchGoverningType, ref useSiteDiagnostics);
                 diagnostics.Add(node, useSiteDiagnostics);
                 if (!conversion.IsValid)
                 {
@@ -228,7 +244,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(ErrorCode.WRN_GotoCaseShouldConvert, node.Location, switchGoverningType);
                 }
 
-                convertedCaseExpression = this.CreateConversion(caseExpression, conversion, switchGoverningType, diagnostics);
+                convertedCaseExpression = sectionBinder.CreateConversion(caseExpression, conversion, switchGoverningType, diagnostics);
             }
 
             if (switchGoverningType.IsNullableType()
@@ -240,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // We are not intested in the diagnostic that get created here
                 var diagnosticBag = DiagnosticBag.GetInstance();
-                constantValueOpt = CreateConversion(operand, switchGoverningType.GetNullableUnderlyingType(), diagnosticBag).ConstantValue;
+                constantValueOpt = sectionBinder.CreateConversion(operand, switchGoverningType.GetNullableUnderlyingType(), diagnosticBag).ConstantValue;
                 diagnosticBag.Free();
             }
             else
@@ -297,6 +313,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             return s_emptyLabelsList;
         }
 
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            if (_switchSyntax == scopeDesignator)
+            {
+                return this.Locals;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            if (_switchSyntax == scopeDesignator)
+            {
+                return this.LocalFunctions;
+            }
+
+            throw ExceptionUtilities.Unreachable;
+        }
+
         # region "Switch statement binding methods"
 
         /// <summary>
@@ -312,18 +348,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 _isPatternSwitch = true;
                 return PatternsEnabled
-                    ? (BoundStatement)BindPatternSwitch(node, diagnostics)
+                    ? (BoundStatement)BindPatternSwitch(node, originalBinder, diagnostics)
                     : new BoundBlock(node, ImmutableArray<LocalSymbol>.Empty, ImmutableArray<LocalFunctionSymbol>.Empty, ImmutableArray<BoundStatement>.Empty, true);
             }
 
             // Bind switch expression and set the switch governing type. If it isn't valid as a traditional
             // switch statement's controlling expression, try to bind it as a pattern-matching switch statement
             var localDiagnostics = DiagnosticBag.GetInstance();
-            var boundSwitchExpression = BindSwitchExpressionAndGoverningType(node.Expression, localDiagnostics);
+            var boundSwitchExpression = BindSwitchExpressionAndGoverningType(node.Expression, originalBinder, localDiagnostics);
             if (localDiagnostics.HasAnyResolvedErrors() && PatternsEnabled)
             {
                 _isPatternSwitch = true;
-                return BindPatternSwitch(node, diagnostics);
+                return BindPatternSwitch(node, originalBinder, diagnostics);
             }
             _isPatternSwitch = false;
             diagnostics.AddRangeAndFree(localDiagnostics);
@@ -346,19 +382,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Bind switch section
             ImmutableArray<BoundSwitchSection> boundSwitchSections = BindSwitchSections(node.Sections, originalBinder, diagnostics);
 
-            return new BoundSwitchStatement(node, null, boundSwitchExpression, constantTargetOpt, Locals, LocalFunctions, boundSwitchSections, this.BreakLabel, null);
+            return new BoundSwitchStatement(node, null, boundSwitchExpression, constantTargetOpt, 
+                                            GetDeclaredLocalsForScope(node), 
+                                            GetDeclaredLocalFunctionsForScope(node), boundSwitchSections, this.BreakLabel, null);
         }
 
         // Bind the switch expression and set the switch governing type
-        private BoundExpression BindSwitchExpressionAndGoverningType(ExpressionSyntax node, DiagnosticBag diagnostics)
+        private BoundExpression BindSwitchExpressionAndGoverningType(ExpressionSyntax node, Binder originalBinder, DiagnosticBag diagnostics)
         {
-            var boundSwitchExpression = BindSwitchExpression(node, diagnostics);
+            var boundSwitchExpression = BindSwitchExpression(node, originalBinder, diagnostics);
             Interlocked.CompareExchange(ref _switchGoverningType, boundSwitchExpression.Type, null);
             return boundSwitchExpression;
         }
 
         // Bind the switch expression
-        private BoundExpression BindSwitchExpression(ExpressionSyntax node, DiagnosticBag diagnostics)
+        private BoundExpression BindSwitchExpression(ExpressionSyntax node, Binder originalBinder, DiagnosticBag diagnostics)
         {
             // We are at present inside the switch binder, but the switch expression is not
             // bound in the context of the switch binder; it's bound in the context of the
@@ -376,7 +414,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             // should therefore produce a CS0135 "local decl conflicts with simple name that
             // meant something else" error, not a "you used local x before it was declared" error.
             // 
-            var switchExpression = this.Next.BindValue(node, diagnostics, BindValueKind.RValue);
+
+            Debug.Assert(node == _switchSyntax.Expression);
+            var binder = originalBinder.GetBinder(node);
+            Debug.Assert(binder != null);
+
+            var switchExpression = binder.BindValue(node, diagnostics, BindValueKind.RValue);
             var switchGoverningType = switchExpression.Type;
 
             if ((object)switchGoverningType != null && !switchGoverningType.IsErrorType())
@@ -408,7 +451,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     TypeSymbol resultantGoverningType;
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    Conversion conversion = Conversions.ClassifyImplicitUserDefinedConversionForSwitchGoverningType(switchGoverningType, out resultantGoverningType, ref useSiteDiagnostics);
+                    Conversion conversion = binder.Conversions.ClassifyImplicitUserDefinedConversionForSwitchGoverningType(switchGoverningType, out resultantGoverningType, ref useSiteDiagnostics);
                     diagnostics.Add(node, useSiteDiagnostics);
                     if (conversion.IsValid)
                     {
@@ -419,7 +462,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert((object)resultantGoverningType != null);
                         Debug.Assert(resultantGoverningType.IsValidSwitchGoverningType(isTargetTypeOfUserDefinedOp: true));
 
-                        return CreateConversion(node, switchExpression, conversion, false, resultantGoverningType, diagnostics);
+                        return binder.CreateConversion(node, switchExpression, conversion, false, resultantGoverningType, diagnostics);
                     }
                     else
                     {
@@ -484,13 +527,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundSwitchSection BindSwitchSection(SwitchSectionSyntax node, Binder originalBinder, DiagnosticBag diagnostics)
         {
-            var sectionBinder = GetBinder(node);
+            var sectionBinder = originalBinder.GetBinder(node);
 
             // Bind switch section labels
             var boundLabelsBuilder = ArrayBuilder<BoundSwitchLabel>.GetInstance();
             foreach (var labelSyntax in node.Labels)
             {
-                BoundSwitchLabel boundLabel = BindSwitchSectionLabel(labelSyntax, diagnostics);
+                BoundSwitchLabel boundLabel = BindSwitchSectionLabel(labelSyntax, sectionBinder, diagnostics);
                 boundLabelsBuilder.Add(boundLabel);
             }
 
@@ -504,7 +547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundSwitchSection(node, boundLabelsBuilder.ToImmutableAndFree(), boundStatementsBuilder.ToImmutableAndFree());
         }
 
-        private BoundSwitchLabel BindSwitchSectionLabel(SwitchLabelSyntax node, DiagnosticBag diagnostics)
+        private BoundSwitchLabel BindSwitchSectionLabel(SwitchLabelSyntax node, Binder sectionBinder, DiagnosticBag diagnostics)
         {
             var switchGoverningType = GetSwitchGoverningType(diagnostics);
             BoundExpression boundLabelExpressionOpt = null;
@@ -521,9 +564,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.CaseSwitchLabel:
                 var caseLabelSyntax = (CaseSwitchLabelSyntax)node;
                 // Bind the label case expression
-                boundLabelExpressionOpt = BindValue(caseLabelSyntax.Value, diagnostics, BindValueKind.RValue);
+                boundLabelExpressionOpt = sectionBinder.BindValue(caseLabelSyntax.Value, diagnostics, BindValueKind.RValue);
 
-                boundLabelExpressionOpt = ConvertCaseExpression(switchGoverningType, caseLabelSyntax, boundLabelExpressionOpt, ref labelExpressionConstant, diagnostics);
+                boundLabelExpressionOpt = ConvertCaseExpression(switchGoverningType, caseLabelSyntax, boundLabelExpressionOpt, sectionBinder, ref labelExpressionConstant, diagnostics);
 
                 // Check for bind errors
                 hasErrors = hasErrors || boundLabelExpressionOpt.HasAnyErrors;
@@ -549,7 +592,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         Error(diagnostics, ErrorCode.ERR_FeatureIsUnimplemented, node, MessageID.IDS_FeaturePatternMatching.Localize());
                         hasErrors = true;
-            }
+                    }
                     matchedLabelSymbols = new List<SourceLabelSymbol>();
                     break;
                 case SyntaxKind.DefaultSwitchLabel:
@@ -601,7 +644,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors: hasErrors || hasDuplicateErrors);
         }
 
-        internal BoundStatement BindGotoCaseOrDefault(GotoStatementSyntax node, DiagnosticBag diagnostics)
+        internal BoundStatement BindGotoCaseOrDefault(GotoStatementSyntax node, Binder gotoBinder, DiagnosticBag diagnostics)
         {
             Debug.Assert(node.Kind() == SyntaxKind.GotoCaseStatement || node.Kind() == SyntaxKind.GotoDefaultStatement);
             if (this._isPatternSwitch == true)
@@ -637,9 +680,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(node.Kind() == SyntaxKind.GotoCaseStatement);
 
                     // Bind the goto case expression
-                    gotoCaseExpressionOpt = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
+                    gotoCaseExpressionOpt = gotoBinder.BindValue(node.Expression, diagnostics, BindValueKind.RValue);
 
-                    gotoCaseExpressionOpt = ConvertCaseExpression(switchGoverningType, node, gotoCaseExpressionOpt,
+                    gotoCaseExpressionOpt = ConvertCaseExpression(switchGoverningType, node, gotoCaseExpressionOpt, gotoBinder,
                         ref gotoCaseExpressionConstant, diagnostics, isGotoCaseExpr: true);
 
                     // Check for bind errors
@@ -695,7 +738,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 // Can reach here only when we are called from the Binding API
                 // Let us bind the switch expression and switch governing type
-                BindSwitchExpressionAndGoverningType(_switchSyntax.Expression, diagnostics);
+                BindSwitchExpressionAndGoverningType(_switchSyntax.Expression, this, diagnostics);
                 Debug.Assert((object)_switchGoverningType != null);
             }
             return _switchGoverningType;

--- a/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WhileBinder.cs
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var node = (WhileStatementSyntax)_syntax;
 
-            var condition = BindBooleanExpression(node.Condition, diagnostics);
+            var condition = originalBinder.BindBooleanExpression(node.Condition, diagnostics);
             var body = originalBinder.BindPossibleEmbeddedStatement(node.Statement, diagnostics);
             Debug.Assert(this.Locals.IsDefaultOrEmpty);
             return new BoundWhileStatement(node, condition, body, this.BreakLabel, this.ContinueLabel);
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             var node = (DoStatementSyntax)_syntax;
 
-            var condition = BindBooleanExpression(node.Condition, diagnostics);
+            var condition = originalBinder.BindBooleanExpression(node.Condition, diagnostics);
             var body = originalBinder.BindPossibleEmbeddedStatement(node.Statement, diagnostics);
             Debug.Assert(this.Locals.IsDefaultOrEmpty);
             return new BoundDoStatement(node, condition, body, this.BreakLabel, this.ContinueLabel);

--- a/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/WithLambdaParametersBinder.cs
@@ -159,5 +159,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             return false;
         }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -2765,8 +2765,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            foreachBinder = foreachBinder.WithAdditionalFlags(GetSemanticModelBinderFlags());
-            LocalSymbol local = foreachBinder.Locals.FirstOrDefault();
+            LocalSymbol local = foreachBinder.GetDeclaredLocalsForScope(forEachStatement).FirstOrDefault();
             return ((object)local != null && local.DeclarationKind == LocalDeclarationKind.ForEachIterationVariable)
                 ? local
                 : null;
@@ -2796,8 +2795,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            catchBinder = enclosingBinder.GetBinder(catchClause).WithAdditionalFlags(GetSemanticModelBinderFlags());
-            LocalSymbol local = catchBinder.Locals.FirstOrDefault();
+            catchBinder = enclosingBinder.GetBinder(catchClause);
+            LocalSymbol local = catchBinder.GetDeclaredLocalsForScope(catchClause).FirstOrDefault();
             return ((object)local != null && local.DeclarationKind == LocalDeclarationKind.CatchVariable)
                 ? local
                 : null;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -2,11 +2,11 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Globalization;
 using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
+using System.Diagnostics;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -223,8 +223,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             /// <param name="currentBoundNode">The bound node.</param>
             private bool ShouldAddNode(BoundNode currentBoundNode)
             {
+                BoundBlock block;
+
+                // PROTOTYPE(patterns): Need to confirm how extra compiler generated blocks affect caching.
+                //                      Do we actually benefit from adding them to the cache, or effect is negative or neutral.
+
                 // Do not add compiler generated nodes.
-                if (currentBoundNode.WasCompilerGenerated)
+                if (currentBoundNode.WasCompilerGenerated &&
+                    (currentBoundNode.Kind != BoundKind.Block ||
+                     (block = (BoundBlock)currentBoundNode).Statements.Length != 1 ||
+                     block.Statements.Single().WasCompilerGenerated))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -84,7 +84,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             position = CheckAndAdjustPosition(position);
 
             var methodSymbol = (MethodSymbol)this.MemberSymbol;
-            var executablebinder = new ExecutableCodeBinder(body, methodSymbol, this.RootBinder.Next); // Strip off ExecutableCodeBinder (see ctor).
+
+            // Strip off ExecutableCodeBinder (see ctor).
+            Binder binder = this.RootBinder;
+
+            do
+            {
+                if (binder is ExecutableCodeBinder)
+                {
+                    binder = binder.Next;
+                    break;
+                }
+
+                binder = binder.Next;
+            }
+            while (binder != null);
+
+            Debug.Assert(binder != null);
+
+            var executablebinder = new ExecutableCodeBinder(body, methodSymbol, binder ?? this.RootBinder);
             var blockBinder = executablebinder.GetBinder(body).WithAdditionalFlags(GetSemanticModelBinderFlags());
             speculativeModel = CreateSpeculative(parentModel, methodSymbol, body, blockBinder, position);
             return true;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -71,7 +71,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind == SyntaxKind.Attribute ||
                 kind == SyntaxKind.ArgumentList ||
                 kind == SyntaxKind.ArrowExpressionClause ||
-                (syntax is ExpressionSyntax && (syntax.Parent as LambdaExpressionSyntax)?.Body == syntax);
+                (syntax is ExpressionSyntax && 
+                    ((syntax.Parent as LambdaExpressionSyntax)?.Body == syntax ||
+                     (syntax.Parent as SwitchStatementSyntax)?.Expression == syntax ||
+                     (syntax.Parent as ForEachStatementSyntax)?.Expression == syntax ||
+                     (syntax.Parent as IfStatementSyntax)?.Condition == syntax));
         }
 
         /// <summary>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
@@ -123,5 +123,15 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             return builder.ToImmutableAndFree();
         }
+
+        internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
     }
 }


### PR DESCRIPTION
Related to #8817.

@gafter, @dotnet/roslyn-compiler Please review. 