### PR TITLE
Fix object initalizer intellisense with generics

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/ObjectInitializerCompletionProviderTests.cs
@@ -743,6 +743,32 @@ class Container
             await VerifyItemExistsAsync(markup, "D");
         }
 
+        [WorkItem(4754, "https://github.com/dotnet/roslyn/issues/4754")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ObjectInitializerOfGenericTypeConstructedWithInaccessibleType()
+        {
+            var markup = @"
+class Generic<T>
+{
+    public string Value { get; set; }
+}
+
+class Program
+{
+    private class InaccessibleToGeneric
+    {
+
+    }
+
+    static void Main(string[] args)
+    {
+        var g = new Generic<InaccessibleToGeneric> { $$ }
+    }
+}";
+
+            await VerifyItemExistsAsync(markup, "Value");
+        }
+
         private async Task VerifyExclusiveAsync(string markup, bool exclusive)
         {
             using (var workspace = await TestWorkspace.CreateCSharpAsync(markup))

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectInitializerCompletionProvider.cs
@@ -43,10 +43,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             {
                 context.MakeExclusive(true);
             }
-            var enclosing = semanticModel.GetEnclosingNamedTypeOrAssembly(position, cancellationToken);
+            var enclosing = semanticModel.GetEnclosingNamedType(position, cancellationToken);
             // Find the members that can be initialized. If we have a NamedTypeSymbol, also get the overridden members.
             IEnumerable<ISymbol> members = semanticModel.LookupSymbols(position, initializedType);
-            members = members.Where(m => IsInitializable(m, initializedType) &&
+            members = members.Where(m => IsInitializable(m, enclosing) &&
                                          m.CanBeReferencedByName &&
                                          IsLegalFieldOrProperty(m, enclosing) &&
                                          !m.IsImplicitlyDeclared);


### PR DESCRIPTION
When doing accessibility checks to offer members initializable from the
calling typing, object initializer completion incorrectly checked that the
member being initialized was accessible from the type containing the
member instead of the type where the object initializer was being written.
This check almost always returned true, but was noticable in #10435 where
the type being initialized was a generic type constructed with a type not
accessible to the generic type. This resulted in the accessibility check
returning false. The fix is to simply check accessibility of the correct
type.