### PR TITLE
Add parameter xml documentation code fix provider [work in progress]

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxExtensions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return SyntaxFactory.TriviaList(sequence);
         }
 
-        internal static XmlNameAttributeElementKind GetElementKind(this XmlNameAttributeSyntax attributeSyntax)
+        public static XmlNameAttributeElementKind GetElementKind(this XmlNameAttributeSyntax attributeSyntax)
         {
             CSharpSyntaxNode parentSyntax = attributeSyntax.Parent;
             SyntaxKind parentKind = parentSyntax.Kind();

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -156,6 +156,7 @@
     <Compile Include="CodeActions\InvertIf\InvertIfTests.cs" />
     <Compile Include="CodeActions\LambdaSimplifier\LambdaSimplifierTests.cs" />
     <Compile Include="CodeActions\ReplacePropertyWithMethods\ReplacePropertyWithMethodsTests.cs" />
+    <Compile Include="Diagnostics\AddParameterXmlDocumentation\AddParameterXmlDocumentationTests.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests_NuGet.cs" />
     <Compile Include="Diagnostics\GenerateMethod\GenerateConversionTests.cs" />
     <Compile Include="Diagnostics\MakeMethodSynchronous\MakeMethodSynchronousTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Diagnostics/AddParameterXmlDocumentation/AddParameterXmlDocumentationTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/AddParameterXmlDocumentation/AddParameterXmlDocumentationTests.cs
@@ -1,0 +1,297 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.AddParameterXmlDocumentation;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.AddParameterXmlDocumentation
+{
+    public class AddParameterXmlDocumentationTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return Tuple.Create<DiagnosticAnalyzer, CodeFixProvider>(null, new AddParameterXmlDocumentationCodeFixProvider());
+        }
+
+        // TODO: I don't think I completely understand how I'm supposed to use this hierarchy of base classes for unit tests
+        private ParseOptions _regularParseOptions = Options.Regular.WithDocumentationMode(DocumentationMode.Diagnose);
+        private ParseOptions _scriptParseOptions = Options.Script.WithDocumentationMode(DocumentationMode.Diagnose);
+        private async Task MyTestAsync(string initialMarkup, string expectedMarkup)
+        {
+            await TestAsync(initialMarkup, expectedMarkup, _regularParseOptions);
+            await TestAsync(initialMarkup, expectedMarkup, _scriptParseOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public Task TestClassesBefore()
+        {
+            return MyTestAsync(@"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""U""></typeparam>
+class C<[|T|], U, V> { }
+", @"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""T""></typeparam>
+/// <typeparam name=""U""></typeparam>
+class C<T, U, V> { }
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public Task TestClassesAfter()
+        {
+            return MyTestAsync(@"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""U""></typeparam>
+class C<T, U, [|V|]> { }
+", @"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""U""></typeparam>
+/// <typeparam name=""V""></typeparam>
+class C<T, U, V> { }
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public Task TestClassesNoOtherDocumentedParamter()
+        {
+            return MyTestAsync(@"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""XXX""></typeparam>
+class C<T, U, [|V|]> { }
+", @"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""V""></typeparam>
+/// <typeparam name=""XXX""></typeparam>
+class C<T, U, V> { }
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public Task TestClassesInBetween()
+        {
+            return MyTestAsync(@"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""T""></typeparam>
+/// <typeparam name=""V""></typeparam>
+class C<T, [|U|], V> { }
+", @"
+/// <summary> should stay the same </summary>
+/// <typeparam name=""T""></typeparam>
+/// <typeparam name=""U""></typeparam>
+/// <typeparam name=""V""></typeparam>
+class C<T, U, V> { }
+");
+        }
+
+        // TODO remove: I don't know how to do a test like this
+        //[Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public async Task TestOnDifferentItems()
+        {
+            var input = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""arg1""></param>
+        /// <typeparam name=""U""></typeparam>
+        static void M<[|T, U|]> ([|int arg1, int arg2|]) { }
+
+        /// <param name=""arg1""></param>
+        /// <typeparam name=""U""></typeparam>
+        delegate void D<[|T, U|]> ([|int arg1, int arg2|]);
+
+        /// <summary>
+        /// </summary>
+        /// <typeparam name=""U""></typeparam>
+        interface I<[|T, U|]> { }
+
+        /// <summary> should stay the same </summary>
+        /// <typeparam name=""U""></typeparam>
+        class C<[|T, U, V|]>
+        {
+            /// <summary></summary>
+            /// <param name=""arg2""></param>
+            public C([|C<V, V, V> arg1, int arg2|]) { }
+
+            public static explicit operator int(C<T, U, V> arg1) { return 1; }
+
+            /// <param name=""arg1""></param>
+            public static C<T, U, V> operator *([|C<T, U, V> arg1, C<T, U, U> arg2|]) { return null; }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <typeparam name=""U""></typeparam>
+        struct S<[|T, U, V|]> { }
+    }
+}";
+            var expected = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""arg1""></param>
+        /// <param name=""arg2""></param>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        static void M<T, U> (int arg1, int arg2) { }
+
+        /// <param name=""arg1""></param>
+        /// <param name=""arg2""></param>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        delegate void D<T, U> (int arg1, int arg2);
+
+        /// <summary>
+        /// </summary>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        interface I<T, U> { }
+
+        /// <summary> should stay the same </summary>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        /// <typeparam name=""V""></typeparam>
+        class C<T, U, V>
+        {
+            /// <summary></summary>
+            /// <param name=""arg1""></param>
+            /// <param name=""arg2""></param>
+            public C(C<V, V, V> arg1, int arg2) { }
+
+            public static explicit operator int(C<T, U, V> arg1) { return 1; }
+
+            /// <param name=""arg1""></param>
+            /// <param name=""arg2""></param>
+            public static C<T, U, V> operator *(C<T, U, V> arg1, C<T, U, U> arg2) { return null; }
+        }
+
+        /// <summary>
+        /// </summary>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        /// <typeparam name=""V""></typeparam>
+        struct S<T, U, V> { }
+    }
+}";
+            await TestAsync(input, expected, _regularParseOptions);
+            await TestAsync(input, expected, _scriptParseOptions);
+        }
+
+        // TODO remove; this is only for testing the unit test helpers
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public async Task TestTest()
+        {
+            var input = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""arg2""></param>
+        static void M[|(int arg1, int arg2)|] { }
+    }
+}";
+            var expected = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""arg1""></param>
+        /// <param name=""arg2""></param>
+        static void M(int arg1, int arg2) { }
+    }
+}";
+            await TestAsync(input, expected, _regularParseOptions);
+            await TestAsync(input, expected, _scriptParseOptions);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public async Task TestQuotesAndPlacement()
+        {
+            Func<string, string> inputTemplate = doc => $@"
+namespace ConsoleApplication1
+{{
+    class Programm
+    {{
+        /// <summary>
+        /// Should stay intact.
+        /// </summary>
+        /// {doc}
+        /// <summary> Should stay intact. </summary>
+        void m[|(int p1, int p2)|] {{ }}
+    }}
+}}
+";
+
+            Func<string, string> expectedTemplate = quote => $@"
+namespace ConsoleApplication1
+{{
+    class Programm
+    {{
+        /// <summary>
+        /// Should stay intact.
+        /// </summary>
+        /// <param name={quote}p1{quote}></param>
+        /// <param name={quote}p2{quote}></param>
+        /// <summary> Shoulp stay intact. </summary>
+        void m(int p1, int p2) {{ }}
+    }}
+}}
+";
+            foreach (var givenParam in new[] { "p1", "p2" })
+            {
+                foreach (var quote in new[] { "'", "\"" })
+                {
+                    var input = inputTemplate($"<param name={quote}{givenParam}{quote}></param>");
+                    var expected = expectedTemplate(quote);
+                    await MyTestAsync(input, expected);
+                }
+            }
+        }
+
+        // TODO remove: I don't know how to do a test like this
+        //[Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddParameterXmlDocumentation)]
+        public async Task TestNoOtherParamAvailable()
+        {
+            var input = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""a""></param>
+        /// <param name=""b""></param>
+        /// <typeparam name=""A""></typeparam>
+        /// <typeparam name=""B""></typeparam>
+        static void M<[|T, U|]>([|int arg1, int arg2|]) { }
+    }
+}";
+            var expected = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        /// <param name=""arg1""></param>
+        /// <param name=""arg2""></param>
+        /// <param name=""a""></param>
+        /// <param name=""b""></param>
+        /// <typeparam name=""T""></typeparam>
+        /// <typeparam name=""U""></typeparam>
+        /// <typeparam name=""A""></typeparam>
+        /// <typeparam name=""B""></typeparam>
+        static void M<T, U>(int arg1, int arg2) { }
+    }
+}";
+            await TestAsync(input, expected, _regularParseOptions);
+            await TestAsync(input, expected, _scriptParseOptions);
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -147,6 +147,7 @@ namespace Roslyn.Test.Utilities
             public const string XmlTagCompletion = nameof(XmlTagCompletion);
             public const string CodeActionsAddOverload = "CodeActions.AddOverloads";
             public const string CodeActionsAddNew = "CodeActions.AddNew";
+            public const string CodeActionsAddParameterXmlDocumentation = "CodeActions.AddParameterXmlDocumentation";
         }
     }
 }

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -65,6 +65,7 @@
     <Compile Include="ChangeSignature\CSharpChangeSignatureService.cs" />
     <Compile Include="ChangeSignature\UnifiedArgumentSyntax.cs" />
     <Compile Include="CodeFixes\AddImport\CSharpAddImportCodeFixProvider.cs" />
+    <Compile Include="CodeFixes\AddParameterXmlDocumentation\AddParameterXmlDocumentationCodeFixProvider.cs" />
     <Compile Include="CodeFixes\AddMissingReference\AddMissingReferenceCodeFixProvider.cs" />
     <Compile Include="CodeFixes\Async\CSharpAddAsyncCodeFixProvider.cs" />
     <Compile Include="CodeFixes\Async\CSharpAddAwaitCodeFixProvider.cs" />

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -62,6 +62,24 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add XML documentation for parameter {0}.
+        /// </summary>
+        internal static string AddParameterXmlDocumentation {
+            get {
+                return ResourceManager.GetString("AddParameterXmlDocumentation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Add XML documentation for type parameter {0}.
+        /// </summary>
+        internal static string AddTypeParameterXmlDocumentation {
+            get {
+                return ResourceManager.GetString("AddTypeParameterXmlDocumentation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to anonymous method.
         /// </summary>
         internal static string AnonymousMethod {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -454,5 +454,10 @@
   </data>
   <data name="UseImplicitTypeDiagnosticTitle" xml:space="preserve">
     <value>Use implicit type</value>
+  <data name="AddParameterXmlDocumentation" xml:space="preserve">
+    <value>Add XML documentation for parameter {0}</value>
+  </data>
+  <data name="AddTypeParameterXmlDocumentation" xml:space="preserve">
+    <value>Add XML documentation for type parameter {0}</value>
   </data>
 </root>

--- a/src/Features/CSharp/Portable/CodeFixes/AddParameterXmlDocumentation/AddParameterXmlDocumentationCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddParameterXmlDocumentation/AddParameterXmlDocumentationCodeFixProvider.cs
@@ -1,0 +1,316 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Composition;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddParameterXmlDocumentation
+{
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.AddParameterXmlDocumentaion), Shared]
+    internal partial class AddParameterXmlDocumentationCodeFixProvider : CodeFixProvider
+    {
+        // Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+        private const string CS1573 = nameof(CS1573);
+        // Type parameter 'type parameter' has no matching typeparam tag in the XML comment on 'type' (but other type parameters do)
+        private const string CS1712 = nameof(CS1712);
+
+        public sealed override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(CS1573, CS1712);
+
+        public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+        private BaseParameterListSyntax FindFirstAncestorParameterItem(SyntaxNode node)
+        {
+            for (; node != null; node = node.Parent)
+            {
+                if (node is BaseMethodDeclarationSyntax)
+                {
+                    return ((BaseMethodDeclarationSyntax)node).ParameterList;
+                }
+                if (node is IndexerDeclarationSyntax)
+                {
+                    return ((IndexerDeclarationSyntax)node).ParameterList;
+                }
+                if (node is DelegateDeclarationSyntax)
+                {
+                    return ((DelegateDeclarationSyntax)node).ParameterList;
+                }
+            }
+            return null;
+        }
+
+        // Can't use the generic GetAncestor method because structs and classes can nest each other.
+        private TypeParameterListSyntax FindFirstAncestorTypeParameterItem(SyntaxNode node)
+        {
+            for (; node != null; node = node.Parent)
+            {
+                if (node is MethodDeclarationSyntax)
+                {
+                    return ((MethodDeclarationSyntax)node).TypeParameterList;
+                }
+                if (node is ClassDeclarationSyntax)
+                {
+                    return ((ClassDeclarationSyntax)node).TypeParameterList;
+                }
+                if (node is StructDeclarationSyntax)
+                {
+                    return ((StructDeclarationSyntax)node).TypeParameterList;
+                }
+                if (node is InterfaceDeclarationSyntax)
+                {
+                    return ((InterfaceDeclarationSyntax)node).TypeParameterList;
+                }
+                if (node is DelegateDeclarationSyntax)
+                {
+                    return ((DelegateDeclarationSyntax)node).TypeParameterList;
+                }
+            }
+            return null;
+        }
+
+        public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+            // TODO many CodeFixProvider seem to do that and it works. Shouldn't there be a loop over all of the fixes?
+            var diagnostic = context.Diagnostics.First();
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+
+            if (diagnostic.Id == CS1573)
+            {
+                var parameterList = FindFirstAncestorParameterItem(root.FindToken(diagnosticSpan.Start).Parent);
+                if (parameterList == null) { return; }
+
+                var parameterSyntax = root.FindToken(diagnosticSpan.Start).GetAncestor<ParameterSyntax>();
+                if (parameterSyntax == null) { return; }
+                var parameterName = parameterSyntax.Identifier.ValueText;
+
+                XmlNameAttributeSyntax adjacentAttribute;
+                bool adjacentAttributeIsBefore;
+                FindAdjacentParameterDocumentation(
+                    parameterName,
+                    allParameterNames: parameterList.Parameters.Select(p => p.Identifier.ValueText),
+                    tokenWithDocumentationComment: parameterList.Parent.GetFirstToken(),
+                    elementKind: XmlNameAttributeElementKind.Parameter,
+                    adjacentNameAttribute: out adjacentAttribute,
+                    adjacentAttributeIsBefore: out adjacentAttributeIsBefore);
+
+                if (adjacentAttribute == null) { return; }
+
+                context.RegisterCodeFix(
+                    new AddParameterXmlDocumentationCodeAction(context.Document, parameterName, adjacentAttribute,
+                        adjacentAttributeIsBefore, isTypeParameter: false),
+                    diagnostic);
+            }
+            else if (diagnostic.Id == CS1712)
+            {
+                var parameterList = FindFirstAncestorTypeParameterItem(root.FindToken(diagnosticSpan.Start).Parent);
+                if (parameterList == null) { return; }
+
+                var parameterSyntax = root.FindToken(diagnosticSpan.Start).GetAncestor<TypeParameterSyntax>();
+                if (parameterSyntax == null) { return; }
+                var parameterName = parameterSyntax.Identifier.ValueText;
+
+                XmlNameAttributeSyntax adjacentAttribute;
+                bool adjacentAttributeIsBefore;
+                FindAdjacentParameterDocumentation(
+                    parameterName,
+                    allParameterNames: parameterList.Parameters.Select(p => p.Identifier.ValueText),
+                    tokenWithDocumentationComment: parameterList.Parent.GetFirstToken(),
+                    elementKind: XmlNameAttributeElementKind.TypeParameter,
+                    adjacentNameAttribute: out adjacentAttribute,
+                    adjacentAttributeIsBefore: out adjacentAttributeIsBefore);
+
+                if (adjacentAttribute == null) { return; }
+
+                context.RegisterCodeFix(
+                    new AddParameterXmlDocumentationCodeAction(context.Document, parameterName, adjacentAttribute,
+                        adjacentAttributeIsBefore, isTypeParameter: true),
+                    diagnostic);
+            }
+        }
+
+        /// <summary>
+        /// Finds a xml documentation tag with a name attribute at which another a new tag can be inserted.
+        /// </summary>
+        /// <param name="parameterName">The parameter of the new tag</param>
+        /// <param name="allParameterNames">All the parameter of which <paramref name="parameterName"/> is one.</param>
+        /// <param name="tokenWithDocumentationComment"></param>
+        /// <param name="elementKind">Specifies which elements can be found.</param>
+        /// <param name="adjacentNameAttribute">The name attribute of the adjacent parameter. If null no parameter was found.</param>
+        /// <param name="adjacentAttributeIsBefore">Indicates if the found adjacent attribute is before or after the parameter.</param>
+        private static void FindAdjacentParameterDocumentation(string parameterName, IEnumerable<string> allParameterNames, SyntaxToken tokenWithDocumentationComment,
+            XmlNameAttributeElementKind elementKind, out XmlNameAttributeSyntax adjacentNameAttribute, out bool adjacentAttributeIsBefore)
+        {
+            FindAdjacentParameterDocumentationWalker.FindAdjacentParameterDocumenteden(parameterName, allParameterNames, tokenWithDocumentationComment,
+                elementKind, out adjacentNameAttribute, out adjacentAttributeIsBefore);
+        }
+
+        private class FindAdjacentParameterDocumentationWalker : CSharpSyntaxWalker
+        {
+            private FindAdjacentParameterDocumentationWalker(int parameterIndex, Dictionary<string, int> parameterIndices, XmlNameAttributeElementKind elementKind)
+                : base(SyntaxWalkerDepth.StructuredTrivia)
+            {
+                _parameterIndex = parameterIndex;
+                _parameterIndices = parameterIndices;
+                _elementKind = elementKind;
+            }
+
+            private int _parameterIndex = -1;
+            private Dictionary<string, int> _parameterIndices = new Dictionary<string, int>();
+
+            private XmlNameAttributeSyntax _documentedParameterBefore = null;
+            private int _documentedParameterBeforeIndex = -1;
+            private XmlNameAttributeSyntax _documentedParameterAfter = null;
+            private int _documentedParameterAfterIndex = int.MaxValue;
+
+            private XmlNameAttributeElementKind _elementKind;
+
+            public static void FindAdjacentParameterDocumenteden(string parameterName, IEnumerable<string> allParameterNames,
+                SyntaxToken tokenWithDocumentationComment, XmlNameAttributeElementKind elementKind, out XmlNameAttributeSyntax adjacentNameAttribute, out bool adjacentAttributeIsBefore)
+            {
+                var parameterIndices = new Dictionary<string, int>();
+                int index = 0;
+                foreach (var param in allParameterNames)
+                {
+                    parameterIndices.Add(param, index);
+                    index++;
+                }
+                if (!parameterIndices.ContainsKey(parameterName))
+                {
+                    // something went very wrong
+                    Debug.Assert(false); // TODO message or remove assert
+                    adjacentNameAttribute = null;
+                    adjacentAttributeIsBefore = false;
+                    return;
+                }
+
+                var walker = new FindAdjacentParameterDocumentationWalker(parameterIndices[parameterName], parameterIndices, elementKind);
+                walker.VisitLeadingTrivia(tokenWithDocumentationComment);
+
+                if (walker._documentedParameterBefore != null)
+                {
+                    adjacentNameAttribute = walker._documentedParameterBefore;
+                    adjacentAttributeIsBefore = true;
+                }
+                else
+                {
+                    adjacentNameAttribute = walker._documentedParameterAfter;
+                    adjacentAttributeIsBefore = false;
+                }
+            }
+
+            public override void VisitXmlNameAttribute(XmlNameAttributeSyntax node)
+            {
+                if (node.GetElementKind() == _elementKind)
+                {
+                    int index;
+                    if (_parameterIndices.TryGetValue(node.Identifier.Identifier.ValueText, out index))
+                    {
+                        if (_documentedParameterBeforeIndex < index & index < _documentedParameterAfterIndex)
+                        {
+                            if (index < _parameterIndex)
+                            {
+                                _documentedParameterBefore = node;
+                                _documentedParameterBeforeIndex = index;
+                            }
+                            if (_parameterIndex < index)
+                            {
+                                _documentedParameterAfter = node;
+                                _documentedParameterAfterIndex = index;
+                            }
+                        }
+                    }
+                    else if (_documentedParameterAfter == null)
+                    {
+                        // in case all the param or typeparam tags that exist are not a parameter
+                        _documentedParameterAfter = node;
+                    }
+                }
+                base.VisitXmlNameAttribute(node);
+            }
+        }
+
+        private class AddParameterXmlDocumentationCodeAction : CodeAction
+        {
+            private string _title;
+            private Document _document;
+            private string _parameterName;
+            private XmlNameAttributeSyntax _adjacentAttribute;
+            private bool _adjacentAttributeIsBefore;
+            private bool _isTypeParameter;
+
+            public override string Title => _title;
+
+            public AddParameterXmlDocumentationCodeAction(Document document, string parameterName, XmlNameAttributeSyntax adjacentAttribute,
+                bool adjacentAttributeIsBefore, bool isTypeParameter)
+            {
+                if (isTypeParameter)
+                {
+                    _title = string.Format(CSharpFeaturesResources.AddTypeParameterXmlDocumentation, parameterName);
+                }
+                else
+                {
+                    _title = string.Format(CSharpFeaturesResources.AddParameterXmlDocumentation, parameterName);
+                }
+                _document = document;
+                _parameterName = parameterName;
+                _adjacentAttribute = adjacentAttribute;
+                _adjacentAttributeIsBefore = adjacentAttributeIsBefore;
+                _isTypeParameter = isTypeParameter;
+            }
+
+            protected override async Task<Document> GetChangedDocumentAsync(CancellationToken cancellationToken)
+            {
+                var root = await _document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+                // TODO Handle (or disallow) /** */ comments
+                var newLineAndSpace = GetXmlCommentNewLineAndSpace("///");
+                var elementName = _isTypeParameter ? "typeparam" : "param";
+                var newDocumentation = GetNewDocumentationParamElement(_parameterName, elementName, _adjacentAttribute);
+
+                if (_adjacentAttributeIsBefore)
+                {
+                    root = root.InsertNodesAfter(_adjacentAttribute.Parent.Parent,
+                        new SyntaxNode[] { newLineAndSpace, newDocumentation });
+                }
+                else
+                {
+                    root = root.InsertNodesBefore(_adjacentAttribute.Parent.Parent,
+                        new SyntaxNode[] { newDocumentation, newLineAndSpace });
+                }
+
+                return _document.WithSyntaxRoot(root);
+            }
+
+            private static XmlTextSyntax GetXmlCommentNewLineAndSpace(string commentPrefix)
+            {
+                var newlineToken = SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.XmlTextLiteralNewLineToken, "\n", "\n", default(SyntaxTriviaList));
+                var documentationComment = SyntaxFactory.SyntaxTrivia(SyntaxKind.DocumentationCommentExteriorTrivia, commentPrefix);
+                var spaceToken = SyntaxFactory.Token(SyntaxTriviaList.Create(documentationComment), SyntaxKind.XmlTextLiteralToken, " ", " ", default(SyntaxTriviaList));
+                return SyntaxFactory.XmlText(SyntaxFactory.TokenList(newlineToken, spaceToken));
+            }
+
+            private static XmlElementSyntax GetNewDocumentationParamElement(string parameterName, string elementName,
+                XmlNameAttributeSyntax referenceDocumentationAttribute)
+            {
+                var quote = referenceDocumentationAttribute.StartQuoteToken;
+                var nameAttribute = SyntaxFactory.XmlNameAttribute(referenceDocumentationAttribute.Name, quote, parameterName, quote);
+
+                var xmlElementName = SyntaxFactory.XmlName(elementName);
+                var startTag = SyntaxFactory.XmlElementStartTag(xmlElementName,
+                    SyntaxFactory.List(Enumerable.Repeat((XmlAttributeSyntax)nameAttribute, 1)));
+                var endTag = SyntaxFactory.XmlElementEndTag(xmlElementName);
+                return SyntaxFactory.XmlElement(startTag, endTag);
+            }
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
+++ b/src/Features/Core/Portable/CodeFixes/PredefinedCodeFixProviderNames.cs
@@ -42,5 +42,6 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         public const string AddNew = "Add new keyword to member";
         public const string UseImplicitType = nameof(UseImplicitType);
         public const string UseExplicitType = nameof(UseExplicitType);
+        public const string AddParameterXmlDocumentaion = "Add xml documentation for a parameter or type parameter";
     }
 }


### PR DESCRIPTION
This is about #5611 and #7070.

###### Questions
* I use the SyntaxExtensions [GetElementKind](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Syntax/SyntaxExtensions.cs,a76a73b7059fb837) but it's internal  and in a different project. Currently I pretty much need this exact functionality. It's the only method that has  [XmlNameAttributeElementKind](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Syntax/XmlNameAttributeElementKind.cs,7229a8a7617ccd8f) in its signature and XmlNameAttributeElementKind is public. How bad is the idea to make it part of the public API in the compiler layer?
* Should we have the same CodeFixProvider for param and typeparam as I have now?
  * Note: I even use the same EquivalenceKey for the resulting code action.

###### TODO
- [ ] `/** */` comments are handled incorrect! An idea and details in #5611.
- [ ] I'm still working to get several occurrences fixed at once.
- [ ] I need more unit tests for different things with parameters or type parametes  (e.g. delegates).
- [ ] Small things and `// TODO` comments

###### Marginal remarks
* I copied some of the practices from the [HideBaseCodeFixProvider](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp.Features/CodeFixes/HideBase/HideBaseCodeFixProvider.cs).
* Performance: I don't really know. I think that it might not be so important as this only executes if the warning appears.
* In the pull request #9246 the file src\Features\CSharp\Portable\CSharpFeaturesResources.resx changed which causes Visual Studio to change the ....Designer.cs (only the comments). That produced changes that don't belong here so I'll remove them before this PR becomes ready for review. Maybe someone should fix that (maybe not?). I would make a pull request if someone wants me to.
* I'll squash all commits.
* I'm new to programming things that have many other involved and are supposed to live a little longer. So I especially welcome critique/comments as my code may not be the result of taste but of ignorance.