### PR TITLE
Applying ulimit workaround on Mac and Linux

### DIFF
--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -6,13 +6,9 @@ DOTNET_PATH=$ROSLYN_TOOLSET_PATH/dotnet-cli/dotnet
 # Workaround, see https://github.com/dotnet/roslyn/issues/10210
 export HOME=$(cd ~ && pwd)
 
-# NuGet often exceeds the limit of open files on Mac
+# NuGet often exceeds the limit of open files on Mac and Linux
 # https://github.com/NuGet/Home/issues/2163
-OS=$(uname -s)
-if [ "$OS" == "Darwin" || "$OS" == "Linux" ]
-then
-    ulimit -n 6500
-fi
+ulimit -n 6500
 
 echo "Restoring toolset packages"
 


### PR DESCRIPTION
It seems there was a bug in `restore.sh` and bash requires double angled brackets if the condition has `||`. See demo below.

Andy suggested to remove the check altogether since `restore.sh` is only run on Linux and Mac anyways.

Fixes #10952.

```
#!/usr/bin/env bash
OS=Darwin
if [[ "$OS" == "Darwin" || "$OS" == "Linux" ]]
then
   echo "Done"
fi

if [ "$OS" == "Darwin" || "$OS" == "Linux" ]
then
   echo "NOT DONE"
fi

echo "Reached"

if [ "$OS" == "Linux" ]
then
   echo "Done too"
fi

echo "Reached too"

OS=Linux
if [[ "$OS" == "Darwin" || "$OS" == "Linux" ]]
then
   echo "Done"
fi

if [ "$OS" == "Darwin" || "$OS" == "Linux" ]
then
   echo "NOT DONE"
fi

echo "Reached"

if [ "$OS" == "Linux" ]
then
   echo "Done too"
fi

```
Produces:
```
Done
./test.bash: line 8: [: missing `]'
./test.bash: line 8: Darwin: command not found
Reached
Reached too
Done
./test.bash: line 28: [: missing `]'
./test.bash: line 28: Linux: command not found
Reached
Done too
```