### PR TITLE
Consume VS SDK tasks and targets via NuGet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ UnitTestResults.html
 *.nuget.props
 *.nuget.targets
 project.lock.json
+*.project.lock.json
 
 *_i.c
 *_p.c

--- a/Restore.cmd
+++ b/Restore.cmd
@@ -19,6 +19,12 @@ popd
 echo Restoring packages: Toolsets
 call %NugetExe% restore "%~dp0build\ToolsetPackages\project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 
+echo Restoring packages: Toolsets (Dev14 VS SDK build tools)
+call %NugetExe% restore "%~dp0build\ToolsetPackages\dev14.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
+
+echo Restoring packages: Toolsets (Dev15 VS SDK build tools)
+call %NugetExe% restore "%~dp0build\ToolsetPackages\dev15.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
+
 echo Restoring packages: Samples
 call %NugetExe% restore "%~dp0src\Samples\Samples.sln" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -81,7 +81,6 @@
     <VisualStudioReferenceAssemblyVersion Condition="'$(VisualStudioReferenceAssemblyVersion)' == ''">$(VisualStudioReferenceMajorVersion).0.0.0</VisualStudioReferenceAssemblyVersion>
     <VisualStudioCodename>Dev$(VisualStudioReferenceMajorVersion)</VisualStudioCodename>
 
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <MinimumVisualStudioVersion>$(VisualStudioVersion)</MinimumVisualStudioVersion>
 
     <VSLToolsPath Condition="'$(VSLToolsPath)' == ''">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..'))</VSLToolsPath>
@@ -122,6 +121,22 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '15.0'">
+      <PropertyGroup>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25201-dev15preview2</VisualStudioBuildToolsNuGetPackagePath>
+      </PropertyGroup>
+    </When>
+
+    <Otherwise>
+      <PropertyGroup>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\14.2.25201</VisualStudioBuildToolsNuGetPackagePath>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.props" Condition="'$(OS)' == 'Windows_NT'" />
 
   <!-- Build reliability -->
   <PropertyGroup>

--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -271,7 +271,8 @@
 
        ==================================================================================== -->
 
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != '' AND '$(ImportVSSDKTargets)' == 'true'" />
+  <Import Project="$(VisualStudioBuildToolsNuGetPackagePath)\build\Microsoft.VsSDK.BuildTools.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(ImportVSSDKTargets)' == 'true'" />
 
   <!-- ====================================================================================
 

--- a/build/ToolsetPackages/.gitignore
+++ b/build/ToolsetPackages/.gitignore
@@ -1,5 +1,0 @@
-# The project.json in this directory exists simply to download packages; since
-# nothing will ever read the project.lock.json here, we should not check them
-# in
-
-project.lock.json

--- a/build/ToolsetPackages/dev14.project.json
+++ b/build/ToolsetPackages/dev14.project.json
@@ -1,0 +1,9 @@
+{
+    "dependencies": {
+        "Microsoft.VSSDK.BuildTools": "14.2.25201"
+    },
+    "frameworks": {
+        "net46": {}
+    }
+}
+

--- a/build/ToolsetPackages/dev15.project.json
+++ b/build/ToolsetPackages/dev15.project.json
@@ -1,0 +1,9 @@
+{
+    "dependencies": {
+        "Microsoft.VSSDK.BuildTools": "15.0.25201-Dev15Preview2"
+    },
+    "frameworks": {
+        "net46": {}
+    }
+}
+

--- a/src/EditorFeatures/.gitignore
+++ b/src/EditorFeatures/.gitignore
@@ -1,6 +1,0 @@
-# We cannot ignore project.lock.json everywhere in our codebase
-# since we need the files to be checked in for Linux and Mac builds.
-# This tree (src/EditorFeatures) doesn't build at all under those builds
-# so we can delete them here.
-
-project.lock.json

--- a/src/ExpressionEvaluator/.gitignore
+++ b/src/ExpressionEvaluator/.gitignore
@@ -1,6 +1,0 @@
-# We cannot ignore project.lock.json everywhere in our codebase
-# since we need the files to be checked in for Linux and Mac builds.
-# This tree (src/ExpressionEvaluator) doesn't build at all under those builds
-# so we can delete them here.
-
-project.lock.json

--- a/src/Features/.gitignore
+++ b/src/Features/.gitignore
@@ -1,6 +1,0 @@
-# We cannot ignore project.lock.json everywhere in our codebase
-# since we need the files to be checked in for Linux and Mac builds.
-# This tree (src/Features) doesn't build at all under those builds
-# so we can delete them here.
-
-project.lock.json

--- a/src/VisualStudio/.gitignore
+++ b/src/VisualStudio/.gitignore
@@ -1,6 +1,0 @@
-# We cannot ignore project.lock.json everywhere in our codebase
-# since we need the files to be checked in for Linux and Mac builds.
-# This tree (src/VisualStudio) doesn't build at all under those builds
-# so we can delete them here.
-
-project.lock.json


### PR DESCRIPTION
The NuGet packages for the SDK don't currently support cross-targeting,
so we must pick the right version to consume based on the version of
Visual Studio you are targeting. I implement this by simply restoring
both versions, and conditioning our MSBuild includes to the right one.
The annoying bit is since we need to restore two different versions
of the same package name via NuGet, we have to put the dependencies
in separate project.json files.

*Review:* @dotnet/roslyn-infrastructure, @dotnet/roslyn-ide, @Pilchie