### PR TITLE
Clean-up PatternVariableBinder and PatternVariableFinder.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -772,24 +772,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 #endif
         
-        internal void BuildAndAddPatternVariables(
-            ArrayBuilder<LocalSymbol> builder,
-            CSharpSyntaxNode node = null,
-            ImmutableArray<CSharpSyntaxNode> nodes = default(ImmutableArray<CSharpSyntaxNode>))
-        {
-            var patterns = ArrayBuilder<DeclarationPatternSyntax>.GetInstance();
-            PatternVariableFinder.FindPatternVariables(patterns, node, nodes);
-            foreach (var pattern in patterns)
-            {
-                builder.Add(SourceLocalSymbol.MakeLocal(ContainingMemberOrLambda, this, RefKind.None, pattern.Type, pattern.Identifier, LocalDeclarationKind.PatternVariable));
-            }
-            patterns.Free();
-        }
-
         internal BoundExpression WrapWithVariablesIfAny(CSharpSyntaxNode scopeDesignator, BoundExpression expression)
         {
             var locals = this.GetDeclaredLocalsForScope(scopeDesignator);
-            return (locals.Length == 0)
+            return (locals.IsEmpty)
                 ? expression
                 : new BoundSequence(scopeDesignator, locals, ImmutableArray<BoundExpression>.Empty, expression, expression.Type) { WasCompilerGenerated = true };
         }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -453,7 +453,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors |= this.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
             }
 
-            // Binder could be null in error scenarios (as above)
             BoundBlock block;
             if (node.Body != null)
             {

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (_syntax.Filter != null)
             {
-                BuildAndAddPatternVariables(locals, _syntax.Filter.FilterExpression);
+                PatternVariableFinder.FindPatternVariables(this, locals, _syntax.Filter.FilterExpression);
             }
 
             return locals.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (declarator.Initializer != null)
                     {
-                        BuildAndAddPatternVariables(locals, declarator.Initializer.Value);
+                        PatternVariableFinder.FindPatternVariables(this, locals, declarator.Initializer.Value);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -39,21 +39,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (variable.Initializer != null)
                     {
-                        BuildAndAddPatternVariables(locals, variable.Initializer.Value);
+                        PatternVariableFinder.FindPatternVariables(this, locals, variable.Initializer.Value);
                     }
                 }
             }
             else
             {
-                BuildAndAddPatternVariables(locals, nodes:_syntax.Initializers.ToImmutableArray<CSharpSyntaxNode>());
+                PatternVariableFinder.FindPatternVariables(this, locals, _syntax.Initializers);
             }
 
             if (_syntax.Condition != null)
             {
-                BuildAndAddPatternVariables(locals, node: _syntax.Condition);
+                PatternVariableFinder.FindPatternVariables(this, locals, node: _syntax.Condition);
             }
 
-            BuildAndAddPatternVariables(locals, nodes: _syntax.Incrementors.ToImmutableArray<CSharpSyntaxNode>());
+            PatternVariableFinder.FindPatternVariables(this, locals, _syntax.Incrementors);
 
             return locals.ToImmutableAndFree();
         }

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (syntax is ExpressionSyntax)
             {
-                var binder = new PatternVariableBinder(syntax, (ExpressionSyntax)syntax, enclosing);
+                var binder = new PatternVariableBinder(syntax, enclosing);
                 builder.AddToMap(syntax, binder);
                 builder.Visit(syntax, binder);
             }
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                var binder = new PatternVariableBinder(body, (ExpressionSyntax)body, _enclosing);
+                var binder = new PatternVariableBinder(body, _enclosing);
                 AddToMap(body, binder);
                 Visit(body, binder);
             }
@@ -227,14 +227,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
         {
-            var arrowBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+            var arrowBinder = new PatternVariableBinder(node, _enclosing);
             AddToMap(node, arrowBinder);
             Visit(node.Expression, arrowBinder);
         }
 
         public override void VisitEqualsValueClause(EqualsValueClauseSyntax node)
         {
-            var valueBinder = new PatternVariableBinder(node, node.Value, _enclosing);
+            var valueBinder = new PatternVariableBinder(node, _enclosing);
             AddToMap(node, valueBinder);
             Visit(node.Value, valueBinder);
         }
@@ -258,7 +258,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (_root == node)
             {
                 // We are supposed to get here only for constructor initializers
-                var argBinder = new PatternVariableBinder(node, node.Arguments, _enclosing);
+                Debug.Assert(node.Parent is ConstructorInitializerSyntax);
+                var argBinder = new PatternVariableBinder(node, _enclosing);
                 AddToMap(node, argBinder);
 
                 foreach (var arg in node.Arguments)
@@ -337,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitWhileStatement(WhileStatementSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new PatternVariableBinder(node, node.Condition, _enclosing);
+            var patternBinder = new PatternVariableBinder(node, _enclosing);
             var whileBinder = new WhileBinder(patternBinder, node);
             AddToMap(node, whileBinder);
 
@@ -348,7 +349,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitDoStatement(DoStatementSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new PatternVariableBinder(node, node.Condition, _enclosing);
+            var patternBinder = new PatternVariableBinder(node, _enclosing);
             var whileBinder = new WhileBinder(patternBinder, node);
             AddToMap(node, whileBinder);
 
@@ -397,7 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitForEachStatement(ForEachStatementSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new PatternVariableBinder(node.Expression, node.Expression, _enclosing);
+            var patternBinder = new PatternVariableBinder(node.Expression, _enclosing);
 
             AddToMap(node.Expression, patternBinder);
             Visit(node.Expression, patternBinder);
@@ -446,7 +447,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitLockStatement(LockStatementSyntax node)
         {
-            var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+            var patternBinder = new PatternVariableBinder(node, _enclosing);
             var lockBinder = new LockBinder(patternBinder, node);
             AddToMap(node, lockBinder);
 
@@ -465,7 +466,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitSwitchStatement(SwitchStatementSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new PatternVariableBinder(node.Expression, node.Expression, _enclosing);
+            var patternBinder = new PatternVariableBinder(node.Expression, _enclosing);
             AddToMap(node.Expression, patternBinder);
 
             Visit(node.Expression, patternBinder);
@@ -505,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitIfStatement(IfStatementSyntax node)
         {
-            var ifBinder = new PatternVariableBinder(node.Condition, node.Condition, _enclosing);
+            var ifBinder = new PatternVariableBinder(node.Condition, _enclosing);
             AddToMap(node.Condition, ifBinder);
             Visit(node.Condition, ifBinder);
             VisitPossibleEmbeddedStatement(node.Statement, ifBinder);
@@ -519,7 +520,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // Note that we do *not* include variables defined in a let statement's pattern in the let statement's scope.
             // Those are instead included in the enclosing scope.
-            var letBinder = new PatternVariableBinder(node, ImmutableArray.Create(node.Expression, node.WhenClause?.Condition), _enclosing);
+            var letBinder = new PatternVariableBinder(node, _enclosing);
             Visit(node.Expression, letBinder);
 
             if (node.WhenClause != null)
@@ -616,7 +617,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node.Expression != null)
             {
-                var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+                var patternBinder = new PatternVariableBinder(node, _enclosing);
                 AddToMap(node, patternBinder);
                 Visit(node.Expression, patternBinder);
             }
@@ -626,14 +627,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override void VisitExpressionStatement(ExpressionStatementSyntax node)
         {
-            var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+            var patternBinder = new PatternVariableBinder(node, _enclosing);
             AddToMap(node, patternBinder);
             Visit(node.Expression, patternBinder);
         }
 
         public override void VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
         {
-            var patternBinder = new PatternVariableBinder(node, node.Declaration.Variables, _enclosing);
+            var patternBinder = new PatternVariableBinder(node, _enclosing);
             AddToMap(node, patternBinder);
 
             foreach (var decl in node.Declaration.Variables)
@@ -650,7 +651,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node.Expression != null)
             {
-                var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+                var patternBinder = new PatternVariableBinder(node, _enclosing);
                 AddToMap(node, patternBinder);
                 Visit(node.Expression, patternBinder);
             }
@@ -660,7 +661,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (node.Expression != null)
             {
-                var patternBinder = new PatternVariableBinder(node, node.Expression, _enclosing);
+                var patternBinder = new PatternVariableBinder(node, _enclosing);
                 AddToMap(node, patternBinder);
                 Visit(node.Expression, patternBinder);
             }

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             if (decl.Pattern != null)
                             {
                                 // Patterns from the let statement introduce bindings into the enclosing scope.
-                                BuildAndAddPatternVariables(locals, decl.Pattern);
+                                PatternVariableFinder.FindPatternVariables(this, locals, decl.Pattern);
                             }
                             else
                             {

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableBinder.cs
@@ -11,96 +11,17 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed class PatternVariableBinder : LocalScopeBinder
     {
-        private readonly CSharpSyntaxNode _node;
-        private readonly ImmutableArray<CSharpSyntaxNode> _nodes;
         public readonly CSharpSyntaxNode ScopeDesignator;
 
-        internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, ImmutableArray<ExpressionSyntax> expressions, Binder next) : base(next)
+        internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, Binder next) : base(next)
         {
             this.ScopeDesignator = scopeDesignator;
-            this._nodes = StaticCast<CSharpSyntaxNode>.From(expressions);
-        }
-
-        internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, IEnumerable<VariableDeclaratorSyntax> declarations, Binder next) : base(next)
-        {
-            this.ScopeDesignator = scopeDesignator;
-            var nodes = ArrayBuilder<CSharpSyntaxNode>.GetInstance();
-            foreach (var decl in declarations)
-            {
-                var value = decl.Initializer?.Value;
-                if (value != null) nodes.Add(value);
-            }
-            this._nodes = nodes.ToImmutableAndFree();
-        }
-
-        internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, IEnumerable<ArgumentSyntax> arguments, Binder next) : base(next)
-        {
-            this.ScopeDesignator = scopeDesignator;
-            var nodes = ArrayBuilder<CSharpSyntaxNode>.GetInstance();
-            foreach (var arg in arguments)
-            {
-                var value = arg.Expression;
-                if (value != null) nodes.Add(value);
-            }
-            this._nodes = nodes.ToImmutableAndFree();
-        }
-
-        internal PatternVariableBinder(SwitchSectionSyntax scopeDesignator, Binder next) : base(next)
-        {
-            this.ScopeDesignator = scopeDesignator;
-            var nodes = ArrayBuilder<CSharpSyntaxNode>.GetInstance();
-            foreach (var label in scopeDesignator.Labels)
-            {
-                var match = label as CasePatternSwitchLabelSyntax;
-                if (match != null)
-                {
-                    nodes.Add(match.Pattern);
-                    if (match.WhenClause != null)
-                    {
-                        nodes.Add(match.WhenClause.Condition);
-                    }
-                }
-            }
-
-            this._nodes = nodes.ToImmutableAndFree();
-        }
-
-        internal PatternVariableBinder(MatchSectionSyntax scopeDesignator, Binder next) : base(next)
-        {
-            this.ScopeDesignator = scopeDesignator;
-            this._nodes = scopeDesignator.WhenClause != null
-                ? ImmutableArray.Create<CSharpSyntaxNode>(scopeDesignator.Pattern, scopeDesignator.WhenClause.Condition, scopeDesignator.Expression)
-                : ImmutableArray.Create<CSharpSyntaxNode>(scopeDesignator.Pattern, scopeDesignator.Expression)
-                ;
-        }
-
-        internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, ExpressionSyntax expression, Binder next) : base(next)
-        {
-            this._node = expression;
-            this.ScopeDesignator = scopeDesignator;
-        }
-
-        internal PatternVariableBinder(AttributeSyntax scopeDesignator, Binder next) : base(next)
-        {
-            this.ScopeDesignator = scopeDesignator;
-
-            if (scopeDesignator.ArgumentList?.Arguments.Count > 0)
-            {
-                var expressions = ArrayBuilder<CSharpSyntaxNode>.GetInstance(scopeDesignator.ArgumentList.Arguments.Count);
-
-                foreach (var argument in scopeDesignator.ArgumentList.Arguments)
-                {
-                    expressions.Add(argument.Expression);
-                }
-
-                this._nodes = expressions.ToImmutableAndFree();
-            }
         }
 
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            BuildAndAddPatternVariables(builder, _node, _nodes);
+            PatternVariableFinder.FindPatternVariables(this, builder, ScopeDesignator);
             return builder.ToImmutableAndFree();
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (expressionSyntax != null)
             {
                 var locals = ArrayBuilder<LocalSymbol>.GetInstance();
-                BuildAndAddPatternVariables(locals, expressionSyntax);
+                PatternVariableFinder.FindPatternVariables(this, locals, expressionSyntax);
                 return locals.ToImmutableAndFree();
             }
             else
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (declarator.Initializer != null)
                     {
-                        BuildAndAddPatternVariables(locals, declarator.Initializer.Value);
+                        PatternVariableFinder.FindPatternVariables(this, locals, declarator.Initializer.Value);
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -72,6 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 kind == SyntaxKind.ArgumentList ||
                 kind == SyntaxKind.ArrowExpressionClause ||
                 (syntax is ExpressionSyntax && 
+                    // All these nodes are valid scope designators due to the pattern matching feature.
                     ((syntax.Parent as LambdaExpressionSyntax)?.Body == syntax ||
                      (syntax.Parent as SwitchStatementSyntax)?.Expression == syntax ||
                      (syntax.Parent as ForEachStatementSyntax)?.Expression == syntax ||


### PR DESCRIPTION
Remove unnecessary allocations and layers of translation.
Related to #8817.

@gafter, @agocke, @dotnet/roslyn-compiler Please review.