### PR TITLE
Reflect on test objects to avoid dynamic in script file

### DIFF
--- a/src/Test/Perf/runner.csx
+++ b/src/Test/Perf/runner.csx
@@ -4,9 +4,10 @@
 #load "./util/test_util.csx"
 #load "./util/trace_manager_util.csx"
 
+using System;
 using System.Collections.Generic;
 using System.IO;
-using System;
+using System.Linq;
 
 var directoryInfo = new RelativeDirectory();
 var testDirectory = Path.Combine(directoryInfo.MyWorkingDirectory, "tests");
@@ -16,7 +17,7 @@ Log("Starting Performance Test Run");
 Log("hash: " + StdoutFrom("git", "show --format=\"%h\" HEAD --").Split(new[] {"\r\n", "\r", "\n"}, StringSplitOptions.None)[0]);
 Log("time: " + DateTime.Now.ToString());
 
-var testInstances = new List<dynamic>();
+var testInstances = new List<object>();
 
 // Find all the tests from inside of the csx files.
 foreach (var script in GetAllCsxRecursive(testDirectory))
@@ -28,9 +29,11 @@ foreach (var script in GetAllCsxRecursive(testDirectory))
     testInstances.AddRange(tests);
 }
 
+var convertedTests = testInstances.Select(t => ConvertToPerfTestReflected(t));
+
 var traceManager = TraceManagerFactory.GetTraceManager();
 traceManager.Initialize();
-foreach (dynamic test in testInstances)
+foreach (var test in convertedTests)
 {
     test.Setup();
     traceManager.Setup();

--- a/src/Test/Perf/util/test_util.csx
+++ b/src/Test/Perf/util/test_util.csx
@@ -6,6 +6,7 @@ using System.IO;
 using System.IO.Compression;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Threading;
@@ -127,17 +128,7 @@ class RelativeDirectory
 }
 
 abstract class PerfTest: RelativeDirectory {
-    private List<Tuple<int, string, object>> _metrics = new List<Tuple<int, string, object>>();
-    
     public PerfTest([CallerFilePath] string workingFile = ""): base(workingFile) {}
-    
-    /// Reports a metric to be recorded in the performance monitor.
-    protected void Report(ReportKind reportKind, string description, object value)
-    {
-        _metrics.Add(Tuple.Create((int) reportKind, description, value));
-        Log(description + ": " + value.ToString());
-    }
-    
     public abstract bool ProvidesScenarios { get; }
     public abstract string[] GetScenarios();
     public abstract void Setup();
@@ -169,6 +160,85 @@ static void TestThisPlease(params PerfTest[] tests)
             }
         }
     }
+}
+
+// This class built using reflection from PerfTest object to mimic it
+// This is a workaround for the issue where dynamic objects cannot be compiled
+// in a CSharpScript invoked run. When the issue is fixed, this reflection code can be removed
+class PerfTestReflected
+{
+    private readonly Func<string[]> _getScenariosMethodLambda;
+    private readonly Action _setupMethodLambda;
+    private readonly Action _testMethodLambda;
+
+    public int Iterations { get; set; }
+    public string MeasuredProc { get; set; }
+    public string Name { get; set; }
+    public bool ProvidesScenarios { get; private set; }
+
+    public PerfTestReflected(
+        Action setupMethodLambda,
+        Action testMethodLambda,
+        Func<string[]> getScenariosMethodLambda,
+        int iterations,
+        string measuredProc,
+        string name,
+        bool providesScenarios)
+    {
+        _setupMethodLambda = setupMethodLambda;
+        _testMethodLambda = testMethodLambda;
+        _getScenariosMethodLambda = getScenariosMethodLambda;
+
+        Iterations = iterations;
+        MeasuredProc = measuredProc;
+        Name = name;
+        ProvidesScenarios = providesScenarios;
+    }
+
+    public void Setup()
+    {
+        _setupMethodLambda();
+    }
+
+    public void Test()
+    {
+        _testMethodLambda();
+    }
+
+    public string[] GetScenarios()
+    {
+        return _getScenariosMethodLambda();
+    }
+}
+
+static PerfTestReflected ConvertToPerfTestReflected(object p)
+{
+    Action setupMethodLambda = GetMethod<Action>("Setup", p);
+    Action testMethodLambda = GetMethod<Action>("Test", p);
+    Func<string[]> getScenariosMethodLambda = GetMethod<Func<string[]>>("GetScenarios", p);
+    int iterations = GetProperty<int>("Iterations", p);
+    string measuredProc = GetProperty<string>("MeasuredProc", p);
+    string name = GetProperty<string>("Name", p);
+    bool providesScenarios = GetProperty<bool>("ProvidesScenarios", p);
+    return new PerfTestReflected(
+        setupMethodLambda,
+        testMethodLambda,
+        getScenariosMethodLambda,
+        iterations,
+        measuredProc,
+        name,
+        providesScenarios);
+}
+
+static T GetMethod<T>(string methodName, object obj)
+{
+    var methodInfo = obj.GetType().GetMethod(methodName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public);
+    return Expression.Lambda<T>(Expression.Call(Expression.Constant(obj), methodInfo)).Compile();
+}
+
+static T GetProperty<T>(string propertyName, object obj)
+{
+    return (T)obj.GetType().GetProperty(propertyName, System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public).GetValue(obj, null);
 }
 
 //
@@ -328,19 +398,6 @@ static long WalltimeMs<R>(Func<R> action)
     action();
     return stopwatch.ElapsedMilliseconds;
 }
-
-//
-// Reporting and logging
-//
-
-enum ReportKind: int {
-    CompileTime,
-    RunTime,
-    FileSize,
-}
-
-/// A list of
-static var Metrics = new List<Tuple<int, string, object>>();
 
 /// Logs a message.
 ///


### PR DESCRIPTION
Currently we use dynamic objects in the runner.csx to represent the test objects that are procured from the csx files that contains the information about the tests.

Because of the Script issue #10693(this particular issue talks about CoreClr but this is a general issue) we are not able to bind dynamic expressions in csx scripts if the script is run programmatically. This issue prevents us from running run_and_report.csx and automation.csx

This change circumvents this issue by using reflection. We reflect on the test objects and produce a new reflected_test_object which has the same members as the original test members.When the CSharpScripting issue is fixed, we can remove this reflection.

Also some minor cleanup

Tagging @KevinH-MS @rchande @TyOverby for review