### PR TITLE
Go to the start of the current member first

### DIFF
--- a/src/EditorFeatures/CSharpTest/GoToAdjacentMember/CSharpGoToAdjacentMemberTests.cs
+++ b/src/EditorFeatures/CSharpTest/GoToAdjacentMember/CSharpGoToAdjacentMemberTests.cs
@@ -495,6 +495,27 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.GoToAdjacentMember)]
         [WorkItem(4311, "https://github.com/dotnet/roslyn/issues/4311")]
+        [WorkItem(10588, "https://github.com/dotnet/roslyn/issues/10588")]
+        public async Task PreviousFromInsideCurrent()
+        {
+            var code = @"
+class C
+{
+    [||]void M1()
+    {
+        Console.WriteLine($$);
+    }
+
+    void M2()
+    {
+    }
+}";
+
+            await AssertNavigatedAsync(code, next: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.GoToAdjacentMember)]
+        [WorkItem(4311, "https://github.com/dotnet/roslyn/issues/4311")]
         public async Task NextInScript()
         {
             var code = @"

--- a/src/EditorFeatures/Core/CommandHandlers/GoToAdjacentMemberCommandHandler.cs
+++ b/src/EditorFeatures/Core/CommandHandlers/GoToAdjacentMemberCommandHandler.cs
@@ -98,8 +98,8 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 return null;
             }
 
-            var spans = members.Select(m => m.Span).ToArray();
-            var index = Array.BinarySearch(spans, new TextSpan(caretPosition, 0), PositionToTextSpanComparer.Instance);
+            var starts = members.Select(m => MemberStart(m)).ToArray();
+            var index = Array.BinarySearch(starts, caretPosition);
             if (index >= 0)
             {
                 // We're actually contained in a member, go to the next or previous.
@@ -122,32 +122,13 @@ namespace Microsoft.CodeAnalysis.Editor.CommandHandlers
                 index = members.Count - 1;
             }
 
-            // TODO: Better position within the node (e.g. attributes?)
-            return members[index].Span.Start;
+            return MemberStart(members[index]);
         }
 
-        /// <summary>
-        /// A custom comparer that returns true if two <see cref="TextSpan"/>'s intersect, and otherwise
-        /// compares by <see cref="TextSpan.Start"/>.
-        /// </summary>
-        private class PositionToTextSpanComparer : IComparer
+        private static int MemberStart(SyntaxNode node)
         {
-            public static IComparer Instance { get; } = new PositionToTextSpanComparer();
-
-            private PositionToTextSpanComparer() { }
-
-            int IComparer.Compare(object x, object y)
-            {
-                var left = (TextSpan)x;
-                var right = (TextSpan)y;
-
-                if (left.IntersectsWith(right))
-                {
-                    return 0;
-                }
-
-                return left.Start - right.Start;
-            }
+            // TODO: Better position within the node (e.g. attributes?)
+            return node.SpanStart;
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/GoToAdjacentMember/VisualBasicGoToAdjacentMemberTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/GoToAdjacentMember/VisualBasicGoToAdjacentMemberTests.vb
@@ -417,6 +417,23 @@ End Class"
 
         <Fact, Trait(Traits.Feature, Traits.Features.GoToAdjacentMember)>
         <WorkItem(4311, "https://github.com/dotnet/roslyn/issues/4311")>
+        <WorkItem(10588, "https://github.com/dotnet/roslyn/issues/10588")>
+        Public Async Function PreviousFromInsideCurrent() As Task
+            Dim code = "
+class C
+    [||]Sub M1()
+        Console.WriteLine($$)
+    End Sub
+
+    Sub M2()
+    End Sub
+End Class"
+
+            Await AssertNavigatedAsync(code, next:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.GoToAdjacentMember)>
+        <WorkItem(4311, "https://github.com/dotnet/roslyn/issues/4311")>
         Public Async Function PreviousFromBetweenMethodsInTrailingTrivia() As Task
             Dim code = "
 Class C


### PR DESCRIPTION
In turns out that the behavior of "Go to previous member" in VB was actually
to go to the start of the current member if you weren't already at the start.
Support that again.

Fixes #10588