### PR TITLE
When inserting overridden members from completion, do not add a using…

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -1171,7 +1171,9 @@ class d : c
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitAbstractMethodThrows()
         {
-            var markupBeforeCommit = @"abstract class c
+            var markupBeforeCommit = @"using System;
+
+abstract class c
 {
     public abstract void foo();
 }
@@ -1599,9 +1601,7 @@ class d : MyIndexer<T>
     override $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-public class MyIndexer<T>
+            var expectedCodeAfterCommit = @"public class MyIndexer<T>
 {
     private T[] arr = new T[100];
     public abstract T this[int i] { get; set; }
@@ -1613,12 +1613,12 @@ class d : MyIndexer<T>
     {
         get
         {
-            throw new NotImplementedException();$$
+            throw new System.NotImplementedException();$$
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }";
@@ -1729,7 +1729,9 @@ public class SomeClass : Base
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitEscapedMethodName()
         {
-            var markupBeforeCommit = @"public abstract class Base
+            var markupBeforeCommit = @"using System;
+
+public abstract class Base
 {
     public abstract void @class();
 }
@@ -1829,7 +1831,9 @@ public class SomeClass : Base
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitRefParameter()
         {
-            var markupBeforeCommit = @"public abstract class Base
+            var markupBeforeCommit = @"using System;
+
+public abstract class Base
 {
     public abstract void foo(int x, ref string y);
 }
@@ -1860,7 +1864,9 @@ public class SomeClass : Base
         [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task CommitOutParameter()
         {
-            var markupBeforeCommit = @"public abstract class Base
+            var markupBeforeCommit = @"using System;
+
+public abstract class Base
 {
     public abstract void foo(int x, out string y);
 }
@@ -2554,6 +2560,73 @@ namespace ConsoleApplication46
                 // there should only be one change: the replacement of "override " with a method.
                 Assert.Equal(change.Span, TextSpan.FromBounds(136, 145));
             }
+        }
+
+        [WorkItem(8257, "https://github.com/dotnet/roslyn/issues/8257")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotImplementedQualifiedWhenSystemUsingNotPresent_Property()
+        {
+            var markupBeforeCommit = @"abstract class C
+{
+    public abstract int foo { get; set; };
+}
+
+class Program : C
+{
+    override $$
+}";
+
+            var expectedCodeAfterCommit = @"abstract class C
+{
+    public abstract int foo { get; set; };
+}
+
+class Program : C
+{
+    public override int foo
+    {
+        get
+        {
+            throw new System.NotImplementedException();$$
+        }
+
+        set
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "foo", expectedCodeAfterCommit);
+        }
+
+        [WorkItem(8257, "https://github.com/dotnet/roslyn/issues/8257")]
+        public async Task NotImplementedQualifiedWhenSystemUsingNotPresent_Method()
+        {
+            var markupBeforeCommit = @"abstract class C
+{
+    public abstract void foo();
+}
+
+class Program : C
+{
+    override $$
+}";
+
+            var expectedCodeAfterCommit = @"abstract class C
+{
+    public abstract void foo();
+}
+
+class Program : C
+{
+    public override void foo()
+    {
+        throw new System.NotImplementedException();$$
+    }
+}";
+
+            await VerifyCustomCommitProviderAsync(markupBeforeCommit, "foo()", expectedCodeAfterCommit);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/PartialMethodCompletionProviderTests.cs
@@ -244,15 +244,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion.CompletionPr
     partial $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-partial class c
+            var expectedCodeAfterCommit = @"partial class c
 {
     partial void foo();
 
     partial void foo()
     {
-        throw new NotImplementedException();$$
+        throw new System.NotImplementedException();$$
     }
 }";
 
@@ -269,15 +267,13 @@ partial class c
     partial $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-partial class c<T>
+            var expectedCodeAfterCommit = @"partial class c<T>
 {
     partial void foo(T bar);
 
     partial void foo(T bar)
     {
-        throw new NotImplementedException();$$
+        throw new System.NotImplementedException();$$
     }
 }";
 
@@ -294,15 +290,13 @@ partial class c<T>
     private partial $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-partial class c
+            var expectedCodeAfterCommit = @"partial class c
 {
     partial void foo();
 
     partial void foo()
     {
-        throw new NotImplementedException();$$
+        throw new System.NotImplementedException();$$
     }
 }";
 
@@ -322,9 +316,7 @@ partial class c
     partial $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-partial class c
+            var expectedCodeAfterCommit = @"partial class c
 {
     partial void foo();
 }
@@ -333,7 +325,7 @@ partial class c
 {
     partial void foo()
     {
-        throw new NotImplementedException();$$
+        throw new System.NotImplementedException();$$
     }
 }";
 
@@ -350,15 +342,13 @@ partial class c
     partial $$
 }";
 
-            var expectedCodeAfterCommit = @"using System;
-
-partial struct c
+            var expectedCodeAfterCommit = @"partial struct c
 {
     partial void foo();
 
     partial void foo()
     {
-        throw new NotImplementedException();$$
+        throw new System.NotImplementedException();$$
     }
 }";
 
@@ -469,9 +459,7 @@ partial class Bar
 }
 ";
 
-            var expected = @"using System;
-
-namespace PartialClass
+            var expected = @"namespace PartialClass
 {
     partial class PClass
     {
@@ -479,7 +467,7 @@ namespace PartialClass
 
         partial void PMethod(int i)
         {
-            throw new NotImplementedException();$$
+            throw new System.NotImplementedException();$$
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -1499,7 +1499,6 @@ namespace My
 }",
 @"// Copyright ...
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Win32;
 
@@ -1514,7 +1513,7 @@ namespace My
     {
         public override void Bar(List<object> values)
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }", compareTokens: false);

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests.cs
@@ -70,9 +70,7 @@ class [|Program|] : Foo
     {
     }
 }",
-@"using System;
-
-abstract class Foo
+@"abstract class Foo
 {
     protected abstract string FooMethod();
     public abstract void Blah();
@@ -95,12 +93,12 @@ class Program : Foo
 
     public override void Blah()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     protected override string FooMethod()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -118,9 +116,7 @@ class Program : Foo
 class [|Program|] : Base
 {
 }",
-@"using System;
-
-abstract class Base
+@"abstract class Base
 {
     protected abstract (int a, int b) Method((string, string d) x);
 }
@@ -129,7 +125,7 @@ class Program : Base
 {
     protected override (int a, int b) Method((string, string d) x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -161,9 +157,7 @@ struct [|Program|] : Foo
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(int x = 3);
 }
@@ -172,7 +166,7 @@ class b : d
 {
     public override void foo(int x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -189,9 +183,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(char x = 'a');
 }
@@ -200,7 +192,7 @@ class b : d
 {
     public override void foo(char x = 'a')
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -217,9 +209,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(string x = ""x"");
 }
@@ -228,7 +218,7 @@ class b : d
 {
     public override void foo(string x = ""x"")
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -245,9 +235,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(short x = 3);
 }
@@ -256,7 +244,7 @@ class b : d
 {
     public override void foo(short x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -273,9 +261,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(decimal x = 3);
 }
@@ -284,7 +270,7 @@ class b : d
 {
     public override void foo(decimal x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -301,9 +287,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(double x = 3);
 }
@@ -312,7 +296,7 @@ class b : d
 {
     public override void foo(double x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -329,9 +313,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(long x = 3);
 }
@@ -340,7 +322,7 @@ class b : d
 {
     public override void foo(long x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -357,9 +339,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(float x = 3);
 }
@@ -368,7 +348,7 @@ class b : d
 {
     public override void foo(float x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -385,9 +365,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(ushort x = 3);
 }
@@ -396,7 +374,7 @@ class b : d
 {
     public override void foo(ushort x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -413,9 +391,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(uint x = 3);
 }
@@ -424,7 +400,7 @@ class b : d
 {
     public override void foo(uint x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -441,9 +417,7 @@ class b : d
 class [|b|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void foo(ulong x = 3);
 }
@@ -452,7 +426,7 @@ class b : d
 {
     public override void foo(ulong x = 3)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -473,9 +447,7 @@ abstract class d
 class [|c|] : d
 {
 }",
-@"using System;
-
-struct b
+@"struct b
 {
 }
 
@@ -488,7 +460,7 @@ class c : d
 {
     public override void foo(b x = default(b))
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -510,9 +482,7 @@ abstract class d
 class [|c|] : d
 {
 }",
-@"using System;
-
-struct b
+@"struct b
 {
 }
 
@@ -525,7 +495,7 @@ class c : d
 {
     public override void m(b? x = default(b?), b? y = default(b?))
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -543,9 +513,7 @@ class c : d
 class [|c|] : d
 {
 }",
-@"using System;
-
-abstract class d
+@"abstract class d
 {
     public abstract void m(int? x = 5, int? y = default(int?));
 }
@@ -554,7 +522,7 @@ class c : d
 {
     public override void m(int? x = 5, int? y = default(int?))
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -575,9 +543,7 @@ abstract class d
 class [|c|] : d
 {
 }",
-@"using System;
-
-class b
+@"class b
 {
 }
 
@@ -590,7 +556,7 @@ class c : d
 {
     public override void foo(b x = null)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -608,9 +574,7 @@ class c : d
 class [|c2|] : c1
 {
 }",
-@"using System;
-
-abstract class c1
+@"abstract class c1
 {
     public abstract c1 this[c1 x] { get; internal set; }
 }
@@ -621,12 +585,12 @@ class c2 : c1
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         internal set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -885,9 +849,7 @@ abstract class B : A
 class [|C|] : B
 {
 }",
-@"using System;
-
-class A
+@"class A
 {
     public virtual void Foo(int x, params int[] y)
     {
@@ -903,7 +865,7 @@ class C : B
 {
     public override void Foo(int x, params int[] y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -921,9 +883,7 @@ class C : B
 class [|D|] : C
 {
 }",
-@"using System;
-
-abstract class C
+@"abstract class C
 {
     unsafe public abstract void Foo(int* x = null);
 }
@@ -932,7 +892,7 @@ class D : C
 {
     public override unsafe void Foo(int* x = null)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -954,8 +914,6 @@ class [|D|] : C
 }",
 @"extern alias var;
 
-using System;
-
 abstract class C
 {
     public abstract void Foo(var::X x);
@@ -965,7 +923,7 @@ class D : C
 {
     public override void Foo(X x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -986,9 +944,7 @@ class D : C
         }
     }
 }",
-@"using System;
-
-abstract class A<T>
+@"abstract class A<T>
 {
     public abstract void M(T x);
 
@@ -998,7 +954,7 @@ abstract class A<T>
         {
             public override void M(B.T x)
             {
-                throw new NotImplementedException();
+                throw new System.NotImplementedException();
             }
         }
     }
@@ -1019,9 +975,7 @@ abstract class A<T>
     }
 }
 ",
-@"using System;
-
-abstract class A<T>
+@"abstract class A<T>
 {
     public abstract void M(T x);
     abstract class B : A<B>
@@ -1030,7 +984,7 @@ abstract class A<T>
         {
             public override void M(A<A<T>.B>.B.T x)
             {
-                throw new NotImplementedException();
+                throw new System.NotImplementedException();
             }
         }
     }
@@ -1215,16 +1169,14 @@ partial class A : Base
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract void M(int x);
 }
 
 class T : A
 {
-    public override void M(int x) => throw new NotImplementedException();
+    public override void M(int x) => throw new System.NotImplementedException();
 }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedMethods, CodeStyleOptions.TrueWithNoneEnforcement));
         }
 
@@ -1241,16 +1193,14 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { get; }
 }
 
 class T : A
 {
-    public override int M => throw new NotImplementedException();
+    public override int M => throw new System.NotImplementedException();
 }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, CodeStyleOptions.TrueWithNoneEnforcement));
         }
 
@@ -1267,9 +1217,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { set; }
 }
@@ -1280,7 +1228,7 @@ class T : A
     {
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }", options: OptionsSet(
@@ -1301,9 +1249,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { get; set; }
 }
@@ -1314,12 +1260,12 @@ class T : A
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }", options: OptionsSet(
@@ -1340,16 +1286,14 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int this[int i] { get; }
 }
 
 class T : A
 {
-    public override int this[int i] => throw new NotImplementedException();
+    public override int this[int i] => throw new System.NotImplementedException();
 }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedIndexers, CodeStyleOptions.TrueWithNoneEnforcement));
         }
 
@@ -1366,9 +1310,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int this[int i] { set; }
 }
@@ -1379,7 +1321,7 @@ class T : A
     {
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }", options: OptionsSet(
@@ -1400,9 +1342,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int this[int i] { get; set; }
 }
@@ -1413,12 +1353,12 @@ class T : A
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }", options: OptionsSet(
@@ -1439,9 +1379,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { get; }
 }
@@ -1450,7 +1388,7 @@ class T : A
 {
     public override int M
     {
-        get => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
         }
     }", options: OptionsSet(
     SingleOption(CSharpCodeStyleOptions.PreferExpressionBodiedProperties, false, NotificationOption.None),
@@ -1470,9 +1408,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { set; }
 }
@@ -1481,7 +1417,7 @@ class T : A
 {
     public override int M
     {
-        set => throw new NotImplementedException();
+        set => throw new System.NotImplementedException();
         }
     }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CodeStyleOptions.TrueWithNoneEnforcement));
         }
@@ -1499,9 +1435,7 @@ class T : A
 class [|T|] : A
 {
 }",
-@"using System;
-
-abstract class A
+@"abstract class A
 {
     public abstract int M { get; set; }
 }
@@ -1510,8 +1444,8 @@ class T : A
 {
     public override int M
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
         }
     }", options: Option(CSharpCodeStyleOptions.PreferExpressionBodiedAccessors, CodeStyleOptions.TrueWithNoneEnforcement));
         }
@@ -1530,9 +1464,7 @@ class [|Derived|] : Base
 {
     void Foo() { }
 }",
-@"using System;
-
-abstract class Base
+@"abstract class Base
 {
     public abstract int Prop { get; }
 }
@@ -1541,7 +1473,7 @@ class Derived : Base
 {
     void Foo() { }
 
-    public override int Prop => throw new NotImplementedException();
+    public override int Prop => throw new System.NotImplementedException();
 }", options: Option(ImplementTypeOptions.InsertionBehavior, ImplementTypeInsertionBehavior.AtTheEnd));
         }
 

--- a/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementAbstractClass/ImplementAbstractClassTests_FixAllTests.cs
@@ -64,8 +64,6 @@ class B3 : A1
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public abstract class A1
 {
     public abstract void F1();
@@ -80,14 +78,14 @@ class B1 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -169,8 +167,6 @@ class B3 : A1
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public abstract class A1
 {
     public abstract void F1();
@@ -185,33 +181,31 @@ class B1 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -286,8 +280,6 @@ class B3 : A1
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public abstract class A1
 {
     public abstract void F1();
@@ -302,33 +294,31 @@ class B1 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -337,20 +327,18 @@ class B2 : A1
     <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
         <ProjectReference>Assembly1</ProjectReference>
         <Document>
-using System;
-
 class B3 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C3 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -419,8 +407,6 @@ class B3 : A1
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public abstract class A1
 {
     public abstract void F1();
@@ -435,33 +421,31 @@ class B1 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : A1
 {
     public override void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : A1, I1
     {
         public override void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -3458,7 +3458,9 @@ class A<T>
     {
     }
 }",
-@"class A<T>
+@"using System;
+
+class A<T>
 {
     class B
     {
@@ -3540,9 +3542,7 @@ class A<T>
     {
     }
 }",
-@"using System;
-
-class A<T>
+@"class A<T>
 {
     class B
     {
@@ -3770,7 +3770,8 @@ interface IFoo
 public class C : [|IFoo|]
 {
 }",
-@"using System.Runtime.CompilerServices;
+@"using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 interface IFoo
@@ -3880,8 +3881,7 @@ interface IFoo
 public class C : [|IFoo|]
 {
 }",
-@"using System;
-using System.Runtime.CompilerServices;
+@"using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 interface IFoo

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -97,9 +97,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     void Method1();
 }
@@ -108,7 +106,7 @@ class Class : IInterface
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -125,9 +123,7 @@ class Class : IInterface
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     (int, int) Method((string, string) x);
 }
@@ -136,7 +132,7 @@ class Class : IInterface
 {
     public (int, int) Method((string, string) x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -182,16 +178,14 @@ class C : I
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     void Method1();
 }
 
 class Class : IInterface
 {
-    public void Method1() => throw new NotImplementedException();
+    public void Method1() => throw new System.NotImplementedException();
 }");
         }
 
@@ -216,9 +210,7 @@ class Class : IInterface
 class Class : [|IInterface|]
 {
 }" + s_tupleElementNamesAttribute,
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })]
     (int a, int b)[] Method1((int c, string) x);
@@ -228,7 +220,7 @@ class Class : IInterface
 {
     public (int a, int b)[] Method1((int c, string) x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }" + s_tupleElementNamesAttribute);
         }
@@ -246,9 +238,7 @@ class Class : IInterface
 class Class : [|IInterface|]
 {
 }" + s_tupleElementNamesAttribute,
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })]
     (int a, int b)[] Method1((int c, string) x);
@@ -258,7 +248,7 @@ class Class : IInterface
 {
     (int a, int b)[] IInterface.Method1((int c, string) x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }" + s_tupleElementNamesAttribute,
 index: 1);
@@ -277,9 +267,7 @@ index: 1);
 class Class : [|IInterface|]
 {
 }" + s_tupleElementNamesAttribute,
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })]
     (int a, int b)[] Property1 { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] get; [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] set; }
@@ -291,12 +279,12 @@ class Class : IInterface
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }" + s_tupleElementNamesAttribute);
@@ -340,9 +328,7 @@ class Class : IInterface
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     [return: System.Runtime.CompilerServices.DynamicAttribute()]
     object Method1();
@@ -352,7 +338,7 @@ class Class : IInterface
 {
     public object Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -367,9 +353,7 @@ class Class : IInterface
 }
 
 class Class : [|IInterface|]",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     void Method1();
 }
@@ -378,7 +362,7 @@ class Class : IInterface
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -399,8 +383,7 @@ interface IInterface2 : IInterface1
 class Class : [|IInterface2|]
 {
 }",
-@"using System;
-
+@"
 interface IInterface1
 {
     void Method1();
@@ -414,7 +397,7 @@ class Class : IInterface2
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -435,9 +418,7 @@ interface IInterface2 : IInterface1
 class Class : [|IInterface2|]
 {
 }",
-@"using System;
-
-interface IInterface1
+@"interface IInterface1
 {
 }
 
@@ -450,7 +431,7 @@ class Class : IInterface2
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -472,9 +453,7 @@ interface IInterface2 : IInterface1
 class Class : [|IInterface2|]
 {
 }",
-@"using System;
-
-interface IInterface1
+@"interface IInterface1
 {
     void Method1();
 }
@@ -488,12 +467,12 @@ class Class : IInterface2
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Method2()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -515,9 +494,7 @@ interface IInterface2 : IInterface1
 class Class : [|IInterface2|]
 {
 }",
-@"using System;
-
-interface IInterface1
+@"interface IInterface1
 {
     void Method1();
 }
@@ -531,7 +508,7 @@ class Class : IInterface2
 {
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -552,9 +529,7 @@ class Class : [|IInterface1|]
         return 0;
     }
 }",
-@"using System;
-
-interface IInterface1
+@"interface IInterface1
 {
     void Method1();
 }
@@ -568,7 +543,7 @@ class Class : IInterface1
 
     void IInterface1.Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -588,9 +563,7 @@ class Class : [|IInterface1|]
     {
     }
 }",
-@"using System;
-
-interface IInterface1
+@"interface IInterface1
 {
     void Method1(int i);
 }
@@ -603,7 +576,7 @@ class Class : IInterface1
 
     public void Method1(int i)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -620,9 +593,7 @@ class Class : IInterface1
 class Class : [|IInterface1<int>|]
 {
 }",
-@"using System;
-
-interface IInterface1<T>
+@"interface IInterface1<T>
 {
     void Method1(T t);
 }
@@ -631,7 +602,7 @@ class Class : IInterface1<int>
 {
     public void Method1(int t)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -648,9 +619,7 @@ class Class : IInterface1<int>
 class Class : [|IInterface1<int>|]
 {
 }",
-@"using System;
-
-interface IInterface1<T>
+@"interface IInterface1<T>
 {
     void Method1<U>(T t, U u);
 }
@@ -659,7 +628,7 @@ class Class : IInterface1<int>
 {
     public void Method1<U>(int t, U u)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -676,9 +645,7 @@ class Class : IInterface1<int>
 class Class : [|IInterface1<int>|]
 {
 }",
-@"using System;
-
-interface IInterface1<T>
+@"interface IInterface1<T>
 {
     void Method1<U>(T t, U u) where U : IList<T>;
 }
@@ -687,7 +654,7 @@ class Class : IInterface1<int>
 {
     public void Method1<U>(int t, U u) where U : IList<int>
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -704,9 +671,7 @@ class Class : IInterface1<int>
 class Class : [|IInterface1<int>|]
 {
 }",
-@"using System;
-
-interface IInterface1<T>
+@"interface IInterface1<T>
 {
     void Method1<U>(T t, U u) where U : T;
 }
@@ -715,7 +680,7 @@ class Class : IInterface1<int>
 {
     void IInterface1<int>.Method1<U>(int t, U u)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -732,9 +697,7 @@ class Class : IInterface1<int>
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     string[] M();
 }
@@ -743,7 +706,7 @@ class C : I
 {
     public string[] M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -946,9 +909,7 @@ interface I
 {
     void Method1();
 }",
-@"using System;
-
-class B
+@"class B
 {
     public int Method1()
     {
@@ -959,7 +920,7 @@ class C : B, I
 {
     void I.Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }
 
@@ -982,9 +943,7 @@ interface I1
 {
     int Prop { get; set; }
 }",
-@"using System;
-
-class Test : I1
+@"class Test : I1
 {
     int Prop { get; set; }
 
@@ -992,12 +951,12 @@ class Test : I1
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -1045,9 +1004,7 @@ class C : [|I2|]
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     void @M();
 }
@@ -1056,7 +1013,7 @@ class Class : IInterface
 {
     public void M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1074,9 +1031,7 @@ class Class : IInterface
 class Class : [|IInterface|]
 {
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     void @int();
 }
@@ -1085,7 +1040,7 @@ class Class : IInterface
 {
     public void @int()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1104,9 +1059,7 @@ class Class : [|@IInterface|]
 {
     string M();
 }",
-@"using System;
-
-interface @IInterface
+@"interface @IInterface
 {
     void M();
 }
@@ -1117,7 +1070,7 @@ class Class : @IInterface
 
     void IInterface.M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1136,9 +1089,7 @@ class Class : [|@IInterface|]
 {
     string M();
 }",
-@"using System;
-
-interface @IInterface
+@"interface @IInterface
 {
     void @M();
 }
@@ -1149,7 +1100,7 @@ class Class : @IInterface
 
     void IInterface.M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1168,9 +1119,7 @@ class Class : [|@int|]
 {
     string M();
 }",
-@"using System;
-
-interface @int
+@"interface @int
 {
     void M();
 }
@@ -1181,7 +1130,7 @@ class Class : @int
 
     void @int.M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1200,9 +1149,7 @@ class Class : [|@int|]
 {
     string @bool();
 }",
-@"using System;
-
-interface @int
+@"interface @int
 {
     void @bool();
 }
@@ -1213,7 +1160,7 @@ class Class : @int
 
     void @int.@bool()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -1230,9 +1177,7 @@ class Class : @int
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; set; }
 }
@@ -1242,12 +1187,12 @@ public class A : DD
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }",
@@ -1266,16 +1211,14 @@ compareTokens: false);
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; }
 }
 
 public class A : DD
 {
-    public int Prop => throw new NotImplementedException();
+    public int Prop => throw new System.NotImplementedException();
 }");
         }
 
@@ -1291,9 +1234,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; }
 }
@@ -1302,7 +1243,7 @@ public class A : DD
 {
     public int Prop
     {
-        get => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1319,16 +1260,14 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; }
 }
 
 public class A : DD
 {
-    public int this[int i] => throw new NotImplementedException();
+    public int this[int i] => throw new System.NotImplementedException();
 }");
         }
 
@@ -1344,9 +1283,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; }
 }
@@ -1355,7 +1292,7 @@ public class A : DD
 {
     public int this[int i]
     {
-        get => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1372,16 +1309,14 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int M();
 }
 
 public class A : DD
 {
-    public int M() => throw new NotImplementedException();
+    public int M() => throw new System.NotImplementedException();
 }");
         }
 
@@ -1397,15 +1332,13 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; }
 }
 public class A : DD
 {
-    public int Prop => throw new NotImplementedException();
+    public int Prop => throw new System.NotImplementedException();
 }", compareTokens: false);
         }
 
@@ -1422,9 +1355,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; }
 }
@@ -1433,7 +1364,7 @@ public class A : DD
 {
     public int Prop
     {
-        get => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1451,9 +1382,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; set; }
 }
@@ -1462,8 +1391,8 @@ public class A : DD
 {
     public int Prop
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1481,9 +1410,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int Prop { get; }
 }
@@ -1494,7 +1421,7 @@ public class A : DD
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -1512,16 +1439,14 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; }
 }
 
 public class A : DD
 {
-    public int this[int i] => throw new NotImplementedException();
+    public int this[int i] => throw new System.NotImplementedException();
 }");
         }
 
@@ -1537,9 +1462,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; set; }
 }
@@ -1548,8 +1471,8 @@ public class A : DD
 {
     public int this[int i]
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1566,9 +1489,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; }
 }
@@ -1577,7 +1498,7 @@ public class A : DD
 {
     public int this[int i]
     {
-        get => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1594,9 +1515,7 @@ public class A : DD
 public class A : [|DD|]
 {
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     int this[int i] { get; set; }
 }
@@ -1605,8 +1524,8 @@ public class A : DD
 {
     public int this[int i]
     {
-        get => throw new NotImplementedException();
-        set => throw new NotImplementedException();
+        get => throw new System.NotImplementedException();
+        set => throw new System.NotImplementedException();
         }
     }");
         }
@@ -1623,9 +1542,7 @@ public class A : [|DD|]
 {
     //comments
 }",
-@"using System;
-
-public interface DD
+@"public interface DD
 {
     void Foo();
 }
@@ -1634,7 +1551,7 @@ public class A : DD
     //comments
     public void Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 compareTokens: false);
@@ -1691,9 +1608,7 @@ class Test : [|ITest|]
 class c1 : [|i1|]
 {
 }",
-@"using System;
-
-interface i1
+@"interface i1
 {
     int p { get; set; }
 }
@@ -1704,12 +1619,12 @@ class c1 : i1
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }",
@@ -1741,9 +1656,7 @@ class C : [|I|]
 {
     I i { get; set; }
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Method1();
 }
@@ -1754,7 +1667,7 @@ class C : I
 
     public void Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 0);
@@ -1793,9 +1706,7 @@ class C : [|I|]
 {
     I i { get; set; }
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Method1();
 }
@@ -1806,7 +1717,7 @@ class C : I
 
     void I.Method1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 2);
@@ -2580,7 +2491,6 @@ abstract class Foo : [|IFoo|]
 {
 }",
 @"using System;
-
 interface IFoo
 {
     event System.EventHandler E;
@@ -2670,9 +2580,7 @@ index: 2);
 class Program : [|IFoo|]
 {
 }",
-@"using System;
-
-interface IFoo
+@"interface IFoo
 {
     static string Name { set; get; }
 
@@ -2685,18 +2593,18 @@ class Program : IFoo
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 
     public int Foo(string s)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -2713,9 +2621,7 @@ class Program : IFoo
 class IndexerClass : [|ISomeInterface|]
 {
 }",
-@"using System;
-
-public interface ISomeInterface
+@"public interface ISomeInterface
 {
     int this[int index] { get; set; }
 }
@@ -2726,12 +2632,12 @@ class IndexerClass : ISomeInterface
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -2749,9 +2655,7 @@ class IndexerClass : ISomeInterface
 class IndexerClass : [|ISomeInterface|]
 {
 }",
-@"using System;
-
-public interface ISomeInterface
+@"public interface ISomeInterface
 {
     int this[int index] { get; set; }
 }
@@ -2762,12 +2666,12 @@ class IndexerClass : ISomeInterface
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }",
@@ -2786,9 +2690,7 @@ index: 1);
 class IndexerClass : [|ISomeInterface|]
 {
 }",
-@"using System;
-
-public interface ISomeInterface
+@"public interface ISomeInterface
 {
     int this[int index] { get; }
 }
@@ -2799,7 +2701,7 @@ class IndexerClass : ISomeInterface
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -2818,9 +2720,7 @@ class IndexerClass : ISomeInterface
 class A : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo<T>() where T : class;
 }
@@ -2829,7 +2729,7 @@ class A : I
 {
     public void Foo<T>() where T : class
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -2847,9 +2747,7 @@ class A : I
 class A : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo<T>() where T : class;
 }
@@ -2858,7 +2756,7 @@ class A : I
 {
     void I.Foo<T>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 1);
@@ -2878,7 +2776,6 @@ class A : [|I|]
 {
 }",
 @"using System;
-
 interface I
 {
     void Foo<T>() where T : System.Attribute;
@@ -2906,9 +2803,7 @@ class A : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     int this[int x] { get; set; }
 }
@@ -2919,12 +2814,12 @@ class C : I
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
 
         set
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -3006,9 +2901,7 @@ index: 1);
 class A : [|I<string>|]
 {
 }",
-@"using System;
-
-interface I<S>
+@"interface I<S>
 {
     void Foo<T>() where T : class, S;
 }
@@ -3017,7 +2910,7 @@ class A : I<string>
 {
     void I<string>.Foo<T>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -3035,9 +2928,7 @@ class A : I<string>
 class A : [|I<object>|]
 {
 }",
-@"using System;
-
-interface I<S>
+@"interface I<S>
 {
     void Foo<T>() where T : class, S;
 }
@@ -3046,7 +2937,7 @@ class A : I<object>
 {
     public void Foo<T>() where T : class
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -3064,9 +2955,7 @@ class A : I<object>
 class A : [|I<object>|]
 {
 }",
-@"using System;
-
-interface I<S>
+@"interface I<S>
 {
     void Foo<T>() where T : class, S;
 }
@@ -3075,7 +2964,7 @@ class A : I<object>
 {
     void I<object>.Foo<T>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 1);
@@ -3569,9 +3458,7 @@ class A<T>
     {
     }
 }",
-@"using System;
-
-class A<T>
+@"class A<T>
 {
     class B
     {
@@ -3612,9 +3499,7 @@ class A<T>
     {
     }
 }",
-@"using System;
-
-class A<T>
+@"class A<T>
 {
     class B
     {
@@ -3629,7 +3514,7 @@ class A<T>
     {
         public void Foo(B[] x)
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -3672,7 +3557,7 @@ class A<T>
     {
         public void Foo(B[][,][,,][,,,] x)
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -3731,9 +3616,7 @@ class C : [|I1|]
 class Opt : [|IOptional|]
 {
 }",
-@"using System;
-
-interface IOptional
+@"interface IOptional
 {
     int Foo(int g = 0);
 }
@@ -3742,7 +3625,7 @@ class Opt : IOptional
 {
     public int Foo(int g = 0)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -3760,9 +3643,7 @@ class Opt : IOptional
 class Opt : [|IOptional|]
 {
 }",
-@"using System;
-
-interface IOptional
+@"interface IOptional
 {
     int Foo(int g = 0);
 }
@@ -3771,7 +3652,7 @@ class Opt : IOptional
 {
     int IOptional.Foo(int g)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 1);
@@ -3889,8 +3770,7 @@ interface IFoo
 public class C : [|IFoo|]
 {
 }",
-@"using System;
-using System.Runtime.CompilerServices;
+@"using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 interface IFoo
@@ -3960,8 +3840,7 @@ interface IFoo
 public class C : [|IFoo|]
 {
 }",
-@"using System;
-using System.Runtime.CompilerServices;
+@"using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 interface IFoo
@@ -3974,12 +3853,12 @@ public class C : IFoo
 {
     public void Foo1([IUnknownConstant, Optional] object x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Foo2([IDispatchConstant, Optional] object x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4015,12 +3894,12 @@ public class C : IFoo
 {
     void IFoo.Foo1(object x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     void IFoo.Foo2(object x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 1);
@@ -4039,9 +3918,7 @@ index: 1);
 public class Foo : [|IFoo|]
 {
 }",
-@"using System;
-
-interface IFoo
+@"interface IFoo
 {
     void Foo();
 }
@@ -4050,7 +3927,7 @@ public class Foo : IFoo
 {
     void IFoo.Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4060,7 +3937,7 @@ public class Foo : IFoo
         {
             await TestWithAllCodeStyleOptionsOffAsync(
 @"interface IFoo { void Foo ( string s = ""\"""" ) ; } class B : [|IFoo|] { } ",
-@"using System ; interface IFoo { void Foo ( string s = ""\"""" ) ; } class B : IFoo { public void Foo ( string s = ""\"""" ) { throw new NotImplementedException ( ) ; } } ");
+@"interface IFoo { void Foo ( string s = ""\"""" ) ; } class B : IFoo { public void Foo ( string s = ""\"""" ) { throw new System.NotImplementedException ( ) ; } } ");
         }
 
         [WorkItem(916114, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/916114")]
@@ -4080,9 +3957,7 @@ interface d
 class c : [|d|]
 {
 }",
-@"using System;
-
-struct b
+@"struct b
 {
 }
 
@@ -4095,7 +3970,7 @@ class c : d
 {
     public void m(b? x = default(b?), b? y = default(b?))
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4117,9 +3992,7 @@ interface d
 class c : [|d|]
 {
 }",
-@"using System;
-
-struct b
+@"struct b
 {
 }
 
@@ -4132,7 +4005,7 @@ class c : d
 {
     void d.m(b? x, b? y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }", 1);
         }
@@ -4150,9 +4023,7 @@ class c : d
 class c : [|d|]
 {
 }",
-@"using System;
-
-interface d
+@"interface d
 {
     void m(int? x = 5, int? y = null);
 }
@@ -4161,7 +4032,7 @@ class c : d
 {
     public void m(int? x = 5, int? y = default(int?))
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4181,8 +4052,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -4193,7 +4063,7 @@ class C : I
 {
     public void Foo([Optional] I o)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4233,9 +4103,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void M01(short s = short.MinValue);
     void M02(short s = -1);
@@ -4267,122 +4135,122 @@ class C : I
 {
     public void M01(short s = short.MinValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M02(short s = -1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M03(short s = short.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M04(ushort s = 0)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M05(ushort s = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M06(ushort s = ushort.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M07(int s = int.MinValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M08(int s = -1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M09(int s = int.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M10(uint s = 0)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M11(uint s = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M12(uint s = uint.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M13(long s = long.MinValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M14(long s = -1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M15(long s = long.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M16(ulong s = 0)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M17(ulong s = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M18(ulong s = ulong.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M19(float s = float.MinValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M20(float s = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M21(float s = float.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M22(double s = double.MinValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M23(double s = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void M24(double s = double.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 compareTokens: false);
@@ -4600,9 +4468,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo(decimal x = decimal.MaxValue);
 }
@@ -4611,7 +4477,7 @@ class C : I
 {
     public void Foo(decimal x = decimal.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4629,9 +4495,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo(decimal? x = decimal.MaxValue);
 }
@@ -4640,7 +4504,7 @@ class C : I
 {
     public void Foo(decimal? x = decimal.MaxValue)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4689,9 +4553,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo(byte x = 1);
 }
@@ -4700,7 +4562,7 @@ class C : I
 {
     public void Foo(byte x = 1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4787,9 +4649,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-
-enum E
+@"enum E
 {
     A = 1,
 }
@@ -4803,7 +4663,7 @@ class C : I
 {
     public void Foo(E x = 0)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4823,8 +4683,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -4835,7 +4694,7 @@ class C : I
 {
     public void Foo([DefaultParameterValue(1), Optional] int x = 1, int[,] y = null)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4855,8 +4714,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -4867,7 +4725,7 @@ class C : I
 {
     public void Foo([DefaultParameterValue(1), Optional] int x = 1, int[] y = null, int[] z = null)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4921,9 +4779,7 @@ compareTokens: false);
 class C<T> : [|I<T>|]
 {
 }",
-@"using System;
-
-interface I<S>
+@"interface I<S>
 {
     void T1<T>(S x, T y);
 }
@@ -4932,7 +4788,7 @@ class C<T> : I<T>
 {
     public void T1<T2>(T x, T2 y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4952,8 +4808,7 @@ interface I<S>
 class D<T> : [|I<T>|]
 {
 }",
-@"using System;
-using System.Collections.Generic;
+@"using System.Collections.Generic;
 
 interface I<S>
 {
@@ -4964,7 +4819,7 @@ class D<T> : I<T>
 {
     public void Foo<T1>(T y, List<T1>.Enumerator x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -4982,9 +4837,7 @@ class D<T> : I<T>
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo(float x = 1E10F);
 }
@@ -4993,7 +4846,7 @@ class C : I
 {
     public void Foo(float x = 1E+10F)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5009,9 +4862,7 @@ class C : I
 }
 
 class C : [|I|]",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo<@class>();
 }
@@ -5020,7 +4871,7 @@ class C : I
 {
     public void Foo<@class>()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5039,9 +4890,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo1(decimal x = 1E28M);
     void Foo2(decimal x = -1E28M);
@@ -5051,12 +4900,12 @@ class C : I
 {
     public void Foo1(decimal x = 10000000000000000000000000000M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Foo2(decimal x = -10000000000000000000000000000M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5074,9 +4923,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo(decimal x = 0.1M);
 }
@@ -5085,7 +4932,7 @@ class C : I
 {
     public void Foo(decimal x = 0.1M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5489,9 +5336,7 @@ interface I
 class D : [|I|]
 {
 }",
-@"using System;
-
-class C<T>
+@"class C<T>
 {
     public enum E
     {
@@ -5508,7 +5353,7 @@ class D : I
 {
     public void Foo<T>(C<T>.E x = C<T>.E.X)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5601,9 +5446,7 @@ class C : IServiceProvider """" {
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void Foo1(decimal x = 1E-25M);
     void Foo2(decimal x = -1E-25M);
@@ -5615,22 +5458,22 @@ class C : I
 {
     public void Foo1(decimal x = 0.0000000000000000000000001M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Foo2(decimal x = -0.0000000000000000000000001M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Foo3(decimal x = 0.000000000000000000000001M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     public void Foo4(decimal x = -0.000000000000000000000001M)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5656,9 +5499,7 @@ interface I<S>
 class D<T> : [|I<T>|]
 {
 }",
-@"using System;
-
-class C<T>
+@"class C<T>
 {
     public enum E
     {
@@ -5675,7 +5516,7 @@ class D<T> : I<T>
 {
     public void Foo<T1>(T y, C<T1>.E x = C<T1>.E.X)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5693,9 +5534,7 @@ class D<T> : I<T>
 class C<T> : [|I<T>|]
 {
 }",
-@"using System;
-
-interface I<S>
+@"interface I<S>
 {
     void Foo<T>(S T1);
 }
@@ -5704,7 +5543,7 @@ class C<T> : I<T>
 {
     public void Foo<T2>(T T1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5725,8 +5564,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -5739,7 +5577,7 @@ class C : I
     [return: MarshalAs(UnmanagedType.U1)]
     public bool Foo([MarshalAs(UnmanagedType.U1)] bool x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5760,8 +5598,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -5773,7 +5610,7 @@ class C : I
 {
     bool I.Foo(bool x)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 index: 1);
@@ -5827,8 +5664,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Collections.Generic;
+@"using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
 interface I
@@ -5842,7 +5678,7 @@ class C : I
     [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(List<>))]
     public void Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5863,9 +5699,7 @@ class C : I
 class C : [|N.I|]
 {
 }",
-@"using System;
-
-namespace N
+@"namespace N
 {
     public interface I
     {
@@ -5877,7 +5711,7 @@ class C : N.I
 {
     public void M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -5898,8 +5732,7 @@ class C : N.I
 class C : [|N.I|]
 {
 }",
-@"using System;
-using N;
+@"using N;
 
 namespace N
 {
@@ -5913,7 +5746,7 @@ class C : N.I
 {
     void I.M()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }", index: 1);
         }
@@ -5935,9 +5768,7 @@ partial class C
 partial class C : [|I|]
 {
 }",
-@"using System;
-
-public interface I
+@"public interface I
 {
     void Foo();
 }
@@ -5950,7 +5781,7 @@ partial class C : I
 {
     void I.Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }", index: 1);
         }
@@ -5972,9 +5803,7 @@ partial class C : [|I|]
 partial class C
 {
 }",
-@"using System;
-
-public interface I
+@"public interface I
 {
     void Foo();
 }
@@ -5983,7 +5812,7 @@ partial class C : I
 {
     void I.Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }
 
@@ -6014,9 +5843,7 @@ partial class C : [|I|]
 partial class C : I2
 {
 }",
-@"using System;
-
-public interface I
+@"public interface I
 {
     void Foo();
 }
@@ -6030,7 +5857,7 @@ partial class C : I
 {
     void I.Foo()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }
 
@@ -6063,18 +5890,16 @@ public class Test : [|IFoo|]
 </Workspace>";
 
             var expected = @"
-using System;
-
 public class Test : IFoo
 {
     string IFoo.get_IndexProp(int p1)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     void IFoo.set_IndexProp(int p1, string Value)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }
 ";
@@ -6263,9 +6088,7 @@ sealed class Program : IDisposable
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     void M([System.Runtime.InteropServices.ComAliasName(""pAlias"")] int p);
 }
@@ -6274,7 +6097,7 @@ class C : I
 {
     public void M(int p)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -6295,8 +6118,7 @@ interface I
 class C : [|I|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 interface I
 {
@@ -6308,7 +6130,7 @@ class C : I
 {
     public long M(int p)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }");
         }
@@ -6326,9 +6148,7 @@ class C : I
 class C : [|I|]
 {
 }",
-@"using System;
-
-interface I
+@"interface I
 {
     long this[[System.Runtime.InteropServices.ComAliasName(""pAlias"")] int p] { get; }
 }
@@ -6339,7 +6159,7 @@ class C : I
     {
         get
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }");
@@ -6362,9 +6182,7 @@ class C : I
 
     // Comment
 }",
-@"using System;
-
-namespace Scenarios
+@"namespace Scenarios
 {
     public interface TestInterface
     {
@@ -6375,7 +6193,7 @@ namespace Scenarios
     {
         public void M1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
     // Comment
@@ -6689,9 +6507,7 @@ class Class : [|IInterface|]
 {
     (int, string) x;
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     (int, string, int, string, int, string, int, string) Method1((int, string, int, string, int, string, int, string) y);
 }
@@ -6702,7 +6518,7 @@ class Class : IInterface
 
     public (int, string, int, string, int, string, int, string) Method1((int, string, int, string, int, string, int, string) y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 parseOptions: TestOptions.Regular, withScriptOption: true);
@@ -6721,9 +6537,7 @@ class Class : [|IInterface|]
 {
     (int, string) x;
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     (int a, string b, int c, string d, int e, string f, int g, string h) Method1((int a, string b, int c, string d, int e, string f, int g, string h) y);
 }
@@ -6734,7 +6548,7 @@ class Class : IInterface
 
     public (int a, string b, int c, string d, int e, string f, int g, string h) Method1((int a, string b, int c, string d, int e, string f, int g, string h) y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 parseOptions: TestOptions.Regular, withScriptOption: true);
@@ -6753,9 +6567,7 @@ class Class : [|IInterface<(int, string), int>|]
 {
     (int, string) x;
 }",
-@"using System;
-
-interface IInterface<TA, TB>
+@"interface IInterface<TA, TB>
 {
     (TA, TB) Method1((TA, TB) y);
 }
@@ -6766,7 +6578,7 @@ class Class : IInterface<(int, string), int>
 
     public ((int, string), int) Method1(((int, string), int) y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 parseOptions: TestOptions.Regular, withScriptOption: true);
@@ -6785,9 +6597,7 @@ class Class : [|IInterface<(int, string), int>|]
 {
     (int, string) x;
 }",
-@"using System;
-
-interface IInterface<TA, TB>
+@"interface IInterface<TA, TB>
 {
     (TA a, TB b) Method1((TA a, TB b) y);
 }
@@ -6798,7 +6608,7 @@ class Class : IInterface<(int, string), int>
 
     public ((int, string) a, int b) Method1(((int, string) a, int b) y)
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 }",
 parseOptions: TestOptions.Regular, withScriptOption: true);
@@ -6818,9 +6628,7 @@ class Class : [|IInterface|]
 {
     void M() { }
 }",
-@"using System;
-
-interface IInterface
+@"interface IInterface
 {
     int Prop { get; }
 }
@@ -6829,7 +6637,7 @@ class Class : IInterface
 {
     void M() { }
 
-    public int Prop => throw new NotImplementedException();
+    public int Prop => throw new System.NotImplementedException();
     
 }", options: Option(ImplementTypeOptions.InsertionBehavior, ImplementTypeInsertionBehavior.AtTheEnd));
         }
@@ -6854,8 +6662,7 @@ interface IComInterface
 class Class : [|IComInterface|]
 {
 }",
-@"using System;
-using System.Runtime.InteropServices;
+@"using System.Runtime.InteropServices;
 
 [ComImport]
 interface IComInterface
@@ -6868,10 +6675,10 @@ interface IComInterface
 
 class Class : IComInterface
 {
-    public void MOverload() { throw new NotImplementedException(); }
-    public void X() { throw new NotImplementedException(); }
-    public void MOverload(int i) { throw new NotImplementedException(); }
-    public int Prop => throw new NotImplementedException();
+    public void MOverload() { throw new System.NotImplementedException(); }
+    public void X() { throw new System.NotImplementedException(); }
+    public void MOverload(int i) { throw new System.NotImplementedException(); }
+    public int Prop => throw new System.NotImplementedException();
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests_FixAllTests.cs
@@ -65,8 +65,6 @@ class B3 : I1, I2
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public interface I1
 {
     void F1();
@@ -81,14 +79,14 @@ class B1 : I1, I2
 {
     public void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : I1, I2
     {
         public void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -172,8 +170,6 @@ class B3 : I1, I2
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public interface I1
 {
     void F1();
@@ -188,33 +184,31 @@ class B1 : I1, I2
 {
     public void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : I1, I2
     {
         public void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : I1, I2
 {
     public void F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : I1, I2
     {
         public void F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -290,8 +284,6 @@ class B3 : I1, I2
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public interface I1
 {
     void F1();
@@ -306,33 +298,31 @@ class B1 : I1, I2
 {
     void I2.F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : I1, I2
     {
         void I2.F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : I1, I2
 {
     void I2.F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : I1, I2
     {
         void I2.F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -341,20 +331,18 @@ class B2 : I1, I2
     <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
         <ProjectReference>Assembly1</ProjectReference>
         <Document>
-using System;
-
 class B3 : I1, I2
 {
     void I2.F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C3 : I1, I2
     {
         void I2.F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
@@ -428,8 +416,6 @@ class B3 : I1, I2
 <Workspace>
     <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
         <Document>
-using System;
-
 public interface I1
 {
     void F1();
@@ -444,33 +430,31 @@ class B1 : I1, I2
 {
     void I2.F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C1 : I1, I2
     {
         void I2.F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }
         </Document>
         <Document>
-using System;
-
 class B2 : I1, I2
 {
     void I2.F1()
     {
-        throw new NotImplementedException();
+        throw new System.NotImplementedException();
     }
 
     class C2 : I1, I2
     {
         void I2.F1()
         {
-            throw new NotImplementedException();
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/OverrideCompletionProviderTests.vb
@@ -844,7 +844,9 @@ End Class</a>
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestCommitAbstractThrows() As Task
-            Dim markupBeforeCommit = <a>Public MustInherit Class c
+            Dim markupBeforeCommit = <a>Imports System
+
+Public MustInherit Class c
     Public MustOverride Sub foo()
 End Class
 
@@ -1407,9 +1409,7 @@ Class Derived
     Overrides $$
 End Class</a>
 
-            Dim expectedCode = <a>Imports System
-
-MustInherit Class CBase
+            Dim expectedCode = <a>MustInherit Class CBase
     MustOverride Sub Foo()
 End Class
 
@@ -1417,7 +1417,7 @@ Class Derived
     Inherits CBase
 
     Public Overrides Sub Foo()
-        Throw New NotImplementedException()$$
+        Throw New System.NotImplementedException()$$
     End Sub
 End Class</a>
 

--- a/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementAbstractClass/ImplementAbstractClassTests.vb
@@ -23,18 +23,17 @@ End Class
 Public Class [|Bar|]
     Inherits Foo
 End Class",
-"Imports System
-Public MustInherit Class Foo
+"Public MustInherit Class Foo
     Public MustOverride Sub Foo(i As Integer)
     Protected MustOverride Function Bar(s As String, ByRef d As Double) As Boolean
 End Class
 Public Class Bar
     Inherits Foo
     Public Overrides Sub Foo(i As Integer)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
     Protected Overrides Function Bar(s As String, ByRef d As Double) As Boolean
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -48,14 +47,13 @@ End Class
 Public Class [|Derived|]
     Inherits Base
 End Class",
-"Imports System
-Public MustInherit Class Base
+"Public MustInherit Class Base
     Protected MustOverride Function Bar(x As (a As Integer, Integer)) As (c As Integer, Integer)
 End Class
 Public Class Derived
     Inherits Base
     Protected Overrides Function Bar(x As (a As Integer, Integer)) As (c As Integer, Integer)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -69,14 +67,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Integer = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Integer = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -90,14 +87,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Boolean = True)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Boolean = True)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -111,14 +107,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Boolean = False)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Boolean = False)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -132,14 +127,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As String = ""a"")
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As String = ""a"")
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -153,14 +147,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Char = ""c""c)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Char = ""c""c)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -174,14 +167,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Long = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Long = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -195,14 +187,14 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
+"
 MustInherit Class b
     Public MustOverride Sub g(Optional x As Short = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Short = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -216,14 +208,14 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
+"
 MustInherit Class b
     Public MustOverride Sub g(Optional x As UShort = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As UShort = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -237,14 +229,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Integer = -3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Integer = -3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -258,14 +249,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As UInteger = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As UInteger = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -279,14 +269,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As ULong = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As ULong = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -300,14 +289,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Decimal = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Decimal = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -321,14 +309,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Double = 3)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Double = 3)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -344,8 +331,7 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-Structure S
+"Structure S
 End Structure
 MustInherit Class b
     Public MustOverride Sub g(Optional x As S = Nothing)
@@ -353,7 +339,7 @@ End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As S = Nothing)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -370,8 +356,7 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-Structure S
+"Structure S
 End Structure
 MustInherit Class b
     Public MustOverride Sub g(Optional x As S? = Nothing)
@@ -379,7 +364,7 @@ End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As S? = Nothing)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -394,14 +379,13 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-MustInherit Class b
+"MustInherit Class b
     Public MustOverride Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5)
 End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As Integer? = Nothing, Optional y As Integer? = 5)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -417,8 +401,7 @@ End Class
 Class [|c|]
     Inherits b
 End Class",
-"Imports System
-Class S
+"Class S
 End Class
 MustInherit Class b
     Public MustOverride Sub g(Optional x As S = Nothing)
@@ -426,7 +409,7 @@ End Class
 Class c
     Inherits b
     Public Overrides Sub g(Optional x As S = Nothing)
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -481,14 +464,13 @@ End Class
 Class [|C(Of S)|]
     Inherits A(Of S)
 End Class",
-"Imports System
-MustInherit Class A(Of T)
+"MustInherit Class A(Of T)
     MustOverride Sub Foo(Of S As T)()
 End Class
 Class C(Of S)
     Inherits A(Of S)
     Public Overrides Sub Foo(Of S1 As S)()
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
@@ -23,14 +23,13 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class C
     Implements I
     Public Sub M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -68,14 +67,13 @@ Class C
     Function M() As Integer
     End Function
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class C
     Implements I
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
     Function M() As Integer
     End Function
@@ -93,8 +91,7 @@ Class C
     Public Sub Bar()
     End Sub
 End Class",
-"Imports System
-Interface IFoo
+"Interface IFoo
     Sub Bar()
 End Interface
 Class C
@@ -102,7 +99,7 @@ Class C
     Public Sub Bar()
     End Sub
     Private Sub IFoo_Bar() Implements IFoo.Bar
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -118,15 +115,14 @@ Class C
     Implements [|I|]
     Private m As Integer
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class C
     Implements I
     Private m As Integer
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -142,8 +138,7 @@ Class C
     Implements [|I|]
     Public Property M As Integer
 End Class",
-"Imports System
-Interface I
+"Interface I
     Property M As Integer
 End Interface
 Class C
@@ -151,10 +146,10 @@ Class C
     Public Property M As Integer
     Private Property I_M As Integer Implements I.M
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -177,8 +172,7 @@ Class C
         End Set
     End Property
 End Class",
-"Imports System
-Interface I
+"Interface I
     Property M As Integer
 End Interface
 Class C
@@ -194,10 +188,10 @@ Class C
 
     Private Property I_M As Integer Implements I.M
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -218,8 +212,7 @@ Class C
     Inherits B
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class B
@@ -230,7 +223,7 @@ Class C
     Inherits B
     Implements I
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -249,8 +242,7 @@ Class C
     Inherits B
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class B
@@ -260,7 +252,7 @@ Class C
     Inherits B
     Implements I
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -279,8 +271,7 @@ Class C
     Inherits B
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class B
@@ -290,7 +281,7 @@ Class C
     Inherits B
     Implements I
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -323,14 +314,13 @@ End Interface
 Class [Class]
     Implements [|IInterface1(Of Integer)|]
 End Class",
-"Imports System
-Interface IInterface1(Of T)
+"Interface IInterface1(Of T)
     Sub Method1(t As T)
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
     Public Sub Method1(t As Integer) Implements IInterface1(Of Integer).Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -344,14 +334,13 @@ End Interface
 Class [Class]
     Implements [|IInterface1(Of Integer)|]
 End Class",
-"Imports System
-Interface IInterface1(Of T)
+"Interface IInterface1(Of T)
     Sub Method1(Of U)(arg As T, arg1 As U)
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
     Public Sub Method1(Of U)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -366,15 +355,14 @@ End Interface
 Class [Class]
     Implements [|IInterface1(Of Integer)|]
 End Class",
-"Imports System
-Imports System.Collections.Generic
+"Imports System.Collections.Generic
 Interface IInterface1(Of T)
     Sub Method1(Of U As IList(Of T))(arg As T, arg1 As U)
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
     Public Sub Method1(Of U As IList(Of Integer))(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -388,14 +376,13 @@ End Interface
 Class [Class]
     Implements [|IInterface1(Of Integer)|]
 End Class",
-"Imports System
-Interface IInterface1(Of T)
+"Interface IInterface1(Of T)
     Sub Method1(Of U As T)(arg As T, arg1 As U)
 End Interface
 Class [Class]
     Implements IInterface1(Of Integer)
     Public Sub Method1(Of U As Integer)(arg As Integer, arg1 As U) Implements IInterface1(Of Integer).Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -410,15 +397,14 @@ Class C
     Implements [|I|]
     Private x As I
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class C
     Implements I
     Private x As I
     Public Sub M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -578,18 +564,17 @@ End Interface
 Class M
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Property Foo() As Integer
 End Interface
 Class M
     Implements I1
     Public Property Foo As Integer Implements I1.Foo
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -604,14 +589,13 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Function M() As String()
 End Interface
 Class C
     Implements I
     Public Function M() As String() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -627,15 +611,14 @@ Interface I
     Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer)
     Function Method2() As Integer
 End Interface",
-"Imports System
-Class C
+"Class C
     Implements I
     Private foo As I
     Public Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) Implements I.Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
     Public Function Method2() As Integer Implements I.Method2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class
 Interface I
@@ -653,14 +636,13 @@ End Interface
 Class C
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Function Method1$()
 End Interface
 Class C
     Implements I1
     Public Function Method1() As String Implements I1.Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -674,14 +656,13 @@ End Interface
 Class C
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Sub Method1(ByRef arg#)
 End Interface
 Class C
     Implements I1
     Public Sub Method1(ByRef arg As Double) Implements I1.Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -710,15 +691,14 @@ Interface I
     Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer)
     Function Method2() As Integer
 End Interface",
-"Imports System
-Class C
+"Class C
     Implements I
     Private foo As I
     Public Sub Method1(ByRef x As Integer, ByRef y As Integer, z As Integer) Implements I.Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
     Public Function Method2() As Integer Implements I.Method2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class
 Interface I
@@ -737,18 +717,17 @@ End Interface
 Class C
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Default Property Foo(ByVal arg As Integer)
 End Interface
 Class C
     Implements I1
     Default Public Property Foo(arg As Integer) As Object Implements I1.Foo
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Object)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -767,8 +746,7 @@ End Interface
 Class C
     Implements [|I1.I2|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Sub Foo()
     Delegate Sub Del(ByVal arg As Integer)
     Interface I2
@@ -778,7 +756,7 @@ End Interface
 Class C
     Implements I1.I2
     Public Sub Foo(arg As I1.Del) Implements I1.I2.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -793,14 +771,13 @@ End Interface
 Class C
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Sub Method1(ByVal arg() As Integer)
 End Interface
 Class C
     Implements I1
     Public Sub Method1(arg() As Integer) Implements I1.Method1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -817,15 +794,14 @@ End Class")
         Implements [|I1|]
     End Class
 End Namespace",
-"Imports System
-Namespace ConsoleApplication
+"Namespace ConsoleApplication
     Interface I1
         Sub Method1()
     End Interface
     Class C
         Implements I1
         Public Sub Method1() Implements I1.Method1
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Sub
     End Class
 End Namespace",
@@ -842,14 +818,13 @@ End Interface
 Class A
     Implements [|I2|]
 End Class",
-"Imports System
-Interface I2
+"Interface I2
     Function G(ParamArray args As Double()) As Integer
 End Interface
 Class A
     Implements I2
     Public Function G(ParamArray args() As Double) As Integer Implements I2.G
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -864,14 +839,13 @@ End Interface
 Class A
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Private Sub Foo()
 End Interface
 Class A
     Implements I1
     Public Sub Foo() Implements I1.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -912,15 +886,14 @@ Class C
     Implements [|I|]
     Public Property X As I
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class C
     Implements I
     Public Property X As I
     Public Sub M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
 
@@ -1520,9 +1493,7 @@ End Interface
 Class M
     Implements [|I1|]
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
-
-Interface I1
+<Text>Interface I1
     Function Foo()
 End Interface
 
@@ -1530,7 +1501,7 @@ Class M
     Implements I1
 
     Public Function Foo() As Object Implements I1.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
@@ -1551,8 +1522,7 @@ Class C
     Inherits B
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub M()
 End Interface
 Class B
@@ -1563,7 +1533,7 @@ Class C
     Inherits B
     Implements I
     Private Sub I_M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1578,14 +1548,13 @@ End Interface
 Class C
     Implements [|I|] ' Implement interface 
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub [Rem]
 End Interface
 Class C
     Implements I ' Implement interface 
     Public Sub [Rem]() Implements I.[Rem]
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1671,14 +1640,13 @@ End Interface
 Class C(Of T, R)
     Implements [|I(Of T, R)|]
 End Class",
-"Imports System
-Interface I(Of In T, Out R)
+"Interface I(Of In T, Out R)
     Sub Foo()
 End Interface
 Class C(Of T, R)
     Implements I(Of T, R)
     Public Sub Foo() Implements I(Of T, R).Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1697,8 +1665,7 @@ End Interface
 Class C
     Implements [|I2|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Property Bar As Integer
 End Interface
 Interface I2
@@ -1709,18 +1676,18 @@ Class C
     Implements I2
     Public Property Bar As Integer Implements I2.Bar
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
     Private Property I1_Bar As Integer Implements I1.Bar
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -1753,8 +1720,7 @@ Class C
     Inherits B
     Implements [|I1|]
 End Class",
-"Imports System
-Interface I1
+"Interface I1
     Property Bar As Integer
     Sub Foo()
 End Interface
@@ -1766,14 +1732,14 @@ Class C
     Implements I1
     Private Property I1_Bar As Integer Implements I1.Bar
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
     Public Sub Foo() Implements I1.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1806,14 +1772,13 @@ End Interface
 Class Bar
     Implements [|IFoo|]
 End Class",
-"Imports System
-Interface IFoo
+"Interface IFoo
     Sub Foo(Optional s As String = """""""")
 End Interface
 Class Bar
     Implements IFoo
     Public Sub Foo(Optional s As String = """""""") Implements IFoo.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1822,8 +1787,7 @@ End Class")
         <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Async Function TestVBConstantValue1() As Task
             Await TestAsync(
-"Imports System
-Imports Microsoft.VisualBasic
+"Imports Microsoft.VisualBasic
 Interface I
     Sub VBNullChar(Optional x As String = Constants.vbNullChar)
 End Interface
@@ -1831,8 +1795,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports Microsoft.VisualBasic
+"Imports Microsoft.VisualBasic
 Interface I
     Sub VBNullChar(Optional x As String = Constants.vbNullChar)
 End Interface
@@ -1840,7 +1803,7 @@ End Interface
 Class C
     Implements I
     Public Sub VBNullChar(Optional x As String = Constants.vbNullChar) Implements I.VBNullChar
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1913,14 +1876,13 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Date = #6/29/2012#)
 End Interface
 Class C
     Implements I
     Public Sub Foo(Optional x As Date = #6/29/2012 12:00:00 AM#) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -1963,15 +1925,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(x As Integer()())
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(x As Integer()()) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2014,15 +1975,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Long = Long.MinValue)
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x As Long = Long.MinValue) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2048,9 +2008,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
-
-Interface I
+<Text>Interface I
     Sub M01(Optional x As Short = Short.MinValue)
     Sub M02(Optional x As Short = Short.MaxValue)
     Sub M03(Optional x As UShort = UShort.MinValue)
@@ -2069,51 +2027,51 @@ Class C
     Implements I
 
     Public Sub M01(Optional x As Short = Short.MinValue) Implements I.M01
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M02(Optional x As Short = Short.MaxValue) Implements I.M02
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M03(Optional x As UShort = 0) Implements I.M03
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M04(Optional x As UShort = UShort.MaxValue) Implements I.M04
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M05(Optional x As Integer = Integer.MinValue) Implements I.M05
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M06(Optional x As Integer = Integer.MaxValue) Implements I.M06
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M07(Optional x As UInteger = 0) Implements I.M07
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M08(Optional x As UInteger = UInteger.MaxValue) Implements I.M08
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M09(Optional x As Long = Long.MinValue) Implements I.M09
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M10(Optional x As Long = Long.MaxValue) Implements I.M10
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M11(Optional x As ULong = 0) Implements I.M11
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M12(Optional x As ULong = ULong.MaxValue) Implements I.M12
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
@@ -2140,9 +2098,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
-
-Interface I
+<Text>Interface I
     Sub D1(Optional x As Double = Double.Epsilon)
     Sub D2(Optional x As Double = Double.MaxValue)
     Sub D3(Optional x As Double = Double.MinValue)
@@ -2161,51 +2117,51 @@ Class C
     Implements I
 
     Public Sub D1(Optional x As Double = Double.Epsilon) Implements I.D1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub D2(Optional x As Double = Double.MaxValue) Implements I.D2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub D3(Optional x As Double = Double.MinValue) Implements I.D3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub D4(Optional x As Double = Double.NaN) Implements I.D4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub D5(Optional x As Double = Double.NegativeInfinity) Implements I.D5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub D6(Optional x As Double = Double.PositiveInfinity) Implements I.D6
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S1(Optional x As Single = Single.Epsilon) Implements I.S1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S2(Optional x As Single = Single.MaxValue) Implements I.S2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S3(Optional x As Single = Single.MinValue) Implements I.S3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S4(Optional x As Single = Single.NaN) Implements I.S4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S5(Optional x As Single = Single.NegativeInfinity) Implements I.S5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S6(Optional x As Single = Single.PositiveInfinity) Implements I.S6
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class</Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
@@ -2340,15 +2296,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(x As Integer(,))
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(x(,) As Integer) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2389,15 +2344,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Object = ""‟"")
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x As Object = ""‟"") Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2606,15 +2560,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(x As Integer?())
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(x As Integer?()) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2630,15 +2583,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Integer() = Nothing)
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x() As Integer = Nothing) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2689,15 +2641,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Byte = 1)
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x As Byte = 1) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2713,15 +2664,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Object = 1L)
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x As Object = 1L) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2741,8 +2691,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Enum E
+"Enum E
     A = 1
 End Enum
 
@@ -2753,7 +2702,7 @@ End Interface
 Class C
     Implements I
     Public Sub Foo(Optional x As E = 0) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2769,15 +2718,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As Object = CByte(1))
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Optional x As Object = CByte(1)) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2802,8 +2750,6 @@ Class C
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
 <Text>Option Strict On
-Imports System
-
 Interface I
     Sub M1(Optional x As Decimal = 2D)
     Sub M2(Optional x As Decimal = 2.0D)
@@ -2817,27 +2763,27 @@ Class C
     Implements I
 
     Public Sub M1(Optional x As Decimal = 2) Implements I.M1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M2(Optional x As Decimal = 2.0D) Implements I.M2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M3(Optional x As Decimal = 0) Implements I.M3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M4(Optional x As Decimal = 0.0D) Implements I.M4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M5(Optional x As Decimal = 0.1D) Implements I.M5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M6(Optional x As Decimal = 0.10D) Implements I.M6
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf))
@@ -2857,7 +2803,6 @@ Class C
     Implements [|I|]
 End Class",
 "Option Strict On
-Imports System
 Interface I
     Sub Foo(Optional x As Decimal = Long.MinValue)
 End Interface
@@ -2865,7 +2810,7 @@ End Interface
 Class C
     Implements I
     Public Sub Foo(Optional x As Decimal = -9223372036854775808D) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -2989,14 +2934,13 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Optional x As String = ""𪛖"")
 End Interface
 Class C
     Implements I
     Public Sub Foo(Optional x As String = ""𪛖"") Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3039,15 +2983,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Of [TO], TP, TQ)()
 End Interface
 
 Class C
     Implements I
     Public Sub Foo(Of [TO], TP, TQ)() Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3117,7 +3060,6 @@ End Class
             Dim expected =
 <File>
 Option Strict On
-Imports System
 
 Interface I
     Sub F1(Optional x As Decimal = 1E-25D)
@@ -3146,83 +3088,83 @@ Class C
     Implements I
 
     Public Sub F1(Optional x As Decimal = 0.0000000000000000000000001D) Implements I.F1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub F2(Optional x As Decimal = 0.00000000000000000000000001D) Implements I.F2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub F3(Optional x As Decimal = 0.000000000000000000000000001D) Implements I.F3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub F4(Optional x As Decimal = 0.0000000000000000000000000001D) Implements I.F4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub F5(Optional x As Decimal = 0.0000000000000000000000000000D) Implements I.F5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M1(Optional x As Decimal = 0.00000000000000000000000011D) Implements I.M1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M2(Optional x As Decimal = 0.000000000000000000000000011D) Implements I.M2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M3(Optional x As Decimal = 0.0000000000000000000000000011D) Implements I.M3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M4(Optional x As Decimal = 0.0000000000000000000000000001D) Implements I.M4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub M5(Optional x As Decimal = 0.0000000000000000000000000000D) Implements I.M5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S1(Optional x As Decimal = -0.0000000000000000000000001D) Implements I.S1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S2(Optional x As Decimal = -0.00000000000000000000000001D) Implements I.S2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S3(Optional x As Decimal = -0.000000000000000000000000001D) Implements I.S3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S4(Optional x As Decimal = -0.0000000000000000000000000001D) Implements I.S4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub S5(Optional x As Decimal = 0.0000000000000000000000000000D) Implements I.S5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub T1(Optional x As Decimal = -0.00000000000000000000000011D) Implements I.T1
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub T2(Optional x As Decimal = -0.000000000000000000000000011D) Implements I.T2
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub T3(Optional x As Decimal = -0.0000000000000000000000000011D) Implements I.T3
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub T4(Optional x As Decimal = -0.0000000000000000000000000001D) Implements I.T4
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 
     Public Sub T5(Optional x As Decimal = 0.0000000000000000000000000000D) Implements I.T5
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class
 </File>
@@ -3360,15 +3302,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub ［ＲＥＭ］()
 End Interface
 
 Class C
     Implements I
     Public Sub [ＲＥＭ]() Implements I.[ＲＥＭ]
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3383,15 +3324,14 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     Sub Foo(Of ［ＲＥＭ］)()
 End Interface
 Class C
     Implements I
 
     Public Sub Foo(Of [ＲＥＭ])() Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3413,7 +3353,6 @@ Class C
     Implements [|I|] ' Implement 
 End Class",
 "Option Strict On
-Imports System
 Class C(Of T)
     Enum E
         X
@@ -3425,7 +3364,7 @@ End Interface
 Class C
     Implements I ' Implement 
     Public Sub Foo(Of M)(Optional x As C(Of M()).E = C(Of M()).E.X) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3447,7 +3386,6 @@ Class C
     Implements [|I|]
 End Class",
 "Option Strict On
-Imports System
 Class C(Of T)
     Enum E
         X
@@ -3459,7 +3397,7 @@ End Interface
 Class C
     Implements I
     Public Sub Foo(Of T)(Optional x As C(Of T()).E = C(Of T()).E.X) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3506,8 +3444,7 @@ End Class
 Partial Class C
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
 
     Sub M()
 
@@ -3520,7 +3457,7 @@ End Class
 Partial Class C
     Implements I
     Public Sub M() Implements I.M
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3538,8 +3475,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports System.Runtime.InteropServices
+"Imports System.Runtime.InteropServices
 
 Interface I
     Function Foo(<MarshalAs(UnmanagedType.U1)> x As Boolean) As <MarshalAs(UnmanagedType.U1)> Boolean
@@ -3550,7 +3486,7 @@ Class C
     Public Function Foo(<MarshalAs(UnmanagedType.U1)>
     x As Boolean) As <MarshalAs(UnmanagedType.U1)>
     Boolean Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -3567,14 +3503,13 @@ Class C
     Implements [|I|] ' Implement 
 End Class",
 "Option Strict On
-Imports System
 Interface I
     Sub Foo(Optional x As Decimal = 1000000000000000000D)
 End Interface
 Class C
     Implements I ' Implement 
     Public Sub Foo(Optional x As Decimal = 1000000000000000000) Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3590,8 +3525,7 @@ End Interface
 MustInherit Class C
     Implements [|I|] ' Implement interface abstractly 
 End Class",
-"Imports System
-Interface I
+"Interface I
     Property Foo() As Integer
 End Interface
 
@@ -3599,10 +3533,10 @@ MustInherit Class C
     Implements I ' Implement interface abstractly 
     Public Property Foo As Integer Implements I.Foo
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -3620,15 +3554,14 @@ Class c
 End Class
 Structure S
 End Structure",
-"Imports System
-Interface I
+"Interface I
     ReadOnly Property g(Optional x As S? = Nothing)
 End Interface
 Class c
     Implements I
     Public ReadOnly Property g(Optional x As S? = Nothing) As Object Implements I.g
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
     End Property
 End Class
@@ -3646,15 +3579,14 @@ End Interface
 Class c
     Implements [|I|]
 End Class",
-"Imports System
-Interface I
+"Interface I
     ReadOnly Property g(Optional x As Long? = Nothing, Optional y As Long? = 5)
 End Interface
 Class c
     Implements I
     Public ReadOnly Property g(Optional x As Long? = Nothing, Optional y As Long? = 5) As Object Implements I.g
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
     End Property
 End Class")
@@ -3674,8 +3606,7 @@ Class C
     Implements [|I|] ' Implement
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
-Imports System.Runtime.InteropServices
+<Text>Imports System.Runtime.InteropServices
 
 Interface I
     Function Foo(&lt;MarshalAs(UnmanagedType.U1)&gt; x As Boolean) As &lt;MarshalAs(UnmanagedType.U1)&gt; Boolean
@@ -3685,7 +3616,7 @@ Class C
     Implements I ' Implement
 
     Public Function Foo(&lt;MarshalAs(UnmanagedType.U1)&gt; x As Boolean) As &lt;MarshalAs(UnmanagedType.U1)&gt; Boolean Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
@@ -3705,8 +3636,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports System.Runtime.InteropServices
+"Imports System.Runtime.InteropServices
 
 Interface I
     Property P(<MarshalAs(UnmanagedType.I4)> x As Integer) As <MarshalAs(UnmanagedType.I4)> Integer
@@ -3716,10 +3646,10 @@ Class C
     Implements I
     Public Property P(<MarshalAs(UnmanagedType.I4)> x As Integer) As <MarshalAs(UnmanagedType.I4)> Integer Implements I.P
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
     End Property
 End Class")
@@ -3737,8 +3667,7 @@ End Class
 Partial Class C
     Implements [|I|]
 End Class",
-"Imports System
-Public Interface I
+"Public Interface I
     Sub Foo()
 End Interface
 Partial Class C
@@ -3746,7 +3675,7 @@ End Class
 Partial Class C
     Implements I
     Public Sub Foo() Implements I.Foo
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Sub
 End Class")
         End Function
@@ -3768,9 +3697,7 @@ End Class")
     End Interface
 End Interface
 </Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Imports System
-
-Interface A(Of B)
+<Text>Interface A(Of B)
     Sub M()
     Interface C(Of D)
         Inherits A(Of C(Of D))
@@ -3780,7 +3707,7 @@ Interface A(Of B)
                 Implements E
 
                 Public Sub M() Implements A(Of A(Of A(Of A(Of B).C(Of D)).C(Of A(Of B).C(Of D).E)).C(Of A(Of A(Of B).C(Of D)).C(Of A(Of B).C(Of D).E).E)).M
-                    Throw New NotImplementedException()
+                    Throw New System.NotImplementedException()
                 End Sub
             End Class
         End Interface
@@ -3891,8 +3818,7 @@ End Interface
 MustInherit Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports System.Runtime.InteropServices
+"Imports System.Runtime.InteropServices
 
 Interface I
     Function F(<ComAliasName(""pAlias"")> p As Long) As Integer
@@ -3902,7 +3828,7 @@ MustInherit Class C
     Implements I
 
     Public Function F(p As Long) As Integer Implements I.F
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -3920,8 +3846,7 @@ End Interface
 MustInherit Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports System.Runtime.InteropServices
+"Imports System.Runtime.InteropServices
 
 Interface I
     Function F(<ComAliasName(""pAlias1"")> p As Long) As <ComAliasName(""pAlias2"")> Integer
@@ -3931,7 +3856,7 @@ MustInherit Class C
     Implements I
 
     Public Function F(p As Long) As Integer Implements I.F
-        Throw New NotImplementedException()
+        Throw New System.NotImplementedException()
     End Function
 End Class")
         End Function
@@ -3949,8 +3874,7 @@ End Interface
 Class C
     Implements [|I|]
 End Class",
-"Imports System
-Imports System.Runtime.InteropServices
+"Imports System.Runtime.InteropServices
 
 Interface I
     Default Property Prop(<ComAliasName(""pAlias"")> p As Long) As Integer
@@ -3962,11 +3886,11 @@ Class C
     Default Public Property Prop(p As Long) As Integer Implements I.Prop
 
         Get
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Get
 
         Set(value As Integer)
-            Throw New NotImplementedException()
+            Throw New System.NotImplementedException()
         End Set
 
     End Property

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 if (ThroughMember == null)
                 {
                     var factory = this.Document.GetLanguageService<SyntaxGenerator>();
-                    return factory.CreateThrowNotImplementedStatement(compilation, addImport: false);
+                    return factory.CreateThrowNotImplementedStatement(compilation);
                 }
                 else
                 {

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 if (ThroughMember == null)
                 {
                     var factory = this.Document.GetLanguageService<SyntaxGenerator>();
-                    return factory.CreateThrowNotImplementStatement(compilation);
+                    return factory.CreateThrowNotImplementedStatement(compilation, addImport: false);
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/CodeGeneration/AbstractImportsAdder.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/AbstractImportsAdder.cs
@@ -43,6 +43,11 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                if (annotatedNode.GetAnnotations(DoNotAddImportsAnnotation.Kind).Any())
+                {
+                    continue;
+                }
+
                 SyntaxNode namespaceScope = null;
                 var annotations = annotatedNode.GetAnnotations(SymbolAnnotation.Kind);
                 foreach (var annotation in annotations)

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1629,8 +1629,8 @@ namespace Microsoft.CodeAnalysis.Editing
         public abstract SyntaxNode TypeExpression(ITypeSymbol typeSymbol);
 
         /// <summary>
-        /// Creates an expression that denotes a type.
-        /// Adds a <see cref="DoNotAddImportsAnnotation"/> which will prevent any
+        /// Creates an expression that denotes a type. If addImport is false,
+        /// adds a <see cref="DoNotAddImportsAnnotation"/> which will prevent any
         /// imports or usings from being added for the type.
         /// </summary>
         public SyntaxNode TypeExpression(ITypeSymbol typeSymbol, bool addImport)

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1637,8 +1637,8 @@ namespace Microsoft.CodeAnalysis.Editing
         {
             var expression = TypeExpression(typeSymbol);
             return addImport
-                ? expression.WithAdditionalAnnotations(DoNotAddImportsAnnotation.Annotation)
-                : expression;
+                ? expression
+                : expression.WithAdditionalAnnotations(DoNotAddImportsAnnotation.Annotation);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Simplification;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editing
@@ -1626,6 +1627,19 @@ namespace Microsoft.CodeAnalysis.Editing
         /// Creates an expression that denotes a type.
         /// </summary>
         public abstract SyntaxNode TypeExpression(ITypeSymbol typeSymbol);
+
+        /// <summary>
+        /// Creates an expression that denotes a type.
+        /// Adds a <see cref="DoNotAddImportsAnnotation"/> which will prevent any
+        /// imports or usings from being added for the type.
+        /// </summary>
+        public SyntaxNode TypeExpression(ITypeSymbol typeSymbol, bool addImport)
+        {
+            var expression = TypeExpression(typeSymbol);
+            return addImport
+                ? expression.WithAdditionalAnnotations(DoNotAddImportsAnnotation.Annotation)
+                : expression;
+        }
 
         /// <summary>
         /// Creates an expression that denotes a special type name.

--- a/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
@@ -370,6 +370,7 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceDeclaration(string name,
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceDeclaration(string name, params Microsoft.CodeAnalysis.SyntaxNode[] declarations) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceImportDeclaration(string name) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NullLiteralExpression() -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.SyntaxNode type, params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.OperatorDeclaration(Microsoft.CodeAnalysis.IMethodSymbol method, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements = null) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
@@ -370,7 +370,6 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceDeclaration(string name,
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceDeclaration(string name, params Microsoft.CodeAnalysis.SyntaxNode[] declarations) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NamespaceImportDeclaration(string name) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NullLiteralExpression() -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.SyntaxNode type, params Microsoft.CodeAnalysis.SyntaxNode[] arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.OperatorDeclaration(Microsoft.CodeAnalysis.IMethodSymbol method, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> statements = null) -> Microsoft.CodeAnalysis.SyntaxNode

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -43,7 +43,6 @@ abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddEventHandler(Microsof
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement) -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.SyntaxNode>
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.InsertSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, int index, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveEventHandler(Microsoft.CodeAnalysis.SyntaxNode event, Microsoft.CodeAnalysis.SyntaxNode handler) -> Microsoft.CodeAnalysis.SyntaxNode
-abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.SyntaxNode namedType, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ThrowExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.XmlDocumentationProvider.GetSourceStream(System.Threading.CancellationToken cancellationToken) -> System.IO.Stream
 const Microsoft.CodeAnalysis.Tags.WellKnownTags.Assembly = "Assembly" -> string

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -22,6 +22,8 @@ Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.OldActiveContextDoc
 Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.Solution.get -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.SourceTextContainer.get -> Microsoft.CodeAnalysis.Text.SourceTextContainer
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
+Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TypeExpression(Microsoft.CodeAnalysis.ITypeSymbol typeSymbol, bool addImport) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Options.DocumentOptionSet
 Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option) -> T
 Microsoft.CodeAnalysis.Options.IOption.StorageLocations.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Options.OptionStorageLocation>
@@ -42,6 +44,7 @@ abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddEventHandler(Microsof
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement) -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.SyntaxNode>
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.InsertSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, int index, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveEventHandler(Microsoft.CodeAnalysis.SyntaxNode event, Microsoft.CodeAnalysis.SyntaxNode handler) -> Microsoft.CodeAnalysis.SyntaxNode
+abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.SyntaxNode namedType, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ThrowExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.XmlDocumentationProvider.GetSourceStream(System.Threading.CancellationToken cancellationToken) -> System.IO.Stream
 const Microsoft.CodeAnalysis.Tags.WellKnownTags.Assembly = "Assembly" -> string

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -22,7 +22,6 @@ Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.OldActiveContextDoc
 Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.Solution.get -> Microsoft.CodeAnalysis.Solution
 Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.SourceTextContainer.get -> Microsoft.CodeAnalysis.Text.SourceTextContainer
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
-Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ObjectCreationExpression(Microsoft.CodeAnalysis.ITypeSymbol type, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> arguments) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.TypeExpression(Microsoft.CodeAnalysis.ITypeSymbol typeSymbol, bool addImport) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Options.DocumentOptionSet
 Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option) -> T

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
@@ -15,21 +15,21 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static partial class ICodeDefinitionFactoryExtensions
     {
-        public static SyntaxNode CreateThrowNotImplementStatement(
+        public static SyntaxNode CreateThrowNotImplementedStatement(
             this SyntaxGenerator codeDefinitionFactory,
             Compilation compilation)
         {
             return codeDefinitionFactory.ThrowStatement(
-                codeDefinitionFactory.ObjectCreationExpression(
-                    compilation.NotImplementedExceptionType(),
-                    SpecializedCollections.EmptyList<SyntaxNode>()));
+               codeDefinitionFactory.ObjectCreationExpression(
+                   codeDefinitionFactory.TypeExpression(compilation.NotImplementedExceptionType(), addImport: false),
+                   SpecializedCollections.EmptyList<SyntaxNode>()));
         }
 
         public static IList<SyntaxNode> CreateThrowNotImplementedStatementBlock(
             this SyntaxGenerator codeDefinitionFactory,
             Compilation compilation)
         {
-            return new[] { CreateThrowNotImplementStatement(codeDefinitionFactory, compilation) };
+            return new[] { CreateThrowNotImplementedStatement(codeDefinitionFactory, compilation) };
         }
 
         public static IList<SyntaxNode> CreateArguments(
@@ -223,8 +223,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (overriddenProperty.IsAbstract)
             {
                 var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                getBody = codeFactory.CreateThrowNotImplementStatement(compilation);
-                setBody = getBody;
+                var statement = codeFactory.CreateThrowNotImplementedStatement(compilation);
+
+                getBody = statement;
+                setBody = statement;
             }
             else if (overriddenProperty.IsIndexer() && document.Project.Language == LanguageNames.CSharp)
             {
@@ -361,11 +363,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             if (overriddenMethod.IsAbstract)
             {
                 var compilation = await newDocument.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                var statement = codeFactory.CreateThrowNotImplementedStatement(compilation);
+
                 return CodeGenerationSymbolFactory.CreateMethodSymbol(
                     overriddenMethod,
                     accessibility: overriddenMethod.ComputeResultantAccessibility(newContainingType),
                     modifiers: modifiers,
-                    statements: new[] { codeFactory.CreateThrowNotImplementStatement(compilation) });
+                    statements: new[] { statement });
             }
             else
             {

--- a/src/Workspaces/Core/Portable/Simplification/DoNotAddImportsAnnotation.cs
+++ b/src/Workspaces/Core/Portable/Simplification/DoNotAddImportsAnnotation.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Simplification
+{
+    // When applied to a SyntaxNode, prevents AbstractImportsAdder from
+    // adding imports for this node. Applied alongside SymbolAnnotation
+    // when a type should be simplified without adding a using for the type.
+    //
+    // For example, override completion adds 
+    // void foo() => throw new System.NotImplementedException()
+    // with a SymbolAnnotation and a DoNotAddImportsAnnotation.
+    //
+    // This allows the simplifier to remove the `System.` if 
+    // `using System` is already in the file but prevents the addition
+    // of `using System` just for the NotImplementedException. 
+    //
+    // This could have been implemented as an additional bit serialized
+    // into the `Data` string of SymbolAnnotation. However that would
+    // require additional substring operations to retrieve SymbolAnnotation
+    // symbols even in the common case where we don't need to supress
+    // add imports. This is therefore implemented as a separate annnotation.
+    internal class DoNotAddImportsAnnotation
+    {
+        public static readonly SyntaxAnnotation Annotation = new SyntaxAnnotation(Kind);
+        public const string Kind = "DoNotAddImports";
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -395,6 +395,7 @@
     <Compile Include="NamingStyles\Serialization\NamingStylePreferences.cs" />
     <Compile Include="NamingStyles\Serialization\SymbolSpecification.cs" />
     <Compile Include="Shared\Extensions\SolutionExtensions.cs" />
+    <Compile Include="Simplification\DoNotAddImportsAnnotation.cs" />
     <Compile Include="SymbolKey\SymbolKey.AnonymousFunctionOrDelegateSymbolKey.cs" />
     <Compile Include="Workspace\Host\TaskScheduler\WorkspaceTaskSchedulerFactory.WorkspaceTaskScheduler.cs" />
     <Compile Include="Tags\WellKnownTags.cs" />


### PR DESCRIPTION
… for System.

Instead, fully qualify NotImplementedException if the using is not present.

@dotnet/roslyn-ide  for review
