### PR TITLE
Suppress dynamic analysis for implicit constructor initializers.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -276,7 +276,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!statement.WasCompilerGenerated)
                 {
-                    return CollectDynamicAnalysis(visited);
+                    // Do not instrument implicit constructor initializers
+                    if (!statement.IsConstructorInitializer() || statement.Syntax.Kind() != SyntaxKind.ConstructorDeclaration)
+                    {
+                        return CollectDynamicAnalysis(visited);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -254,7 +254,6 @@ Hello
 Flushing
 1
 True
-True
 2
 False
 True


### PR DESCRIPTION
Related to #9819.

@JohnHamby FYI