### PR TITLE
Move DeployTestDependencies to use same targets as Dependencies

### DIFF
--- a/build/Targets/ProducesNoOutput.Imports.targets
+++ b/build/Targets/ProducesNoOutput.Imports.targets
@@ -9,7 +9,6 @@
   </PropertyGroup>
   
   <Target Name="CoreCompile" />                               <!-- Prevent Csc from being called -->  
-  <Target Name="CopyFilesToOutputDirectory" />                <!-- Prevent non-existent output from being copied -->
   <Target Name="GenerateTargetFrameworkMonikerAttribute" />   <!-- Don't generate TFM attribute -->  
   <Target Name="RuntimeImplementationProjectOutputGroup" />   <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
   

--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -2,13 +2,28 @@
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  
+
   <PropertyGroup>
+    <IsDeployment Condition="'$(IsDeployment)' == ''">false</IsDeployment>
+    <IsPortable Condition="'$(IsPortable)' == ''">true</IsPortable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsDeployment)' == 'false'">
+    <!-- While UseCommonOutputDirectory will prevent NuGet implementations from being
+         copied, we still need to turn off CopyNuGetImplementations to prevent the build
+         task from complaining about a lack of a runtime section in our dependencies 
+         projects -->
     <CopyNuGetImplementations>false</CopyNuGetImplementations>
     <UseCommonOutputDirectory>true</UseCommonOutputDirectory>
     <OutputPath>bin</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <OutputType>Library</OutputType>
-    <IsPortable Condition="'$(IsPortable)' == ''">true</IsPortable>
+    <OutputPath Condition="'$(OutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\Binaries\$(Configuration)'))\</OutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\Binaries\Obj\$(MSBuildProjectName)'))\</BaseIntermediateOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsPortable)' == 'true'">

--- a/src/ProjectSystem/DeployTestDependencies/DeployTestDependencies.csproj
+++ b/src/ProjectSystem/DeployTestDependencies/DeployTestDependencies.csproj
@@ -1,22 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\..\build\Targets\VSL.Settings.targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <SchemaVersion>2.0</SchemaVersion>
+    <IsPortable>false</IsPortable>
+    <IsDeployment>true</IsDeployment>
+  </PropertyGroup>
+  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Settings.targets" />
+  <PropertyGroup>
     <ProjectGuid>{37BA82E6-9ABD-4ACA-AA26-2DFD39A359A5}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <RootNamespace>Microsoft.VisualStudio</RootNamespace>
-    <AssemblyName>ProjectSystem</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-    <NoDocumentationFile>true</NoDocumentationFile>
-    <CopyNuGetImplementations>true</CopyNuGetImplementations>
-    <CopyReferencesByDefault>true</CopyReferencesByDefault>
-    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -82,5 +74,5 @@
   <ItemGroup>
     <Content Include="Readme.txt" />
   </ItemGroup>
-  <Import Project="..\..\..\build\Targets\VSL.Imports.targets" />
+  <Import Project="..\..\..\build\Targets\ProducesNoOutput.Imports.targets" />
 </Project>

--- a/src/ProjectSystem/DeployTestDependencies/project.json
+++ b/src/ProjectSystem/DeployTestDependencies/project.json
@@ -6,7 +6,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win": { }
   }
 }


### PR DESCRIPTION
This lets us stop calling csc.exe for a project who's sole job is to copy binaries.

This partially fixes https://github.com/dotnet/roslyn/issues/10184