### PR TITLE
Remove Redundant Cast should not incorrectly suggest to remove a cast within a logical not expression

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/CastSimplificationTests.vb
@@ -4908,6 +4908,134 @@ static void Main(string[] args)
             Await TestAsync(input, expected)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(10311, "https://github.com/dotnet/roslyn/issues/10311")>
+        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean1() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    public bool GetBool(object value)
+    {
+        // "Cast is redundant".
+        return {|Simplify:(bool)value|};
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+class C
+{
+    public bool GetBool(object value)
+    {
+        // "Cast is redundant".
+        return (bool)value;
+    }
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(10311, "https://github.com/dotnet/roslyn/issues/10311")>
+        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean2() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    public bool NegateBool(object value)
+    {
+        // "Cast is redundant".
+        return !{|Simplify:(bool)value|};
+    }
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+class C
+{
+    public bool NegateBool(object value)
+    {
+        // "Cast is redundant".
+        return !(bool)value;
+    }
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(10311, "https://github.com/dotnet/roslyn/issues/10311")>
+        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean1_ExpressionBody() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    public bool GetBool(object value) => {|Simplify:(bool)value|};
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+class C
+{
+    public bool GetBool(object value) => (bool)value;
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        <WorkItem(10311, "https://github.com/dotnet/roslyn/issues/10311")>
+        Public Async Function TestCSharp_DontRemove_NecessaryUnboxingCastFromObjectToBoolean2_ExpressionBody() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document><![CDATA[
+class C
+{
+    public bool NegateBool(object value) => !{|Simplify:(bool)value|};
+}
+]]>
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code><![CDATA[
+class C
+{
+    public bool NegateBool(object value) => !(bool)value;
+}
+]]>
+</code>
+
+            Await TestAsync(input, expected)
+        End Function
+
 #End Region
 
 #Region "Visual Basic tests"

--- a/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/SpeculationAnalyzer.cs
@@ -280,6 +280,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 // If replacing the node will result in a broken binary expression, we won't remove it.
                 return ReplacementBreaksBinaryExpression((BinaryExpressionSyntax)currentOriginalNode, (BinaryExpressionSyntax)currentReplacedNode);
             }
+            else if (currentOriginalNode.Kind() == SyntaxKind.LogicalNotExpression)
+            {
+                return !SymbolsAreCompatible(((PrefixUnaryExpressionSyntax)currentOriginalNode).Operand, ((PrefixUnaryExpressionSyntax)currentReplacedNode).Operand);
+            }
             else if (currentOriginalNode.Kind() == SyntaxKind.ConditionalAccessExpression)
             {
                 return ReplacementBreaksConditionalAccessExpression((ConditionalAccessExpressionSyntax)currentOriginalNode, (ConditionalAccessExpressionSyntax)currentReplacedNode);


### PR DESCRIPTION
Fixes #10311

cc @dotnet/roslyn-ide 