### PR TITLE
Provide multiple fixes for 'make method synchronous'.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.cs
@@ -350,7 +350,38 @@ public class Class1
     {
         Foo();
     }
-}", compareTokens: false, fixAllActionEquivalenceKey: AbstractMakeMethodSynchronousCodeFixProvider.EquivalenceKey);
+}",
+fixAllActionEquivalenceKey: AbstractMakeMethodSynchronousCodeFixProvider.MakeMethodSynchronousChangingReturnTypeKey);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)]
+        public async Task TestOverride()
+        {
+            await TestAsync(
+@"
+using System.Threading.Tasks;
+
+class Base
+{
+    public virtual Task OnStart() { .. }
+}
+
+class Derived : Base 
+{
+    public override async Task [|OnStart|]() {  }
+}",
+@"
+using System.Threading.Tasks;
+
+class Base
+{
+    public virtual Task OnStart() { .. }
+}
+
+class Derived : Base 
+{
+    public override Task OnStart() {  }
+}", index: 1);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/MakeMethodSynchronous/MakeMethodSynchronousTests.vb
@@ -233,5 +233,37 @@ Class C
 End Class",
 compareTokens:=False)
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMakeMethodSynchronous)>
+        Public Async Function TestOverride() As Task
+            Await TestAsync(
+"
+imports System.Threading.Tasks
+
+class Base
+    public overridable function OnStart() as Task
+    end function
+end class
+
+class Derived 
+    inherits Base 
+    public overrides async function [|OnStart|]() as Task
+    end function
+end class",
+"
+imports System.Threading.Tasks
+
+class Base
+    public overridable function OnStart() as Task
+    end function
+end class
+
+class Derived 
+    inherits Base 
+    public overrides function OnStart() as Task
+    end function
+end class",
+index:=1)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1529,6 +1529,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Make method synchronous (changing return type).
+        /// </summary>
+        internal static string Make_method_synchronous_changing_return_type {
+            get {
+                return ResourceManager.GetString("Make_method_synchronous_changing_return_type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to method.
         /// </summary>
         internal static string Method {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -961,4 +961,7 @@ This version used in: {2}</value>
   <data name="AddMissingSwitchCases" xml:space="preserve">
     <value>Add missing switch cases</value>
   </data>
+  <data name="Make_method_synchronous_changing_return_type" xml:space="preserve">
+    <value>Make method synchronous (changing return type)</value>
+  </data>
 </root>


### PR DESCRIPTION
One fix will remove 'await' and also change the return type (if it is Type or Type<T>).
The other will just remove 'await'.

The latter is useful for people who don't want to be using 'async/await', but still want
to return tasks (but now in a synchronous fashion).

Fixes https://github.com/dotnet/roslyn/issues/10456