### PR TITLE
Updates reference to SCI in SyntaxVisualizer to 1.1.37

### DIFF
--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/packages.config
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerControl/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerDgmlHelper/packages.config
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerDgmlHelper/packages.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.37" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.2.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net46" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/10479