### PR TITLE
Tuples: addressing PROTOTYPE markers for merge

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -433,7 +433,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (typesArray.Length < 2)
             {
                 // PROTOTYPE(tuples):
-                return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_PrototypeNotYetImplemented, syntax.Location));
+                return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_TupleTooFewElements, syntax.Location));
             }
 
             return TupleTypeSymbol.Create(

--- a/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs
@@ -437,12 +437,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal static int IsMemberNameReserved(string name)
         {
-            // PROTOTYPE(tuples): handle others like "ToString"?
-
             if (String.Equals(name, "Rest", StringComparison.Ordinal))
             {
                 return 0;
             }
+
             if (name.StartsWith("Item", StringComparison.Ordinal))
             {
                 string tail = name.Substring(4);
@@ -563,7 +562,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                // PROTOTYPE(tuples): need to figure what is the right behavior when underlying is obsolete
                 return null;
             }
         }
@@ -575,8 +573,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override ImmutableArray<Symbol> GetMembers(string name)
         {
-            // PROTOTYPE(tuples): PERF do we need to have a dictionary here?
-            //                    tuples will be typically small 2 or 3 elements only
             return ImmutableArray<Symbol>.CastUp(_fields).WhereAsArray(field => field.Name == name);
         }
 
@@ -657,8 +653,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             if (ignoreDynamic)
             {
-                // PROTOTYPE(tuples): rename ignoreDynamic or introduce another "ignoreTuple" flag
-                //                    if ignoring dynamic, compare underlying tuple types
                 if (t2?.IsTupleType == true)
                 {
                     t2 = ((TupleTypeSymbol)t2).UnderlyingTupleType;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -1417,7 +1417,6 @@ static class C
 }
 " + trivial2uple;
 
-            // PROTOTYPE(tuples): this should probably fail with diagnostics. No extension methods on tuple types (but you can on ValueTuple)
             CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
         }
 
@@ -1666,7 +1665,6 @@ class C3
             var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular.WithTuplesFeature());
             var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature());
 
-            // PROTOTYPE(tuples) this error is misleading or worse.
             comp.VerifyDiagnostics(
                 // (7,13): error CS0029: Cannot implicitly convert type '(int c, int d)' to '(int a, int b)'
                 //         x = C2.M();

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -313,9 +313,9 @@ class A
     // (5,46): error CS0102: The type 'A' already contains a definition for ''
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "").WithArguments("A", "").WithLocation(5, 46),
-    // (5,43): error CS8204: PROTOTYPE(tuples) This is not supported yet.
+    // (5,43): error CS8200: Tuple must contain at least two elements.
     //     protected virtual void Finalize const () { }
-    Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "()").WithLocation(5, 43),
+    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
     // (5,23): error CS0670: Field cannot have void type
     //     protected virtual void Finalize const () { }
     Diagnostic(ErrorCode.ERR_FieldCantHaveVoidType, "void").WithLocation(5, 23),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1062,9 +1062,9 @@ class C
     // (5,18): error CS1026: ) expected
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_CloseParenExpected, "{").WithLocation(5, 18),
-    // (5,15): error CS8204: PROTOTYPE This is not supported yet.
+    // (5,15): error CS8200: Tuple must contain at least two elements.
     //     int F<int>() { }  // CS0081
-    Diagnostic(ErrorCode.ERR_PrototypeNotYetImplemented, "()").WithLocation(5, 15),
+    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
     // (5,9): error CS0161: 'C.F<>(int, ?)': not all code paths return a value
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_ReturnExpected, "F").WithArguments("NS.C.F<>(int, ?)").WithLocation(5, 9)


### PR DESCRIPTION
Fixed one of the PROTOTYPE markers and filled issues for the others.
See #10808 #10806 #10805 #10803 #10802

@VSadov @dotnet/roslyn-compiler for review.