### PR TITLE
Remove invokation of FlushPayLoad method from code instrumentation

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -63,24 +63,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     ImmutableArray<BoundStatement> newStatements = newMethodBody.Statements.Insert(0, payloadIf);
                     newMethodBody = newMethodBody.Update(newMethodBody.Locals, newMethodBody.LocalFunctions, newStatements);
 
-                    if (IsTestMethod(method))
-                    {
-                        // If the method is a test method, wrap the body in:
-                        //
-                        // try
-                        // {
-                        //     ... body ...
-                        // }
-                        // finally
-                        // {
-                        //     Instrumentation.FlushPayload();
-                        // }
-
-                        BoundStatement flush = factory.ExpressionStatement(factory.Call(null, flushPayload));
-                        BoundStatement tryFinally = factory.Try(newMethodBody, ImmutableArray<BoundCatchBlock>.Empty, factory.Block(ImmutableArray.Create(flush)));
-                        newMethodBody = factory.Block(ImmutableArray.Create(tryFinally));
-                    }
-
                     return newMethodBody;
                 }
             }
@@ -123,20 +105,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static MethodSymbol GetFlushPayload(CSharpCompilation compilation, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             return (MethodSymbol)Binder.GetWellKnownTypeMember(compilation, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload, diagnostics, syntax: syntax);
-        }
-
-        private static bool IsTestMethod(MethodSymbol method)
-        {
-            // PROTOTYPE (https://github.com/dotnet/roslyn/issues/9811): Make this real. 
-            var attributes = method.GetAttributes();
-            foreach (var attribute in attributes)
-            {
-                if (attribute.IsTargetAttribute("Xunit", "FactAttribute"))
-                {
-                    return true;
-                }
-            }
-            return false;
         }
     }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -54,16 +54,6 @@ namespace Microsoft.CodeAnalysis.CSharp.DynamicAnalysis.UnitTests
     }
 }
 ";
-        const string XunitFactAttributeSource = @"
-namespace Xunit
-{
-    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-    public class FactAttribute : Attribute
-    {
-        public FactAttribute() { }
-    }
-}
-";
 
         [Fact]
         public void GotoCoverage()
@@ -76,9 +66,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         Console.WriteLine(""foo"");
@@ -125,6 +115,7 @@ public class Program
 bar
 Flushing
 1
+True
 True
 2
 True
@@ -196,7 +187,7 @@ True
   IL_0052:  ret
 }
 ";
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
             verifier.VerifyIL("Program.Barney", expectedBarneyIL);
         }
 
@@ -231,9 +222,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         MyBox<object> x = new MyBox<object>(null);
@@ -259,6 +250,7 @@ False
 True
 True
 3
+True
 True
 4
 True
@@ -303,7 +295,7 @@ True
   IL_0051:  ret
 }
 ";
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
             verifier.VerifyIL("MyBox<T>.GetValue", expectedGetValueIL);
         }
        
@@ -318,9 +310,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
     
-    [Xunit.Fact]
     static void TestMain()
     {
         int x = Count;
@@ -344,6 +336,7 @@ public class Program
             string expectedOutput = @"Flushing
 1
 True
+True
 2
 True
 True
@@ -361,7 +354,7 @@ True
 True
 ";
 
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]
@@ -375,9 +368,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         int x;
@@ -411,6 +404,7 @@ public class Program
             string expectedOutput = @"Flushing
 1
 True
+True
 2
 True
 True
@@ -426,7 +420,7 @@ False
 True
 ";
 
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]
@@ -441,9 +435,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         using (var memoryStream = new MemoryStream())
@@ -480,6 +474,7 @@ public class Program
             string expectedOutput = @"Flushing
 1
 True
+True
 2
 True
 True
@@ -495,7 +490,7 @@ True
 True
 ";
            
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, options: TestOptions.UnsafeDebugExe,  emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.UnsafeDebugExe,  emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]
@@ -509,10 +504,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-
-    [Xunit.Fact]
     static void TestMain()
     {
         VariousStatements(2);
@@ -608,6 +602,7 @@ public class Program
 Flushing
 1
 True
+True
 2
 True
 3
@@ -645,7 +640,7 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]
@@ -659,9 +654,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         int y = 5;
@@ -687,6 +682,7 @@ public class Program
 Flushing
 1
 True
+True
 2
 True
 True
@@ -699,7 +695,7 @@ False
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         [Fact]
@@ -714,9 +710,9 @@ public class Program
     public static void Main(string[] args)
     {
         TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
     }
 
-    [Xunit.Fact]
     static void TestMain()
     {
         Console.WriteLine(Outer(""Goo"").Result);
@@ -754,6 +750,7 @@ public class Program
 Flushing
 1
 True
+True
 2
 True
 3
@@ -773,137 +770,7 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
-        }
-
-        [Fact]
-        public void XunitFactAttribute()
-        {
-            string source = @"
-using System;
-
-public class Program
-{
-    public static void Main(string[] args)
-    {
-        MethodWithFactAttribute(1);
-        MethodWithOutFactAttribute(1);
-        MethodWithFactAttribute(1);
-    }
-
-    [Xunit.Fact]
-    static int MethodWithFactAttribute(int x)
-    {
-        var y = x + 1;
-        var z = y + 1;
-        return z;
-    }
-
-    static int MethodWithOutFactAttribute(int x)
-    {
-        var y = x + 1;
-        var z = y + 1;
-        return z;
-    }
-}
-";
-            string expectedOutput = @"Flushing
-1
-True
-False
-False
-2
-True
-True
-True
-Flushing
-1
-False
-True
-True
-2
-True
-True
-True
-3
-True
-True
-True
-";
-
-            string expectedMethodWithFactAttributeIL = @"{
-  // Code size       68 (0x44)
-  .maxstack  4
-  .locals init (int V_0)
-  .try
-  {
-    IL_0000:  ldsfld     ""bool[] Program.<MethodWithFactAttribute>1ipayload__Field""
-    IL_0005:  brtrue.s   IL_001c
-    IL_0007:  ldsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
-    IL_000c:  ldtoken    ""int Program.MethodWithFactAttribute(int)""
-    IL_0011:  ldsflda    ""bool[] Program.<MethodWithFactAttribute>1ipayload__Field""
-    IL_0016:  ldc.i4.3
-    IL_0017:  call       ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, ref bool[], int)""
-    IL_001c:  ldsfld     ""bool[] Program.<MethodWithFactAttribute>1ipayload__Field""
-    IL_0021:  ldc.i4.0
-    IL_0022:  ldc.i4.1
-    IL_0023:  stelem.i1
-    IL_0024:  ldarg.0
-    IL_0025:  ldc.i4.1
-    IL_0026:  add
-    IL_0027:  ldsfld     ""bool[] Program.<MethodWithFactAttribute>1ipayload__Field""
-    IL_002c:  ldc.i4.1
-    IL_002d:  ldc.i4.1
-    IL_002e:  stelem.i1
-    IL_002f:  ldc.i4.1
-    IL_0030:  add
-    IL_0031:  ldsfld     ""bool[] Program.<MethodWithFactAttribute>1ipayload__Field""
-    IL_0036:  ldc.i4.2
-    IL_0037:  ldc.i4.1
-    IL_0038:  stelem.i1
-    IL_0039:  stloc.0
-    IL_003a:  leave.s    IL_0042
-  }
-  finally
-  {
-    IL_003c:  call       ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
-    IL_0041:  endfinally
-  }
-  IL_0042:  ldloc.0
-  IL_0043:  ret
-}";
-            string expectedMethodWithOutFactAttributeIL = @"{
-  // Code size       58 (0x3a)
-  .maxstack  4
-  IL_0000:  ldsfld     ""bool[] Program.<MethodWithOutFactAttribute>2ipayload__Field""
-  IL_0005:  brtrue.s   IL_001c
-  IL_0007:  ldsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
-  IL_000c:  ldtoken    ""int Program.MethodWithOutFactAttribute(int)""
-  IL_0011:  ldsflda    ""bool[] Program.<MethodWithOutFactAttribute>2ipayload__Field""
-  IL_0016:  ldc.i4.3
-  IL_0017:  call       ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, ref bool[], int)""
-  IL_001c:  ldsfld     ""bool[] Program.<MethodWithOutFactAttribute>2ipayload__Field""
-  IL_0021:  ldc.i4.0
-  IL_0022:  ldc.i4.1
-  IL_0023:  stelem.i1
-  IL_0024:  ldarg.0
-  IL_0025:  ldc.i4.1
-  IL_0026:  add
-  IL_0027:  ldsfld     ""bool[] Program.<MethodWithOutFactAttribute>2ipayload__Field""
-  IL_002c:  ldc.i4.1
-  IL_002d:  ldc.i4.1
-  IL_002e:  stelem.i1
-  IL_002f:  ldc.i4.1
-  IL_0030:  add
-  IL_0031:  ldsfld     ""bool[] Program.<MethodWithOutFactAttribute>2ipayload__Field""
-  IL_0036:  ldc.i4.2
-  IL_0037:  ldc.i4.1
-  IL_0038:  stelem.i1
-  IL_0039:  ret
-}";
-            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource + XunitFactAttributeSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
-            verifier.VerifyIL("Program.MethodWithFactAttribute", expectedMethodWithFactAttributeIL);
-            verifier.VerifyIL("Program.MethodWithOutFactAttribute", expectedMethodWithOutFactAttributeIL);
+            CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
         private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)


### PR DESCRIPTION
It's analysis driver's responsibility to invoke this method appropriately, compiler only needs to instrument code. This change can't be merged until the driver side change is in place.

FYI @dotnet/testimpact @dotnet/roslyn-compiler 