### PR TITLE
Remove as/is after various expressions

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/AsKeywordRecommenderTests.cs
@@ -114,5 +114,111 @@ $$");
             await VerifyAbsenceAsync(AddInsideMethod(
 @"var x = .$$0;"));
         }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterCtor()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var x = new C()$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAnonymousType()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var x = new { }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterDelegateAssignment()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"System.Action a = delegate { };
+var x = a $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterMethodWithOverloadResolutionFailure()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"class C
+{
+    void F()
+    {
+        var x = G() $$
+    }
+
+    void G() { }
+    int G() { }
+}"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodGroup1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.Console.Beep $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodGroup2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.String.Empty.GetType $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterVoidMethod()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.Console.Beep()$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAnonymousMethod1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action a = delegate { }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAnonymousMethod2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Func<int> a = delegate { return 0; }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action b = (() => { })$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Func<int> b = (() => { return 0; })$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda3()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action b = (() => 0)$$"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IsKeywordRecommenderTests.cs
@@ -167,5 +167,111 @@ $$");
             await VerifyAbsenceAsync(AddInsideMethod(
 @"var x = .$$0;"));
         }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterCtor()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var x = new C()$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterAnonymousType()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"var x = new { }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterDelegateAssignment()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"System.Action a = delegate { };
+var x = a $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestAfterMethodWithOverloadResolutionFailure()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"class C
+{
+    void F()
+    {
+        var x = G() $$
+    }
+
+    void G() { }
+    int G() { }
+}"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodGroup1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.Console.Beep $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterMethodGroup2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.String.Empty.GetType $$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterVoidMethod()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"var b = System.Console.Beep()$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAnonymousMethod1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action a = delegate { }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterAnonymousMethod2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Func<int> a = delegate { return 0; }$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda1()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action b = (() => { })$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda2()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Func<int> b = (() => { return 0; })$$"));
+        }
+
+        [WorkItem(8319, "https://github.com/dotnet/roslyn/issues/8319")]
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task TestNotAfterLambda3()
+        {
+            await VerifyAbsenceAsync(AddInsideMethod(
+@"System.Action b = (() => 0)$$"));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 syntaxTree.IsTypeArgumentOfConstraintClause(position, cancellationToken),
                 syntaxTree.IsNamespaceDeclarationNameContext(position, cancellationToken),
                 syntaxTree.IsRightOfDotOrArrowOrColonColon(position, cancellationToken),
-                syntaxTree.IsIsOrAsContext(position, leftToken, cancellationToken),
+                syntaxTree.IsIsOrAsContext(position, leftToken, semanticModel, cancellationToken),
                 syntaxTree.IsObjectCreationTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsDefiniteCastTypeContext(position, leftToken, cancellationToken),
                 syntaxTree.IsGenericTypeArgumentContext(position, leftToken, cancellationToken),


### PR DESCRIPTION
Includes lambdas, anonymous methods, and expressions of type 'void' or 'method group'

Fixes #8319
