### PR TITLE
Move groovy to dotnet-ci standard functions

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -57,31 +57,6 @@ static void addWrappers(def myJob) {
   }
 }
 
-static void addArtifactArchiving(def myJob, String patternString, String excludeString) {
-  myJob.with {
-    publishers {
-      flexiblePublish {
-        conditionalAction {
-          condition {
-            status('ABORTED', 'FAILURE')
-          }
-
-          publishers {
-            archiveArtifacts {
-              allowEmpty(true)
-              defaultExcludes(false)
-              exclude(excludeString)
-              fingerprint(false)
-              onlyIfSuccessful(false)
-              pattern(patternString)
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
 static void addEmailPublisher(def myJob) {
   myJob.with {
     publishers {
@@ -173,7 +148,7 @@ static void addStandardJob(def myJob, String jobName, String branchName, String 
 
   def includePattern = "Binaries/**/*.pdb,Binaries/**/*.xml,Binaries/**/*.log,Binaries/**/*.dmp,Binaries/**/*.zip,Binaries/**/*.png,Binaries/**/*.xml"
   def excludePattern = "Binaries/Obj/**,Binaries/Bootstrap/**,Binaries/**/nuget*.zip"
-  addArtifactArchiving(myJob, includePattern, excludePattern)
+  Utilities.addArchival(myJob, includePattern, excludePattern)
 
   if (branchName == 'prtest') {
     addPullRequestTrigger(myJob, jobName, triggerPhrase, triggerPhraseOnly);

--- a/netci.groovy
+++ b/netci.groovy
@@ -30,7 +30,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, String tr
   Utilities.addArchival(myJob, includePattern, excludePattern)
 
   // Create the standard job.  This will setup parameter, SCM, timeout, etc ...
-  def isPr = branchName = 'prtest'
+  def isPr = branchName == 'prtest'
   def defaultBranch = "*/${branchName}"
   Utilities.standardJobSetup(myJob, jobName, isPr, defaultBranch)
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -22,17 +22,9 @@ static void addLogRotator(def myJob) {
   }
 }
 
-static void addConcurrentBuild(def myJob, String category) {
+static void addConcurrentBuild(def myJob) {
   myJob.with {
-    concurrentBuild(true)
-    if (category != null)  {
-      throttleConcurrentBuilds {
-        throttleDisabled(false)
-        maxTotal(0)
-        maxPerNode(1)
-        categories([category])
-      }
-    }
+    concurrentBuild()
   }
 }
 
@@ -237,7 +229,7 @@ set TMP=%TEMP%
                 }
                 Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto')
                 // Generic throttling for Windows, no category
-                addConcurrentBuild(myJob, null)
+                addConcurrentBuild(myJob)
                 break;
               case 'linux':
                 myJob.with {
@@ -246,7 +238,7 @@ set TMP=%TEMP%
                     shell("./cibuild.sh --nocache --debug")
                   }
                 }
-                addConcurrentBuild(myJob, 'roslyn/lin/unit')
+                addConcurrentBuild(myJob)
                 break;
               case 'mac':
                 myJob.with {
@@ -255,7 +247,7 @@ set TMP=%TEMP%
                     shell("./cibuild.sh --nocache --debug")
                   }
                 }
-                addConcurrentBuild(myJob, 'roslyn/mac/unit')
+                addConcurrentBuild(myJob)
                 triggerPhraseOnly = true;
                 break;
             }
@@ -284,7 +276,7 @@ set TMP=%TEMP%
   }
 
   Utilities.setMachineAffinity(determinismJob, 'Windows_NT', 'latest-or-auto')
-  addConcurrentBuild(determinismJob, null)
+  addConcurrentBuild(determinismJob)
   addStandardJob(determinismJob, determinismJobName, branchName,  "(?i).*test\\W+determinism.*", true);
 }
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -57,50 +57,13 @@ static void addWrappers(def myJob) {
   }
 }
 
+// Email the results of aborted / failed jobs to our infrastructure alias
 static void addEmailPublisher(def myJob) {
   myJob.with {
     publishers {
       extendedEmail('$DEFAULT_RECIPIENTS, cc:mlinfraswat@microsoft.com', '$DEFAULT_SUBJECT', '$DEFAULT_CONTENT') {
         trigger('Aborted', '$PROJECT_DEFAULT_SUBJECT', '$PROJECT_DEFAULT_CONTENT', null, true, true, true, true)
         trigger('Failure', '$PROJECT_DEFAULT_SUBJECT', '$PROJECT_DEFAULT_CONTENT', null, true, true, true, true)
-      }
-    }
-  }
-}
-
-static void addUnitPublisher(def myJob) {
-  myJob.with {
-    configure { node ->
-      node / 'publishers' << {
-      'xunit'('plugin': 'xunit@1.97') {
-      'types' {
-        'XUnitDotNetTestType' {
-          'pattern'('**/xUnitResults/*.xml')
-            'skipNoTestFiles'(false)
-            'failIfNotNew'(true)
-            'deleteOutputFiles'(true)
-            'stopProcessingIfError'(true)
-          }
-        }
-        'thresholds' {
-          'org.jenkinsci.plugins.xunit.threshold.FailedThreshold' {
-            'unstableThreshold'('')
-            'unstableNewThreshold'('')
-            'failureThreshold'('0')
-            'failureNewThreshold'('')
-          }
-          'org.jenkinsci.plugins.xunit.threshold.SkippedThreshold' {
-              'unstableThreshold'('')
-              'unstableNewThreshold'('')
-              'failureThreshold'('')
-              'failureNewThreshold'('')
-            }
-          }
-          'thresholdMode'('1')
-          'extraConfiguration' {
-            testTimeMargin('3000')
-          }
-        }
       }
     }
   }
@@ -227,8 +190,8 @@ set TMP=%TEMP%
                 break;
             }
 
-            addUnitPublisher(myJob)
-            addStandardJob(myJob, jobName, branchName, triggerPhrase, triggerPhraseOnly);
+            Utilities.addXUnitDotNETResults(myJob, '**/xUnitResults/*.xml')
+            addStandardJob(myJob, jobName, branchName, triggerPhrase, triggerPhraseOnly)
           }
         }
       }

--- a/netci.groovy
+++ b/netci.groovy
@@ -87,7 +87,6 @@ set TMP=%TEMP%
                 }
                 Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto')
                 // Generic throttling for Windows, no category
-                addConcurrentBuild(myJob)
                 break;
               case 'linux':
                 myJob.with {
@@ -96,7 +95,6 @@ set TMP=%TEMP%
                     shell("./cibuild.sh --nocache --debug")
                   }
                 }
-                addConcurrentBuild(myJob)
                 break;
               case 'mac':
                 myJob.with {
@@ -105,7 +103,6 @@ set TMP=%TEMP%
                     shell("./cibuild.sh --nocache --debug")
                   }
                 }
-                addConcurrentBuild(myJob)
                 triggerPhraseOnly = true;
                 break;
             }
@@ -134,7 +131,6 @@ set TMP=%TEMP%
   }
 
   Utilities.setMachineAffinity(determinismJob, 'Windows_NT', 'latest-or-auto')
-  addConcurrentBuild(determinismJob)
   addRoslynJob(determinismJob, determinismJobName, branchName,  "(?i).*test\\W+determinism.*", true);
 }
 


### PR DESCRIPTION
Our groovy script had significantly diverged from the standard definitions of dotnet-ci.  This meant we were behind today and unable to take advantage of many planned changes to the system.  As a first step of getting back into step with the rest of DevDiv I switched our groovy script to call into all of the standard functions instead of the copy / paste ones that we had. 

Next step will be to move Roslyn to use folders.  Small compared to this one.

Intent is to push this today so I can deal with the fallout tonight and have everything up and running again on Monday. 