### PR TITLE
some code clean up and made active and project state to be merged when a file is closed

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     {
                         // if not all version is same, set version as default.
                         // this can happen at the initial data loading or
-                        // when document is closed and we put active file state to project state (not implemented yet)
+                        // when document is closed and we put active file state to project state
                         version = VersionStamp.Default;
                     }
 

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -122,15 +122,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                     if (!version.HasValue)
                     {
-                        if (result.Version != VersionStamp.Default)
-                        {
-                            version = result.Version;
-                        }
+                        version = result.Version;
                     }
-                    else
+                    else if (version.Value != VersionStamp.Default && version.Value != result.Version)
                     {
-                        // all version must be same or default (means not there yet)
-                        Contract.Requires(version == result.Version || result.Version == VersionStamp.Default);
+                        // if not all version is same, set version as default.
+                        // this can happen at the initial data loading or
+                        // when document is closed and we put active file state to project state (not implemented yet)
+                        version = VersionStamp.Default;
                     }
 
                     builder.Add(stateSet.Analyzer, result);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
@@ -151,23 +152,25 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 return stateSets.ToImmutable();
             }
 
-            public bool OnDocumentReset(IEnumerable<StateSet> stateSets, DocumentId documentId)
+            public async Task<bool> OnDocumentResetAsync(IEnumerable<StateSet> stateSets, Document document)
             {
+                // can not be cancelled
                 var removed = false;
                 foreach (var stateSet in stateSets)
                 {
-                    removed |= stateSet.OnDocumentReset(documentId);
+                    removed |= await stateSet.OnDocumentResetAsync(document).ConfigureAwait(false);
                 }
 
                 return removed;
             }
 
-            public bool OnDocumentClosed(IEnumerable<StateSet> stateSets, DocumentId documentId)
+            public async Task<bool> OnDocumentClosedAsync(IEnumerable<StateSet> stateSets, Document document)
             {
+                // can not be cancelled
                 var removed = false;
                 foreach (var stateSet in stateSets)
                 {
-                    removed |= stateSet.OnDocumentClosed(documentId);
+                    removed |= await stateSet.OnDocumentClosedAsync(document).ConfigureAwait(false);
                 }
 
                 return removed;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
@@ -213,6 +216,45 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 default:
                     return Contract.FailWithReturn<ImmutableArray<DiagnosticData>>("shouldn't reach here");
             }
+        }
+
+        public override void LogAnalyzerCountSummary()
+        {
+            DiagnosticAnalyzerLogger.LogAnalyzerCrashCountSummary(_correlationId, DiagnosticLogAggregator);
+            DiagnosticAnalyzerLogger.LogAnalyzerTypeCountSummary(_correlationId, DiagnosticLogAggregator);
+
+            // reset the log aggregator
+            ResetDiagnosticLogAggregator();
+        }
+
+        private static string GetDocumentLogMessage(string title, Document document, DiagnosticAnalyzer analyzer)
+        {
+            return string.Format($"{title}: {document.FilePath ?? document.Name}, {analyzer.ToString()}");
+        }
+
+        private static string GetProjectLogMessage(Project project, IEnumerable<StateSet> stateSets)
+        {
+            return string.Format($"project: {project.FilePath ?? project.Name}, {string.Join(",", stateSets.Select(s => s.Analyzer.ToString()))}");
+        }
+
+        private static string GetResetLogMessage(Document document)
+        {
+            return string.Format($"document close/reset: {document.FilePath ?? document.Name}");
+        }
+
+        private static string GetOpenLogMessage(Document document)
+        {
+            return string.Format($"document open: {document.FilePath ?? document.Name}");
+        }
+
+        private static string GetRemoveLogMessage(DocumentId id)
+        {
+            return string.Format($"document remove: {id.ToString()}");
+        }
+
+        private static string GetRemoveLogMessage(ProjectId id)
+        {
+            return string.Format($"project remove: {id.ToString()}");
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/ExternalErrorDiagnosticUpdateSource.cs
@@ -322,6 +322,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
 
         public void AddNewErrors(DocumentId documentId, DiagnosticData diagnostic)
         {
+            // capture state that will be processed in background thread.
             var state = GetOrCreateInprogressState();
 
             var asyncToken = _listener.BeginAsyncOperation("Document New Errors");
@@ -334,6 +335,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
         public void AddNewErrors(
             ProjectId projectId, HashSet<DiagnosticData> projectErrors, Dictionary<DocumentId, HashSet<DiagnosticData>> documentErrorMap)
         {
+            // capture state that will be processed in background thread
             var state = GetOrCreateInprogressState();
 
             var asyncToken = _listener.BeginAsyncOperation("Project New Errors");


### PR DESCRIPTION
added ETW events similar to v1. added some comments. and made active file's diagnostic data to merged back to project state when the file is closed. this removes flashing between active file and close file stage change.