### PR TITLE
Revert "turn off csharp full solution analysis."

### DIFF
--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -10,7 +10,6 @@ Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Options
-Imports Microsoft.CodeAnalysis.Shared.Options
 Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
@@ -1916,9 +1915,6 @@ class MyClass
                        </Workspace>
 
             Using workspace = TestWorkspace.CreateWorkspace(test)
-                ' set csharp closed diagnostic option on
-                workspace.Options = workspace.Options.WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, True)
-
                 Dim project = workspace.CurrentSolution.Projects.Single()
 
                 ' Add analyzer

--- a/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.Shared.Options
@@ -14,7 +13,6 @@ namespace Microsoft.CodeAnalysis.Shared.Options
         /// this option doesn't mean we will show all diagnostics that belong to opened files when turned off,
         /// rather it means we will only show diagnostics that are cheap to calculate for small scope such as opened files.
         /// </summary>
-        public static readonly PerLanguageOption<bool> ClosedFileDiagnostic = new PerLanguageOption<bool>(
-            OptionName, "Closed File Diagnostic", defaultValue: true, perLanguageDefaults: ImmutableDictionary<string, bool>.Empty.Add(LanguageNames.CSharp, false));
+        public static readonly PerLanguageOption<bool> ClosedFileDiagnostic = new PerLanguageOption<bool>(OptionName, "Closed File Diagnostic", defaultValue: true);
     }
 }

--- a/src/VisualStudio/Core/Impl/Options/AbstractSettingStoreOptionSerializer.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractSettingStoreOptionSerializer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             return TryPersist(optionKey, value, (r, k, o, v) => r.SetValue(k, (bool)v ? 1 : 0, RegistryValueKind.DWord));
         }
 
-        protected bool TryFetch(OptionKey optionKey, Func<RegistryKey, string, OptionKey, object> valueGetter, out object value)
+        protected bool TryFetch(OptionKey optionKey, Func<RegistryKey, string, IOption, object> valueGetter, out object value)
         {
             if (this.RegistryKey == null)
             {
@@ -58,7 +58,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                         return false;
                     }
 
-                    value = valueGetter(subKey, collectionPathAndPropertyName.Item2, optionKey);
+                    value = valueGetter(subKey, collectionPathAndPropertyName.Item2, optionKey.Option);
                     return true;
                 }
             }

--- a/src/VisualStudio/Core/Impl/Options/AbstractSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractSettingsManagerOptionSerializer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
             }
 
             var storageKey = GetStorageKeyForOption(optionKey.Option);
-            value = this.Manager.GetValueOrDefault(storageKey, optionKey.DefaultValue);
+            value = this.Manager.GetValueOrDefault(storageKey, optionKey.Option.DefaultValue);
 
             return true;
         }

--- a/src/Workspaces/Core/Portable/Options/IOption2.cs
+++ b/src/Workspaces/Core/Portable/Options/IOption2.cs
@@ -1,9 +1,0 @@
-﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
-namespace Microsoft.CodeAnalysis.Options
-{
-    internal interface IOption2 : IOption
-    {
-        object GetDefaultValue(string language);
-    }
-}

--- a/src/Workspaces/Core/Portable/Options/OptionKey.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionKey.cs
@@ -10,8 +10,6 @@ namespace Microsoft.CodeAnalysis.Options
         public IOption Option { get; }
         public string Language { get; }
 
-        internal object DefaultValue => ((IOption2)Option).GetDefaultValue(Language);
-
         public OptionKey(IOption option, string language = null)
         {
             if (option == null)

--- a/src/Workspaces/Core/Portable/Options/OptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionService.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                 // Just use the default. We will still cache this so we aren't trying to deserialize
                 // over and over.
-                return optionKey.DefaultValue;
+                return optionKey.Option.DefaultValue;
             }
         }
 

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CodeAnalysis.Options
 
                 if (!_values.TryGetValue(optionKey, out value))
                 {
-                    value = _service != null ? _service.GetOption(optionKey) : optionKey.DefaultValue;
+                    value = _service != null ? _service.GetOption(optionKey) : optionKey.Option.DefaultValue;
                     _values = _values.Add(optionKey, value);
                 }
 

--- a/src/Workspaces/Core/Portable/Options/Option`1.cs
+++ b/src/Workspaces/Core/Portable/Options/Option`1.cs
@@ -7,7 +7,7 @@ namespace Microsoft.CodeAnalysis.Options
     /// <summary>
     /// An global option. An instance of this class can be used to access an option value from an OptionSet.
     /// </summary>
-    public class Option<T> : IOption2, IOption
+    public class Option<T> : IOption
     {
         /// <summary>
         /// Feature this option is associated with.
@@ -22,7 +22,10 @@ namespace Microsoft.CodeAnalysis.Options
         /// <summary>
         /// The type of the option value.
         /// </summary>
-        public Type Type => typeof(T);
+        public Type Type
+        {
+            get { return typeof(T); }
+        }
 
         /// <summary>
         /// The default value of the option.
@@ -46,13 +49,19 @@ namespace Microsoft.CodeAnalysis.Options
             this.DefaultValue = defaultValue;
         }
 
-        Type IOption.Type => typeof(T);
-        object IOption.DefaultValue => this.DefaultValue;
-        bool IOption.IsPerLanguage => false;
-
-        object IOption2.GetDefaultValue(string language)
+        Type IOption.Type
         {
-            return this.DefaultValue;
+            get { return typeof(T); }
+        }
+
+        object IOption.DefaultValue
+        {
+            get { return this.DefaultValue; }
+        }
+
+        bool IOption.IsPerLanguage
+        {
+            get { return false; }
         }
 
         public override string ToString()

--- a/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
+++ b/src/Workspaces/Core/Portable/Options/PerLanguageOption.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -10,13 +8,8 @@ namespace Microsoft.CodeAnalysis.Options
     /// An option that can be specified once per language.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class PerLanguageOption<T> : IOption2, IOption
+    public class PerLanguageOption<T> : IOption
     {
-        /// <summary>
-        /// Save per language defaults
-        /// </summary>
-        private readonly IImmutableDictionary<string, T> _perLanguageDefaults;
-
         /// <summary>
         /// Feature this option is associated with.
         /// </summary>
@@ -40,32 +33,7 @@ namespace Microsoft.CodeAnalysis.Options
         /// </summary>
         public T DefaultValue { get; }
 
-        /// <summary>
-        /// The default option value of specific language
-        /// </summary>
-        internal T GetDefaultValue(string language)
-        {
-            if (_perLanguageDefaults.Count == 0)
-            {
-                return DefaultValue;
-            }
-
-            T languageSpecificDefault;
-            if (!_perLanguageDefaults.TryGetValue(language, out languageSpecificDefault))
-            {
-                return DefaultValue;
-            }
-
-            return languageSpecificDefault;
-        }
-
-        public PerLanguageOption(string feature, string name, T defaultValue) :
-            this(feature, name, defaultValue, ImmutableDictionary<string, T>.Empty)
-        {
-        }
-
-        internal PerLanguageOption(
-            string feature, string name, T defaultValue, IDictionary<string, T> perLanguageDefaults)
+        public PerLanguageOption(string feature, string name, T defaultValue)
         {
             if (string.IsNullOrWhiteSpace(feature))
             {
@@ -77,18 +45,9 @@ namespace Microsoft.CodeAnalysis.Options
                 throw new ArgumentException(nameof(name));
             }
 
-            if (perLanguageDefaults == null)
-            {
-                throw new ArgumentNullException(nameof(perLanguageDefaults));
-            }
-
             this.Feature = feature;
             this.Name = name;
             this.DefaultValue = defaultValue;
-
-            this._perLanguageDefaults =
-                (perLanguageDefaults as IImmutableDictionary<string, T>) ??
-                        ImmutableDictionary.CreateRange<string, T>(perLanguageDefaults);
         }
 
         Type IOption.Type
@@ -104,11 +63,6 @@ namespace Microsoft.CodeAnalysis.Options
         bool IOption.IsPerLanguage
         {
             get { return true; }
-        }
-
-        object IOption2.GetDefaultValue(string language)
-        {
-            return this.GetDefaultValue(language);
         }
 
         public override string ToString()

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -387,7 +387,6 @@
     <Compile Include="FindSymbols\DeclaredSymbolInfo.cs" />
     <Compile Include="FindSymbols\FindReferences\Finders\ILanguageServiceReferenceFinder.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingLogger.cs" />
-    <Compile Include="Options\IOption2.cs" />
     <Compile Include="Packaging\IPackageInstallerService.cs" />
     <Compile Include="Packaging\IPackageSearchService.cs" />
     <Compile Include="FindSymbols\SymbolTree\ISymbolTreeInfoCacheService.cs" />


### PR DESCRIPTION
Reverts dotnet/roslyn#10758

The fix for turning off FSD was incomplete and we want to a signed build with just the leak fix. So reverting this change until we have a complete fix.

@jasonmalinowski @mavasani @heejaechang @jmarolf 