### PR TITLE
Update Solution.GetProject(IAssemblySymbol) [Fixes unit test flakiness]

### DIFF
--- a/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
+++ b/src/EditorFeatures/Test2/GoToDefinition/GoToDefinitionTests.vb
@@ -1594,8 +1594,9 @@ End Module
             Await TestAsync(workspace)
         End Function
 
+        <WorkItem(10132, "https://github.com/dotnet/roslyn/issues/10132")>
         <WorkItem(545661, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545661")>
-        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/10132"), Trait(Traits.Feature, Traits.Features.GoToDefinition)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.GoToDefinition)>
         Public Async Function TestCrossLanguageParameterizedPropertyOverride() As Task
             Dim workspace =
 <Workspace>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -327,14 +327,15 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Project GetProject(IAssemblySymbol assemblySymbol, CancellationToken cancellationToken = default(CancellationToken))
         {
-            Compilation compilation;
-            ProjectId id;
+            if (assemblySymbol == null)
+            {
+                return null;
+            }
 
-            // The symbol must be from one of the compilations already built.
-            // if the symbol is a source symbol then one of the compilations must be its source
-            // if the symbol is metadata then one of the compilations must have a reference to it's metadata assembly.
+            // TODO: Remove this loop when we add source assembly symbols to s_assemblyOrModuleSymbolToProjectMap
             foreach (var state in _projectIdToProjectStateMap.Values)
             {
+                Compilation compilation;
                 if (this.TryGetCompilation(state.Id, out compilation))
                 {
                     // if the symbol is the compilation's assembly symbol, we are done
@@ -342,19 +343,12 @@ namespace Microsoft.CodeAnalysis
                     {
                         return this.GetProject(state.Id);
                     }
-
-                    // otherwise check to see if this compilation has a metadata reference for this assembly symbol
-                    // and if we know what project that metadata reference is associated with.
-                    var mdref = compilation.GetMetadataReference(assemblySymbol);
-                    if (mdref != null && s_metadataReferenceToProjectMap.TryGetValue(mdref, out id))
-                    {
-                        return this.GetProject(id);
-                    }
                 }
             }
 
-            // no project was found in this solution to be associated with this assembly symbol
-            return null;
+            ProjectId id;
+            s_assemblyOrModuleSymbolToProjectMap.TryGetValue(assemblySymbol, out id);
+            return id == null ? null : this.GetProject(id);
         }
 
         /// <summary>
@@ -2056,18 +2050,28 @@ namespace Microsoft.CodeAnalysis
                 : project.Solution.GetProjectState(project.Id).HasAllInformation ? SpecializedTasks.True : SpecializedTasks.False;
         }
 
-        private static readonly ConditionalWeakTable<MetadataReference, ProjectId> s_metadataReferenceToProjectMap =
-            new ConditionalWeakTable<MetadataReference, ProjectId>();
+        /// <summary>
+        /// Symbols need to be either <see cref="IAssemblySymbol"/> or <see cref="IModuleSymbol"/>.
+        /// </summary>
+        private static readonly ConditionalWeakTable<ISymbol, ProjectId> s_assemblyOrModuleSymbolToProjectMap =
+            new ConditionalWeakTable<ISymbol, ProjectId>();
 
-        private void RecordReferencedProject(MetadataReference reference, ProjectId projectId)
+        private static void RecordSourceOfAssemblySymbol(ISymbol assemblyOrModuleSymbol, ProjectId projectId)
         {
-            // remember which project is associated with this reference
+            if (assemblyOrModuleSymbol == null)
+            {
+                return;
+            }
+
+            Contract.ThrowIfNull(projectId);
+
+            // remember which project is associated with this assembly
             ProjectId tmp;
-            if (!s_metadataReferenceToProjectMap.TryGetValue(reference, out tmp))
+            if (!s_assemblyOrModuleSymbolToProjectMap.TryGetValue(assemblyOrModuleSymbol, out tmp))
             {
                 // use GetValue to avoid race condition exceptions from Add.
                 // the first one to set the value wins.
-                s_metadataReferenceToProjectMap.GetValue(reference, _ => projectId);
+                s_assemblyOrModuleSymbolToProjectMap.GetValue(assemblyOrModuleSymbol, _ => projectId);
             }
             else
             {
@@ -2077,31 +2081,17 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        internal ProjectId GetProjectId(MetadataReference reference)
-        {
-            ProjectId id = null;
-            s_metadataReferenceToProjectMap.TryGetValue(reference, out id);
-            return id;
-        }
-
         /// <summary>
         /// Get a metadata reference for the project's compilation
         /// </summary>
-        internal async Task<MetadataReference> GetMetadataReferenceAsync(ProjectReference projectReference, ProjectState fromProject, CancellationToken cancellationToken)
+        internal Task<MetadataReference> GetMetadataReferenceAsync(ProjectReference projectReference, ProjectState fromProject, CancellationToken cancellationToken)
         {
             try
             {
                 // Get the compilation state for this project.  If it's not already created, then this
                 // will create it.  Then force that state to completion and get a metadata reference to it.
                 var tracker = this.GetCompilationTracker(projectReference.ProjectId);
-                var mdref = await tracker.GetMetadataReferenceAsync(this, fromProject, projectReference, cancellationToken).ConfigureAwait(false);
-
-                if (mdref != null)
-                {
-                    RecordReferencedProject(mdref, projectReference.ProjectId);
-                }
-
-                return mdref;
+                return tracker.GetMetadataReferenceAsync(this, fromProject, projectReference, cancellationToken);
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
@@ -2126,14 +2116,7 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            var mdref = state.GetPartialMetadataReference(this, fromProject, projectReference, cancellationToken);
-
-            if (mdref != null)
-            {
-                RecordReferencedProject(mdref, projectReference.ProjectId);
-            }
-
-            return mdref;
+            return state.GetPartialMetadataReference(this, fromProject, projectReference, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #10132

Adds a map from ISymbol (assembly or module symbols) to ProjectId so we can find projects for skeleton assemblies even after its compilation could have been GC'd.