### PR TITLE
Fix the check for closed file diagnostic options in diagnostic engine…

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -407,7 +407,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var workspace = project.Solution.Workspace;
                 var language = project.Language;
 
-                if (ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, language) ||
+                if (!ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, language) ||
                     !workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
                 {
                     return false;


### PR DESCRIPTION
… v2 (this got negated by my change today morning to turn off full solution analysis for C#)