### PR TITLE
Fix a NullReferenceException in DocumentExtensions

### DIFF
--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -61,8 +61,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 var node = token.Parent.AncestorsAndSelf().FirstOrDefault(a => a.FullSpan.Contains(span));
                 if (node == null)
                 {
-                    return await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                    throw new ArgumentOutOfRangeException(nameof(span));
                 }
+
                 return await GetSemanticModelForNodeAsync(semanticModelService, syntaxFactService, document, node, span, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 }
 
                 var node = token.Parent.AncestorsAndSelf().FirstOrDefault(a => a.FullSpan.Contains(span));
+                if (node == null)
+                {
+                    return await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+                }
                 return await GetSemanticModelForNodeAsync(semanticModelService, syntaxFactService, document, node, span, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))

--- a/src/Workspaces/CoreTest/ExtensionsTests/DocumentExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/ExtensionsTests/DocumentExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -8,34 +9,27 @@ namespace Microsoft.CodeAnalysis.UnitTests.ExtensionsTests
 {
     public class DocumentExtensionsTests
     {
-        private readonly AdhocWorkspace _ws = new AdhocWorkspace();
-        private readonly Project _emptyProject;
+        private readonly AdhocWorkspace _workspace;
+        private readonly Project _project;
 
         public DocumentExtensionsTests()
         {
-            _emptyProject = _ws.AddProject(
-                ProjectInfo.Create(
-                    ProjectId.CreateNewId(),
-                    VersionStamp.Default,
-                    "test",
-                    "test.dll",
-                    LanguageNames.CSharp,
-                    metadataReferences: new[] { TestReferences.NetFx.v4_0_30319.mscorlib }));
+            _workspace = new AdhocWorkspace();
+            _project = _workspace.AddProject("test", LanguageNames.CSharp);
         }
 
         private Document GetDocument(string code)
         {
-            return _emptyProject.AddDocument("test.cs", code);
+            return _project.AddDocument("test.cs", code);
         }
 
         [Fact]
-        public async Task GetSemanticModelForSpanAsync_TextSpanOutsideDocument()
+        public async Task GetSemanticModelForSpanAsync_TextSpanOutsideDocumentThrows()
         {
             const string code = @"class Test { }";
             var document = GetDocument(code);
-            var expected = await document.GetSemanticModelAsync();
-            var actual = await document.GetSemanticModelForSpanAsync(new TextSpan(code.Length, 1), CancellationToken.None);
-            Assert.Same(expected, actual);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () => 
+                await document.GetSemanticModelForSpanAsync(new TextSpan(code.Length, 1), CancellationToken.None));
         }
     }
 }

--- a/src/Workspaces/CoreTest/ExtensionsTests/DocumentExtensionsTests.cs
+++ b/src/Workspaces/CoreTest/ExtensionsTests/DocumentExtensionsTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.ExtensionsTests
+{
+    public class DocumentExtensionsTests
+    {
+        private readonly AdhocWorkspace _ws = new AdhocWorkspace();
+        private readonly Project _emptyProject;
+
+        public DocumentExtensionsTests()
+        {
+            _emptyProject = _ws.AddProject(
+                ProjectInfo.Create(
+                    ProjectId.CreateNewId(),
+                    VersionStamp.Default,
+                    "test",
+                    "test.dll",
+                    LanguageNames.CSharp,
+                    metadataReferences: new[] { TestReferences.NetFx.v4_0_30319.mscorlib }));
+        }
+
+        private Document GetDocument(string code)
+        {
+            return _emptyProject.AddDocument("test.cs", code);
+        }
+
+        [Fact]
+        public async Task GetSemanticModelForSpanAsync_TextSpanOutsideDocument()
+        {
+            const string code = @"class Test { }";
+            var document = GetDocument(code);
+            var expected = await document.GetSemanticModelAsync();
+            var actual = await document.GetSemanticModelForSpanAsync(new TextSpan(code.Length, 1), CancellationToken.None);
+            Assert.Same(expected, actual);
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -73,6 +73,7 @@
     <Compile Include="DependentTypeFinderTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="ExtensionOrdererTests.cs" />
+    <Compile Include="ExtensionsTests\DocumentExtensionsTests.cs" />
     <Compile Include="Host\WorkspaceServices\TestProjectCacheService.cs" />
     <Compile Include="Host\WorkspaceServices\TestTemporaryStorageService.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingTests.TextMerging.cs" />


### PR DESCRIPTION
I encountered this while using the `Classifier`. This happens if you specify a span outside the the document. I wasn't sure if it should return the entire document's semantic model or throw an `ArgumentOutOfRangeException`; I chose the former.

Stack trace:

```
at Microsoft.CodeAnalysis.CSharp.CSharpSyntaxFactsService.GetMemberBodySpanForSpeculativeBinding(SyntaxNode node)
at async Microsoft.CodeAnalysis.Shared.Extensions.DocumentExtensions.GetSemanticModelForNodeAsync(ISemanticModelService semanticModelService, ISyntaxFactsService syntaxFactService, Document document, SyntaxNode node, TextSpan span, CancellationToken cancellationToken)
at async Microsoft.CodeAnalysis.Shared.Extensions.DocumentExtensions.GetSemanticModelForSpanAsync(?)
at async Microsoft.CodeAnalysis.Classification.Classifier.GetClassifiedSpansAsync(?)
```
