### PR TITLE
Fix parsing of constant patterns such as int.MaxValue

### DIFF
--- a/docs/features/patterns.md
+++ b/docs/features/patterns.md
@@ -33,7 +33,7 @@ pattern
     ;
 
 type_pattern
-    : type identifier?
+    : type identifier
     ;
 
 wildcard_pattern
@@ -84,7 +84,7 @@ property_subpattern
 
 ### Type Pattern
 
-The *type_pattern* both tests that an expression is of a given type and, if the *identifier* is present, casts it to that type if the test succeeds. This introduces a local variable of the given type named by the given identifier. That local variable is *definitely assigned* when the result of the pattern-matching operation is true.
+The *type_pattern* both tests that an expression is of a given type and casts it to that type if the test succeeds. This introduces a local variable of the given type named by the given identifier. That local variable is *definitely assigned* when the result of the pattern-matching operation is true.
 
 ```antlr
 type_pattern
@@ -92,11 +92,9 @@ type_pattern
     ;
 ```
 
-The runtime semantic of this expression is that it tests the runtime type of the left-hand *relational_expression* operand against the *type* in the pattern. If it is of that runtime type (or some subtype), the result of the `is operator` is `true`. If the *identifier* is present, it declares a new local variable that is assigned the value of the left-hand operand when the result is `true`.
+The runtime semantic of this expression is that it tests the runtime type of the left-hand *relational_expression* operand against the *type* in the pattern. If it is of that runtime type (or some subtype), the result of the `is operator` is `true`. It declares a new local variable named by the *identifier* that is assigned the value of the left-hand operand when the result is `true`.
 
 Certain combinations of static type of the left-hand-side and the given type are considered incompatible and result in compile-time error. A value of static type `E` is said to be *pattern compatible* with the type `T` if there exists an identity conversion, an implicit reference conversion, a boxing conversion, an explicit reference conversion, or an unboxing conversion from `E` to `T`. It is a compile-time error if an expression of type `E` is not pattern compatible with the type in a type pattern that it is matched with.
-
-> Note: For compatibility with previous versions of the language we make an exception to this; this situation is merely a warning (not an error) in an *is_expression* if the *identifier* is absent.
 
 The type pattern is useful for performing run-time type tests of reference types, and replaces the idiom
 
@@ -124,9 +122,11 @@ The condition of the `if` statement is `true` at runtime and the variable `v` ho
 
 ### Constant Pattern
 
-A constant pattern tests the value of an expression against a constant value. The constant may be any constant expression, such as a literal, the name of a declared `const` variable, or an enumeration constant.
+A constant pattern tests the value of an expression against a constant value. The constant may be any constant expression, such as a literal, the name of a declared `const` variable, or an enumeration constant, or a `typeof` expression.
 
-An expression *e* matches a constant pattern *c* if `object.Equals(e, c)` returns `true`.
+If both *e* and *c* are of integral types, the pattern is considered matched if the result of the expression `e == c` is `true`.
+
+Otherwise the pattern is considered matching if `object.Equals(e, c)` returns `true`. In this case it is a compile-time error if the static type of *e* is not *pattern compatible* with the type of the constant.
 
 ```antlr
 constant_pattern
@@ -134,15 +134,11 @@ constant_pattern
     ;
 ```
 
-It is a compile-time error if the static type of *e* is not *pattern compatible* with the type of the constant.
-
-| Note |
-| --- |
-| We plan to relax the rules for matching constants so that a literal such as `1` would match a value of any integral type (`byte`, `sbyte`, `short`, `ushort`, `int`, `uint`, `long`, or `ulong`) whose value is `1`. |
-
 ### Var Pattern
 
 An expression *e* matches the pattern `var identifier` always. In other words, a match to a *var pattern* always succeeds. At runtime the value of *e* is bounds to a newly introduced local variable. The type of the local variable is the static type of *e*.
+
+If the name `var` binds to a type, then we instead treat the pattern as a *type_pattern*.
 
 ### Wildcard Pattern
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2588,12 +2588,36 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundExpression BindIsOperator(BinaryExpressionSyntax node, DiagnosticBag diagnostics)
         {
+            var resultType = (TypeSymbol)GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
             var operand = BindValue(node.Left, diagnostics, BindValueKind.RValue);
             AliasSymbol alias;
-            TypeSymbol targetType = BindType(node.Right, diagnostics, out alias);
+            TypeSymbol targetType;
+            {
+                // try binding as a type, but back off to binding as an expression if that does not work.
+                var tempBag = DiagnosticBag.GetInstance();
+                targetType = BindType(node.Right, tempBag, out alias);
+                if (targetType?.IsErrorType() == true && tempBag.HasAnyResolvedErrors() &&
+                    ((CSharpParseOptions)node.SyntaxTree.Options).IsFeatureEnabled(MessageID.IDS_FeaturePatternMatching))
+                {
+                    // it did not bind as a type; try binding as a constant expression pattern
+                    bool wasExpression;
+                    var tempBag2 = DiagnosticBag.GetInstance();
+                    var boundConstantPattern = BindConstantPattern(node, operand, operand.Type, node.Right, node.Right.HasErrors, tempBag2, out wasExpression);
+                    if (wasExpression)
+                    {
+                        tempBag.Free();
+                        diagnostics.AddRangeAndFree(tempBag2);
+                        return new BoundIsPatternExpression(node, operand, boundConstantPattern, resultType);
+                    }
+
+                    tempBag2.Free();
+                }
+
+                diagnostics.AddRangeAndFree(tempBag);
+            }
+
             var typeExpression = new BoundTypeExpression(node.Right, alias, targetType);
             var targetTypeKind = targetType.TypeKind;
-            var resultType = (TypeSymbol)GetSpecialType(SpecialType.System_Boolean, diagnostics, node);
             if (IsOperandErrors(node, operand, diagnostics) || IsOperatorErrors(node, operand.Type, typeExpression, diagnostics))
             {
                 return new BoundIsOperator(node, operand, typeExpression, Conversion.NoConversion, resultType, hasErrors: true);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -524,10 +524,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool hasErrors,
             DiagnosticBag diagnostics)
         {
-            var expression = BindValue(node.Expression, diagnostics, BindValueKind.RValue);
+            bool wasExpression;
+            return BindConstantPattern(node, operand, operandType, node.Expression, hasErrors, diagnostics, out wasExpression);
+        }
+
+        private BoundPattern BindConstantPattern(
+            CSharpSyntaxNode node,
+            BoundExpression left,
+            TypeSymbol leftType,
+            ExpressionSyntax right,
+            bool hasErrors,
+            DiagnosticBag diagnostics,
+            out bool wasExpression)
+        {
+            var expression = BindValue(right, diagnostics, BindValueKind.RValue);
+            wasExpression = expression.Type?.IsErrorType() != true;
             if (!node.HasErrors && expression.ConstantValue == null)
             {
-                diagnostics.Add(ErrorCode.ERR_ConstantExpected, node.Expression.Location);
+                diagnostics.Add(ErrorCode.ERR_ConstantExpected, right.Location);
                 hasErrors = true;
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -727,7 +727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // rather than add, semantics.
             Binder existing;
             // Note that a lock statement has two outer binders (a second one for pattern variable scope)
-            Debug.Assert(!_map.TryGetValue(node, out existing) || existing == binder.Next || existing == binder.Next?.Next);
+            Debug.Assert(!_map.TryGetValue(node, out existing) || existing == binder || existing == binder.Next || existing == binder.Next?.Next);
 
             _map[node] = binder;
         }
@@ -741,6 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case SyntaxKind.LocalDeclarationStatement:
                     case SyntaxKind.LetStatement:
                     case SyntaxKind.LabeledStatement:
+                    case SyntaxKind.LocalFunctionStatement:
                         // It is an error to have a declaration or a label in an embedded statement,
                         // but we still want to bind it.  We'll pretend that the statement was
                         // inside a block.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     {
                         Debug.Assert(Precedence.Shift == Precedence.Relational + 1);
                         if ((IsExpectedBinaryOperator(tk) && GetPrecedence(SyntaxFacts.GetBinaryExpression(tk)) > Precedence.Relational) ||
-                            tk == SyntaxKind.DotToken)
+                            tk == SyntaxKind.DotToken) // member selection is not formally a binary operator but has higher precedence than relational
                         {
                             this.Reset(ref resetPoint);
                             // We parse a shift-expression ONLY (nothing looser) - i.e. not a relational expression

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -65,13 +65,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     if (node == null)
                     {
                         Debug.Assert(Precedence.Shift == Precedence.Relational + 1);
-                        if (IsExpectedBinaryOperator(tk) && GetPrecedence(SyntaxFacts.GetBinaryExpression(tk)) > Precedence.Relational)
+                        if ((IsExpectedBinaryOperator(tk) && GetPrecedence(SyntaxFacts.GetBinaryExpression(tk)) > Precedence.Relational) ||
+                            tk == SyntaxKind.DotToken)
                         {
                             this.Reset(ref resetPoint);
                             // We parse a shift-expression ONLY (nothing looser) - i.e. not a relational expression
                             // So x is y < z should be parsed as (x is y) < z
                             // But x is y << z should be parsed as x is (y << z)
-                            node = _syntaxFactory.ConstantPattern(this.ParseExpression(Precedence.Shift));
+                            node = _syntaxFactory.ConstantPattern(this.ParseSubExpression(Precedence.Shift));
                         }
                         // it is a typical is operator! 
                         else
@@ -90,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             else
             {
-                // it still might be a pattern such as (operand is 3) or (operand is -3)
+                // it still might be a pattern such as (operand is 3) or (operand is nameof(x))
                 node = _syntaxFactory.ConstantPattern(this.ParseExpressionCore());
             }
             return node;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using System;
 using Xunit;
 
@@ -3672,6 +3673,29 @@ class Program
     Diagnostic(ErrorCode.ERR_FeatureIsExperimental, @"void Local()
         {
         }").WithArguments("local functions", "localFunctions").WithLocation(6, 9)
+                );
+        }
+
+        [Fact, WorkItem(10521, "https://github.com/dotnet/roslyn/issues/10521")]
+        public void LocalFunctionInIf()
+        {
+            var source = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        if () // typing at this point
+        int Add(int x, int y) => x + y;
+    }
+}
+";
+            VerifyDiagnostics(source,
+                // (6,13): error CS1525: Invalid expression term ')'
+                //         if () // typing at this point
+                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 13),
+                // (7,9): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //         int Add(int x, int y) => x + y;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "int Add(int x, int y) => x + y;").WithLocation(7, 9)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -15218,6 +15218,8 @@ public class X
         Console.WriteLine(1L is int.MaxValue); // OK, but false
         Console.WriteLine(1 is int.MaxValue); // false
         Console.WriteLine(int.MaxValue is int.MaxValue); // true
+        Console.WriteLine(""foo"" is System.String); // true
+        Console.WriteLine(Int32.MaxValue is Int32.MaxValue); // true
         Console.WriteLine(new int[] {1, 2} is int[] a); // true
         object o = null;
         switch (o)
@@ -15241,6 +15243,8 @@ public class X
 @"True
 False
 False
+True
+True
 True
 True
 null");

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -15169,7 +15169,7 @@ True
 False");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/10465")]
+        [Fact, WorkItem(10465, "https://github.com/dotnet/roslyn/issues/10465")]
         public void Constants_Fail()
         {
             var source =
@@ -15179,17 +15179,32 @@ public class X
 {
     public static void Main()
     {
-        Console.WriteLine(1L is 1); // should fail to compile due to type mismatch
-        Console.WriteLine(1L is int.MaxValue); // should fail to compile due to type mismatch
+        Console.WriteLine(1L is string); // warning: type mismatch
         Console.WriteLine(1 is int[]); // warning: expression is never of the provided type
+
+        Console.WriteLine(1L is string s); // error: type mismatch
+        Console.WriteLine(1 is int[] a); // error: expression is never of the provided type
     }
 }
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
-            compilation.VerifyDiagnostics();
+            compilation.VerifyDiagnostics(
+                // (7,27): warning CS0184: The given expression is never of the provided ('string') type
+                //         Console.WriteLine(1L is string); // warning: type mismatch
+                Diagnostic(ErrorCode.WRN_IsAlwaysFalse, "1L is string").WithArguments("string").WithLocation(7, 27),
+                // (8,27): warning CS0184: The given expression is never of the provided ('int[]') type
+                //         Console.WriteLine(1 is int[]); // warning: expression is never of the provided type
+                Diagnostic(ErrorCode.WRN_IsAlwaysFalse, "1 is int[]").WithArguments("int[]").WithLocation(8, 27),
+                // (10,33): error CS0030: Cannot convert type 'long' to 'string'
+                //         Console.WriteLine(1L is string s); // error: type mismatch
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "string").WithArguments("long", "string").WithLocation(10, 33),
+                // (11,32): error CS0030: Cannot convert type 'int' to 'int[]'
+                //         Console.WriteLine(1 is int[] a); // error: expression is never of the provided type
+                Diagnostic(ErrorCode.ERR_NoExplicitConv, "int[]").WithArguments("int", "int[]").WithLocation(11, 32)
+                );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/10465")]
+        [Fact, WorkItem(10465, "https://github.com/dotnet/roslyn/issues/10465")]
         public void Types_Pass()
         {
             var source =
@@ -15199,9 +15214,11 @@ public class X
 {
     public static void Main()
     {
-        Console.WriteLine(1 is 1);
-        Console.WriteLine(1 is int.MaxValue);
-        Console.WriteLine(new int[] {1, 2} is int[]);
+        Console.WriteLine(1 is 1); // true
+        Console.WriteLine(1L is int.MaxValue); // OK, but false
+        Console.WriteLine(1 is int.MaxValue); // false
+        Console.WriteLine(int.MaxValue is int.MaxValue); // true
+        Console.WriteLine(new int[] {1, 2} is int[] a); // true
         object o = null;
         switch (o)
         {
@@ -15212,6 +15229,7 @@ public class X
             case int i:
                 break;
             case null:
+                Console.WriteLine(""null"");
                 break;
         }
     }
@@ -15219,6 +15237,13 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput:
+@"True
+False
+False
+True
+True
+null");
         }
     }
 }


### PR DESCRIPTION
Fix parsing of constant patterns such as int.MaxValue
Remove two ambiguities in the formal grammar for type_pattern
Fixes #10465 

The issue (and fix) arises because of the inherent ambiguity between _type_ and _expression_ in the grammar

```antlr
relational_expression
    : relational_expression 'is' type
    | relational_expression 'is' pattern
    ;

pattern
    : constant_pattern
    ;

constant_pattern
    : shift_expression
    ;
```

I've adjusted the heuristics used to disambiguate them. In truly ambiguous cases, we parse as a type and then, if the binder finds a constant expression, we just use the value of that expression.

I'm doing some research now to determine if these heuristics introduce any incompatibilities.

@agocke @AlekseyTs Please review
@dotnet/roslyn-compiler FYI
