### PR TITLE
Remove harcoded method signature and check of flush method from compiler

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/Instrumentation.cs
@@ -19,11 +19,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CSharpCompilation compilation = compilationState.Compilation;
 
                 MethodSymbol createPayload = GetCreatePayload(compilation, methodBody.Syntax, diagnostics);
-                MethodSymbol flushPayload = GetFlushPayload(compilation, methodBody.Syntax, diagnostics);
 
                 // Do not instrument the instrumentation helpers if they are part of the current compilation (which occurs only during testing). GetCreatePayload will fail with an infinite recursion if it is instrumented.
                 // PROTOTYPE (https://github.com/dotnet/roslyn/issues/10266): It is not correct to always skip implict methods, because that will miss field initializers.
-                if ((object)createPayload != null && (object)flushPayload != null && !method.IsImplicitlyDeclared && !method.Equals(createPayload) && !method.Equals(flushPayload))
+                if ((object)createPayload != null && !method.IsImplicitlyDeclared && !method.Equals(createPayload))
                 {
                     SyntheticBoundNodeFactory factory = new SyntheticBoundNodeFactory(method, methodBody.Syntax, compilationState, diagnostics);
                     bool methodHasExplicitBlock = MethodHasExplicitBlock(method);
@@ -87,11 +86,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         private static MethodSymbol GetCreatePayload(CSharpCompilation compilation, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             return (MethodSymbol)Binder.GetWellKnownTypeMember(compilation, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload, diagnostics, syntax: syntax);
-        }
-
-        private static MethodSymbol GetFlushPayload(CSharpCompilation compilation, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
-        {
-            return (MethodSymbol)Binder.GetWellKnownTypeMember(compilation, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload, diagnostics, syntax: syntax);
         }
     }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -59,6 +59,190 @@ namespace Microsoft.CodeAnalysis.Runtime
 ";
 
         [Fact]
+        public void HelpersInstrumentation()
+        {
+            string source = @"
+using System;
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
+    }
+}
+";
+            string expectedOutput = @"Flushing
+1
+True
+4
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+";
+            string expectedCreatePayloadIL = @"{
+  // Code size       66 (0x42)
+  .maxstack  3
+  IL_0000:  ldsfld     ""System.Guid Microsoft.CodeAnalysis.Runtime.Instrumentation._mvid""
+  IL_0005:  ldarg.0
+  IL_0006:  call       ""bool System.Guid.op_Inequality(System.Guid, System.Guid)""
+  IL_000b:  brfalse.s  IL_001f
+  IL_000d:  ldc.i4.s   100
+  IL_000f:  newarr     ""bool[]""
+  IL_0014:  stsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_0019:  ldarg.0
+  IL_001a:  stsfld     ""System.Guid Microsoft.CodeAnalysis.Runtime.Instrumentation._mvid""
+  IL_001f:  ldarg.2
+  IL_0020:  ldarg.3
+  IL_0021:  newarr     ""bool""
+  IL_0026:  ldnull
+  IL_0027:  call       ""bool[] System.Threading.Interlocked.CompareExchange<bool[]>(ref bool[], bool[], bool[])""
+  IL_002c:  brtrue.s   IL_003a
+  IL_002e:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_0033:  ldarg.1
+  IL_0034:  ldarg.2
+  IL_0035:  ldind.ref
+  IL_0036:  stelem.ref
+  IL_0037:  ldarg.2
+  IL_0038:  ldind.ref
+  IL_0039:  ret
+  IL_003a:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_003f:  ldarg.1
+  IL_0040:  ldelem.ref
+  IL_0041:  ret
+}";
+
+            string expectedFlushPayloadIL = @"{
+  // Code size      179 (0xb3)
+  .maxstack  4
+  .locals init (bool[] V_0,
+                int V_1, //i
+                bool[] V_2, //payload
+                int V_3) //j
+  IL_0000:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_0005:  ldtoken    ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
+  IL_000a:  ldelem.ref
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  brtrue.s   IL_0030
+  IL_000f:  ldsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
+  IL_0014:  ldtoken    ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
+  IL_0019:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_001e:  ldtoken    ""void Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload()""
+  IL_0023:  ldelema    ""bool[]""
+  IL_0028:  ldc.i4.s   12
+  IL_002a:  call       ""bool[] Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, ref bool[], int)""
+  IL_002f:  stloc.0
+  IL_0030:  ldloc.0
+  IL_0031:  ldc.i4.0
+  IL_0032:  ldc.i4.1
+  IL_0033:  stelem.i1
+  IL_0034:  ldstr      ""Flushing""
+  IL_0039:  call       ""void System.Console.WriteLine(string)""
+  IL_003e:  ldloc.0
+  IL_003f:  ldc.i4.2
+  IL_0040:  ldc.i4.1
+  IL_0041:  stelem.i1
+  IL_0042:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_0047:  brtrue.s   IL_004e
+  IL_0049:  ldloc.0
+  IL_004a:  ldc.i4.1
+  IL_004b:  ldc.i4.1
+  IL_004c:  stelem.i1
+  IL_004d:  ret
+  IL_004e:  ldloc.0
+  IL_004f:  ldc.i4.3
+  IL_0050:  ldc.i4.1
+  IL_0051:  stelem.i1
+  IL_0052:  ldc.i4.0
+  IL_0053:  stloc.1
+  IL_0054:  br.s       IL_00a8
+  IL_0056:  ldloc.0
+  IL_0057:  ldc.i4.5
+  IL_0058:  ldc.i4.1
+  IL_0059:  stelem.i1
+  IL_005a:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_005f:  ldloc.1
+  IL_0060:  ldelem.ref
+  IL_0061:  stloc.2
+  IL_0062:  ldloc.0
+  IL_0063:  ldc.i4.s   11
+  IL_0065:  ldc.i4.1
+  IL_0066:  stelem.i1
+  IL_0067:  ldloc.2
+  IL_0068:  brfalse.s  IL_00a0
+  IL_006a:  ldloc.0
+  IL_006b:  ldc.i4.6
+  IL_006c:  ldc.i4.1
+  IL_006d:  stelem.i1
+  IL_006e:  ldloc.1
+  IL_006f:  call       ""void System.Console.WriteLine(int)""
+  IL_0074:  ldloc.0
+  IL_0075:  ldc.i4.7
+  IL_0076:  ldc.i4.1
+  IL_0077:  stelem.i1
+  IL_0078:  ldc.i4.0
+  IL_0079:  stloc.3
+  IL_007a:  br.s       IL_009a
+  IL_007c:  ldloc.0
+  IL_007d:  ldc.i4.s   9
+  IL_007f:  ldc.i4.1
+  IL_0080:  stelem.i1
+  IL_0081:  ldloc.2
+  IL_0082:  ldloc.3
+  IL_0083:  ldelem.u1
+  IL_0084:  call       ""void System.Console.WriteLine(bool)""
+  IL_0089:  ldloc.0
+  IL_008a:  ldc.i4.s   10
+  IL_008c:  ldc.i4.1
+  IL_008d:  stelem.i1
+  IL_008e:  ldloc.2
+  IL_008f:  ldloc.3
+  IL_0090:  ldc.i4.0
+  IL_0091:  stelem.i1
+  IL_0092:  ldloc.0
+  IL_0093:  ldc.i4.8
+  IL_0094:  ldc.i4.1
+  IL_0095:  stelem.i1
+  IL_0096:  ldloc.3
+  IL_0097:  ldc.i4.1
+  IL_0098:  add
+  IL_0099:  stloc.3
+  IL_009a:  ldloc.3
+  IL_009b:  ldloc.2
+  IL_009c:  ldlen
+  IL_009d:  conv.i4
+  IL_009e:  blt.s      IL_007c
+  IL_00a0:  ldloc.0
+  IL_00a1:  ldc.i4.4
+  IL_00a2:  ldc.i4.1
+  IL_00a3:  stelem.i1
+  IL_00a4:  ldloc.1
+  IL_00a5:  ldc.i4.1
+  IL_00a6:  add
+  IL_00a7:  stloc.1
+  IL_00a8:  ldloc.1
+  IL_00a9:  ldsfld     ""bool[][] Microsoft.CodeAnalysis.Runtime.Instrumentation._payloads""
+  IL_00ae:  ldlen
+  IL_00af:  conv.i4
+  IL_00b0:  blt.s      IL_0056
+  IL_00b2:  ret
+}";
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
+            verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload", expectedCreatePayloadIL);
+            verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload", expectedFlushPayloadIL);
+        }
+
+        [Fact]
         public void GotoCoverage()
         {
             string source = @"
@@ -145,6 +329,19 @@ False
 False
 False
 6
+True
+9
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
 True
 ";
 
@@ -266,6 +463,19 @@ True
 True
 True
 True
+7
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
 ";
 
             string expectedGetValueIL = @"{
@@ -368,6 +578,19 @@ True
 True
 7
 True
+10
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
@@ -434,6 +657,19 @@ True
 False
 False
 True
+7
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
@@ -494,6 +730,19 @@ True
 2
 True
 True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+5
+True
+False
 True
 True
 True
@@ -654,6 +903,19 @@ True
 False
 True
 True
+6
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
 ";
 
             CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
@@ -708,6 +970,19 @@ True
 True
 True
 False
+True
+5
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
 True
 ";
 
@@ -782,6 +1057,19 @@ True
 True
 True
 False
+True
+True
+8
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
 True
 True
 ";

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -601,7 +601,6 @@ namespace System
                         // Not available yet, but will be in upcoming release.
                         continue;
                     case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload:
-                    case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload:
                         // Not always available.
                         continue;
                 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -360,7 +360,6 @@ namespace Microsoft.CodeAnalysis
         System_String__Format_IFormatProvider,
 
         Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload,
-        Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload,
 
         Count
     }

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2553,13 +2553,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
                     (byte)SignatureTypeCode.ByReference, (byte)SignatureTypeCode.SZArray, (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Boolean,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Int32,
-
-                // Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.Microsoft_CodeAnalysis_Runtime_Instrumentation,                                         // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    0,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
             };
 
             string[] allNames = new string[(int)WellKnownMember.Count]
@@ -2861,7 +2854,6 @@ namespace Microsoft.CodeAnalysis
                 "SustainedLowLatency",                      // System_Runtime_GCLatencyMode__SustainedLowLatency
                 "Format",                                   // System_String__Format_IFormatProvider
                 "CreatePayload",                            // Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
-                "FlushPayload",                             // Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload
             };
 
             s_descriptors = MemberDescriptor.InitializeFromStream(new System.IO.MemoryStream(initializationBytes, writable: false), allNames);

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/WellKnownTypeValidationTests.vb
@@ -569,7 +569,7 @@ End Namespace
                     Case WellKnownMember.System_Array__Empty
                         ' Not available yet, but will be in upcoming release.
                         Continue For
-                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload
+                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
                         ' Not always available.
                         Continue For
                 End Select
@@ -649,7 +649,7 @@ End Namespace
                     Case WellKnownMember.System_Array__Empty
                         ' Not available yet, but will be in upcoming release.
                         Continue For
-                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload, WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__FlushPayload
+                    Case WellKnownMember.Microsoft_CodeAnalysis_Runtime_Instrumentation__CreatePayload
                         ' Not always available.
                         Continue For
                 End Select


### PR DESCRIPTION
Since compiler no longer needs to instrument code to call flush method. Remove the check for flush
method when instrumenting code is safe because it is provided as a binary reference and this only affects tests.

FYI @JohnHamby @AlekseyTs @jcouv @drognanar 
@dotnet/roslyn-interactive @dotnet/roslyn-compiler 