### PR TITLE
Fixed complex trivia tab indentation

### DIFF
--- a/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
+++ b/src/Workspaces/VisualBasic/Portable/Formatting/Engine/Trivia/TriviaDataFactory.ComplexTrivia.vb
@@ -81,6 +81,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Formatting
 
                 Debug.Assert(Me.SecondTokenIsFirstTokenOnLine OrElse beginningOfNewLine)
 
+                If Me.OptionSet.GetOption(FormattingOptions.UseTabs, LanguageNames.VisualBasic) Then
+                    Return True
+                End If
+
                 Return CodeShapeAnalyzer.ShouldFormatMultiLine(context, beginningOfNewLine, list)
             End Function
 

--- a/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
+++ b/src/Workspaces/VisualBasicTest/Formatting/FormattingTests.vb
@@ -1775,6 +1775,33 @@ End Class</Code>
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
+        <WorkItem(10742, "https://github.com/dotnet/roslyn/issues/10742")>
+        Public Async Function ReFormatWithTabsEnabled6() As Task
+            Dim code =
+                "Class SomeClass" + vbCrLf +
+                "    Sub Foo() ' Comment" + vbCrLf +
+                "        Foo()" + vbCrLf +
+                "    End Sub" + vbCrLf +
+                "End Class"
+
+            Dim expected =
+                "Class SomeClass" + vbCrLf +
+                vbTab + "Sub Foo() ' Comment" + vbCrLf +
+                vbTab + vbTab + "Foo()" + vbCrLf +
+                vbTab + "End Sub" + vbCrLf +
+                "End Class"
+
+            Dim optionSet = New Dictionary(Of OptionKey, Object) From
+            {
+                {New OptionKey(FormattingOptions.UseTabs, LanguageNames.VisualBasic), True},
+                {New OptionKey(FormattingOptions.TabSize, LanguageNames.VisualBasic), 4},
+                {New OptionKey(FormattingOptions.IndentationSize, LanguageNames.VisualBasic), 4}
+            }
+
+            Await AssertFormatAsync(code, expected, changedOptionSet:=optionSet)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Formatting)>
         Public Async Function ReFormatWithTabsDisabled() As Task
             Dim code =
                 "Class SomeClass" + vbCrLf +


### PR DESCRIPTION
Fix should address bug number #10742. Problem was with formatting of complex trivias in VB.NET only. To fix the issue, logic from `Microsoft.CodeAnalysis.CSharp.Formatting.TriviaDataFactory.ComplexTrivia.ShouldFormat` method was copied over to `Microsoft.CodeAnalysis.VisualBasic.Formatting.TriviaDataFactory.ComplexTrivia.ShouldFormat`.