### PR TITLE
Code Model: Implement IParameterKind legacy interface

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/CSharpCodeModelService.cs
@@ -24,6 +24,7 @@ using Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.MethodXml;
 using Microsoft.VisualStudio.LanguageServices.CSharp.Utilities;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements;
+using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
@@ -1965,6 +1966,34 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel
             }
 
             return parameter.WithModifiers(newModifiers);
+        }
+
+        public override EnvDTE80.vsCMParameterKind UpdateParameterKind(EnvDTE80.vsCMParameterKind parameterKind, PARAMETER_PASSING_MODE passingMode)
+        {
+            var updatedParameterKind = parameterKind;
+
+            switch (passingMode)
+            {
+                case PARAMETER_PASSING_MODE.cmParameterTypeIn:
+                    updatedParameterKind |= EnvDTE80.vsCMParameterKind.vsCMParameterKindNone;
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindRef;
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindOut;
+                    break;
+
+                case PARAMETER_PASSING_MODE.cmParameterTypeInOut:
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindNone;
+                    updatedParameterKind |= EnvDTE80.vsCMParameterKind.vsCMParameterKindRef;
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindOut;
+                    break;
+
+                case PARAMETER_PASSING_MODE.cmParameterTypeOut:
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindNone;
+                    updatedParameterKind &= ~EnvDTE80.vsCMParameterKind.vsCMParameterKindRef;
+                    updatedParameterKind |= EnvDTE80.vsCMParameterKind.vsCMParameterKindOut;
+                    break;
+            }
+
+            return updatedParameterKind;
         }
 
         public override EnvDTE.vsCMFunction ValidateFunctionKind(SyntaxNode containerNode, EnvDTE.vsCMFunction kind, string name)

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Editor.OptionsExtensionMethods;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
+using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 {
@@ -732,6 +733,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
 
         public abstract EnvDTE80.vsCMParameterKind GetParameterKind(SyntaxNode node);
         public abstract SyntaxNode SetParameterKind(SyntaxNode node, EnvDTE80.vsCMParameterKind kind);
+        public abstract EnvDTE80.vsCMParameterKind UpdateParameterKind(EnvDTE80.vsCMParameterKind parameterKind, PARAMETER_PASSING_MODE passingMode);
+
         public abstract SyntaxNode CreateParameterNode(string name, string type);
 
         public abstract EnvDTE.vsCMFunction ValidateFunctionKind(SyntaxNode containerNode, EnvDTE.vsCMFunction kind, string name);

--- a/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/ICodeModelService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.InternalElements;
+using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
@@ -198,6 +199,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
         EnvDTE80.vsCMParameterKind GetParameterKind(SyntaxNode node);
         SyntaxNode SetParameterKind(SyntaxNode node, EnvDTE80.vsCMParameterKind kind);
         IEnumerable<SyntaxNode> GetParameterNodes(SyntaxNode parent);
+        EnvDTE80.vsCMParameterKind UpdateParameterKind(EnvDTE80.vsCMParameterKind parameterKind, PARAMETER_PASSING_MODE passingMode);
 
         EnvDTE.vsCMFunction ValidateFunctionKind(SyntaxNode containerNode, EnvDTE.vsCMFunction kind, string name);
 

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -201,12 +201,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         int IParameterKind.GetParameterArrayCount()
         {
-            var type = ParameterSymbol.Type;
-            int count = 0;
-            while (type?.TypeKind == TypeKind.Array)
+            var arrayType = ParameterSymbol.Type as IArrayTypeSymbol;
+            var count = 0;
+
+            while (arrayType != null)
             {
                 count++;
-                type = ((IArrayTypeSymbol)type).ElementType;
+                arrayType = arrayType.ElementType as IArrayTypeSymbol;
             }
 
             return count;
@@ -214,7 +215,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         int IParameterKind.GetParameterArrayDimensions(int index)
         {
-            throw new NotImplementedException();
+            if (index < 0)
+            {
+                throw Exceptions.ThrowEInvalidArg();
+            }
+
+            var arrayType = ParameterSymbol.Type as IArrayTypeSymbol;
+            var count = 0;
+
+            while (count < index && arrayType != null)
+            {
+                count++;
+                arrayType = arrayType.ElementType as IArrayTypeSymbol;
+            }
+
+            if (arrayType == null)
+            {
+                throw Exceptions.ThrowEInvalidArg();
+            }
+
+            return arrayType.Rank;
         }
 
         PARAMETER_PASSING_MODE IParameterKind.GetParameterPassingMode()

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Collections;
+using Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Interop;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Utilities;
 using Roslyn.Utilities;
@@ -13,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 {
     [ComVisible(true)]
     [ComDefaultInterface(typeof(EnvDTE80.CodeParameter2))]
-    public sealed class CodeParameter : AbstractCodeElement, EnvDTE.CodeParameter, EnvDTE80.CodeParameter2
+    public sealed class CodeParameter : AbstractCodeElement, EnvDTE.CodeParameter, EnvDTE80.CodeParameter2, IParameterKind
     {
         internal static EnvDTE.CodeParameter Create(
             CodeModelState state,
@@ -186,6 +187,44 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
             {
                 return FileCodeModel.AddAttribute(LookupNode(), name, value, position);
             });
+        }
+
+        void IParameterKind.SetParameterPassingMode(PARAMETER_PASSING_MODE passingMode)
+        {
+            ParameterKind = State.CodeModelService.UpdateParameterKind(ParameterKind, passingMode);
+        }
+
+        void IParameterKind.SetParameterArrayDimensions(int dimensions)
+        {
+            throw new NotImplementedException();
+        }
+
+        int IParameterKind.GetParameterArrayCount()
+        {
+            throw new NotImplementedException();
+        }
+
+        int IParameterKind.GetParameterArrayDimensions(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        PARAMETER_PASSING_MODE IParameterKind.GetParameterPassingMode()
+        {
+            var parameterKind = this.ParameterKind;
+
+            if ((parameterKind & EnvDTE80.vsCMParameterKind.vsCMParameterKindRef) != 0)
+            {
+                return PARAMETER_PASSING_MODE.cmParameterTypeInOut;
+            }
+            else if ((parameterKind & EnvDTE80.vsCMParameterKind.vsCMParameterKindOut) != 0)
+            {
+                return PARAMETER_PASSING_MODE.cmParameterTypeOut;
+            }
+            else
+            {
+                return PARAMETER_PASSING_MODE.cmParameterTypeIn;
+            }
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -201,7 +201,15 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
         int IParameterKind.GetParameterArrayCount()
         {
-            throw new NotImplementedException();
+            var type = ParameterSymbol.Type;
+            int count = 0;
+            while (type?.TypeKind == TypeKind.Array)
+            {
+                count++;
+                type = ((IArrayTypeSymbol)type).ElementType;
+            }
+
+            return count;
         }
 
         int IParameterKind.GetParameterArrayDimensions(int index)

--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeParameter.cs
@@ -205,10 +205,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
 
             // The original C# implementation had a weird behavior where it wold allow setting array dimensions
             // to 0 to create an array with a single rank.
-            var rank = dimensions > 0
-                ? dimensions
-                : 1;
-
+            var rank = Math.Max(dimensions, 1);
             var newType = compilation.CreateArrayTypeSymbol(elementType, rank);
 
             this.Type = CodeTypeRef.Create(this.State, this, GetProjectId(), newType);

--- a/src/VisualStudio/Core/Impl/CodeModel/Interop/IParameterKind.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/Interop/IParameterKind.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
+{
+    internal enum PARAMETER_PASSING_MODE
+    {
+        cmParameterTypeIn = 1,
+        cmParameterTypeOut = 2,
+        cmParameterTypeInOut = 3
+    }
+
+    [ComImport]
+    [Guid("A55CCBCC-7031-432d-B30A-A68DE7BDAD75")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [ComVisible(true)]
+    internal interface IParameterKind
+    {
+        void SetParameterPassingMode(PARAMETER_PASSING_MODE ParamPassingMode);
+        void SetParameterArrayDimensions(int ulDimensions);
+        int GetParameterArrayCount();
+        int GetParameterArrayDimensions(int uIndex);
+        PARAMETER_PASSING_MODE GetParameterPassingMode();
+    }
+}

--- a/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
+++ b/src/VisualStudio/Core/Impl/ServicesVisualStudioImpl.csproj
@@ -203,6 +203,7 @@
     <Compile Include="CodeModel\Interop\IEventHandler.cs" />
     <Compile Include="CodeModel\Interop\IMethodXML.cs" />
     <Compile Include="CodeModel\Interop\IMethodXML2.cs" />
+    <Compile Include="CodeModel\Interop\IParameterKind.cs" />
     <Compile Include="CodeModel\Interop\IVBFileCodeModelEvents.cs" />
     <Compile Include="CodeModel\Interop\PropertyTypeEnum.cs" />
     <Compile Include="CodeModel\Interop\ReferenceSelectionEnum.cs" />

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeElementTests`1.vb
@@ -145,7 +145,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 End Sub
         End Function
 
-        Protected Delegate Sub SetterAction(Of T)(newValue As T, valueSetter As Action(Of T))
+        Protected Friend Delegate Sub SetterAction(Of T)(newValue As T, valueSetter As Action(Of T))
 
         Protected Function NoThrow(Of T)() As SetterAction(Of T)
             Return _

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -142,5 +142,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     Assert.Equal(expected, actual)
                 End Sub)
         End Function
+
+        Friend Async Function TestGetParameterArrayDimensions(code As XElement, index As Integer, expected As Integer) As Task
+            Await TestElement(code,
+                Sub(codeElement)
+                    Dim parameterKind = TryCast(codeElement, IParameterKind)
+                    Assert.NotNull(parameterKind)
+
+                    Dim actual = parameterKind.GetParameterArrayDimensions(index)
+                    Assert.Equal(expected, actual)
+                End Sub)
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -131,5 +131,16 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     action(passingMode, setter)
                 End Sub)
         End Function
+
+        Friend Async Function TestGetParameterArrayCount(code As XElement, expected As Integer) As Task
+            Await TestElement(code,
+                Sub(codeElement)
+                    Dim parameterKind = TryCast(codeElement, IParameterKind)
+                    Assert.NotNull(parameterKind)
+
+                    Dim actual = parameterKind.GetParameterArrayCount()
+                    Assert.Equal(expected, actual)
+                End Sub)
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -3,68 +3,69 @@
 Imports System.Threading.Tasks
 Imports EnvDTE
 Imports EnvDTE80
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
     Public MustInherit Class AbstractCodeParameterTests
-        Inherits AbstractCodeElementTests(Of CodeParameter2)
+        Inherits AbstractCodeElementTests(Of EnvDTE80.CodeParameter2)
 
-        Protected Overrides Function GetComment(codeElement As CodeParameter2) As String
+        Protected Overrides Function GetComment(codeElement As EnvDTE80.CodeParameter2) As String
             Throw New NotImplementedException()
         End Function
 
-        Protected Function GetDefaultValueSetter(codeElement As CodeParameter2) As Action(Of String)
+        Protected Function GetDefaultValueSetter(codeElement As EnvDTE80.CodeParameter2) As Action(Of String)
             Return Sub(defaultValue) codeElement.DefaultValue = defaultValue
         End Function
 
-        Protected Overrides Function GetDocComment(codeElement As CodeParameter2) As String
+        Protected Overrides Function GetDocComment(codeElement As EnvDTE80.CodeParameter2) As String
             Throw New NotImplementedException()
         End Function
 
-        Protected Overrides Function GetEndPointFunc(codeElement As CodeParameter2) As Func(Of vsCMPart, TextPoint)
+        Protected Overrides Function GetEndPointFunc(codeElement As EnvDTE80.CodeParameter2) As Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)
             Return Function(part) codeElement.GetEndPoint(part)
         End Function
 
-        Protected Overrides Function GetFullName(codeElement As CodeParameter2) As String
+        Protected Overrides Function GetFullName(codeElement As EnvDTE80.CodeParameter2) As String
             Return codeElement.FullName
         End Function
 
-        Protected Overrides Function GetKind(codeElement As CodeParameter2) As vsCMElement
+        Protected Overrides Function GetKind(codeElement As EnvDTE80.CodeParameter2) As EnvDTE.vsCMElement
             Return codeElement.Kind
         End Function
 
-        Protected Overrides Function GetName(codeElement As CodeParameter2) As String
+        Protected Overrides Function GetName(codeElement As EnvDTE80.CodeParameter2) As String
             Return codeElement.Name
         End Function
 
-        Protected Overrides Function GetNameSetter(codeElement As CodeParameter2) As Action(Of String)
+        Protected Overrides Function GetNameSetter(codeElement As EnvDTE80.CodeParameter2) As Action(Of String)
             Throw New NotImplementedException()
         End Function
 
-        Protected Function GetParameterKindSetter(codeElement As CodeParameter2) As Action(Of EnvDTE80.vsCMParameterKind)
+        Protected Function GetParameterKindSetter(codeElement As EnvDTE80.CodeParameter2) As Action(Of EnvDTE80.vsCMParameterKind)
             Return Sub(kind) codeElement.ParameterKind = kind
         End Function
 
-        Protected Overrides Function GetParent(codeElement As CodeParameter2) As Object
+        Protected Overrides Function GetParent(codeElement As EnvDTE80.CodeParameter2) As Object
             Return codeElement.Parent
         End Function
 
-        Protected Overrides Function GetStartPointFunc(codeElement As CodeParameter2) As Func(Of vsCMPart, TextPoint)
+        Protected Overrides Function GetStartPointFunc(codeElement As EnvDTE80.CodeParameter2) As Func(Of EnvDTE.vsCMPart, EnvDTE.TextPoint)
             Return Function(part) codeElement.GetStartPoint(part)
         End Function
 
-        Protected Overrides Function GetTypeProp(codeElement As CodeParameter2) As CodeTypeRef
+        Protected Overrides Function GetTypeProp(codeElement As EnvDTE80.CodeParameter2) As EnvDTE.CodeTypeRef
             Return codeElement.Type
         End Function
 
-        Protected Overrides Function GetTypePropSetter(codeElement As CodeParameter2) As Action(Of CodeTypeRef)
+        Protected Overrides Function GetTypePropSetter(codeElement As EnvDTE80.CodeParameter2) As Action(Of EnvDTE.CodeTypeRef)
             Return Sub(value) codeElement.Type = value
         End Function
 
-        Protected Overrides Function AddAttribute(codeElement As CodeParameter2, data As AttributeData) As CodeAttribute
+        Protected Overrides Function AddAttribute(codeElement As EnvDTE80.CodeParameter2, data As AttributeData) As EnvDTE.CodeAttribute
             Return codeElement.AddAttribute(data.Name, data.Value, data.Position)
         End Function
 
-        Protected Async Function TestParameterKind(code As XElement, kind As vsCMParameterKind) As Task
+        Protected Async Function TestParameterKind(code As XElement, kind As EnvDTE80.vsCMParameterKind) As Task
             Await TestElement(code,
                 Sub(codeElement)
                     Assert.Equal(kind, codeElement.ParameterKind)
@@ -99,6 +100,35 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                 Sub(codeElement)
                     Dim defaultValueSetter = GetDefaultValueSetter(codeElement)
                     action(defaultValue, defaultValueSetter)
+                End Sub)
+        End Function
+
+        Friend Async Function TestGetParameterPassingMode(code As XElement, expected As PARAMETER_PASSING_MODE) As Task
+            Await TestElement(code,
+                Sub(codeElement)
+                    Dim parameterKind = TryCast(codeElement, IParameterKind)
+                    Assert.NotNull(parameterKind)
+
+                    Dim actual = parameterKind.GetParameterPassingMode()
+                    Assert.Equal(expected, actual)
+                End Sub)
+        End Function
+
+        Friend Async Function TestSetParameterPassingMode(code As XElement, expectedCode As XElement, passingMode As PARAMETER_PASSING_MODE) As Task
+            Await TestSetParameterPassingMode(code, expectedCode, passingMode, NoThrow(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        Friend Async Function TestSetParameterPassingMode(code As XElement, expectedCode As XElement, passingMode As PARAMETER_PASSING_MODE, action As SetterAction(Of PARAMETER_PASSING_MODE)) As Task
+            Await TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim setter = Sub(mode As PARAMETER_PASSING_MODE)
+                                     Dim parameterKind = TryCast(codeElement, IParameterKind)
+                                     Assert.NotNull(parameterKind)
+
+                                     parameterKind.SetParameterPassingMode(mode)
+                                 End Sub
+
+                    action(passingMode, setter)
                 End Sub)
         End Function
     End Class

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeParameterTests.vb
@@ -153,5 +153,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
                     Assert.Equal(expected, actual)
                 End Sub)
         End Function
+
+        Friend Async Function TestSetParameterArrayDimensions(code As XElement, expectedCode As XElement, dimensions As Integer) As Task
+            Await TestSetParameterArrayDimensions(code, expectedCode, dimensions, NoThrow(Of Integer)())
+        End Function
+
+        Friend Async Function TestSetParameterArrayDimensions(code As XElement, expectedCode As XElement, dimensions As Integer, action As SetterAction(Of Integer)) As Task
+            Await TestElementUpdate(code, expectedCode,
+                Sub(codeElement)
+                    Dim setter = Sub(d As Integer)
+                                     Dim parameterKind = TryCast(codeElement, IParameterKind)
+                                     Assert.NotNull(parameterKind)
+
+                                     parameterKind.SetParameterArrayDimensions(d)
+                                 End Sub
+
+                    action(dimensions, setter)
+                End Sub)
+        End Function
     End Class
 End Namespace

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -1044,6 +1044,94 @@ class C
 
 #End Region
 
+#Region "IParameterKind.GetParameterArrayDimensions tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_3() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,,] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=3)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_1_1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,,][] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=1, expected:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_1_2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,,][,] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=1, expected:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_2_1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,,][,][] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=2, expected:=1)
+        End Function
+
+#End Region
+
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestTypeDescriptor_GetProperties() As Task
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -984,6 +984,66 @@ class C
 
 #End Region
 
+#Region "IParameterKind.GetParameterArrayCount tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_0() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 0)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[][] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_1_Multi() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[,,] $$s) { }
+}
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 1)
+        End Function
+
+#End Region
+
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestTypeDescriptor_GetProperties() As Task
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
@@ -650,6 +651,335 @@ delegate void Foo(byte?[,] i) { }
 </Code>
 
             Await TestSetTypeProp(code, expected, "byte?[,]")
+        End Function
+
+#End Region
+
+#Region "IParameterKind.GetParameterPassingMode tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_NoModifier() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_RefModifier() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_OutModifier() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(out string $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_ParamsModifier() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(params string[] $$s)
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_DefaultValue() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(string $$s = "Foo")
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_DefaultValueAndRefModifiers() As Task
+            Dim code =
+<Code>
+class C
+{
+    void Foo(ref string $$s = "Foo")
+    {
+    }
+}
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+#End Region
+
+#Region "IParmeterKind.SetParameterPassingMode tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_In() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_InOut() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(ref string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_Out() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(out string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_RefModifier_In() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(ref string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_RefModifier_InOut() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(ref string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(ref string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_RefModifier_Out() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(ref string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(out string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OutModifier_In() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(out string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OutModifier_InOut() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(out string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(ref string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OutModifier_Out() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(out string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(out string s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ParamsModifier_In() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(params string[] $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(params string[] s) { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_DefaultValue_Ref() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s = "hello!") { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(ref string s = "hello!") { }
+}
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
         End Function
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeParameterTests.vb
@@ -1132,6 +1132,118 @@ class C
 
 #End Region
 
+#Region "IParmeterKind.SetParameterArrayDimensions tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_0() As Task
+            ' The C# implementation had a weird behavior where it wold allow setting array dimensions
+            ' to 0 to create an array with a single rank.
+
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string[] s) { }
+}
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=0)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_1() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string[] s) { }
+}
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string[,] s) { }
+}
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_1_2() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[] $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string[,] s) { }
+}
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_1_2_WithInnerArray() As Task
+            Dim code =
+<Code>
+class C
+{
+    void M(string[][] $$s) { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+class C
+{
+    void M(string[,][] s) { }
+}
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+#End Region
+
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
         Public Async Function TestTypeDescriptor_GetProperties() As Task
             Dim code =

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
@@ -1589,6 +1589,94 @@ End Class
 
 #End Region
 
+#Region "IParameterKind.GetParameterArrayDimensions tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String())
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_2() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,))
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_0_3() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,,))
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=0, expected:=3)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_1_1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,,)())
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=1, expected:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_1_2() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,,)(,))
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=1, expected:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayDimensions_2_1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,,)(,)())
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayDimensions(code, index:=2, expected:=1)
+        End Function
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Interop
 Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.VisualBasic
@@ -1136,6 +1137,394 @@ End Class
 </Code>
 
             Await TestSetTypeProp(code, expected, CType(Nothing, EnvDTE.CodeTypeRef))
+        End Function
+
+#End Region
+
+#Region "IParameterKind.GetParameterPassingMode tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_NoModifier() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_ByRefModifier() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo(ByRef $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_ParamArrayModifier() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo(ParamArray $$s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_OptionalModifier() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo(Optional $$s As String = "Foo")
+    End Sub
+End Class
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterPassingMode_OptionalAndByRefModifiers() As Task
+            Dim code =
+<Code>
+Class C
+    Sub Foo(Optional ByRef $$s As String = "Foo")
+    End Sub
+End Class
+</Code>
+
+            Await TestGetParameterPassingMode(code, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+#End Region
+
+#Region "IParmeterKind.SetParameterPassingMode tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_In() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_InOut() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByRef s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_NoModifier_Out() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByValModifier_In() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByVal $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByVal s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByValModifier_InOut() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByVal $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByRef s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByValModifier_Out() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByVal $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByVal s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByRefModifier_In() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByRef $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByRefModifier_InOut() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByRef $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByRef s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ByRefModifier_Out() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ByRef $$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ByRef s As String)
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ParamArrayModifier_In() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ParamArray $$s As String())
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ParamArray s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ParamArrayModifier_InOut() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ParamArray $$s As String())
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ParamArray s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_ParamArrayModifier_Out() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(ParamArray $$s As String())
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(ParamArray s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OptionalModifier_In() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(Optional $$s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(Optional s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeIn)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OptionalModifier_InOut() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(Optional $$s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(Optional ByRef s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeInOut)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterPassingMode_OptionalModifier_Out() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M(Optional $$s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(Optional s As String = "hello")
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterPassingMode(code, expected, PARAMETER_PASSING_MODE.cmParameterTypeOut, ThrowsArgumentException(Of PARAMETER_PASSING_MODE)())
         End Function
 
 #End Region

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
@@ -1529,6 +1529,66 @@ End Class
 
 #End Region
 
+#Region "IParameterKind.GetParameterArrayCount tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_0() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 0)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String())
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_2() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String()())
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_GetParameterArrayCount_1_Multi() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String(,,))
+    End Sub
+End Class
+</Code>
+
+
+            Await TestGetParameterArrayCount(code, 1)
+        End Function
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeParameterTests.vb
@@ -1677,6 +1677,118 @@ End Class
 
 #End Region
 
+#Region "IParmeterKind.SetParameterArrayDimensions tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_0() As Task
+            ' The C# implementation had a weird behavior where it wold allow setting array dimensions
+            ' to 0 to create an array with a single rank.
+
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=0)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_1() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=1)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_None_2() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String)
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String(,))
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_1_2() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String())
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String(,))
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function Test_IParameterKind_SetParameterArrayDimensions_1_2_WithInnerArray() As Task
+            Dim code =
+<Code>
+Class C
+    Sub M($$s As String()())
+    End Sub
+End Class
+</Code>
+
+            Dim expected =
+<Code>
+Class C
+    Sub M(s As String(,)())
+    End Sub
+End Class
+</Code>
+
+            Await TestSetParameterArrayDimensions(code, expected, dimensions:=2)
+        End Function
+
+#End Region
+
         Protected Overrides ReadOnly Property LanguageName As String
             Get
                 Return LanguageNames.VisualBasic


### PR DESCRIPTION
Fixes #10525 

We did not implement the internal legacy interface `IParameterKind` on `EnvDTE.CodeParameter` because there were no known consumers. Unfortunately, it appears that there is some old code in the first (i.e. pre-.NET 4.0) version of the Workflow Designer that depends on this interface being present. Without the interface, at least one Workflow activity can not be properly configured within the designer. 

Unfortunately, because the Workflow Designer ships in the .NET Framework, it's far easier to fix this problem in Code Model rather than update Workflow to use a different API. So, this change implements the `IParameterKind` interface. I've verified that the Workflow Designer doesn't work without this change and *does* work properly with it. Plenty 'o unit tests.

cc @dotnet/roslyn-ide for review