### PR TITLE
Do not throw if initialized by Winforms UI thread

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ForegroundThreadDataKind.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.Utilities
     internal enum ForegroundThreadDataKind
     {
         Wpf,
+        WinForms,
         StaUnitTest,
         JoinableTask,
         ForcedByPackageInitialize,
@@ -42,6 +43,10 @@ namespace Microsoft.CodeAnalysis.Utilities
                 case "Microsoft.VisualStudio.Threading.JoinableTask+JoinableTaskSynchronizationContext":
 
                     return JoinableTask;
+
+                case "System.Windows.Forms.WindowsFormsSynchronizationContext":
+
+                    return WinForms;
 
                 default:
 


### PR DESCRIPTION
Simplest fix for https://github.com/dotnet/roslyn/issues/10510 to be considered for Micro-Update.

Verified that this fixes the issue on the repro machine.  PowerBI team verified that this fixes the issue