### PR TITLE
WIP: Convert csx files containing only static methods into regular cs files.

### DIFF
--- a/src/Test/Perf/projects/HelloWorld.cs
+++ b/src/Test/Perf/projects/HelloWorld.cs
@@ -1,0 +1,7 @@
+public class Hello1
+{
+   public static void Main()
+   {
+      System.Console.WriteLine("Hello, World!");
+   }
+}

--- a/src/Test/Perf/projects/csharp/csharp_compiler.csx
+++ b/src/Test/Perf/projects/csharp/csharp_compiler.csx
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#r "../../../Roslyn.Test.Performance.Utilities.dll"
+using System.IO;
+using Roslyn.Test.Performance.Utilities;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+InitUtilities();
+var logger = new ConsoleAndFileLogger("log.txt");
+DownloadProject("csharp", version: 1, logger:logger);
+
+
+var rspFile = "CSharpCompiler.rsp";
+string responseFile = "@" + Path.Combine(MyTempDirectory(), "csharp", rspFile);
+string keyfileLocation = Path.Combine(MyTempDirectory(), "csharp", "keyfile", "35MSSharedLib1024.snk");
+string args = $"{responseFile} /keyfile:{keyfileLocation}";
+
+string executeInDirectory = Path.Combine(MyTempDirectory(), "csharp");
+
+var msToCompile = WalltimeMs(() => ShellOutVital(CscPath(), args, true, logger, executeInDirectory));
+Report(ReportKind.CompileTime, $"{rspFile} compile duration (ms)", msToCompile, logger);
+logger.Flush();

--- a/src/Test/Perf/projects/csharp/csharp_compiler_no_analyzer.csx
+++ b/src/Test/Perf/projects/csharp/csharp_compiler_no_analyzer.csx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#r "../../../Roslyn.Test.Performance.Utilities.dll"
+using System.IO;
+using Roslyn.Test.Performance.Utilities;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+using System.IO;
+
+InitUtilities();
+var logger = new ConsoleAndFileLogger("log.txt");
+DownloadProject("csharp", version: 1, logger: logger);
+
+var rspFile = "CSharpCompilerNoAnalyzer.rsp";
+string responseFile = "@" + Path.Combine(MyTempDirectory(), "csharp", rspFile);
+string keyfileLocation = Path.Combine(MyTempDirectory(), "csharp", "keyfile", "35MSSharedLib1024.snk");
+string args = $"{responseFile} /keyfile:{keyfileLocation}";
+
+string executeInDirectory = Path.Combine(MyTempDirectory(), "csharp");
+
+var msToCompile = WalltimeMs(() => ShellOutVital(CscPath(), args, true, logger, executeInDirectory));
+Report(ReportKind.CompileTime, $"{rspFile} compile duration (ms)", msToCompile, logger);
+logger.Flush();

--- a/src/Test/Perf/projects/hello_world.csx
+++ b/src/Test/Perf/projects/hello_world.csx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+#r "../../../Roslyn.Test.Performance.Utilities.dll"
+using System.IO;
+using Roslyn.Test.Performance.Utilities;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+InitUtilities();
+
+var logger = new ConsoleAndFileLogger("log.txt");
+var pathToHelloWorld = Path.Combine(MyWorkingDirectory(), "HelloWorld.cs");
+var pathToOutput = Path.Combine(MyArtifactsDirectory(), "HelloWorld.exe");
+
+var msToCompile = WalltimeMs(() => ShellOutVital(CscPath(), pathToHelloWorld + " /out:" + pathToOutput, true, logger));
+Report(ReportKind.CompileTime, "compile duration (ms)", msToCompile, logger);
+logger.Flush();

--- a/src/Test/Perf/tests/csharp/csharp_compiler.csx
+++ b/src/Test/Perf/tests/csharp/csharp_compiler.csx
@@ -1,19 +1,22 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+#r "../../../Roslyn.Test.Performance.Utilities.dll"
 #load "../../util/test_util.csx"
 using System.IO;
 using System.Collections.Generic;
+using Roslyn.Test.Performance.Utilities;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
 
-class CSharpCompilerTest: PerfTest 
+class CSharpCompilerTest: PerfTest
 {
-    private string _rspFile; 
-    public CSharpCompilerTest(string rspFile): base() {
+    private string _rspFile;
+    public CSharpCompilerTest(string rspFile): base(new ConsoleAndFileLogger("log.txt")) {
         _rspFile = rspFile;
     }
     
     public override void Setup() 
     {
-        DownloadProject("csharp", version: 1);
+        DownloadProject("csharp", version: 1, logger: _logger);
     }
     
     public override void Test() 
@@ -24,7 +27,8 @@ class CSharpCompilerTest: PerfTest
 
         string executeInDirectory = Path.Combine(MyTempDirectory, "csharp");
 
-        ShellOutVital(ReleaseCscPath, args, executeInDirectory);
+        ShellOutVital(Path.Combine(MyBinaries(), "csc.exe"), args, true, _logger, executeInDirectory);
+        _logger.Flush();
     }
     
     public override int Iterations => 2;
@@ -37,7 +41,7 @@ class CSharpCompilerTest: PerfTest
     }
 }
 
-TestThisPlease(
-    new CSharpCompilerTest("CSharpCompiler.rsp"),
+TestThisPlease(    new CSharpCompilerTest("CSharpCompiler.rsp"),
     new CSharpCompilerTest("CSharpCompilerNoAnalyzer.rsp"),
-    new CSharpCompilerTest("CSharpCompilerNoAnalyzerNoDeterminism.rsp"));
+    new CSharpCompilerTest("CSharpCompilerNoAnalyzerNoDeterminism.rsp")
+    );

--- a/src/Test/Perf/tests/helloworld/hello_world.csx
+++ b/src/Test/Perf/tests/helloworld/hello_world.csx
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-#load "../../util/test_util.csx"
+#r "../../../Roslyn.Test.Performance.Utilities.dll"
 using System.IO;
 
 class HelloWorldTest: PerfTest 
 {
     private string _pathToHelloWorld;
     private string _pathToOutput;
+    private ILogger _logger;
     
-    public HelloWorldTest(): base() {}
+    public HelloWorldTest(): base() 
+    {
+        _logger = new ConsoleAndFileLogger("log.txt");
+    }
+    
     
     public override void Setup() 
     {
@@ -18,7 +23,8 @@ class HelloWorldTest: PerfTest
     
     public override void Test() 
     {
-        ShellOutVital(ReleaseCscPath, _pathToHelloWorld + " /out:" + _pathToOutput);
+        ShellOutVital(ReleaseCscPath, _pathToHelloWorld + " /out:" + _pathToOutput, _logger);
+        logger.Flush();
     }
     
     public override int Iterations => 2;

--- a/src/Test/Perf/util/DownloadUtilities.cs
+++ b/src/Test/Perf/util/DownloadUtilities.cs
@@ -1,0 +1,40 @@
+﻿using System.IO;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+using static Roslyn.Test.Performance.Utilities.Tools;
+namespace Roslyn.Test.Performance.Utilities
+{
+    internal class DownloadUtilities
+    {
+
+
+    public static void DownloadTools()
+    {
+        DownloadCPC();
+        DownloadViBenchToJson();
+    }
+
+    public static void DownloadCPC()
+    {
+        var cpcDestinationPath = GetCPCDirectoryPath();
+        var cpcSourceBinaryLocation = @"\\mlangfs1\public\basoundr\CpcBinaries";
+
+
+        // Delete the existing CPC folder
+        if (Directory.Exists(cpcDestinationPath))
+        {
+            Directory.Delete(cpcDestinationPath, true);
+        }
+
+        // Copy CPC from the share to cpcDestinationPath
+        CopyDirectory(cpcSourceBinaryLocation, TrivialLogger.Instance, cpcDestinationPath);
+    }
+
+    public static void DownloadViBenchToJson()
+    {
+        var destinationFolderPath = GetCPCDirectoryPath();
+        var sourceFile = @"\\mlangfs1\public\basoundr\vibenchcsv2json";
+
+        CopyDirectory(sourceFile, TrivialLogger.Instance, destinationFolderPath, @"/s");
+    }
+}
+}

--- a/src/Test/Perf/util/ILogger.cs
+++ b/src/Test/Perf/util/ILogger.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public interface ILogger
+    {
+        void Log(string v);
+        void Flush();
+    }
+}

--- a/src/Test/Perf/util/ITraceManager.cs
+++ b/src/Test/Perf/util/ITraceManager.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+namespace Roslyn.Test.Performance.Utilities
+{
+    public interface ITraceManager
+    {
+        int Iterations { get; }
+
+        void Cleanup();
+        void EndEvent();
+        void EndScenario();
+        void EndScenarios();
+        void ResetScenarioGenerator();
+        void Setup();
+        void Start();
+        void StartEvent();
+        void StartScenario(string scenarioName, string processName);
+        void Stop();
+        void WriteScenariosFileToDisk();
+    }
+}

--- a/src/Test/Perf/util/Logger.cs
+++ b/src/Test/Perf/util/Logger.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class ConsoleAndFileLogger : ILogger
+    {
+        private readonly string _file;
+        private readonly StringBuilder _buffer = new StringBuilder();
+
+        public ConsoleAndFileLogger(string file)
+        {
+            _file = file;
+        }
+
+        public void Flush()
+        {
+            File.WriteAllText(_file, _buffer.ToString());
+        }
+
+        public void Log(string v)
+        {
+            Console.WriteLine(v);
+            _buffer.AppendLine(v);
+        }
+    }
+}

--- a/src/Test/Perf/util/NoOpTraceManager.cs
+++ b/src/Test/Perf/util/NoOpTraceManager.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class NoOpTraceManager : ITraceManager
+    {
+        private readonly int _iterations;
+        public NoOpTraceManager(int iterations)
+        {
+            _iterations = iterations;
+        }
+
+        public int Iterations
+        {
+            get
+            {
+                return _iterations;
+            }
+        }
+
+        public void Cleanup()
+        {
+        }
+
+        public void EndEvent()
+        {
+        }
+
+        public void EndScenario()
+        {
+        }
+
+        public void EndScenarios()
+        {
+        }
+
+        public void ResetScenarioGenerator()
+        {
+        }
+
+        public void Setup()
+        {
+        }
+
+        public void Start()
+        {
+        }
+
+        public void StartEvent()
+        {
+        }
+
+        public void StartScenario(string scenarioName, string processName)
+        {
+        }
+
+        public void Stop()
+        {
+        }
+
+        public void WriteScenariosFileToDisk()
+        {
+        }
+    }
+}

--- a/src/Test/Perf/util/PerfTestBase.cs
+++ b/src/Test/Perf/util/PerfTestBase.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public abstract class PerfTest : RelativeDirectory
+    {
+        private List<Tuple<int, string, object>> _metrics = new List<Tuple<int, string, object>>();
+        protected ILogger _logger;
+
+        public PerfTest(ILogger logger, [CallerFilePath] string workingFile = "") : base(workingFile) { _logger = logger; }
+
+        /// Reports a metric to be recorded in the performance monitor.
+        protected void Report(ReportKind reportKind, string description, object value)
+        {
+            _metrics.Add(Tuple.Create((int)reportKind, description, value));
+            _logger.Log(description + ": " + value.ToString());
+        }
+
+        public abstract void Setup();
+        public abstract void Test();
+        public abstract int Iterations { get; }
+        public abstract string Name { get; }
+        public abstract string MeasuredProc { get; }
+
+        public abstract bool ProvidesScenarios { get; }
+        public abstract string[] GetScenarios();
+    }
+}

--- a/src/Test/Perf/util/RelativeDirectory.cs
+++ b/src/Test/Perf/util/RelativeDirectory.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class RelativeDirectory
+    {
+        string _workingDir;
+
+        public RelativeDirectory([CallerFilePath] string workingFile = "")
+        {
+            _workingDir = Directory.GetParent(workingFile).FullName;
+        }
+
+        public string MyWorkingDirectory => _workingDir;
+
+
+        /// Returns the directory that you can put artifacts like
+        /// etl traces or compiled binaries
+        public string MyArtifactsDirectory
+        {
+            get
+            {
+                var path = Path.Combine(MyWorkingDirectory, "artifacts");
+                Directory.CreateDirectory(path);
+                return path;
+            }
+        }
+
+        public string MyTempDirectory
+        {
+            get
+            {
+                var workingDir = MyWorkingDirectory;
+                var path = Path.Combine(workingDir, "temp");
+                Directory.CreateDirectory(path);
+                return path;
+            }
+        }
+
+        public string RoslynDirectory
+        {
+            get
+            {
+                // In Windows, our path could be reported as "src/Test/Perf" (as it should),
+                // or "src/TeSt/PeRf" which is completely insane.
+                var workingDir = MyWorkingDirectory;
+                var srcTestPerf = Path.Combine("src", "Test", "Perf").ToString();
+                CompareInfo inv = CultureInfo.InvariantCulture.CompareInfo;
+                var idx = inv.IndexOf(workingDir, srcTestPerf, CompareOptions.IgnoreCase);
+                return workingDir.Substring(0, idx);
+            }
+        }
+
+        public string MyBinaries()
+        {
+            // The exceptation is that scripts calling this are included
+            // in a project in the solution and have already been deployed
+            // to a binaries folder
+
+            // Debug?
+            var debug = "debug";
+            var debugIndex = _workingDir.IndexOf(debug, StringComparison.CurrentCultureIgnoreCase);
+            if (debugIndex != -1)
+            {
+                return _workingDir.Substring(0, debugIndex + debug.Length);
+            }
+
+            // Release?
+            var release = "release";
+            var releaseIndex = _workingDir.IndexOf(release, StringComparison.CurrentCultureIgnoreCase);
+            if (releaseIndex != -1)
+            {
+                return _workingDir.Substring(0, releaseIndex + release.Length);
+            }
+
+            throw new Exception("Couldn't find binaries. Are you running from the binaries directory?");
+        }
+
+        public string PerfDirectory => Path.Combine(RoslynDirectory, "src", "Test", "Perf");
+
+        public string BinDirectory => Path.Combine(RoslynDirectory, "Binaries");
+
+        public string BinDebugDirectory => Path.Combine(BinDirectory, "Debug");
+
+        public string BinReleaseDirectory => Path.Combine(BinDirectory, "Release");
+
+        public string DebugCscPath => Path.Combine(BinDebugDirectory, "csc.exe");
+
+        public string ReleaseCscPath => Path.Combine(BinReleaseDirectory, "csc.exe");
+
+        public string DebugVbcPath => Path.Combine(BinDebugDirectory, "vbc.exe");
+
+        public string ReleaseVbcPath => Path.Combine(BinReleaseDirectory, "vbc.exe");
+
+        public string CPCDirectoryPath
+        {
+            get
+            {
+                return Environment.ExpandEnvironmentVariables(@"%SYSTEMDRIVE%\CPC");
+            }
+        }
+
+        public string GetViBenchToJsonExeFilePath => Path.Combine(CPCDirectoryPath, "ViBenchToJson.exe");
+
+
+
+        /// Downloads a zip from azure store and extracts it into
+        /// the ./temp directory.
+        ///
+        /// If this current version has already been downloaded
+        /// and extracted, do nothing.
+        public void DownloadProject(string name, int version, ILogger logger)
+        {
+            var zipFileName = $"{name}.{version}.zip";
+            var zipPath = Path.Combine(MyTempDirectory, zipFileName);
+            // If we've already downloaded the zip, assume that it
+            // has been downloaded *and* extracted.
+            if (File.Exists(zipPath))
+            {
+                logger.Log($"Didn't download and extract {zipFileName} because one already exists.");
+                return;
+            }
+
+            // Remove all .zip files that were downloaded before.
+            foreach (var path in Directory.EnumerateFiles(MyTempDirectory, $"{name}.*.zip"))
+            {
+                logger.Log($"Removing old zip {path}");
+                File.Delete(path);
+            }
+
+            // Download zip file to temp directory
+            var downloadTarget = $"https://dotnetci.blob.core.windows.net/roslyn-perf/{zipFileName}";
+            logger.Log($"Downloading {downloadTarget}");
+            var client = new WebClient();
+            client.DownloadFile(downloadTarget, zipPath);
+            logger.Log($"Done Downloading");
+
+            // Extract to temp directory
+            logger.Log($"Extracting {zipPath} to {MyTempDirectory}");
+            ZipFile.ExtractToDirectory(zipPath, MyTempDirectory);
+            logger.Log($"Done Extracting");
+        }
+    }
+}

--- a/src/Test/Perf/util/ReportKind.cs
+++ b/src/Test/Perf/util/ReportKind.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public enum ReportKind : int
+    {
+        CompileTime,
+        RunTime,
+        FileSize,
+    }
+}

--- a/src/Test/Perf/util/ScenarioGenerator.cs
+++ b/src/Test/Perf/util/ScenarioGenerator.cs
@@ -1,0 +1,80 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class ScenarioGenerator
+    {
+        private const string KernelProviderGuid = @"{9e814aad-3204-11d2-9a82-006008a86939}";
+        private string _fullPath = "scenarios.xml";
+        private List<string> _buffer;
+
+        public ScenarioGenerator(string scenarioFolderPath = "")
+        {
+            if (!string.IsNullOrEmpty(scenarioFolderPath))
+            {
+                _fullPath = Path.Combine(scenarioFolderPath, _fullPath);
+            }
+
+            Initialize();
+        }
+
+        public void Initialize()
+        {
+            // Delete any existing file
+            if (File.Exists(_fullPath))
+            {
+                File.Delete(_fullPath);
+            }
+
+            _buffer = new List<string>();
+            AddScenariosFileStart();
+        }
+
+        public void AddScenariosFileStart()
+        {
+            WriteToBuffer(@"<?xml version=""1.0"" encoding=""utf-8"" ?>");
+            WriteToBuffer(@"<scenarios>");
+        }
+
+        public void AddScenariosFileEnd()
+        {
+            WriteToBuffer(@"</scenarios>");
+        }
+
+        public void AddStartScenario(string scenarioName, string processName)
+        {
+            WriteToBuffer($@"<scenario name=""{scenarioName}"" process=""{processName}"">");
+        }
+
+        public void AddEndScenario()
+        {
+            WriteToBuffer(@"</scenario>");
+        }
+
+        public void AddStartEvent(int absoluteInstance)
+        {
+            WriteToBuffer($@"<from providerGuid=""{KernelProviderGuid}"" absoluteInstance=""{absoluteInstance}"" process=""csc"" eventName = ""Process/Start""/>");
+        }
+
+        public void AddEndEvent()
+        {
+            WriteToBuffer($@"<to providerGuid=""{KernelProviderGuid}"" absoluteInstance=""1"" process=""csc"" eventName=""Process/Stop""/>");
+        }
+
+        public void AddComment(string comment)
+        {
+            WriteToBuffer($@"<!-- {comment} -->");
+        }
+
+        public void WriteToDisk()
+        {
+            File.WriteAllLines(_fullPath, _buffer);
+        }
+
+        private void WriteToBuffer(string content)
+        {
+            _buffer.Add(content);
+        }
+    }
+}

--- a/src/Test/Perf/util/TestUtilities.cs
+++ b/src/Test/Perf/util/TestUtilities.cs
@@ -1,0 +1,347 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Roslyn.Test.Performance.Utilities;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class TestUtilities
+    {
+        //
+        // Directory Locating Functions
+        //
+
+        public static string _myWorkingFile = null;
+
+        public static void InitUtilities([CallerFilePath] string sourceFilePath = "")
+        {
+            _myWorkingFile = sourceFilePath;
+        }
+
+        /// Returns the directory that houses the currenly executing script.
+        public static string MyWorkingDirectory()
+        {
+            if (_myWorkingFile == null)
+            {
+                throw new Exception("Tests must call InitUtilities before doing any path-dependent operations.");
+            }
+            return Directory.GetParent(_myWorkingFile).FullName;
+        }
+
+        /// Returns the directory that you can put artifacts like
+        /// etl traces or compiled binaries
+        public static string MyArtifactsDirectory()
+        {
+            var path = Path.Combine(MyWorkingDirectory(), "artifacts");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static string MyTempDirectory()
+        {
+            var workingDir = MyWorkingDirectory();
+            var path = Path.Combine(workingDir, "temp");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static string RoslynDirectory()
+        {
+            var workingDir = MyWorkingDirectory();
+            var srcTestPerf = Path.Combine("src", "Test", "Perf").ToString();
+            return workingDir.Substring(0, workingDir.IndexOf(srcTestPerf));
+        }
+
+        public static string CscPath()
+        {
+            return Path.Combine(MyBinaries(), "csc.exe");
+        }
+
+        public static string MyBinaries()
+        {
+            var workingDir = MyWorkingDirectory();
+            // We may be a release or debug build
+            var debug = workingDir.IndexOf("debug", StringComparison.CurrentCultureIgnoreCase);
+            if (debug != -1)
+                return workingDir.Substring(0, debug + "debug".Length);
+
+            var release = workingDir.IndexOf("release", StringComparison.CurrentCultureIgnoreCase);
+            if (release != -1)
+                return workingDir.Substring(0, release + "release".Length);
+
+            throw new Exception("You are attempting to run performance test from the src directory. Run it from binaries");
+        }
+
+        public static string PerfDirectory()
+        {
+            return Path.Combine(RoslynDirectory(), "src", "Test", "Perf");
+        }
+
+        public static string BinDirectory()
+        {
+            return Path.Combine(RoslynDirectory(), "Binaries");
+        }
+
+        public static string BinDebugDirectory()
+        {
+            return Path.Combine(BinDirectory(), "Debug");
+        }
+
+        public static string BinReleaseDirectory()
+        {
+            return Path.Combine(BinDirectory(), "Release");
+        }
+
+        public static string DebugCscPath()
+        {
+            return Path.Combine(BinDebugDirectory(), "csc.exe");
+        }
+
+        public static string ReleaseCscPath()
+        {
+            return Path.Combine(BinReleaseDirectory(), "csc.exe");
+        }
+
+        public static string DebugVbcPath()
+        {
+            return Path.Combine(BinDebugDirectory(), "vbc.exe");
+        }
+
+        public static string ReleaseVbcPath()
+        {
+            return Path.Combine(BinReleaseDirectory(), "vbc.exe");
+        }
+
+        public static string GetCPCDirectoryPath()
+        {
+            var path = Path.Combine(PerfDirectory(), "temp", "cpc");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        public static string GetViBenchToJsonExeFilePath()
+        {
+            return Path.Combine(GetCPCDirectoryPath(), "ViBenchToJson.exe");
+        }
+
+        //
+        // Process spawning and error handling.
+        //
+
+        public class ProcessResult
+        {
+            public string ExecutablePath { get; set; }
+            public string Args { get; set; }
+            public int Code { get; set; }
+            public string StdOut { get; set; }
+            public string StdErr { get; set; }
+
+            public bool Failed => Code != 0;
+            public bool Succeeded => !Failed;
+        }
+
+        /// Shells out, and if the process fails, log the error
+        /// and quit the script.
+        public static void ShellOutVital(
+                string file,
+                string args,
+                bool verbose,
+                ILogger logger,
+                string workingDirectory = null,
+                CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var result = ShellOut(file, args, verbose, logger, workingDirectory, cancellationToken);
+            if (result.Failed)
+            {
+                LogProcessResult(result, logger);
+                throw new System.Exception("ShellOutVital Failed");
+            }
+        }
+
+        public static ProcessResult ShellOut(
+                string file,
+                string args,
+                bool verbose,
+                ILogger logger,
+                string workingDirectory = null,
+                CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (workingDirectory == null)
+            {
+                workingDirectory = MyWorkingDirectory();
+            }
+
+            var tcs = new TaskCompletionSource<ProcessResult>();
+            var startInfo = new ProcessStartInfo(file, args);
+            startInfo.RedirectStandardOutput = true;
+            startInfo.RedirectStandardError = true;
+            startInfo.UseShellExecute = false;
+            startInfo.WorkingDirectory = workingDirectory;
+            var process = new Process
+            {
+                StartInfo = startInfo,
+                EnableRaisingEvents = true,
+            };
+
+            if (cancellationToken != default(CancellationToken))
+            {
+                cancellationToken.Register(() => process.Kill());
+            }
+
+            if (verbose)
+            {
+                logger.Log($"running \"{file}\" with arguments \"{args}\" from directory {workingDirectory}");
+            }
+
+            process.Start();
+
+            var output = new StringWriter();
+            var error = new StringWriter();
+
+            process.OutputDataReceived += (s, e) =>
+            {
+                if (!String.IsNullOrEmpty(e.Data))
+                {
+                    output.WriteLine(e.Data);
+                }
+            };
+
+            process.ErrorDataReceived += (s, e) =>
+            {
+                if (!String.IsNullOrEmpty(e.Data))
+                {
+                    error.WriteLine(e.Data);
+                }
+            };
+
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+            process.WaitForExit();
+
+            return new ProcessResult
+            {
+                ExecutablePath = file,
+                Args = args,
+                Code = process.ExitCode,
+                StdOut = output.ToString(),
+                StdErr = error.ToString(),
+            };
+        }
+
+        public static string StdoutFrom(string program, bool verbose, ILogger logger, string args = "")
+        {
+            var result = ShellOut(program, args, verbose, logger);
+            if (result.Failed)
+            {
+                LogProcessResult(result, logger);
+                throw new Exception("Shelling out failed");
+            }
+            return result.StdOut.Trim();
+        }
+
+        //
+        // Timing and Testing
+        //
+
+        public static long WalltimeMs(Action action)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            action();
+            return stopwatch.ElapsedMilliseconds;
+        }
+
+        public static long WalltimeMs<R>(Func<R> action)
+        {
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            action();
+            return stopwatch.ElapsedMilliseconds;
+        }
+
+        //
+        // Reporting and logging
+        //
+
+
+
+        /// A list of
+        public static List<Tuple<int, string, object>> Metrics = new List<Tuple<int, string, object>>();
+
+        /// Logs a message.
+        ///
+        /// The actual implementation of this method may change depending on
+        /// if the script is being run standalone or through the test runner.
+        public static void Log(string info, string logFile)
+        {
+            System.Console.WriteLine(info);
+            if (logFile != null)
+            {
+                File.AppendAllText(logFile, info + System.Environment.NewLine);
+            }
+        }
+
+        /// Logs the result of a finished process
+        public static void LogProcessResult(ProcessResult result, ILogger logger)
+        {
+            logger.Log(String.Format("The process \"{0}\" {1} with code {2}",
+                $"{result.ExecutablePath} {result.Args}",
+                result.Failed ? "failed" : "succeeded",
+                result.Code));
+            logger.Log($"Standard Out:\n{result.StdOut}");
+            logger.Log($"\nStandard Error:\n{result.StdErr}");
+        }
+
+        /// Reports a metric to be recorded in the performance monitor.
+        public static void Report(ReportKind reportKind, string description, object value, ILogger logger)
+        {
+            Metrics.Add(Tuple.Create((int)reportKind, description, value));
+            logger.Log(description + ": " + value.ToString());
+        }
+
+        /// Downloads a zip from azure store and extracts it into
+        /// the ./temp directory.
+        ///
+        /// If this current version has already been downloaded
+        /// and extracted, do nothing.
+        public static void DownloadProject(string name, int version, ILogger logger)
+        {
+            var zipFileName = $"{name}.{version}.zip";
+            var zipPath = Path.Combine(MyTempDirectory(), zipFileName);
+            // If we've already downloaded the zip, assume that it
+            // has been downloaded *and* extracted.
+            if (File.Exists(zipPath))
+            {
+                logger.Log($"Didn't download and extract {zipFileName} because one already exists.");
+                return;
+            }
+
+            // Remove all .zip files that were downloaded before.
+            foreach (var path in Directory.EnumerateFiles(MyTempDirectory(), $"{name}.*.zip"))
+            {
+                logger.Log($"Removing old zip {path}");
+                File.Delete(path);
+            }
+
+            // Download zip file to temp directory
+            var downloadTarget = $"https://dotnetci.blob.core.windows.net/roslyn-perf/{zipFileName}";
+            logger.Log($"Downloading {downloadTarget}");
+            var client = new WebClient();
+            client.DownloadFile(downloadTarget, zipPath);
+            logger.Log($"Done Downloading");
+
+            // Extract to temp directory
+            logger.Log($"Extracting {zipPath} to {MyTempDirectory()}");
+            ZipFile.ExtractToDirectory(zipPath, MyTempDirectory());
+            logger.Log($"Done Extracting");
+        }
+    }
+}

--- a/src/Test/Perf/util/Tools.cs
+++ b/src/Test/Perf/util/Tools.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Xml;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    class Tools
+    {
+        /// Takes a consumptionTempResults file and converts to csv file
+        /// Each info contains the <ScenarioName, Metric Key, Metric value>
+        bool ConvertConsumptionToCsv(string source, string destination, string requiredMetricKey, ILogger logger)
+        {
+            logger.Log("Entering ConvertConsumptionToCsv");
+            if (!File.Exists(source))
+            {
+                logger.Log($"File {source} does not exist");
+                return false;
+            }
+
+            try
+            {
+                var result = new List<string>();
+                string currentScenarioName = null;
+
+                using (XmlReader xmlReader = XmlReader.Create(source))
+                {
+                    while (xmlReader.Read())
+                    {
+                        if ((xmlReader.NodeType == XmlNodeType.Element))
+                        {
+                            if (xmlReader.Name.Equals("ScenarioResult"))
+                            {
+                                currentScenarioName = xmlReader.GetAttribute("Name");
+
+                                // These are not test results
+                                if (string.Equals(currentScenarioName, "..TestDiagnostics.."))
+                                {
+                                    currentScenarioName = null;
+                                }
+                            }
+                            else if (currentScenarioName != null && xmlReader.Name.Equals("CounterResult"))
+                            {
+                                var metricKey = xmlReader.GetAttribute("Name");
+
+                                if (string.Equals(metricKey, requiredMetricKey))
+                                {
+                                    var metricScale = xmlReader.GetAttribute("Units");
+                                    xmlReader.Read();
+                                    var metricvalue = xmlReader.Value;
+                                    result.Add($"{currentScenarioName}, {metricKey} ({metricScale}), {metricvalue}");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                File.WriteAllLines(destination, result);
+            }
+            catch (System.Exception e)
+            {
+                System.Console.WriteLine(e.Message);
+                System.Console.WriteLine(e.StackTrace);
+                return false;
+            }
+
+            return true;
+        }
+
+        /// Gets a csv file with metrics and converts them to ViBench supported JSON file
+        string GetViBenchJsonFromCsv(string compilerTimeCsvFilePath, string execTimeCsvFilePath, string fileSizeCsvFilePath, bool verbose, ILogger logger)
+        {
+            logger.Log("Convert the csv to JSON using ViBench tool");
+            string branch = StdoutFrom("git", verbose, logger, "rev-parse --abbrev-ref HEAD");
+            string date = FirstLine(StdoutFrom("git", verbose, logger, $"show --format=\"%aI\" {branch} --"));
+            string hash = FirstLine(StdoutFrom("git", verbose, logger, $"show --format=\"%h\" {branch} --"));
+            string longHash = FirstLine(StdoutFrom("git", verbose, logger, $"show --format=\"%H\" {branch} --"));
+            string username = StdoutFrom("whoami", verbose, logger);
+            string machineName = StdoutFrom("hostname", verbose, logger);
+            string architecture = System.Environment.Is64BitOperatingSystem ? "x86-64" : "x86";
+
+            // File locations
+            string outJson = Path.Combine(GetCPCDirectoryPath(), $"Roslyn-{longHash}.json");
+
+            // ViBenchToJson does not like empty csv files.
+            string files = "";
+            if (compilerTimeCsvFilePath != null && new FileInfo(compilerTimeCsvFilePath).Length != 0)
+            {
+                files += $@"compilertime:""{compilerTimeCsvFilePath}""";
+            }
+            if (execTimeCsvFilePath != null && new FileInfo(execTimeCsvFilePath).Length != 0)
+            {
+                files += $@"exectime:""{execTimeCsvFilePath}""";
+            }
+            if (fileSizeCsvFilePath != null && new FileInfo(fileSizeCsvFilePath).Length != 0)
+            {
+                files += $@"filesize:""{fileSizeCsvFilePath}""";
+            }
+            string arguments = $@"
+    {files}
+    jobName:""RoslynPerf-{hash}-{date}""
+    jobGroupName:""Roslyn-{branch}""
+    jobTypeName:""official""
+    buildInfoName:""{date}-{branch}-{hash}""
+    configName:""Default Configuration""
+    machinePoolName:""4-core-windows""
+    architectureName:""{architecture}""
+    manufacturerName:""unknown-manufacturer""
+    microarchName:""unknown-microarch""
+    userName:""{username}""
+    userAlias:""{username}""
+    osInfoName:""Windows""
+    machineName:""{machineName}""
+    buildNumber:""{date}-{hash}""
+    /json:""{outJson}""
+    ";
+
+            arguments = arguments.Replace("\r\n", " ").Replace("\n", "");
+
+            ShellOutVital(Path.Combine(GetCPCDirectoryPath(), "ViBenchToJson.exe"), arguments, verbose, logger);
+
+            return outJson;
+        }
+
+        string FirstLine(string input)
+        {
+            return input.Split(new[] { "\r\n", "\r", "\n" }, System.StringSplitOptions.None)[0];
+        }
+
+        void UploadTraces(string sourceFolderPath, string destinationFolderPath, ILogger logger)
+        {
+            logger.Log("Uploading traces");
+            if (Directory.Exists(sourceFolderPath))
+            {
+                // Get the latest written databackup
+                var directoryToUpload = new DirectoryInfo(sourceFolderPath).GetDirectories("DataBackup*").OrderByDescending(d => d.LastWriteTimeUtc).FirstOrDefault();
+                if (directoryToUpload == null)
+                {
+                    logger.Log($"There are no trace directory starting with DataBackup in {sourceFolderPath}");
+                    return;
+                }
+
+                var destination = Path.Combine(destinationFolderPath, directoryToUpload.Name);
+                CopyDirectory(directoryToUpload.FullName, logger, destination);
+
+                foreach (var file in new DirectoryInfo(sourceFolderPath).GetFiles().Where(f => f.Name.StartsWith("ConsumptionTemp", StringComparison.OrdinalIgnoreCase) || f.Name.StartsWith("Roslyn-", StringComparison.OrdinalIgnoreCase)))
+                {
+                    File.Copy(file.FullName, Path.Combine(destination, file.Name));
+                }
+            }
+            else
+            {
+                logger.Log($"sourceFolderPath: {sourceFolderPath} does not exist");
+            }
+        }
+
+        public static void CopyDirectory(string source, ILogger logger, string destination, string argument = @"/mir")
+        {
+            var result = ShellOut("Robocopy", $"{argument} {source} {destination}", verbose: true, logger: logger);
+
+            // Robocopy has a success exit code from 0 - 7
+            if (result.Code > 7)
+            {
+                throw new IOException($"Failed to copy \"{source}\" to \"{destination}\".");
+            }
+        }
+
+    }
+}

--- a/src/Test/Perf/util/TraceManager.cs
+++ b/src/Test/Perf/util/TraceManager.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static Roslyn.Test.Performance.Utilities.DownloadUtilities;
+using static Roslyn.Test.Performance.Utilities.TestUtilities;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class TraceManager : ITraceManager
+    {
+        private readonly ScenarioGenerator _scenarioGenerator;
+        private readonly int _iterations;
+        private readonly string _cpcPath;
+
+        private int _startEventAbsoluteInstance = 1;
+        private int _stopEventAbsoluteInstance = 1;
+        private readonly bool _verbose;
+        private readonly ILogger _logger;
+
+        public TraceManager(
+            int iterations,
+            string cpcPath,
+            string scenarioPath,
+            bool verbose,
+            ILogger logger)
+        {
+            _iterations = iterations;
+            _cpcPath = cpcPath;
+            _scenarioGenerator = new ScenarioGenerator(scenarioPath);
+            _verbose = verbose;
+            _logger = logger;
+        }
+
+        public int Iterations
+        {
+            get
+            {
+                return _iterations;
+            }
+        }
+
+        public void Setup()
+        {
+            ShellOutVital(_cpcPath, "/Setup /DisableArchive", _verbose, _logger);
+        }
+
+        public void Start()
+        {
+            ShellOutVital(_cpcPath, "/Start /DisableArchive", _verbose, _logger);
+        }
+
+        public void Stop()
+        {
+            var scenariosXmlPath = Path.Combine(GetCPCDirectoryPath(), "scenarios.xml");
+            var consumptionTempResultsPath = Path.Combine(GetCPCDirectoryPath(), "ConsumptionTempResultsPath.xml");
+            ShellOutVital(_cpcPath, $"/Stop /DisableArchive /ScenarioPath=\"{scenariosXmlPath}\" /ConsumptionTempResultsPath=\"{consumptionTempResultsPath}\"", _verbose, _logger);
+        }
+
+        public void Cleanup()
+        {
+            ShellOutVital(_cpcPath, "/Cleanup /DisableArchive", _verbose, _logger);
+        }
+
+        public void StartScenario(string scenarioName, string processName)
+        {
+            _scenarioGenerator.AddStartScenario(scenarioName, processName);
+        }
+
+        public void StartEvent()
+        {
+            _scenarioGenerator.AddStartEvent(_startEventAbsoluteInstance);
+            _startEventAbsoluteInstance++;
+        }
+
+        public void EndEvent()
+        {
+            _scenarioGenerator.AddEndEvent();
+            _stopEventAbsoluteInstance++;
+        }
+
+        public void EndScenario()
+        {
+            _scenarioGenerator.AddEndScenario();
+        }
+
+        public void EndScenarios()
+        {
+            _scenarioGenerator.AddScenariosFileEnd();
+        }
+
+        public void WriteScenariosFileToDisk()
+        {
+            _scenarioGenerator.WriteToDisk();
+        }
+
+        public void ResetScenarioGenerator()
+        {
+            _scenarioGenerator.Initialize();
+            _startEventAbsoluteInstance = 1;
+            _stopEventAbsoluteInstance = 1;
+        }
+    }
+}

--- a/src/Test/Perf/util/TraceManagerFactory.cs
+++ b/src/Test/Perf/util/TraceManagerFactory.cs
@@ -1,0 +1,21 @@
+﻿using System.IO;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class TraceManagerFactory
+    {
+        public static ITraceManager GetTraceManager(int iterations = 1)
+        {
+            var cpcFullPath = Path.Combine(TestUtilities.GetCPCDirectoryPath(), "CPC.exe");
+            var scenarioPath = TestUtilities.GetCPCDirectoryPath();
+            if (File.Exists(cpcFullPath))
+            {
+                return new TraceManager(iterations, cpcFullPath, scenarioPath, verbose: false, logger: null);
+            }
+            else
+            {
+                return new NoOpTraceManager(iterations);
+            }
+        }
+    }
+}

--- a/src/Test/Perf/util/TrivialLogger.cs
+++ b/src/Test/Perf/util/TrivialLogger.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public class TrivialLogger : ILogger
+    {
+        public static ILogger Instance = new TrivialLogger();
+
+        public void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Log(string v)
+        {
+        }
+    }
+}

--- a/src/Test/Perf/util/test_util.csx
+++ b/src/Test/Perf/util/test_util.csx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 #r "System.IO.Compression.FileSystem"
+#r "../../Roslyn.Test.Performance.Utilities.dll"
 
 using System.IO;
 using System.IO.Compression;
@@ -13,6 +14,7 @@ using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Net;
 using System.Globalization;
+using Roslyn.Test.Performance.Utilities;
 
 class RelativeDirectory 
 {
@@ -126,26 +128,26 @@ class RelativeDirectory
     }
 }
 
-abstract class PerfTest: RelativeDirectory {
-    private List<Tuple<int, string, object>> _metrics = new List<Tuple<int, string, object>>();
+//abstract class PerfTest: RelativeDirectory {
+//    private List<Tuple<int, string, object>> _metrics = new List<Tuple<int, string, object>>();
     
-    public PerfTest([CallerFilePath] string workingFile = ""): base(workingFile) {}
+//    public PerfTest([CallerFilePath] string workingFile = ""): base(workingFile) {}
     
-    /// Reports a metric to be recorded in the performance monitor.
-    protected void Report(ReportKind reportKind, string description, object value)
-    {
-        _metrics.Add(Tuple.Create((int) reportKind, description, value));
-        Log(description + ": " + value.ToString());
-    }
+//    /// Reports a metric to be recorded in the performance monitor.
+//    protected void Report(ReportKind reportKind, string description, object value)
+//    {
+//        _metrics.Add(Tuple.Create((int) reportKind, description, value));
+//        Log(description + ": " + value.ToString());
+//    }
     
-    public abstract bool ProvidesScenarios { get; }
-    public abstract string[] GetScenarios();
-    public abstract void Setup();
-    public abstract void Test();
-    public abstract int Iterations { get; }
-    public abstract string Name { get; }
-    public abstract string MeasuredProc { get; }
-}
+//    public abstract bool ProvidesScenarios { get; }
+//    public abstract string[] GetScenarios();
+//    public abstract void Setup();
+//    public abstract void Test();
+//    public abstract int Iterations { get; }
+//    public abstract string Name { get; }
+//    public abstract string MeasuredProc { get; }
+//}
 
 // This is a workaround for not being able to return
 // arbitrary objects from a csi script while not being
@@ -217,19 +219,19 @@ class ProcessResult
 
 /// Shells out, and if the process fails, log the error
 /// and quit the script.
-static void ShellOutVital(
-        string file,
-        string args,
-        string workingDirectory = null,
-        CancellationToken? cancelationToken = null)
-{
-    var result = ShellOut(file, args, workingDirectory, cancelationToken);
-    if (result.Failed)
-    {
-        LogProcessResult(result);
-        throw new System.Exception("ShellOutVital Failed");
-    }
-}
+//static void ShellOutVital(
+//        string file,
+//        string args,
+//        string workingDirectory = null,
+//        CancellationToken? cancelationToken = null)
+//{
+//    var result = ShellOut(file, args, workingDirectory, cancelationToken);
+//    if (result.Failed)
+//    {
+//        LogProcessResult(result);
+//        throw new System.Exception("ShellOutVital Failed");
+//    }
+//}
 
 static ProcessResult ShellOut(
         string file,

--- a/src/Test/PerformanceTesting.csproj
+++ b/src/Test/PerformanceTesting.csproj
@@ -9,8 +9,8 @@
     <ProjectGuid>{DA0D2A70-A2F9-4654-A99A-3227EDF54FF1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PerformanceTesting</RootNamespace>
-    <AssemblyName>PerformanceTesting</AssemblyName>
+    <RootNamespace>Roslyn.Test.Performance</RootNamespace>
+    <AssemblyName>Roslyn.Test.Performance.Utilities</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -24,7 +24,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>CS2008</NoWarn>
+    <NoWarn>
+    </NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,6 +42,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -49,11 +51,16 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Perf\projects\csharp\" />
     <Folder Include="Perf\temp\cpc\" />
     <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Perf\projects\HelloWorld.cs" />
+    <Compile Include="Perf\util\Logger.cs" />
+    <Compile Include="Perf\util\PerfTestBase.cs" />
+    <Compile Include="Perf\util\RelativeDirectory.cs" />
+    <Compile Include="Perf\util\Tools.cs" />
+    <Compile Include="Perf\util\TrivialLogger.cs" />
     <None Include="Perf\.gitignore" />
     <Content Include="Perf\bootstrap.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -94,6 +101,13 @@
     <Content Include="Perf\runner.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Perf\projects\csharp\csharp_compiler.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Perf\projects\csharp\csharp_compiler_no_analyzer.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <None Include="Perf\projects\hello_world.csx" />
     <None Include="Perf\temp\compiler_time.csv" />
     <None Include="Perf\temp\file_size.csv" />
     <None Include="Perf\temp\run_time.csv" />
@@ -109,9 +123,10 @@
     <Content Include="Perf\util\runner_util.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Perf\util\scenario_generator_util.csx">
+    <Compile Include="Perf\util\ReportKind.cs" />
+    <Compile Include="Perf\util\ScenarioGenerator.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </Compile>
     <Content Include="Perf\util\test_util.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -121,11 +136,21 @@
     <Content Include="Perf\util\trace_manager_util.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Perf\util\scenario_generator_util.csx" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Perf\tests\helloworld\HelloWorld.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Perf\util\DownloadUtilities.cs" />
+    <Compile Include="Perf\util\ILogger.cs" />
+    <Compile Include="Perf\util\ITraceManager.cs" />
+    <Compile Include="Perf\util\NoOpTraceManager.cs" />
+    <Compile Include="Perf\util\TestUtilities.cs" />
+    <Compile Include="Perf\util\TraceManager.cs" />
+    <Compile Include="Perf\util\TraceManagerFactory.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Tools/CommonNetCoreReferences/CommonNetCoreReferences.csproj
+++ b/src/Tools/CommonNetCoreReferences/CommonNetCoreReferences.csproj
@@ -27,12 +27,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\CommonCoreClrRuntime\CommonCoreClrRuntime.csproj">
-      <Project>{1b665337-9d6a-451a-aeac-f7bf1af95ffb}</Project>
-      <Name>CommonCoreClrRuntime</Name>
-    </ProjectReference>
-  </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />
   </ImportGroup>

--- a/src/VisualStudio/Setup/VisualStudioSetup.csproj
+++ b/src/VisualStudio/Setup/VisualStudioSetup.csproj
@@ -151,9 +151,11 @@
   </ItemGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet />
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>


### PR DESCRIPTION
It was really hard to understand what was going on in an actual test script--this change starts moving types like `PerfTest` and various static helpers in `*_util` files into regular cs files that are built with the PerformanceTesting project.

cc @basoundr @KevinH-MS @TyOverby 