### PR TITLE
Only run GetTargetPathWithAuthenticodeCertificateName on projects that end up in VSIX

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -355,7 +355,9 @@
     <MSBuild Projects="@(ProjectReferenceWithConfiguration)"
              Targets="GetTargetPathWithAuthenticodeCertificateName"
              BuildInParallel="$(BuildInParallel)"
-             Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)">
+             Properties="%(ProjectReferenceWithConfiguration.SetConfiguration); %(ProjectReferenceWithConfiguration.SetPlatform)"
+             Condition="'%(ProjectReferenceWithConfiguration.Private)' != 'false'"
+             >
 
       <Output TaskParameter="TargetOutputs" ItemName="VsixInputAssembliesToSign" />
     </MSBuild>


### PR DESCRIPTION
This fixes a signed build failure, we asking reference projects to return the result of
GetTargetPathWithAuthenticodeCertificateName, but this was being called on projects that
never end up in the VSIX, such as the new dependency projects; VisualStudio. Mimic the same logic that VSIX uses to figure out if goes in the VSIX.