### PR TITLE
Address backwards compatibility issue with AssemblyInformationalVersionAttribute handling

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceAssemblySymbol.cs
@@ -2181,6 +2181,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.AssemblyInformationalVersionAttribute))
             {
+                Version dummy;
+                string verString = (string)attribute.CommonConstructorArguments[0].Value;
+                if (!VersionHelper.TryParse(verString, version: out dummy))
+                {
+                    Location attributeArgumentSyntaxLocation = attribute.GetAttributeArgumentSyntaxLocation(0, arguments.AttributeSyntaxOpt);
+                    arguments.Diagnostics.Add(ErrorCode.WRN_InvalidVersionFormat, attributeArgumentSyntaxLocation);
+                }
                 arguments.GetOrCreateData<CommonAssemblyWellKnownAttributeData>().AssemblyInformationalVersionAttributeSetting = (string)attribute.CommonConstructorArguments[0].Value;
             }
             else if (attribute.IsTargetAttribute(this, AttributeDescription.SatelliteContractVersionAttribute))

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Assembly.cs
@@ -501,7 +501,7 @@ public class neutral
             string s = @"[assembly: System.Reflection.AssemblyInformationalVersion(""1.2.3garbage"")] public class C {}";
 
             var other = CreateCompilationWithMscorlib(s, options: TestOptions.ReleaseDll);
-            Assert.Empty(other.GetDiagnostics());
+            other.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_InvalidVersionFormat, @"""1.2.3garbage"""));
             Assert.Equal("1.2.3garbage", ((SourceAssemblySymbol)other.Assembly).InformationalVersion);
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/ResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/ResourceTests.cs
@@ -863,7 +863,7 @@ public class Maine
             string expected =
 @"<?xml version=""1.0"" encoding=""utf-16""?>
 <VersionResource Size=""964"">
-  <VS_FIXEDFILEINFO FileVersionMS=""00050006"" FileVersionLS=""00070008"" ProductVersionMS=""00000000"" ProductVersionLS=""00000000"" />
+  <VS_FIXEDFILEINFO FileVersionMS=""00050006"" FileVersionLS=""00070008"" ProductVersionMS=""00010002"" ProductVersionLS=""00030000"" />
   <KeyValuePair Key=""Comments"" Value=""A classic of magical realist literature"" />
   <KeyValuePair Key=""CompanyName"" Value=""MossBrain"" />
   <KeyValuePair Key=""FileDescription"" Value=""One Hundred Years of Solitude"" />

--- a/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
@@ -198,6 +198,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(1, 1, 31073, 0), version);
             Assert.False(VersionHelper.TryParse("1.1.18446744073709551617999999999999999999999999900001.23garbage", out version));
             Assert.Equal(new Version(1, 1, 31073, 23), version);
+            Assert.False(VersionHelper.TryParse("65536.2.65536.1", out version));
+            Assert.Equal(new Version(0, 2, 0, 1), version);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
@@ -186,6 +186,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(new Version(1, 2, 0, 0), version);
             Assert.False(VersionHelper.TryParse("1.-2.3.4", out version));
             Assert.Equal(new Version(1, 0, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1..1.2", out version));
+            Assert.Equal(new Version(1, 0, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.1.65536", out version));
+            Assert.Equal(new Version(1, 1, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.1.1.10000000", out version));
+            Assert.Equal(new Version(1, 1, 1, 38528), version);
+            Assert.False(VersionHelper.TryParse("1.1.18446744073709551617999999999999999999999999900001.1", out version));
+            Assert.Equal(new Version(1, 1, 31073, 1), version);
+            Assert.False(VersionHelper.TryParse("1.1.18446744073709551617999999999999999999999999900001garbage.1", out version));
+            Assert.Equal(new Version(1, 1, 31073, 0), version);
+            Assert.False(VersionHelper.TryParse("1.1.18446744073709551617999999999999999999999999900001.23garbage", out version));
+            Assert.Equal(new Version(1, 1, 31073, 23), version);
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/VersionHelperTests.cs
@@ -88,95 +88,104 @@ namespace Microsoft.CodeAnalysis.UnitTests
         [Fact]
         public void ParseBad()
         {
+            var expected = new Version(0, 0, 0, 0);
             Version version;
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.234.56.7.*", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.234.56.7.1", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("*", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2. *", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.* ", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.*", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.1.*.*", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("   ", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion(null, allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("a", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("********", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("...", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion(".a.b.", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion(".0.1.", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("65535.65535.65535.65535", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("65535.65535.65535.65535", allowWildcard: false, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion(" 1.2.3.4", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1 .2.3.4", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3.4 ", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2.3. 4", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParseAssemblyVersion("1.2. 3.4", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
 
             // U+FF11 FULLWIDTH DIGIT ONE 
             Assert.False(VersionHelper.TryParseAssemblyVersion("\uFF11.\uFF10.\uFF10.\uFF10", allowWildcard: true, version: out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
         }
 
         [Fact]
         public void ParseBad2()
         {
+            var expected = new Version(0, 0, 0, 0);
             Version version;
             Assert.False(VersionHelper.TryParse("", out version));
-            Assert.Null(version);
+            Assert.Equal(expected,version);
             Assert.False(VersionHelper.TryParse(null, out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("a", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("********", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("...", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse(".a.b.", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse(".1.2.", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("1.234.56.7.8", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("*", out version));
-            Assert.Null(version);
-            Assert.False(VersionHelper.TryParse("1.2. 3", out version));
-            Assert.Null(version);
-            Assert.False(VersionHelper.TryParse("1.2.3 ", out version));
-            Assert.Null(version);
-            Assert.False(VersionHelper.TryParse("1.a", out version));
-            Assert.Null(version);
-            Assert.False(VersionHelper.TryParse("1.2.a.b", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
             Assert.False(VersionHelper.TryParse("-1.2.3.4", out version));
-            Assert.Null(version);
-            Assert.False(VersionHelper.TryParse("1.-2.3.4", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
 
             // U+FF11 FULLWIDTH DIGIT ONE 
             Assert.False(VersionHelper.TryParse("\uFF11.\uFF10.\uFF10.\uFF10", out version));
-            Assert.Null(version);
+            Assert.Equal(expected, version);
+        }
+
+        [Fact]
+        public void ParsePartial()
+        {
+            var expected = new Version(0, 0, 0, 0);
+            Version version;
+            Assert.False(VersionHelper.TryParse("1.2. 3", out version));
+            Assert.Equal(new Version(1, 2, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.2.3 ", out version));
+            Assert.Equal(new Version(1, 2, 3, 0), version);
+            Assert.False(VersionHelper.TryParse("1.a", out version));
+            Assert.Equal(new Version(1, 0, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.2.a.b", out version));
+            Assert.Equal(new Version(1, 2, 0, 0), version);
+            Assert.False(VersionHelper.TryParse("1.-2.3.4", out version));
+            Assert.Equal(new Version(1, 0, 0, 0), version);
         }
     }
 }

--- a/src/Compilers/Core/Portable/CvtRes.cs
+++ b/src/Compilers/Core/Portable/CvtRes.cs
@@ -641,16 +641,11 @@ namespace Microsoft.CodeAnalysis
                 //There's nothing guaranteeing that these are n.n.n.n format.
                 //The documentation says that if they're not that format the behavior is undefined.
                 Version fileVersion;
-                if (!VersionHelper.TryParse(_fileVersionContents, version: out fileVersion))
-                {
-                    fileVersion = new Version(0, 0, 0, 0);
-                }
+                VersionHelper.TryParse(_fileVersionContents, version: out fileVersion);
+
 
                 Version productVersion;
-                if (!VersionHelper.TryParse(_productVersionContents, version: out productVersion))
-                {
-                    productVersion = new Version(0, 0, 0, 0);
-                }
+                VersionHelper.TryParse(_productVersionContents, version: out productVersion);
 
                 writer.Write((DWORD)0xFEEF04BD);
                 writer.Write((DWORD)0x00010000);

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CodeAnalysis
         /// Parses a version string of the form "major [ '.' minor [ '.' build [ '.' revision ] ] ]".
         /// </summary>
         /// <param name="s">The version string to parse.</param>
-        /// <param name="version">If parsing succeeds, the parsed version. Null otherwise.</param>
+        /// <param name="version">If parsing succeeds, the parsed version. Otherwise a version that represents as much of the input as could be parsed successfully.</param>
         /// <returns>True when parsing succeeds completely (i.e. every character in the string was consumed), false otherwise.</returns>
         internal static bool TryParse(string s, out Version version)
         {
-            return TryParse(s, allowWildcard: false, maxValue: ushort.MaxValue, version: out version);
+            return TryParse(s, allowWildcard: false, maxValue: ushort.MaxValue, allowPartialParse: true, version: out version);
         }
 
         /// <summary>
@@ -26,13 +26,13 @@ namespace Microsoft.CodeAnalysis
         /// <param name="s">The version string to parse.</param>
         /// <param name="allowWildcard">Indicates whether or not a wildcard is accepted as the terminal component.</param>
         /// <param name="version">
-        /// If parsing succeeded, the parsed version. Null otherwise.
+        /// If parsing succeeded, the parsed version. Otherwise a version instance with all parts set to zero.
         /// If <paramref name="s"/> contains * the version build and/or revision numbers are set to <see cref="ushort.MaxValue"/>.
         /// </param>
         /// <returns>True when parsing succeeds completely (i.e. every character in the string was consumed), false otherwise.</returns>
         internal static bool TryParseAssemblyVersion(string s, bool allowWildcard, out Version version)
         {
-            return TryParse(s, allowWildcard: allowWildcard, maxValue: ushort.MaxValue - 1, version: out version);
+            return TryParse(s, allowWildcard: allowWildcard, maxValue: ushort.MaxValue - 1, allowPartialParse: false, version: out version);
         }
 
         /// <summary>
@@ -42,18 +42,19 @@ namespace Microsoft.CodeAnalysis
         /// <param name="s">The version string to parse.</param>
         /// <param name="allowWildcard">Indicates whether or not we're parsing an assembly version string. If so, wildcards are accepted and each component must be less than 65535.</param>
         /// <param name="maxValue">The maximum value that a version component may have.</param>
+        /// <param name="allowPartialParse">Allow the parsing of version elements where invalid characters exist. e.g. 1.2.2a.1</param>
         /// <param name="version">
-        /// If parsing succeeded, the parsed version. Null otherwise. 
+        /// If parsing succeeded, the parsed version. When <paramref name="allowPartialParse"/> is true a version with values up to the first invalid character set. Otherwise a version with all parts set to zero.
         /// If <paramref name="s"/> contains * and wildcard is allowed the version build and/or revision numbers are set to <see cref="ushort.MaxValue"/>.
         /// </param>
         /// <returns>True when parsing succeeds completely (i.e. every character in the string was consumed), false otherwise.</returns>
-        private static bool TryParse(string s, bool allowWildcard, ushort maxValue, out Version version)
+        private static bool TryParse(string s, bool allowWildcard, ushort maxValue, bool allowPartialParse, out Version version)
         {
             Debug.Assert(!allowWildcard || maxValue < ushort.MaxValue);
 
-            if (s == null)
+            if (string.IsNullOrWhiteSpace(s))
             {
-                version = null;
+                version = new Version(0, 0, 0, 0);
                 return false;
             }
 
@@ -65,18 +66,43 @@ namespace Microsoft.CodeAnalysis
 
             if ((hasWildcard && elements.Length < 3) || elements.Length > 4)
             {
-                version = null;
+                version = new Version(0, 0, 0, 0);
                 return false;
             }
 
             ushort[] values = new ushort[4];
             int lastExplicitValue = hasWildcard ? elements.Length - 1 : elements.Length;
+            bool parseError = false;
             for (int i = 0; i < lastExplicitValue; i++)
             {
-                if (!ushort.TryParse(elements[i], NumberStyles.None, CultureInfo.InvariantCulture, out values[i]) || values[i] > maxValue)
+                
+                if (allowPartialParse)
                 {
-                    version = null;
-                    return false;
+                    //Shorten the version string until we are at the shortest possible string that can be represented as a ushort
+                    while (!ushort.TryParse(elements[i], NumberStyles.None, CultureInfo.InvariantCulture, out values[i]))
+                    {
+                        parseError = true;
+                        if (elements[i].Length <= 1)
+                        {
+                            break;
+                        }
+
+                        elements[i] = elements[i].Substring(0, elements[i].Length - 1);
+                    }
+                }
+                else
+                {
+                    if (!ushort.TryParse(elements[i], NumberStyles.None, CultureInfo.InvariantCulture, out values[i]) || values[i] > maxValue)
+                    {
+                        version = new Version(0, 0, 0, 0);
+                        return false;
+                    }
+                }
+
+                if (parseError)
+                {
+                    //Don't process any more of the version elements
+                    break;
                 }
             }
 
@@ -89,7 +115,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             version = new Version(values[0], values[1], values[2], values[3]);
-            return true;
+            return !parseError;
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -86,10 +86,19 @@ namespace Microsoft.CodeAnalysis
 
                     parseError = true;
 
-                    if (values[i] > maxValue || string.IsNullOrWhiteSpace(elements[i]))
+                    if (string.IsNullOrWhiteSpace(elements[i]))
                     {
                         values[i] = 0;
                         break;
+                    }
+
+                    
+                    if(values[i] > maxValue)
+                    {
+                        //The only way this can happen is if the value was 65536
+                        //The old compiler would continue parsing from here
+                        values[i] = 0;
+                        continue;
                     }
 
                     bool invalidFormat = false;

--- a/src/Compilers/Core/Portable/VersionHelper.cs
+++ b/src/Compilers/Core/Portable/VersionHelper.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis
 
             if (string.IsNullOrWhiteSpace(s))
             {
-                version = new Version(0, 0, 0, 0);
+                version = AssemblyIdentity.NullVersion;
                 return false;
             }
 
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis
 
             if ((hasWildcard && elements.Length < 3) || elements.Length > 4)
             {
-                version = new Version(0, 0, 0, 0);
+                version = AssemblyIdentity.NullVersion;
                 return false;
             }
 
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis
                 {
                     if (!allowPartialParse)
                     {
-                        version = new Version(0, 0, 0, 0);
+                        version = AssemblyIdentity.NullVersion;
                         return false;
                     }
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceAssemblySymbol.vb
@@ -1021,6 +1021,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyFileVersionAttributeSetting = verString
+            ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyInformationalVersionAttribute) Then
+                Dim dummy As Version = Nothing
+                Dim verString = DirectCast(attrData.CommonConstructorArguments(0).Value, String)
+                If Not VersionHelper.TryParse(verString, version:=dummy) Then
+                    arguments.Diagnostics.Add(ERRID.WRN_InvalidVersionFormat, GetAssemblyAttributeFirstArgumentLocation(arguments.AttributeSyntaxOpt))
+                End If
+
+                arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyInformationalVersionAttributeSetting = verString
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyTitleAttribute) Then
                 arguments.GetOrCreateData(Of CommonAssemblyWellKnownAttributeData)().AssemblyTitleAttributeSetting = DirectCast(attrData.CommonConstructorArguments(0).Value, String)
             ElseIf attrData.IsTargetAttribute(Me, AttributeDescription.AssemblyDescriptionAttribute) Then

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AssemblyAttributes.vb
@@ -736,7 +736,11 @@ End Class
 ]]>
     </file>
 </compilation>, OutputKind.DynamicallyLinkedLibrary)
-        Assert.Empty(other.GetDiagnostics())
+        CompilationUtils.AssertTheseDiagnostics(other,
+<error><![CDATA[
+BC42366: The specified version string does not conform to the recommended format - major.minor.build.revision
+<Assembly: System.Reflection.AssemblyInformationalVersion("1.2.3garbage")>
+                                                          ~~~~~~~~~~~~~~]]></error>)
         Assert.Equal("1.2.3garbage", DirectCast(other.Assembly, SourceAssemblySymbol).InformationalVersion)
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/ResourceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/ResourceTests.vb
@@ -348,7 +348,7 @@ End Module
             Dim expected As String =
 "<?xml version=""1.0"" encoding=""utf-16""?>" & vbCrLf &
 "<VersionResource Size=""964"">" & vbCrLf &
-"  <VS_FIXEDFILEINFO FileVersionMS=""00050006"" FileVersionLS=""00070008"" ProductVersionMS=""00000000"" ProductVersionLS=""00000000"" />" & vbCrLf &
+"  <VS_FIXEDFILEINFO FileVersionMS=""00050006"" FileVersionLS=""00070008"" ProductVersionMS=""00010002"" ProductVersionLS=""00030000"" />" & vbCrLf &
 "  <KeyValuePair Key=""Comments"" Value=""A classic of magical realist literature"" />" & vbCrLf &
 "  <KeyValuePair Key=""CompanyName"" Value=""MossBrain"" />" & vbCrLf &
 "  <KeyValuePair Key=""FileDescription"" Value=""One Hundred Years of Solitude"" />" & vbCrLf &


### PR DESCRIPTION
Make compiler produce the same Product Build, Major, Minor and Private Parts in VersionInfo as VS2013 compiler when Assembly ProductAssemblyFileVersionAttribute and AssemblyInformationalVersion contain invalid format.

Also introduce warning diagnostic for AssemblyInformationalVersion with invalid version string.

This addresses issue #5098