### PR TITLE
Add missing nugets to VS setup VSIX

### DIFF
--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -145,9 +145,11 @@
     <NuGetPackageToIncludeInVsix Include="ManagedEsent" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.CodeAnalysis.Elfie" />
     <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader" />
+    <NuGetPackageToIncludeInVsix Include="Microsoft.DiaSymReader.PortablePdb" />
     <!-- Visual Studio ships with some, but not all, of the assemblies in Microsoft.Composition, but we need them all -->
     <NuGetPackageToIncludeInVsix Include="Microsoft.Composition" />
     <NuGetPackageToIncludeInVsix Include="System.Reflection.Metadata" />
+    <NuGetPackageToIncludeInVsix Include="System.Collections.Immutable" />
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Fixes integration test failures due to missing System.Collections.Immutable v1.2.0