### PR TITLE
invoke next handler in case if no signature help providers can be fou…

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller_TypeChar.cs
@@ -25,6 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
             var allProviders = GetProviders();
             if (allProviders == null)
             {
+                nextHandler();
                 return;
             }
 


### PR DESCRIPTION
…nd (i.e. if document for the text snapshot cannot be found). This PR supersedes #10673 based on offline discussion with @jasonmalinowski 