### PR TITLE
Method Type inference for tuples.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -201,7 +201,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // the delegate.
 
             ImmutableArray<RefKind> formalParameterRefKinds, // Optional; assume all value if missing.
-            ImmutableArray<TypeSymbol> argumentTypes, // Required
             ImmutableArray<BoundExpression> arguments,// Required; in scenarios like method group conversions where there are
                                                       // no arguments per se we cons up some fake arguments.
             ref HashSet<DiagnosticInfo> useSiteDiagnostics
@@ -211,8 +210,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(methodTypeParameters.Length > 0);
             Debug.Assert(!formalParameterTypes.IsDefault);
             Debug.Assert(formalParameterRefKinds.IsDefault || formalParameterRefKinds.Length == formalParameterTypes.Length);
-            Debug.Assert(!argumentTypes.IsDefault);
-            Debug.Assert(!arguments.IsDefault && arguments.Length == argumentTypes.Length);
+            Debug.Assert(!arguments.IsDefault);
 
             // Early out: if the method has no formal parameters then we know that inference will fail.
             if (formalParameterTypes.Length == 0)
@@ -591,7 +589,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 ExplicitParameterTypeInference(argument, target, ref useSiteDiagnostics);
             }
-            if (argument.Kind == BoundKind.TupleLiteral)
+            else if (argument.Kind == BoundKind.TupleLiteral)
             {
                 MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, isExactInference, ref useSiteDiagnostics);
             }
@@ -640,7 +638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // try match up element-wise to the destination tuple (ur underlying type)
+            // try match up element-wise to the destination tuple (or underlying type)
             // Example:
             //      if   "(a: 1, b: "qq")" is passed as   (T, U) arg
             //      then T becomes int and U becomes string

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -717,15 +717,78 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var formalType = _formalParameterTypes[arg];
                 var argument = _arguments[arg];
+                // TODO: VS can this be ever different from argument.Type ?
+                var argumentType = _argumentTypes[arg];
+
+                MakeOutputTypeInferences(binder, argument, argumentType, formalType, ref useSiteDiagnostics);
+            }
+        }
+
+        private void MakeOutputTypeInferences(Binder binder, BoundExpression argument, TypeSymbol argumentType, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            // recurse into tuples
+            // TODO: VS no need if has type
+            if (argument.Kind == BoundKind.TupleLiteral)
+            {
+                MakeOutputTypeInferences(binder, (BoundTupleLiteral)argument, argumentType, formalType, ref useSiteDiagnostics);
+            }
+            else
+            {
                 if (HasUnfixedParamInOutputType(argument, formalType) && !HasUnfixedParamInInputType(argument, formalType))
                 {
-                    var argumentType = _argumentTypes[arg];
                     //UNDONE: if (argument->isTYPEORNAMESPACEERROR() && argumentType->IsErrorType())
                     //UNDONE: {
                     //UNDONE:     argumentType = GetTypeManager().GetErrorSym();
                     //UNDONE: }
                     OutputTypeInference(binder, argument, argumentType, formalType, ref useSiteDiagnostics);
                 }
+            }
+        }
+
+        private void MakeOutputTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol argumentType, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            if (formalType.Kind != SymbolKind.NamedType)
+            {
+                // tuples can only cast to tuples or tuple underlying types.
+                return;
+            }
+
+            var destination = (NamedTypeSymbol)formalType;
+
+            if (destination.IsTupleType)
+            {
+                destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
+            }
+
+            Debug.Assert(argument.Type == null, "should not need dig into elements if tuple has natural type");
+            var sourceArguments = argument.Arguments;
+
+            // check if underlying type is actually a possible underlying type for a tuple of given arity
+            if (!binder.Compilation.IsWellKnownTupleType(destination, sourceArguments.Length))
+            {
+                return;
+            }
+
+            var destTypes = ArrayBuilder<TypeSymbol>.GetInstance(sourceArguments.Length);
+            TupleTypeSymbol.AddElementTypes(destination, destTypes);
+
+            try
+            {
+                if (sourceArguments.Length != destTypes.Count)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < sourceArguments.Length; i++)
+                {
+                    var sourceArgument = sourceArguments[i];
+                    var destType = destTypes[i];
+                    OutputTypeInference(binder, sourceArgument, sourceArgument.Type, destType, ref useSiteDiagnostics);
+                }
+            }
+            finally
+            {
+                destTypes.Free();
             }
         }
 
@@ -1389,6 +1452,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            // SPEC: PROTOTYPE(tuples): spec quote here
+
+            if (ExactTupleInference(source, target, ref useSiteDiagnostics))
+            {
+                return;
+            }
+
             // SPEC: * Otherwise, if V is a constructed type C<V1...Vk> and U is a constructed
             // SPEC:   type C<U1...Uk> then an exact inference is made
             // SPEC:    from each Ui to the corresponding Vi.
@@ -1593,8 +1663,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             //     return;
             // }
 
-            // SPEC: Otherwise... many cases for constructed generic types.
 
+            // SPEC: PROTOTYPE(tuples) spec quote here.
+
+            // NOTE: Tuple inference is exact since tuples are non-variant.
+            if (ExactTupleInference(source, target, ref useSiteDiagnostics))
+            {
+                return;
+            }
+
+            // SPEC: Otherwise... many cases for constructed generic types.
             if (LowerBoundConstructedInference(source, target, ref useSiteDiagnostics))
             {
                 return;
@@ -1712,6 +1790,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
+        private bool ExactTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            Debug.Assert((object)source != null);
+            Debug.Assert((object)target != null);
+
+            // SPEC: PROTOTYPE(tuples): would be nice to quote spec here
+            
+            // NOTE: we are losing tuple element names when unwrapping tuples to underlying types.
+            //       that is ok, because ExactTypeArgumentInference only cares about 
+            //       type arguments, not the types themselves
+
+            bool hasTuples = false;
+            if (source.IsTupleType)
+            {
+                source = ((TupleTypeSymbol)source).UnderlyingTupleType;
+                hasTuples = true;
+            }
+
+            if (target.IsTupleType)
+            {
+                target = ((TupleTypeSymbol)target).UnderlyingTupleType;
+                hasTuples = true;
+            }
+
+            if (!hasTuples || (object)source.OriginalDefinition != target.OriginalDefinition)
+            {
+                return false;
+            }
+            
+            ExactTypeArgumentInference((NamedTypeSymbol)source, (NamedTypeSymbol)target, ref useSiteDiagnostics);
+            return true;
+        }
+
         private bool LowerBoundConstructedInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
@@ -1721,16 +1832,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             if ((object)constructedTarget == null)
             {
                 return false;
-            }
-
-            if (constructedTarget.IsTupleType)
-            {
-                //PROTOTYPE(tuples): we are losing tuple names here
-                //                   need to figure what to do with names. 
-                //                   in particular what if we have conflicting inference 
-                //                   differing in names only.
-                //                   From compat/interop point of view that should be somehow allowed
-                constructedTarget = ((TupleTypeSymbol)constructedTarget).UnderlyingTupleType;
             }
 
             if (constructedTarget.AllTypeArgumentCount() == 0)
@@ -1748,12 +1849,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   is made from each Ui to the corresponding Vi.
 
             var constructedSource = source as NamedTypeSymbol;
-            if (constructedSource?.IsTupleType == true)
-            {
-                //PROTOTYPE(tuples): we are losing tuple names here
-                constructedSource = ((TupleTypeSymbol)constructedSource).UnderlyingTupleType;
-            }
-
             if ((object)constructedSource != null &&
                 constructedSource.OriginalDefinition == constructedTarget.OriginalDefinition)
             {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -539,13 +539,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 bool isExactInference = GetRefKind(arg) != RefKind.None;
 
                 TypeSymbol target = _formalParameterTypes[arg];
-                TypeSymbol source = _arguments[arg].Type;
-
-                MakeExplicitParameterTypeInferences(binder, argument, source, target, isExactInference, ref useSiteDiagnostics);
+                MakeExplicitParameterTypeInferences(binder, argument, target, isExactInference, ref useSiteDiagnostics);
             }
         }
 
-        private void MakeExplicitParameterTypeInferences(Binder binder, BoundExpression argument, TypeSymbol source, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundExpression argument, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             // If the argument is a TYPEORNAMESPACEERROR and the pSource is an
             // error type, then we want to set it to the generic error type 
@@ -587,9 +585,15 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // SPEC: * Otherwise, no inference is made for this argument
 
+            var source = argument.Type;
+
             if (argument.Kind == BoundKind.UnboundLambda)
             {
                 ExplicitParameterTypeInference(argument, target, ref useSiteDiagnostics);
+            }
+            if (argument.Kind == BoundKind.TupleLiteral)
+            {
+                MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, isExactInference, ref useSiteDiagnostics);
             }
             else if (IsReallyAType(source))
             {
@@ -602,14 +606,44 @@ namespace Microsoft.CodeAnalysis.CSharp
                     LowerBoundInference(source, target, ref useSiteDiagnostics);
                 }
             }
-            else if (argument.Kind== BoundKind.TupleLiteral)
-            {
-                MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, ref useSiteDiagnostics);
-            }
         }
 
-        private void MakeExplicitParameterTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
+            // if tuple has a type we will try to match the type as a single input
+            // Example:
+            //      if   "(a: 1, b: 2)" is passed as   T arg
+            //      then T becomes (int a, int b)
+            var source = argument.Type;
+            if (IsReallyAType(source))
+            {
+                if (isExactInference)
+                {
+                    // SPEC: * If V is one of the unfixed Xi then U is added to the set of
+                    // SPEC:   exact bounds for Xi.
+                    if (ExactTypeParameterInference(source, target))
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    // SPEC: A lower-bound inference from a type U to a type V is made as follows:
+
+                    // SPEC: * If V is one of the unfixed Xi then U is added to the set of 
+                    // SPEC:   lower bounds for Xi.
+
+                    if (LowerBoundTypeParameterInference(source, target))
+                    {
+                        return;
+                    }
+                }
+            }
+
+            // try match up element-wise to the destination tuple (ur underlying type)
+            // Example:
+            //      if   "(a: 1, b: "qq")" is passed as   (T, U) arg
+            //      then T becomes int and U becomes string
             if (target.Kind != SymbolKind.NamedType)
             {
                 // tuples can only cast to tuples or tuple underlying types.
@@ -623,12 +657,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
             }
 
-            Debug.Assert(argument.Type == null, "should not need to dig into elements if tuple has natural type");
             var sourceArguments = argument.Arguments;
 
             // check if underlying type is actually a possible underlying type for a tuple of given arity
             if (!binder.Compilation.IsWellKnownTupleType(destination, sourceArguments.Length))
             {
+                // target is not a tuple of appropriate shape
                 return;
             }
 
@@ -642,11 +676,15 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return;
                 }
 
+                // NOTE: we are losing tuple element names when recursing into argument expressions.
+                //       that is ok, because we are inferring type parameters used in the matching elements, 
+                //       This is not the situation where entire tuple literal is used to infer a single type param
+
                 for (int i = 0; i < sourceArguments.Length; i++)
                 {
                     var sourceArgument = sourceArguments[i];
                     var destType = destTypes[i];
-                    MakeExplicitParameterTypeInferences(binder, sourceArgument, sourceArgument.Type, destType, isExactInference: true, useSiteDiagnostics: ref useSiteDiagnostics);
+                    MakeExplicitParameterTypeInferences(binder, sourceArgument, destType, isExactInference, ref useSiteDiagnostics);
                 }
             }
             finally
@@ -654,8 +692,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destTypes.Free();
             }
         }
-
-
 
         ////////////////////////////////////////////////////////////////////////////////
         //
@@ -1503,7 +1539,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // SPEC: PROTOTYPE(tuples): spec quote here
-
             if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
                 return;
@@ -1559,20 +1594,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        private bool LowerNullableInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-        {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
-
-            if (!source.IsNullableType() || !target.IsNullableType())
-            {
-                return false;
-            }
-
-            LowerBoundInference(source.GetNullableUnderlyingType(), target.GetNullableUnderlyingType(), ref useSiteDiagnostics);
-            return true;
-        }
-
         private bool ExactNullableInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
@@ -1587,6 +1608,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
+        //PROTOTYPE(tuples): inference from tuple type is exact since tuples are non-variant.
+        private bool ExactTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            Debug.Assert((object)source != null);
+            Debug.Assert((object)target != null);
+
+            // SPEC: PROTOTYPE(tuples): would be nice to quote spec here
+
+            // NOTE: we are losing tuple element names when unwrapping tuple types to underlying types.
+            //       that is ok, because we are inferring type parameters used in the matching elements, 
+            //       This is not the situation where entire tuple type used to infer a single type param
+
+            bool hasTuples = false;
+            if (source.IsTupleType)
+            {
+                source = ((TupleTypeSymbol)source).UnderlyingTupleType;
+                hasTuples = true;
+            }
+
+            if (target.IsTupleType)
+            {
+                target = ((TupleTypeSymbol)target).UnderlyingTupleType;
+                hasTuples = true;
+            }
+
+            if (!hasTuples || (object)source.OriginalDefinition != target.OriginalDefinition)
+            {
+                return false;
+            }
+
+            ExactTypeArgumentInference((NamedTypeSymbol)source, (NamedTypeSymbol)target, ref useSiteDiagnostics);
+            return true;
+        }
 
         private bool ExactConstructedInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
@@ -1682,7 +1736,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC ERROR: lower bounds of char and int, and choose int. If we make an exact
             // SPEC ERROR: inference of char then type inference fails.
 
-            if (LowerNullableInference(source, target, ref useSiteDiagnostics))
+            if (LowerBoundNullableInference(source, target, ref useSiteDiagnostics))
             {
                 return;
             }
@@ -1716,7 +1770,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // SPEC: PROTOTYPE(tuples) spec quote here.
 
-            // NOTE: Tuple inference is exact since tuples are non-variant.
             if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
                 return;
@@ -1824,52 +1877,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
 
-            // SPEC ISSUE: As noted above, the spec does not clearly call out how
-            // SPEC ISSUE: to do type inference to a nullable target. I propose the
-            // SPEC ISSUE: following:
-            // SPEC ISSUE:
-            // SPEC ISSUE: * Otherwise, if V is nullable type V1? and U is a 
-            // SPEC ISSUE:   non-nullable struct type then an exact inference is made from U to V1.
-
-            if (!target.IsNullableType() || !source.IsValueType || source.IsNullableType())
+            if (!source.IsNullableType() || !target.IsNullableType())
             {
                 return false;
             }
 
-            ExactInference(source, target.GetNullableUnderlyingType(), ref useSiteDiagnostics);
-            return true;
-        }
-
-        private bool ExactTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
-        {
-            Debug.Assert((object)source != null);
-            Debug.Assert((object)target != null);
-
-            // SPEC: PROTOTYPE(tuples): would be nice to quote spec here
-            
-            // NOTE: we are losing tuple element names when unwrapping tuples to underlying types.
-            //       that is ok, because ExactTypeArgumentInference only cares about 
-            //       type arguments, not the types themselves
-
-            bool hasTuples = false;
-            if (source.IsTupleType)
-            {
-                source = ((TupleTypeSymbol)source).UnderlyingTupleType;
-                hasTuples = true;
-            }
-
-            if (target.IsTupleType)
-            {
-                target = ((TupleTypeSymbol)target).UnderlyingTupleType;
-                hasTuples = true;
-            }
-
-            if (!hasTuples || (object)source.OriginalDefinition != target.OriginalDefinition)
-            {
-                return false;
-            }
-            
-            ExactTypeArgumentInference((NamedTypeSymbol)source, (NamedTypeSymbol)target, ref useSiteDiagnostics);
+            LowerBoundInference(source.GetNullableUnderlyingType(), target.GetNullableUnderlyingType(), ref useSiteDiagnostics);
             return true;
         }
 
@@ -2116,6 +2129,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC:   then an exact inference is made from U1 to V1.
 
             if (ExactNullableInference(source, target, ref useSiteDiagnostics))
+            {
+                return;
+            }
+
+            // SPEC: PROTOTYPE(tuples): spec quote here
+
+            if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
                 return;
             }
@@ -2457,12 +2477,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: * If among the remaining candidate types there is a unique type V to
             // SPEC:   which there is an implicit conversion from all the other candidate
             // SPEC:   types, then the parameter is fixed to V.
-
-            // SPEC: 4.7 The Dynamic Type
-            //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
-            // This rule doesn't have to be implemented explicitly due to special handling of 
-            // conversions from dynamic in ImplicitConversionExists helper.
-
             TypeSymbol best = null;
             foreach (var candidate in candidates)
             {
@@ -2478,8 +2492,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     best = candidate;
                 }
-                else if (!(best.IsDynamic() && candidate.IsObjectType()))
+                else if (best.Equals(candidate, ignoreDynamic: true))
                 {
+                    //PROTOTYPE(tuples): SPEC that when having a tuple candidate and another candidate that is a identity-convertable tuple
+                    //                   SPEC or its underlying ValueTuple type, the underlying type is inferred
+                    if (candidate.IsTupleType)
+                    {
+                        best = ((TupleTypeSymbol)candidate).UnderlyingTupleType;
+                        break;
+                    }
+
+                    // SPEC: 4.7 The Dynamic Type
+                    //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
+                    //
+                    // This rule doesn't have to be implemented explicitly due to special handling of 
+                    // conversions from dynamic in ImplicitConversionExists helper.
+                    // 
                     Debug.Assert(!(best.IsObjectType() && candidate.IsDynamic()));
                     Debug.Assert(!(best.IsDynamic() && candidate.IsObjectType()));
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -515,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: phase. The first phase makes some initial inferences of bounds, whereas
             // SPEC: the second phase fixes type parameters to specific types and infers further
             // SPEC: bounds. The second phase may have to be repeated a number of times.
-            InferTypeArgsFirstPhase(ref useSiteDiagnostics);
+            InferTypeArgsFirstPhase(binder, ref useSiteDiagnostics);
             bool success = InferTypeArgsSecondPhase(binder, ref useSiteDiagnostics);
             return new MethodTypeInferenceResult(success, GetResults());
         }
@@ -525,7 +525,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         // The first phase
         //
 
-        private void InferTypeArgsFirstPhase(ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void InferTypeArgsFirstPhase(Binder binder, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert(!_formalParameterTypes.IsDefault);
             Debug.Assert(!_arguments.IsDefault);
@@ -540,69 +540,126 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var argument = _arguments[arg];
 
-                bool isOutOrRef = GetRefKind(arg) != RefKind.None;
+                bool isExactInference = GetRefKind(arg) != RefKind.None;
 
                 TypeSymbol target = _formalParameterTypes[arg];
                 TypeSymbol source = _arguments[arg].Type;
 
-
-                // If the argument is a TYPEORNAMESPACEERROR and the pSource is an
-                // error type, then we want to set it to the generic error type 
-                // that has no name text. This is because of the following scenario:
-                //
-                // void M<T>(T t) { }
-                // void Foo()
-                // {
-                //     UnknownType t;
-                //     M(t);
-                //     M(undefinedVariable);
-                // }
-                //
-                // In the first call to M, we'll have an EXPRLOCAL with an error type,
-                // which is correct - we want the parameter help to display that we've
-                // got an inferred type of UnknownType, which is an error type since 
-                // its undefined.
-                //
-                // However, for the M in the second call, we DON'T want to display parameter
-                // help that gives undefinedVariable as the type parameter for T, because
-                // there is no parameter of that name, let alone that type. This appears
-                // as an EXPRTYPEORNAMESPACEERROR with an ErrorType. We create a new error sym
-                // without the type name.
-
-                // UNDONE: if (pExpr->isTYPEORNAMESPACEERROR() && pSource->IsErrorType())
-                // UNDONE:{
-                // UNDONE:    pSource = GetTypeManager().GetErrorSym();
-                // UNDONE:}
-
-                // SPEC: * If Ei is an anonymous function, an explicit type parameter
-                // SPEC:   inference is made from Ei to Ti.
-
-                // (We cannot make an output type inference from a method group
-                // at this time because we have no fixed types yet to use for
-                // overload resolution.)
-
-                // SPEC: * Otherwise, if Ei has a type U then a lower-bound inference 
-                // SPEC:   or exact inference is made from U to Ti.
-
-                // SPEC: * Otherwise, no inference is made for this argument
-
-                if (argument.Kind == BoundKind.UnboundLambda)
-                {
-                    ExplicitParameterTypeInference(argument, target, ref useSiteDiagnostics);
-                }
-                else if (IsReallyAType(source))
-                {
-                    if (isOutOrRef)
-                    {
-                        ExactInference(source, target, ref useSiteDiagnostics);
-                    }
-                    else
-                    {
-                        LowerBoundInference(source, target, ref useSiteDiagnostics);
-                    }
-                }
+                MakeExplicitParameterTypeInferences(binder, argument, source, target, isExactInference, ref useSiteDiagnostics);
             }
         }
+
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundExpression argument, TypeSymbol source, TypeSymbol target, bool isExactInference, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            // If the argument is a TYPEORNAMESPACEERROR and the pSource is an
+            // error type, then we want to set it to the generic error type 
+            // that has no name text. This is because of the following scenario:
+            //
+            // void M<T>(T t) { }
+            // void Foo()
+            // {
+            //     UnknownType t;
+            //     M(t);
+            //     M(undefinedVariable);
+            // }
+            //
+            // In the first call to M, we'll have an EXPRLOCAL with an error type,
+            // which is correct - we want the parameter help to display that we've
+            // got an inferred type of UnknownType, which is an error type since 
+            // its undefined.
+            //
+            // However, for the M in the second call, we DON'T want to display parameter
+            // help that gives undefinedVariable as the type parameter for T, because
+            // there is no parameter of that name, let alone that type. This appears
+            // as an EXPRTYPEORNAMESPACEERROR with an ErrorType. We create a new error sym
+            // without the type name.
+
+            // UNDONE: if (pExpr->isTYPEORNAMESPACEERROR() && pSource->IsErrorType())
+            // UNDONE:{
+            // UNDONE:    pSource = GetTypeManager().GetErrorSym();
+            // UNDONE:}
+
+            // SPEC: * If Ei is an anonymous function, an explicit type parameter
+            // SPEC:   inference is made from Ei to Ti.
+
+            // (We cannot make an output type inference from a method group
+            // at this time because we have no fixed types yet to use for
+            // overload resolution.)
+
+            // SPEC: * Otherwise, if Ei has a type U then a lower-bound inference 
+            // SPEC:   or exact inference is made from U to Ti.
+
+            // SPEC: * Otherwise, no inference is made for this argument
+
+            if (argument.Kind == BoundKind.UnboundLambda)
+            {
+                ExplicitParameterTypeInference(argument, target, ref useSiteDiagnostics);
+            }
+            else if (IsReallyAType(source))
+            {
+                if (isExactInference)
+                {
+                    ExactInference(source, target, ref useSiteDiagnostics);
+                }
+                else
+                {
+                    LowerBoundInference(source, target, ref useSiteDiagnostics);
+                }
+            }
+            else if (argument.Kind== BoundKind.TupleLiteral)
+            {
+                MakeExplicitParameterTypeInferences(binder, (BoundTupleLiteral)argument, target, ref useSiteDiagnostics);
+            }
+        }
+
+        private void MakeExplicitParameterTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            if (target.Kind != SymbolKind.NamedType)
+            {
+                // tuples can only cast to tuples or tuple underlying types.
+                return;
+            }
+
+            var destination = (NamedTypeSymbol)target;
+
+            if (destination.IsTupleType)
+            {
+                destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
+            }
+
+            Debug.Assert(argument.Type == null, "should not need to dig into elements if tuple has natural type");
+            var sourceArguments = argument.Arguments;
+
+            // check if underlying type is actually a possible underlying type for a tuple of given arity
+            if (!binder.Compilation.IsWellKnownTupleType(destination, sourceArguments.Length))
+            {
+                return;
+            }
+
+            var destTypes = ArrayBuilder<TypeSymbol>.GetInstance(sourceArguments.Length);
+            TupleTypeSymbol.AddElementTypes(destination, destTypes);
+
+            try
+            {
+                if (sourceArguments.Length != destTypes.Count)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < sourceArguments.Length; i++)
+                {
+                    var sourceArgument = sourceArguments[i];
+                    var destType = destTypes[i];
+                    MakeExplicitParameterTypeInferences(binder, sourceArgument, sourceArgument.Type, destType, isExactInference: true, useSiteDiagnostics: ref useSiteDiagnostics);
+                }
+            }
+            finally
+            {
+                destTypes.Free();
+            }
+        }
+
+
 
         ////////////////////////////////////////////////////////////////////////////////
         //
@@ -726,11 +783,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private void MakeOutputTypeInferences(Binder binder, BoundExpression argument, TypeSymbol argumentType, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            // recurse into tuples
-            // TODO: VS no need if has type
-            if (argument.Kind == BoundKind.TupleLiteral)
+            if (argument.Kind == BoundKind.TupleLiteral && (object)argument.Type == null)
             {
-                MakeOutputTypeInferences(binder, (BoundTupleLiteral)argument, argumentType, formalType, ref useSiteDiagnostics);
+                MakeOutputTypeInferences(binder, (BoundTupleLiteral)argument, formalType, ref useSiteDiagnostics);
             }
             else
             {
@@ -745,7 +800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void MakeOutputTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol argumentType, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private void MakeOutputTypeInferences(Binder binder, BoundTupleLiteral argument, TypeSymbol formalType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             if (formalType.Kind != SymbolKind.NamedType)
             {
@@ -760,7 +815,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
             }
 
-            Debug.Assert(argument.Type == null, "should not need dig into elements if tuple has natural type");
+            Debug.Assert(argument.Type == null, "should not need to dig into elements if tuple has natural type");
             var sourceArguments = argument.Arguments;
 
             // check if underlying type is actually a possible underlying type for a tuple of given arity
@@ -783,7 +838,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var sourceArgument = sourceArguments[i];
                     var destType = destTypes[i];
-                    OutputTypeInference(binder, sourceArgument, sourceArgument.Type, destType, ref useSiteDiagnostics);
+                    MakeOutputTypeInferences(binder, sourceArgument, sourceArgument.Type, destType, ref useSiteDiagnostics);
                 }
             }
             finally

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1955,7 +1955,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
             }
 
-            Debug.Assert(tupleSource.Type == null, "should not need dig into elements if tuple has natural type");
+            Debug.Assert(tupleSource.Type == null, "should not need to dig into elements if tuple has natural type");
             var sourceArguments = tupleSource.Arguments;
 
             // check if underlying type is actually a possible underlying type for a tuple of given arity

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1955,7 +1955,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 destination = ((TupleTypeSymbol)destination).UnderlyingTupleType;
             }
 
-            Debug.Assert(tupleSource.Type == null, "should not need to dig into elements if tuple has natural type");
+            Debug.Assert((object)tupleSource.Type == null, "should not need to dig into elements if tuple has natural type");
             var sourceArguments = tupleSource.Arguments;
 
             // check if underlying type is actually a possible underlying type for a tuple of given arity
@@ -2756,12 +2756,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             out MemberAnalysisResult error,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            var argumentTypes = ArrayBuilder<TypeSymbol>.GetInstance();
-            for (int arg = 0; arg < arguments.Arguments.Count; arg++)
-            {
-                argumentTypes.Add(arguments.Argument(arg).Type);
-            }
-
             var args = arguments.Arguments.ToImmutable();
 
             // The reason why we pass the type parameters and formal parameter types
@@ -2775,7 +2769,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 method.ContainingType,
                 originalEffectiveParameters.ParameterTypes,
                 originalEffectiveParameters.ParameterRefKinds,
-                argumentTypes.ToImmutableAndFree(),
                 args,
                 ref useSiteDiagnostics);
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -496,18 +496,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return current;
                 }
 
+                // for tuple types, visit underlying type
+                if (current.IsTupleType)
+                {
+                    return ((TupleTypeSymbol)current).UnderlyingTupleType.VisitType(predicate, arg);
+                }
+
                 switch (current.TypeKind)
                 {
                     case TypeKind.Error:
                     case TypeKind.Dynamic:
                     case TypeKind.TypeParameter:
                     case TypeKind.Submission:
+                    case TypeKind.Enum:
                         return null;
 
                     case TypeKind.Class:
                     case TypeKind.Struct:
                     case TypeKind.Interface:
-                    case TypeKind.Enum:
                     case TypeKind.Delegate:
                         foreach (var typeArg in ((NamedTypeSymbol)current).TypeArgumentsNoUseSiteDiagnostics)
                         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3366,5 +3366,71 @@ second
 4
 ");
         }
+
+        [Fact(Skip = "PROTOTYPE(tuples): this should work, fix overload resolution]")]
+        public void Inference06()
+        {
+            var source = @"
+using System;
+class Program
+{
+    static void Main(string[] args)
+    {
+        M1((() => ""qq"", null));
+    }
+
+    static void M1((Func<object> f, object o) a)
+    {
+        System.Console.WriteLine(1);
+    }
+
+    static void M1((Func<string> f, object o) a)
+    {
+        System.Console.WriteLine(2);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"
+2
+");
+        }
+
+        [Fact]
+        public void Inference07()
+        {
+            var source = @"
+using System;
+
+class C
+{
+    static void Main()
+    {
+        Test((x) => (x, x), (t) => 1);
+        Test1((x) => (x, x), (t) => 1);
+        Test2((a: 1, b: 2), (t) => (t.a, t.b));
+    }
+
+    static void Test<U>(Func<int, ValueTuple<U, U>> f1, Func<ValueTuple<U, U>, int> f2)
+    {
+        System.Console.WriteLine(f2(f1(1)));
+    }
+    static void Test1<U>(Func<int, (U, U)> f1, Func<(U, U), int> f2)
+    {
+        System.Console.WriteLine(f2(f1(1)));
+    }
+    static void Test2<U, T>(U f1, Func<U, (T x, T y)> f2)
+    {
+        System.Console.WriteLine(f2(f1).y);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: @"
+1
+1
+2
+");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3213,7 +3213,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 second
 first
 third
@@ -3251,7 +3251,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 third
 7
 ");
@@ -3287,7 +3287,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 third
 5
 ");
@@ -3320,7 +3320,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 first
 3
 second
@@ -3357,7 +3357,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 first
 2
 3
@@ -3391,7 +3391,7 @@ class Program
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 2
 ");
         }
@@ -3426,7 +3426,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 1
 1
 2
@@ -3469,7 +3469,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 test1
 {1, 2}
 test2_1
@@ -3520,7 +3520,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 test1
 {1, 2}
 test2_1
@@ -3553,7 +3553,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 System.ValueType
 ");
         }
@@ -3580,7 +3580,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source);
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics(
                 // (10,9): error CS0411: The type arguments for method 'C.Test1<T>(ref T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test1(ref t, (ValueType)1);
@@ -3626,7 +3626,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source);
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics(
                 // (12,9): error CS0411: The type arguments for method 'C.Test3<T>(ref T, ref T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test3(ref ab, ref cd);
@@ -3656,7 +3656,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 System.Object
 System.ValueTuple`2[System.Int32,System.Int32]
 System.ValueTuple`2[System.Int32,System.Int32]
@@ -3686,7 +3686,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 System.Object
 System.ValueTuple`2[System.Int32,System.Int32]
 System.ValueTuple`2[System.Int32,System.Int32]
@@ -3715,7 +3715,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source);
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics(
                 // (7,9): error CS0411: The type arguments for method 'C.Test1<T, U>((T, U)?, (T, U?))' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test1((a: 1, b: (a: 1, b: 2)), (a: 1, b: (c: 1, d: 2)));
@@ -3748,7 +3748,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
 System.String
 w
 ");

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -217,6 +217,39 @@ class C
 }");
         }
 
+        [Fact(Skip = "PROTOTYPE(tuples): this should work, just found a bug while working on other stuff.")]
+        public void SimpleTupleNew()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = new (int, int)(1, 2);
+        System.Console.WriteLine(x.ToString());
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}");
+            comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (System.ValueTuple<int, int> V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.2
+  IL_0004:  call       ""System.ValueTuple<int, int>..ctor(int, int)""
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  constrained. ""System.ValueTuple<int, int>""
+  IL_0011:  callvirt   ""string object.ToString()""
+  IL_0016:  call       ""void System.Console.WriteLine(string)""
+  IL_001b:  ret
+}");
+        }
+
         [Fact]
         public void SimpleTuple2()
         {
@@ -2320,7 +2353,7 @@ third
 ");
         }
 
-        [Fact(Skip = "PROTOTYPE: type inference through tuples NYI")]
+        [Fact]
         public void TargetTypingOverload02()
         {
             var source = @"


### PR DESCRIPTION
We can infer type parameters from their use in method arguments which are tuple literals or have tuple types.

Basically the following now works:

```C#
    static void Main()
    {
        Test1((a: ""q"", b: null), (c: null, d: ""w""), (x) => x.z);
    }

    static void Test1<T, U>((T, U) x, (T, U) y, System.Func<(T x, U z), T> f)
    {
        System.Console.WriteLine(f(y));
    }
```