### PR TITLE
Removing the rest of PROTOTYPE comments from tuples branch

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -714,12 +714,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             TypeSymbol expressionType = expression.Type;
 
-            // PROTOTYPE(tuples): we could, in theory, allow restricted field types here
-            //            since they might be target-typed to something safe
-            //            
-
-            // PROTOTYPE(tuples): regardless of the decision on the above, need to test this.
-
             if (!expression.HasAnyErrors)
             {
                 if (expression.HasExpressionType())
@@ -734,7 +728,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     else if (expressionType.IsRestrictedType())
                     {
                         hasError = true;
-                        Error(diagnostics, ErrorCode.ERR_ArrayElementCantBeRefAny, errorSyntax, expressionType);
+                        Error(diagnostics, ErrorCode.ERR_FieldCantBeRefAny, errorSyntax, expressionType);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Lookup.cs
@@ -715,8 +715,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     break;
                 }
 
-                // PROTOTYPE(tuples): consider taking this out of the loop. tuples are always at the end of hierarchy
-                // PROTOTYPE(tuples): match this in other lookups
                 var tuple = currentType as TupleTypeSymbol;
                 if ((object)tuple != null)
                 {
@@ -1531,8 +1529,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case TypeKind.Dynamic:
                     this.AddMemberLookupSymbolsInfoInClass(result, type, options, originalBinder, type);
                     break;
-
-                    //PROTOTYPE(tuples): add special handling for tuple types - we need to collect both tuple members and from the underlying.
 
                 case TypeKind.Submission:
                     this.AddMemberLookupSymbolsInfoInSubmissions(result, type, options, originalBinder);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -412,6 +412,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var argumentType = BindType(argumentSyntax.Type, diagnostics);
                 types.Add(argumentType);
 
+                if (argumentType.IsRestrictedType())
+                {
+                    Error(diagnostics, ErrorCode.ERR_FieldCantBeRefAny, argumentSyntax, argumentType);
+                }
+
                 string name = argumentSyntax.Name?.Identifier.ValueText;
 
                 // validate name if we have one

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -437,7 +437,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             ImmutableArray<TypeSymbol> typesArray = types.ToImmutableAndFree();
             if (typesArray.Length < 2)
             {
-                // PROTOTYPE(tuples):
                 return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_TupleTooFewElements, syntax.Location));
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -370,8 +370,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                // PROTOTYPE(tuples): we have introduced a new kind of implicit conversion in the language
-                //                   make sure it is well documented and conceptually matches the spec
                 return Kind == ConversionKind.ImplicitTuple;
             }
         }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -1536,7 +1536,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            // SPEC: PROTOTYPE(tuples): spec quote here
             if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
                 return;
@@ -1606,13 +1605,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return true;
         }
 
-        //PROTOTYPE(tuples): inference from tuple type is exact since tuples are non-variant.
         private bool ExactTupleInference(TypeSymbol source, TypeSymbol target, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             Debug.Assert((object)source != null);
             Debug.Assert((object)target != null);
-
-            // SPEC: PROTOTYPE(tuples): would be nice to quote spec here
 
             // NOTE: we are losing tuple element names when unwrapping tuple types to underlying types.
             //       that is ok, because we are inferring type parameters used in the matching elements, 
@@ -1636,6 +1632,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return false;
             }
 
+            // NOTE: inference from tuple type is exact since tuples are non-variant.
             ExactTypeArgumentInference((NamedTypeSymbol)source, (NamedTypeSymbol)target, ref useSiteDiagnostics);
             return true;
         }
@@ -1764,9 +1761,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             // {
             //     return;
             // }
-
-
-            // SPEC: PROTOTYPE(tuples) spec quote here.
 
             if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
@@ -2131,8 +2125,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            // SPEC: PROTOTYPE(tuples): spec quote here
-
             if (ExactTupleInference(source, target, ref useSiteDiagnostics))
             {
                 return;
@@ -2492,8 +2484,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (best.Equals(candidate, ignoreDynamic: true))
                 {
-                    //PROTOTYPE(tuples): SPEC that when having a tuple candidate and another candidate that is a identity-convertable tuple
-                    //                   SPEC or its underlying ValueTuple type, the underlying type is inferred
                     if (candidate.IsTupleType)
                     {
                         best = ((TupleTypeSymbol)candidate).UnderlyingTupleType;

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -497,8 +497,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     internal partial class BoundTupleExpression 
     {
-        // PROTOTYPE(tuples): we need to make this its own OperationKind 
-        //                    and expose arguments and names via ITupleExpression
         protected override OperationKind ExpressionKind => OperationKind.None;
 
         public override void Accept(OperationVisitor visitor)

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -62,8 +62,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override object Display
         {
-            // PROTOTYPE(tuples): display should build a view from tuple arguments 
-            //                    when tuple is typeless
             get { return (object)this.Type ?? "<tuple>"; }
         }
     }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7406,15 +7406,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to PROTOTYPE This is not supported yet..
-        /// </summary>
-        internal static string ERR_PrototypeNotYetImplemented {
-            get {
-                return ResourceManager.GetString("ERR_PrototypeNotYetImplemented", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The * or -&gt; operator must be applied to a pointer.
         /// </summary>
         internal static string ERR_PtrExpected {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4866,9 +4866,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TupleReservedMemberName" xml:space="preserve">
     <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>
-  <data name="ERR_PrototypeNotYetImplemented" xml:space="preserve">
-    <value>PROTOTYPE This is not supported yet.</value>
-  </data>
   <data name="ERR_TupleReservedMemberNameAnyPosition" xml:space="preserve">
     <value>Tuple membername '{0}' is disallowed at any position.</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1383,7 +1383,5 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleExplicitNamesOnAllMembersOrNone = 8204,
 
         ERR_PredefinedTypeMemberNotFoundInAssembly = 8205,
-
-        ERR_PrototypeNotYetImplemented = 9000,
     }
 }

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -165,8 +165,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // PROTOTYPE(tuples): we need to settle on final tuple symbol visualization.
-            //                    it feels like tuples would not need any qualification 
             if (this.IsMinimizing || symbol.IsTupleType)
             {
                 MinimallyQualify(symbol);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (sourceType.IsTupleType)
             {
-                // PROTOTYPE(tuples) this check/case should be removed once tuple metadata encoding is implemented
                 ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
                 TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3776,5 +3776,62 @@ w
 ");
 
         }
+
+        [Fact]
+        public void RestrictedTypes1()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (1, 2, new System.ArgIterator());
+        (int x, object y) y = (1, 2, new System.ArgIterator());
+        (int x, System.ArgIterator y) z = (1, 2, new System.ArgIterator());
+    }
+}
+" + trivial2uple + trivial3uple;
+
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            comp.VerifyDiagnostics(
+                // (6,24): error CS0610: Field or property cannot be of type 'ArgIterator'
+                //         var x = (1, 2, new System.ArgIterator());
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "new System.ArgIterator()").WithArguments("System.ArgIterator").WithLocation(6, 24),
+                // (7,38): error CS0610: Field or property cannot be of type 'ArgIterator'
+                //         (int x, object y) y = (1, 2, new System.ArgIterator());
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "new System.ArgIterator()").WithArguments("System.ArgIterator").WithLocation(7, 38),
+                // (8,17): error CS0610: Field or property cannot be of type 'ArgIterator'
+                //         (int x, System.ArgIterator y) z = (1, 2, new System.ArgIterator());
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "System.ArgIterator y").WithArguments("System.ArgIterator").WithLocation(8, 17),
+                // (8,50): error CS0610: Field or property cannot be of type 'ArgIterator'
+                //         (int x, System.ArgIterator y) z = (1, 2, new System.ArgIterator());
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "new System.ArgIterator()").WithArguments("System.ArgIterator").WithLocation(8, 50)
+                );
+        }
+
+        [Fact]
+        public void RestrictedTypes2()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int x, System.ArgIterator y) y;
+    }
+}
+" + trivial2uple + trivial3uple;
+
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            comp.VerifyDiagnostics(
+                // (6,17): error CS0610: Field or property cannot be of type 'ArgIterator'
+                //         (int x, System.ArgIterator y) y;
+                Diagnostic(ErrorCode.ERR_FieldCantBeRefAny, "System.ArgIterator y").WithArguments("System.ArgIterator").WithLocation(6, 17),
+                // (6,39): warning CS0168: The variable 'y' is declared but never used
+                //         (int x, System.ArgIterator y) y;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "y").WithArguments("y").WithLocation(6, 39)
+                );
+        }
+
     }
 }


### PR DESCRIPTION
I think I have got them all...

See related issues:
https://github.com/dotnet/roslyn/issues/10862
https://github.com/dotnet/roslyn/issues/10861
https://github.com/dotnet/roslyn/issues/10857
https://github.com/dotnet/roslyn/issues/10856
https://github.com/dotnet/roslyn/issues/10853
https://github.com/dotnet/roslyn/issues/10852
https://github.com/dotnet/roslyn/issues/10851
https://github.com/dotnet/roslyn/issues/10849




