### PR TITLE
Address performance regression in CompilationWithAnalyzers.GetAnalyze…

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1709,9 +1709,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (_lazyCompilationUnitCompletedTrees.Count == this.SyntaxTrees.Length)
                     {
                         // if that was the last tree, signal the end of compilation
-                        EventQueue.TryEnqueue(new CompilationCompletedEvent(this));
-                        EventQueue.PromiseNotToEnqueue();
-                        EventQueue.TryComplete();
+                        EnsureCompilationCompleted();
                     }
                 }
             }
@@ -1950,6 +1948,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 cancellationToken.ThrowIfCancellationRequested();
 
                 builder.AddRange(GetSourceDeclarationDiagnostics(cancellationToken: cancellationToken));
+
+                if (this.EventQueue != null && this.SyntaxTrees.Length == 0)
+                {
+                    EnsureCompilationCompleted();
+                }
             }
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1709,7 +1709,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (_lazyCompilationUnitCompletedTrees.Count == this.SyntaxTrees.Length)
                     {
                         // if that was the last tree, signal the end of compilation
-                        EnsureCompilationCompleted();
+                        CompleteCompilationEventQueue_NoLock();
                     }
                 }
             }
@@ -1949,9 +1949,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 builder.AddRange(GetSourceDeclarationDiagnostics(cancellationToken: cancellationToken));
 
-                if (this.EventQueue != null && this.SyntaxTrees.Length == 0)
+                if (EventQueue != null && SyntaxTrees.Length == 0)
                 {
-                    EnsureCompilationCompleted();
+                    EnsureCompilationEventQueueCompleted();
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/GetDiagnosticsTests.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -286,6 +287,17 @@ namespace N1
             }
 
             return true;
+        }
+
+        [Fact]
+        public void TestEventQueueCompletionForEmptyCompilation()
+        {
+            var compilation = CreateCompilationWithMscorlib45(SpecializedCollections.EmptyEnumerable<SyntaxTree>()).WithEventQueue(new AsyncQueue<CompilationEvent>());
+            
+            // Force complete compilation event queue
+            var unused = compilation.GetDiagnostics();
+
+            Assert.True(compilation.EventQueue.IsCompleted);
         }
     }
 }

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Binding\AbstractLookupSymbolsInfo.cs" />
     <Compile Include="CaseInsensitiveComparison.cs" />
     <Compile Include="CodeGen\ILEmitStyle.cs" />
+    <Compile Include="DiagnosticAnalyzer\AnalysisResult.cs" />
     <Compile Include="InternalUtilities\EmptyComparer.cs" />
     <Compile Include="InternalUtilities\StringOrdinalComparer.cs" />
     <Compile Include="MetadataReference\AssemblyIdentityMap.cs" />
@@ -177,7 +178,7 @@
     <Compile Include="Compilation\CommonSyntaxAndDeclarationManager.cs" />
     <Compile Include="Compilation\SymbolFilter.cs" />
     <Compile Include="CompilerPathUtilities.cs" />
-    <Compile Include="DiagnosticAnalyzer\AnalysisResult.cs" />
+    <Compile Include="DiagnosticAnalyzer\AnalysisResultBuilder.cs" />
     <Compile Include="DiagnosticAnalyzer\AnalysisScope.cs" />
     <Compile Include="DiagnosticAnalyzer\AnalysisState.AnalyzerStateData.cs" />
     <Compile Include="DiagnosticAnalyzer\AnalysisState.cs" />

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -851,6 +851,22 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public abstract ImmutableArray<Diagnostic> GetDiagnostics(CancellationToken cancellationToken = default(CancellationToken));
 
+        internal void EnsureCompilationCompleted()
+        {
+            Debug.Assert(this.EventQueue != null);
+
+            lock (this.EventQueue)
+            {
+                if (!this.EventQueue.IsCompleted)
+                {
+                    // Signal the end of compilation.
+                    EventQueue.TryEnqueue(new CompilationCompletedEvent(this));
+                    EventQueue.PromiseNotToEnqueue();
+                    EventQueue.TryComplete();
+                }
+            }
+        }
+
         internal abstract CommonMessageProvider MessageProvider { get; }
 
         /// <param name="accumulator">Bag to which filtered diagnostics will be added.</param>

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisResultBuilder.cs
@@ -1,0 +1,359 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// Stores the results of analyzer execution:
+    /// 1. Local and non-local diagnostics, per-analyzer.
+    /// 2. Analyzer execution times, if requested.
+    /// </summary>
+    internal sealed class AnalysisResultBuilder
+    {
+        private readonly object _gate = new object();
+        private readonly Dictionary<DiagnosticAnalyzer, TimeSpan> _analyzerExecutionTimeOpt;
+        private readonly HashSet<DiagnosticAnalyzer> _completedAnalyzers;
+        private readonly Dictionary<DiagnosticAnalyzer, AnalyzerActionCounts> _analyzerActionCounts;
+
+        private Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> _localSemanticDiagnosticsOpt = null;
+        private Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> _localSyntaxDiagnosticsOpt = null;
+        private Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder> _nonLocalDiagnosticsOpt = null;
+        
+        internal AnalysisResultBuilder(bool logAnalyzerExecutionTime, ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            _analyzerExecutionTimeOpt = logAnalyzerExecutionTime ? CreateAnalyzerExecutionTimeMap(analyzers) : null;
+            _completedAnalyzers = new HashSet<DiagnosticAnalyzer>();
+            _analyzerActionCounts = new Dictionary<DiagnosticAnalyzer, AnalyzerActionCounts>(analyzers.Length);
+        }
+
+        private static Dictionary<DiagnosticAnalyzer, TimeSpan> CreateAnalyzerExecutionTimeMap(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            var map = new Dictionary<DiagnosticAnalyzer, TimeSpan>(analyzers.Length);
+            foreach (var analyzer in analyzers)
+            {
+                map[analyzer] = default(TimeSpan);
+            }
+
+            return map;
+        }
+
+        public TimeSpan GetAnalyzerExecutionTime(DiagnosticAnalyzer analyzer)
+        {
+            Debug.Assert(_analyzerExecutionTimeOpt != null);
+
+            lock (_gate)
+            {
+                return _analyzerExecutionTimeOpt[analyzer];
+            }
+        }
+
+        internal ImmutableArray<DiagnosticAnalyzer> GetPendingAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            lock (_gate)
+            {
+                ArrayBuilder<DiagnosticAnalyzer> builder = null;
+                foreach (var analyzer in analyzers)
+                {
+                    if (!_completedAnalyzers.Contains(analyzer))
+                    {
+                        builder = builder ?? ArrayBuilder<DiagnosticAnalyzer>.GetInstance();
+                        builder.Add(analyzer);
+                    }
+                }
+
+                return builder != null ? builder.ToImmutableAndFree() : ImmutableArray<DiagnosticAnalyzer>.Empty;
+            }
+        }
+
+        internal void StoreAnalysisResult(AnalysisScope analysisScope, AnalyzerDriver driver, Compilation compilation, Func<DiagnosticAnalyzer, AnalyzerActionCounts> getAnalyzerActionCounts, bool fullAnalysisResultForAnalyzersInScope)
+        {
+            Debug.Assert(!fullAnalysisResultForAnalyzersInScope || analysisScope.FilterTreeOpt == null, "Full analysis result cannot come from partial (tree) analysis.");
+
+            foreach (var analyzer in analysisScope.Analyzers)
+            {
+                // Dequeue reported analyzer diagnostics from the driver and store them in our maps.
+                var syntaxDiagnostics = driver.DequeueLocalDiagnostics(analyzer, syntax: true, compilation: compilation);
+                var semanticDiagnostics = driver.DequeueLocalDiagnostics(analyzer, syntax: false, compilation: compilation);
+                var compilationDiagnostics = driver.DequeueNonLocalDiagnostics(analyzer, compilation);
+
+                lock (_gate)
+                {
+                    if (_completedAnalyzers.Contains(analyzer))
+                    {
+                        // Already stored full analysis result for this analyzer.
+                        continue;
+                    }
+
+                    if (syntaxDiagnostics.Length > 0 || semanticDiagnostics.Length > 0 || compilationDiagnostics.Length > 0 || fullAnalysisResultForAnalyzersInScope)
+                    {
+                        UpdateLocalDiagnostics_NoLock(analyzer, syntaxDiagnostics, fullAnalysisResultForAnalyzersInScope, ref _localSyntaxDiagnosticsOpt);
+                        UpdateLocalDiagnostics_NoLock(analyzer, semanticDiagnostics, fullAnalysisResultForAnalyzersInScope, ref _localSemanticDiagnosticsOpt);
+                        UpdateNonLocalDiagnostics_NoLock(analyzer, compilationDiagnostics, fullAnalysisResultForAnalyzersInScope);
+                    }
+
+                    if (_analyzerExecutionTimeOpt != null)
+                    {
+                        var timeSpan = driver.ResetAnalyzerExecutionTime(analyzer);
+                        _analyzerExecutionTimeOpt[analyzer] = fullAnalysisResultForAnalyzersInScope ?
+                            timeSpan :
+                            _analyzerExecutionTimeOpt[analyzer] + timeSpan;
+                    }
+
+                    if (!_analyzerActionCounts.ContainsKey(analyzer))
+                    {
+                        _analyzerActionCounts.Add(analyzer, getAnalyzerActionCounts(analyzer));
+                    }
+
+                    if (fullAnalysisResultForAnalyzersInScope)
+                    {
+                        _completedAnalyzers.Add(analyzer);
+                    }
+                }
+            }
+        }
+
+        private void UpdateLocalDiagnostics_NoLock(
+            DiagnosticAnalyzer analyzer,
+            ImmutableArray<Diagnostic> diagnostics,
+            bool overwrite,
+            ref Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> lazyLocalDiagnostics)
+        {
+            if (diagnostics.IsEmpty)
+            {
+                return;
+            }
+
+            lazyLocalDiagnostics = lazyLocalDiagnostics ?? new Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>>();
+
+            foreach (var diagsByTree in diagnostics.GroupBy(d => d.Location.SourceTree))
+            {
+                var tree = diagsByTree.Key;
+
+                Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder> allDiagnostics;
+                if (!lazyLocalDiagnostics.TryGetValue(tree, out allDiagnostics))
+                {
+                    allDiagnostics = new Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>();
+                    lazyLocalDiagnostics[tree] = allDiagnostics;
+                }
+
+                ImmutableArray<Diagnostic>.Builder analyzerDiagnostics;
+                if (!allDiagnostics.TryGetValue(analyzer, out analyzerDiagnostics))
+                {
+                    analyzerDiagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+                    allDiagnostics[analyzer] = analyzerDiagnostics;
+                }
+
+                if (overwrite)
+                {
+                    analyzerDiagnostics.Clear();
+                }
+
+                analyzerDiagnostics.AddRange(diagsByTree);
+            }
+        }
+
+        private void UpdateNonLocalDiagnostics_NoLock(DiagnosticAnalyzer analyzer, ImmutableArray<Diagnostic> diagnostics, bool overwrite)
+        {
+            if (diagnostics.IsEmpty)
+            {
+                return;
+            }
+
+            _nonLocalDiagnosticsOpt = _nonLocalDiagnosticsOpt ?? new Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>();
+
+            ImmutableArray<Diagnostic>.Builder currentDiagnostics;
+            if (!_nonLocalDiagnosticsOpt.TryGetValue(analyzer, out currentDiagnostics))
+            {
+                currentDiagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+                _nonLocalDiagnosticsOpt[analyzer] = currentDiagnostics;
+            }
+
+            if (overwrite)
+            {
+                currentDiagnostics.Clear();
+            }
+
+            currentDiagnostics.AddRange(diagnostics);
+        }
+
+        internal ImmutableArray<Diagnostic> GetDiagnostics(AnalysisScope analysisScope, bool getLocalDiagnostics, bool getNonLocalDiagnostics)
+        {
+            lock (_gate)
+            {
+                return GetDiagnostics_NoLock(analysisScope, getLocalDiagnostics, getNonLocalDiagnostics);
+            }
+        }
+
+        private ImmutableArray<Diagnostic> GetDiagnostics_NoLock(AnalysisScope analysisScope, bool getLocalDiagnostics, bool getNonLocalDiagnostics)
+        {
+            Debug.Assert(getLocalDiagnostics || getNonLocalDiagnostics);
+
+            var builder = ImmutableArray.CreateBuilder<Diagnostic>();
+            if (getLocalDiagnostics)
+            {
+                if (!analysisScope.IsTreeAnalysis)
+                {
+                    AddAllLocalDiagnostics_NoLock(_localSyntaxDiagnosticsOpt, analysisScope, builder);
+                    AddAllLocalDiagnostics_NoLock(_localSemanticDiagnosticsOpt, analysisScope, builder);
+                }
+                else if (analysisScope.IsSyntaxOnlyTreeAnalysis)
+                {
+                    AddLocalDiagnosticsForPartialAnalysis_NoLock(_localSyntaxDiagnosticsOpt, analysisScope, builder);
+                }
+                else
+                {
+                    AddLocalDiagnosticsForPartialAnalysis_NoLock(_localSemanticDiagnosticsOpt, analysisScope, builder);
+                }
+            }
+
+            if (getNonLocalDiagnostics && _nonLocalDiagnosticsOpt != null)
+            {
+                AddDiagnostics_NoLock(_nonLocalDiagnosticsOpt, analysisScope, builder);
+            }
+
+            return builder.ToImmutableArray();
+        }
+
+        private static void AddAllLocalDiagnostics_NoLock(
+            Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> localDiagnostics,
+            AnalysisScope analysisScope,
+            ImmutableArray<Diagnostic>.Builder builder)
+        {
+            if (localDiagnostics != null)
+            {
+                foreach (var localDiagsByTree in localDiagnostics.Values)
+                {
+                    AddDiagnostics_NoLock(localDiagsByTree, analysisScope, builder);
+                }
+            }
+        }
+
+        private static void AddLocalDiagnosticsForPartialAnalysis_NoLock(
+            Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> localDiagnostics,
+            AnalysisScope analysisScope,
+            ImmutableArray<Diagnostic>.Builder builder)
+        {
+            Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder> diagnosticsForTree;
+            if (localDiagnostics != null && localDiagnostics.TryGetValue(analysisScope.FilterTreeOpt, out diagnosticsForTree))
+            {
+                AddDiagnostics_NoLock(diagnosticsForTree, analysisScope, builder);
+            }
+        }
+
+        private static void AddDiagnostics_NoLock(
+            Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder> diagnostics,
+            AnalysisScope analysisScope,
+            ImmutableArray<Diagnostic>.Builder builder)
+        {
+            Debug.Assert(diagnostics != null);
+
+            foreach (var analyzer in analysisScope.Analyzers)
+            {
+                ImmutableArray<Diagnostic>.Builder diagnosticsByAnalyzer;
+                if (diagnostics.TryGetValue(analyzer, out diagnosticsByAnalyzer))
+                {
+                    builder.AddRange(diagnosticsByAnalyzer);
+                }
+            }
+        }
+
+        internal AnalysisResult ToAnalysisResult(ImmutableArray<DiagnosticAnalyzer> analyzers, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            ImmutableDictionary<SyntaxTree, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>> localSyntaxDiagnostics;
+            ImmutableDictionary<SyntaxTree, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>> localSemanticDiagnostics;
+            ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>> nonLocalDiagnostics;
+
+            var analyzersSet = analyzers.ToImmutableHashSet();
+            lock (_gate)
+            {
+                localSyntaxDiagnostics = GetImmutable(analyzersSet, _localSyntaxDiagnosticsOpt);
+                localSemanticDiagnostics = GetImmutable(analyzersSet, _localSemanticDiagnosticsOpt);
+                nonLocalDiagnostics = GetImmutable(analyzersSet, _nonLocalDiagnosticsOpt);
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+            var analyzerTelemetryInfo = GetTelemetryInfo(analyzers, cancellationToken);
+            return new AnalysisResult(analyzers, localSyntaxDiagnostics, localSemanticDiagnostics, nonLocalDiagnostics, analyzerTelemetryInfo);
+        }
+
+        private static ImmutableDictionary<SyntaxTree, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>> GetImmutable(
+            ImmutableHashSet<DiagnosticAnalyzer> analyzers,
+            Dictionary<SyntaxTree, Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder>> localDiagnosticsOpt)
+        {
+            if (localDiagnosticsOpt == null)
+            {
+                return ImmutableDictionary<SyntaxTree, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>>.Empty;
+            }
+
+            var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>>();
+            var perTreeBuilder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>();
+
+            foreach (var diagnosticsByTree in localDiagnosticsOpt)
+            {
+                var tree = diagnosticsByTree.Key;
+                foreach (var diagnosticsByAnalyzer in diagnosticsByTree.Value)
+                {
+                    if (analyzers.Contains(diagnosticsByAnalyzer.Key))
+                    {
+                        perTreeBuilder.Add(diagnosticsByAnalyzer.Key, diagnosticsByAnalyzer.Value.ToImmutable());
+                    }
+                }
+
+                builder.Add(tree, perTreeBuilder.ToImmutable());
+                perTreeBuilder.Clear();
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>> GetImmutable(
+            ImmutableHashSet<DiagnosticAnalyzer> analyzers,
+            Dictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>.Builder> nonLocalDiagnosticsOpt)
+        {
+            if (nonLocalDiagnosticsOpt == null)
+            {
+                return ImmutableDictionary<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>.Empty;
+            }
+
+            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, ImmutableArray<Diagnostic>>();
+            foreach (var diagnosticsByAnalyzer in nonLocalDiagnosticsOpt)
+            {
+                if (analyzers.Contains(diagnosticsByAnalyzer.Key))
+                {
+                    builder.Add(diagnosticsByAnalyzer.Key, diagnosticsByAnalyzer.Value.ToImmutable());
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo> GetTelemetryInfo(
+            ImmutableArray<DiagnosticAnalyzer> analyzers,
+            CancellationToken cancellationToken)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<DiagnosticAnalyzer, AnalyzerTelemetryInfo>();
+
+            lock (_gate)
+            {
+                foreach (var analyzer in analyzers)
+                {
+                    var actionCounts = _analyzerActionCounts[analyzer];
+                    var executionTime = _analyzerExecutionTimeOpt != null ? _analyzerExecutionTimeOpt[analyzer] : default(TimeSpan);
+                    var telemetryInfo = new AnalyzerTelemetryInfo(actionCounts, executionTime);
+                    builder.Add(analyzer, telemetryInfo);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisScope.cs
@@ -44,28 +44,30 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public bool IsTreeAnalysis => FilterTreeOpt != null;
 
         public AnalysisScope(Compilation compilation, ImmutableArray<DiagnosticAnalyzer> analyzers, bool concurrentAnalysis, bool categorizeDiagnostics)
+            : this (compilation.SyntaxTrees, analyzers, filterTreeOpt: null, filterSpanOpt: null, isSyntaxOnlyTreeAnalysis: false, concurrentAnalysis: concurrentAnalysis, categorizeDiagnostics: categorizeDiagnostics)
         {
-            SyntaxTrees = compilation.SyntaxTrees;
-            Analyzers = analyzers;
-            ConcurrentAnalysis = concurrentAnalysis;
-            CategorizeDiagnostics = categorizeDiagnostics;
-
-            FilterTreeOpt = null;
-            FilterSpanOpt = null;
-            IsSyntaxOnlyTreeAnalysis = false;
         }
 
         public AnalysisScope(ImmutableArray<DiagnosticAnalyzer> analyzers, SyntaxTree filterTree, TextSpan? filterSpan, bool syntaxAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
+            : this (SpecializedCollections.SingletonEnumerable(filterTree), analyzers, filterTree, filterSpan, syntaxAnalysis, concurrentAnalysis, categorizeDiagnostics)
         {
             Debug.Assert(filterTree != null);
+        }
 
-            SyntaxTrees = SpecializedCollections.SingletonEnumerable(filterTree);
+        private AnalysisScope(IEnumerable<SyntaxTree> trees, ImmutableArray<DiagnosticAnalyzer> analyzers, SyntaxTree filterTreeOpt, TextSpan? filterSpanOpt, bool isSyntaxOnlyTreeAnalysis, bool concurrentAnalysis, bool categorizeDiagnostics)
+        {
+            SyntaxTrees = trees;
             Analyzers = analyzers;
-            FilterTreeOpt = filterTree;
-            FilterSpanOpt = filterSpan;
-            IsSyntaxOnlyTreeAnalysis = syntaxAnalysis;
+            FilterTreeOpt = filterTreeOpt;
+            FilterSpanOpt = filterSpanOpt;
+            IsSyntaxOnlyTreeAnalysis = isSyntaxOnlyTreeAnalysis;
             ConcurrentAnalysis = concurrentAnalysis;
             CategorizeDiagnostics = categorizeDiagnostics;
+        }
+
+        public AnalysisScope WithAnalyzers(ImmutableArray<DiagnosticAnalyzer> analyzers)
+        {
+            return new AnalysisScope(SyntaxTrees, analyzers, FilterTreeOpt, FilterSpanOpt, IsSyntaxOnlyTreeAnalysis, ConcurrentAnalysis, CategorizeDiagnostics);
         }
 
         public static bool ShouldSkipSymbolAnalysis(SymbolDeclaredCompilationEvent symbolEvent)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalysisState.cs
@@ -431,9 +431,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        internal async Task<AnalyzerActionCounts> GetAnalyzerActionCountsAsync(DiagnosticAnalyzer analyzer, AnalyzerDriver driver, CancellationToken cancellationToken)
+        internal async Task<AnalyzerActionCounts> GetOrComputeAnalyzerActionCountsAsync(DiagnosticAnalyzer analyzer, AnalyzerDriver driver, CancellationToken cancellationToken)
         {
             await EnsureAnalyzerActionCountsInitializedAsync(driver, cancellationToken).ConfigureAwait(false);
+            return _lazyAnalyzerActionCountsMap[analyzer];
+        }
+
+        internal AnalyzerActionCounts GetAnalyzerActionCounts(DiagnosticAnalyzer analyzer)
+        {
+            Debug.Assert(_lazyAnalyzerActionCountsMap != null);
             return _lazyAnalyzerActionCountsMap[analyzer];
         }
 

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1186,8 +1186,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public void Dispose()
         {
-            this.CompilationEventQueue.TryComplete();
-            this.DiagnosticQueue.TryComplete();
+            this.CompilationEventQueue?.TryComplete();
+            this.DiagnosticQueue?.TryComplete();
             _queueRegistration.Dispose();
         }
     }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,15 @@
 Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.AnalyzerTelemetryInfo.get -> System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.Analyzers.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.CompilationDiagnostics.get -> System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.GetAllDiagnostics() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.GetAllDiagnostics(Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer analyzer) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.SemanticDiagnostics.get -> System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.SyntaxTree, System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>>
+Microsoft.CodeAnalysis.Diagnostics.AnalysisResult.SyntaxDiagnostics.get -> System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.SyntaxTree, System.Collections.Immutable.ImmutableDictionary<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic>>>
 Microsoft.CodeAnalysis.Diagnostics.CompilationStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzer> analyzers, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
+Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
 Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext
 Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext.CancellationToken.get -> System.Threading.CancellationToken
 Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext.Compilation.get -> Microsoft.CodeAnalysis.Compilation

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1644,9 +1644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If _lazyCompilationUnitCompletedTrees.Count = SyntaxTrees.Length Then
                         ' if that was the last tree, signal the end of compilation
-                        EventQueue.TryEnqueue(New CompilationCompletedEvent(Me))
-                        EventQueue.PromiseNotToEnqueue()
-                        EventQueue.TryComplete()
+                        EnsureCompilationCompleted()
                     End If
                 End If
             End SyncLock
@@ -1925,6 +1923,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 builder.AddRange(GetBoundReferenceManager().Diagnostics)
                 builder.AddRange(SourceAssembly.GetAllDeclarationErrors(cancellationToken))
                 builder.AddRange(GetClsComplianceDiagnostics(cancellationToken))
+
+                If Me.EventQueue IsNot Nothing AndAlso Me.SyntaxTrees.Length = 0 Then
+                    EnsureCompilationCompleted()
+                End If
             End If
 
             ' Add method body compilation errors.

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1644,7 +1644,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     If _lazyCompilationUnitCompletedTrees.Count = SyntaxTrees.Length Then
                         ' if that was the last tree, signal the end of compilation
-                        EnsureCompilationCompleted()
+                        CompleteCompilationEventQueue_NoLock()
                     End If
                 End If
             End SyncLock
@@ -1924,8 +1924,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 builder.AddRange(SourceAssembly.GetAllDeclarationErrors(cancellationToken))
                 builder.AddRange(GetClsComplianceDiagnostics(cancellationToken))
 
-                If Me.EventQueue IsNot Nothing AndAlso Me.SyntaxTrees.Length = 0 Then
-                    EnsureCompilationCompleted()
+                If EventQueue IsNot Nothing AndAlso SyntaxTrees.Length = 0 Then
+                    EnsureCompilationEventQueueCompleted()
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/GetDiagnosticsTests.vb
@@ -255,5 +255,15 @@ End Namespace
 
             Return True
         End Function
+
+        <Fact>
+        Public Sub TestEventQueueCompletionForEmptyCompilation()
+            Dim compilation = CreateCompilationWithMscorlib45(SpecializedCollections.EmptyEnumerable(Of SyntaxTree)()).WithEventQueue(New AsyncQueue(Of CompilationEvent)())
+
+            ' Force complete compilation event queue
+            Dim unused = compilation.GetDiagnostics()
+
+            Assert.True(compilation.EventQueue.IsCompleted)
+        End Sub
     End Class
 End Namespace

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticAnalyzerDriver.cs
@@ -336,7 +336,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
                 var compilation = await _project.GetCompilationAsync(_cancellationToken).ConfigureAwait(false);
                 var compilationWithAnalyzers = GetCompilationWithAnalyzers(compilation);
-                var compilationDiagnostics = await compilationWithAnalyzers.GetAnalyzerCompilationDiagnosticsAsync(ImmutableArray.Create(analyzer), _cancellationToken).ConfigureAwait(false);
+                var analysisResult = await compilationWithAnalyzers.GetAnalysisResultAsync(ImmutableArray.Create(analyzer), _cancellationToken).ConfigureAwait(false);
+                var compilationDiagnostics = analysisResult.CompilationDiagnostics.Count == 1 ? analysisResult.CompilationDiagnostics[analyzer] : ImmutableArray<Diagnostic>.Empty;
                 await UpdateAnalyzerTelemetryDataAsync(analyzer, compilationWithAnalyzers).ConfigureAwait(false);
                 diagnostics.AddRange(compilationDiagnostics);
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -412,26 +412,42 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
                     return;
                 }
 
+                // PERF: Ensure that we explicitly ignore the skipped analyzers while creating the analyzer driver, otherwise we might end up running hidden analyzers on closed files.
+                var stateSets = _stateManager.GetOrUpdateStateSets(project).ToImmutableArray();
+                var skipAnalyzersMap = new Dictionary<DiagnosticAnalyzer, bool>(stateSets.Length);
+                var shouldRunAnalyzersMap = new Dictionary<DiagnosticAnalyzer, bool>(stateSets.Length);
+                var analyzersBuilder = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>(stateSets.Length);
+                foreach (var stateSet in stateSets)
+                {
+                    var skip = await SkipRunningAnalyzerAsync(project, stateSet.Analyzer, openedDocument: false, skipClosedFileCheck: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    skipAnalyzersMap.Add(stateSet.Analyzer, skip);
+
+                    var shouldRun = !skip && ShouldRunAnalyzerForStateType(stateSet.Analyzer, StateType.Project, diagnosticIds: null);
+                    shouldRunAnalyzersMap.Add(stateSet.Analyzer, shouldRun);
+
+                    if (shouldRun)
+                    {
+                        analyzersBuilder.Add(stateSet.Analyzer);
+                    }
+                }
+
+                var analyzerDriver = new DiagnosticAnalyzerDriver(project, this, analyzersBuilder.ToImmutable(), ConcurrentAnalysis, ReportSuppressedDiagnostics, cancellationToken);
+
                 var projectTextVersion = await project.GetLatestDocumentVersionAsync(cancellationToken).ConfigureAwait(false);
                 var semanticVersion = await project.GetDependentSemanticVersionAsync(cancellationToken).ConfigureAwait(false);
                 var projectVersion = await project.GetDependentVersionAsync(cancellationToken).ConfigureAwait(false);
-
                 var versions = new VersionArgument(projectTextVersion, semanticVersion, projectVersion);
-
-                var stateSets = _stateManager.GetOrUpdateStateSets(project);
-                var analyzers = stateSets.Select(s => s.Analyzer);
-                var analyzerDriver = new DiagnosticAnalyzerDriver(project, this, analyzers, ConcurrentAnalysis, ReportSuppressedDiagnostics, cancellationToken);
 
                 foreach (var stateSet in stateSets)
                 {
                     // Compilation actions can report diagnostics on open files, so we skipClosedFileChecks.
-                    if (await SkipRunningAnalyzerAsync(project, stateSet.Analyzer, openedDocument: false, skipClosedFileCheck: true, cancellationToken: cancellationToken).ConfigureAwait(false))
+                    if (skipAnalyzersMap[stateSet.Analyzer])
                     {
                         await ClearExistingDiagnostics(project, stateSet, cancellationToken).ConfigureAwait(false);
                         continue;
                     }
 
-                    if (ShouldRunAnalyzerForStateType(stateSet.Analyzer, StateType.Project, diagnosticIds: null))
+                    if (shouldRunAnalyzersMap[stateSet.Analyzer])
                     {
                         var data = await _executor.GetProjectAnalysisDataAsync(analyzerDriver, stateSet, versions).ConfigureAwait(false);
                         if (data.FromCache)


### PR DESCRIPTION
…rDiagnosticsAsync and add new public APIs 'GetAnalysisResultAsync' to fetch the entire analysis result with diagnostics categorized by kind (syntax, semantic, compilation), tree and analyzer.

Now only the partial analysis APIs (GetAnalyzerSyntaxDiagnosticsAsync, GetAnalyzerSemanticDiagnosticsAsync and GetAnalyzerCompilationDiagnosticsAsync) do analyzer state tracking. Rest of the APIs execute analyzers without state tracking, improving overall performance.

Fixes https://github.com/dotnet/roslyn/issues/10530