### PR TITLE
Block renaming of tuple fields until properly implemented to prevent IDE crashes.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/AbstractEditorInlineRenameService.cs
@@ -75,6 +75,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                 return new FailureInlineRenameInfo(EditorFeaturesResources.YouCannotRenameThisElement);
             }
 
+            // see https://github.com/dotnet/roslyn/issues/10898
+            // we are disabling rename for tuple fields for now
+            // 1) compiler does not return correct location information in these symbols
+            // 2) renaming tuple fields seems a complex enough thing to require some design
+            if (triggerSymbol.ContainingType?.IsTupleType == true)
+            {
+                return new FailureInlineRenameInfo(EditorFeaturesResources.YouCannotRenameThisElement);
+            }
+
             // If rename is invoked on a member group reference in a nameof expression, then the
             // RenameOverloads option should be forced on.
             var forceRenameOverloads = tokenRenameInfo.IsMemberGroup;

--- a/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
+++ b/src/EditorFeatures/Test2/Rename/RenameNonRenameableSymbols.vb
@@ -482,5 +482,168 @@ End Class
                 AssertTokenNotRenamable(workspace)
             End Using
         End Sub
+
+#Region "Rename In Tuples"
+
+        <WorkItem(10898, "https://github.com/dotnet/roslyn/issues/10898")>
+        <WorkItem(10567, "https://github.com/dotnet/roslyn/issues/10567")>
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <Trait(Traits.Feature, Test.Utilities.Traits.Features.Tuples)>
+        Public Sub RenameTupleFiledInDeclaration()
+
+            Using workspace = CreateWorkspaceWithWaiter(
+                    <Workspace>
+                        <Project Language="C#" CommonReferences="true" PreprocessorSymbols="__DEMO__">
+                            <Document>
+using System;
+
+class C
+{
+    static void Main()
+    {
+        (int $$Alice, int Bob) t = (1, 2);
+        t.Alice = 3;
+    }
+}
+
+namespace System
+{
+    // struct with two values
+    public struct ValueTuple&lt;T1, T2&gt;
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+
+        public override string ToString()
+        {
+            return '{' + Item1?.ToString() + ", " + Item2?.ToString() + '}';
+        }
+    }
+}
+                            </Document>
+                        </Project>
+                    </Workspace>)
+
+                ' NOTE: this is currently intentionally blocked
+                '       see https://github.com/dotnet/roslyn/issues/10898
+                AssertTokenNotRenamable(workspace)
+            End Using
+
+        End Sub
+
+        <WorkItem(10898, "https://github.com/dotnet/roslyn/issues/10898")>
+        <WorkItem(10567, "https://github.com/dotnet/roslyn/issues/10567")>
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <Trait(Traits.Feature, Test.Utilities.Traits.Features.Tuples)>
+        Public Sub RenameTupleFiledInLiteral()
+            Using workspace = CreateWorkspaceWithWaiter(
+                   <Workspace>
+                       <Project Language="C#" CommonReferences="true" PreprocessorSymbols="__DEMO__">
+                           <Document>
+using System;
+
+class C
+{
+    static void Main()
+    {
+        var t = ($$Alice: 1, Bob: 2);
+        t.Alice = 3;
+    }
+}
+
+
+
+namespace System
+{
+    // struct with two values
+    public struct ValueTuple&lt;T1, T2&gt;
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+
+        public override string ToString()
+        {
+            return '{' + Item1?.ToString() + ", " + Item2?.ToString() + '}';
+        }
+    }
+}
+                            </Document>
+                       </Project>
+                   </Workspace>)
+
+                ' NOTE: this is currently intentionally blocked
+                '       see https://github.com/dotnet/roslyn/issues/10898
+                AssertTokenNotRenamable(workspace)
+            End Using
+        End Sub
+
+        <WorkItem(10898, "https://github.com/dotnet/roslyn/issues/10898")>
+        <WorkItem(10567, "https://github.com/dotnet/roslyn/issues/10567")>
+        <WpfFact>
+        <Trait(Traits.Feature, Traits.Features.Rename)>
+        <Trait(Traits.Feature, Test.Utilities.Traits.Features.Tuples)>
+        Public Sub RenameTupleFiledInFieldAccess()
+            Using workspace = CreateWorkspaceWithWaiter(
+       <Workspace>
+           <Project Language="C#" CommonReferences="true" PreprocessorSymbols="__DEMO__">
+               <Document>
+using System;
+
+class C
+{
+    static void Main()
+    {
+        var t = (Alice: 1, Bob: 2);
+        t.$$Alice = 3;
+    }
+}
+
+namespace System
+{
+    // struct with two values
+    public struct ValueTuple&lt;T1, T2&gt;
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+
+        public override string ToString()
+        {
+            return '{' + Item1?.ToString() + ", " + Item2?.ToString() + '}';
+        }
+    }
+}
+                            </Document>
+           </Project>
+       </Workspace>)
+
+                ' NOTE: this is currently intentionally blocked
+                '       see https://github.com/dotnet/roslyn/issues/10898
+                AssertTokenNotRenamable(workspace)
+            End Using
+
+        End Sub
+
+#End Region
+
     End Class
 End Namespace


### PR DESCRIPTION
Block renaming of tuple fields until properly implemented to prevent IDE crashes.

Fixes: https://github.com/dotnet/roslyn/issues/10567

But note also: 
https://github.com/dotnet/roslyn/issues/10898
