### PR TITLE
This change enables the test csx files to provide the scenarios that …

### DIFF
--- a/src/Test/Perf/runner.csx
+++ b/src/Test/Perf/runner.csx
@@ -41,13 +41,22 @@ foreach (dynamic test in testInstances)
                      
     for (int i = 0; i < iterations; i++)
     {
-        traceManager.StartScenarios();
         traceManager.Start();
-        traceManager.StartScenario(test.Name + i, test.MeasuredProc);
-        traceManager.StartEvent();
-        test.Test();
-        traceManager.EndEvent();
-        traceManager.EndScenario();
+        traceManager.StartScenarios();
+        
+        if (test.ProvidesScenarios)
+        {
+            traceManager.WriteScenarios(test.GetScenarios());
+            test.Test();
+        }
+        else
+        {
+            traceManager.StartScenario(test.Name + i, test.MeasuredProc);
+            traceManager.StartEvent();
+            test.Test();
+            traceManager.EndEvent();
+            traceManager.EndScenario();
+        }
         
         traceManager.EndScenarios();
         traceManager.WriteScenariosFileToDisk();

--- a/src/Test/Perf/tests/csharp/csharp_compiler.csx
+++ b/src/Test/Perf/tests/csharp/csharp_compiler.csx
@@ -30,6 +30,11 @@ class CSharpCompilerTest: PerfTest
     public override int Iterations => 2;
     public override string Name => "csharp " + _rspFile;
     public override string MeasuredProc => "csc";
+    public override bool ProvidesScenarios => false;
+    public override string[] GetScenarios()
+    {
+        throw new System.NotImplementedException();
+    }
 }
 
 TestThisPlease(

--- a/src/Test/Perf/tests/helloworld/hello_world.csx
+++ b/src/Test/Perf/tests/helloworld/hello_world.csx
@@ -24,6 +24,11 @@ class HelloWorldTest: PerfTest
     public override int Iterations => 2;
     public override string Name => "hello world";
     public override string MeasuredProc => "csc";
+    public override bool ProvidesScenarios => false;
+    public override string[] GetScenarios()
+    {
+        throw new System.NotImplementedException();
+    }
 }
 
 TestThisPlease(new HelloWorldTest());

--- a/src/Test/Perf/util/scenario_generator_util.csx
+++ b/src/Test/Perf/util/scenario_generator_util.csx
@@ -51,7 +51,7 @@ public class ScenarioGenerator
 
     public void AddStartEvent(int absoluteInstance)
     {
-        WriteToBuffer($@"<from providerGuid=""{KernelProviderGuid}"" absoluteInstance=""{absoluteInstance}"" process=""csc"" eventName = ""Process/Start""/>");
+        WriteToBuffer($@"<from providerGuid=""{KernelProviderGuid}"" absoluteInstance=""{absoluteInstance}"" process=""csc"" eventName=""Process/Start""/>");
     }
 
     public void AddEndEvent()
@@ -62,6 +62,11 @@ public class ScenarioGenerator
     public void AddComment(string comment)
     {
         WriteToBuffer($@"<!-- {comment} -->");
+    }
+    
+    public void AddLine(string line)
+    {
+        WriteToBuffer(line);
     }
 
     public void WriteToDisk()

--- a/src/Test/Perf/util/test_util.csx
+++ b/src/Test/Perf/util/test_util.csx
@@ -138,6 +138,8 @@ abstract class PerfTest: RelativeDirectory {
         Log(description + ": " + value.ToString());
     }
     
+    public abstract bool ProvidesScenarios { get; }
+    public abstract string[] GetScenarios();
     public abstract void Setup();
     public abstract void Test();
     public abstract int Iterations { get; }

--- a/src/Test/Perf/util/trace_manager_util.csx
+++ b/src/Test/Perf/util/trace_manager_util.csx
@@ -21,6 +21,7 @@ interface ITraceManager
     void StartScenario(string scenarioName, string processName);
     void StartScenarios();
     void Stop();
+    void WriteScenarios(string[] scenarios);
     void WriteScenariosFileToDisk();
 }
 
@@ -106,6 +107,10 @@ class NoOpTraceManager : ITraceManager
     {
     }
 
+    public void WriteScenarios(string[] scenarios)
+    {
+    }
+    
     public void WriteScenariosFileToDisk()
     {
     }
@@ -209,6 +214,14 @@ class TraceManager: ITraceManager
     {
         _scenarioGenerator.AddScenariosFileEnd();
     }
+    
+    public void WriteScenarios(string[] scenarios)
+    {
+        foreach (var line in scenarios)
+        {
+            _scenarioGenerator.AddLine(line);
+        }
+    }    
 
     public void WriteScenariosFileToDisk()
     {


### PR DESCRIPTION
…needs to be monitored within a test execution

This enables multiple scenarios cases. For eg: How RPS tracks a bunch of scenarios within a single run of VS

Tagging @KevinH-MS @rchande @TyOverby for review