### PR TITLE
Downgrade Editors to a released version of LanguageServices and add it and AppDesigner to ProjectSystem.sln

### DIFF
--- a/src/ProjectSystem/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
+++ b/src/ProjectSystem/Microsoft.VisualStudio.Editors/Microsoft.VisualStudio.Editors.vbproj
@@ -71,18 +71,6 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
-      <Project>{1ee8cad3-55f9-4d91-96b2-084641da9a6c}</Project>
-      <Name>CodeAnalysis</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Workspaces\Core\Portable\Workspaces.csproj">
-      <Project>{5f8d2414-064a-4b3a-9b42-8e2a04246be5}</Project>
-      <Name>Workspaces</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\..\VisualStudio\Core\Def\ServicesVisualStudio.csproj">
-      <Project>{86fd5b9a-4fa0-4b10-b59f-cfaf077a859c}</Project>
-      <Name>ServicesVisualStudio</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj">
       <Project>{19725D6F-4690-412B-934A-FC48D752B802}</Project>
       <Name>Microsoft.VisualStudio.AppDesigner</Name>

--- a/src/ProjectSystem/Microsoft.VisualStudio.Editors/project.json
+++ b/src/ProjectSystem/Microsoft.VisualStudio.Editors/project.json
@@ -3,5 +3,6 @@
     "net46": {}
   },
   "dependencies": {
+    "Microsoft.VisualStudio.LanguageServices" : "1.2.0"
   }
 }

--- a/src/ProjectSystem/Microsoft.VisualStudio.Editors/project.json
+++ b/src/ProjectSystem/Microsoft.VisualStudio.Editors/project.json
@@ -3,6 +3,9 @@
     "net46": {}
   },
   "dependencies": {
-    "Microsoft.VisualStudio.LanguageServices" : "1.2.0"
+    "Microsoft.VisualStudio.LanguageServices": {
+      "version": "1.2.0",
+      "suppressParent": "all"
+    }
   }
 }

--- a/src/ProjectSystem/ProjectSystem.sln
+++ b/src/ProjectSystem/ProjectSystem.sln
@@ -48,6 +48,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xUnit.net", "..\Dependencie
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Composition", "..\Dependencies\Composition\Composition.csproj", "{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualStudio.AppDesigner", "Microsoft.VisualStudio.AppDesigner\Microsoft.VisualStudio.AppDesigner.vbproj", "{19725D6F-4690-412B-934A-FC48D752B802}"
+EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualStudio.Editors", "Microsoft.VisualStudio.Editors\Microsoft.VisualStudio.Editors.vbproj", "{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +134,14 @@ Global
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{A57DDFE5-AB0E-4371-98E5-11B9218DF11C}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{19725D6F-4690-412B-934A-FC48D752B802}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19725D6F-4690-412B-934A-FC48D752B802}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19725D6F-4690-412B-934A-FC48D752B802}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19725D6F-4690-412B-934A-FC48D752B802}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CD6E5D00-7B0B-442D-9F5D-EAEC1A71838A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This prevents us from needing to reference LanguageServices, Workspaces & CodeAnalysis when inside ProjectSystem.sln. We don't deploy package to output directory so we do not overwrite the "current" version of the assembly.