### PR TITLE
Remove redundant instance of SpeculativeTCompletionProvider inside CSharpCompletionService

### DIFF
--- a/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
+++ b/src/Features/CSharp/Portable/Completion/CSharpCompletionService.cs
@@ -22,7 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion
             {
                 new AttributeNamedParameterCompletionProvider(),
                 new NamedParameterCompletionProvider(),
-                new SpeculativeTCompletionProvider(),
                 new KeywordCompletionProvider(),
                 new SymbolCompletionProvider(),
                 new ExplicitInterfaceCompletionProvider(),


### PR DESCRIPTION
Expand the diff down and see the other `SpeculativeTCompletionProvider`..