### PR TITLE
invoke next handler in case if no signature help providers can be fou…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             var allProviders = GetProviders();
             if (allProviders == null)
             {
+                nextHandler();
                 return;
             }
 


### PR DESCRIPTION
…nd (i.e. if document for the text snapshot was not yet created). This become the issue on the TypeScript side, we analyze open files and its references in order to build the transitive closure of sources that contribute to the program. The actual Roslyn project and documents are created after the analysis is finished. As a consequence when analysis in in progress user cannot type anywhere in the file. 