### PR TITLE
Tuples: adding more tests for IDE scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -597,7 +597,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _underlyingType.IsReferenceType;
+                return _underlyingType.IsErrorType() ? false : _underlyingType.IsReferenceType;
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -158,6 +158,7 @@
     <Compile Include="CodeActions\InvertIf\InvertIfTests.cs" />
     <Compile Include="CodeActions\LambdaSimplifier\LambdaSimplifierTests.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests_NuGet.cs" />
+    <Compile Include="Diagnostics\GenerateMethod\GenerateConversionTests.cs" />
     <Compile Include="Diagnostics\MakeMethodSynchronous\MakeMethodSynchronousTests.cs" />
     <Compile Include="CodeActions\MoveDeclarationNearReference\MoveDeclarationNearReferenceTests.cs" />
     <Compile Include="CodeActions\Preview\ErrorCases\ExceptionInCodeAction.cs" />

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -7,9 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Editor.CSharp.Classification;
 using Microsoft.CodeAnalysis.Editor.Implementation.Classification;
-using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Extensions;
@@ -25,6 +23,7 @@ using Roslyn.Test.Utilities;
 using Roslyn.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Classification
 {
@@ -1470,5 +1469,13 @@ class C
         }
 
         private class Waiter : AsynchronousOperationListener { }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task Tuples()
+        {
+            await TestAsync(@"class C { (int a, int b) x; }",
+                TestOptions.Regular.WithTuplesFeature(),
+                Options.Script.WithTuplesFeature());
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Classification;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -3648,6 +3649,72 @@ void M()
                 Identifier("await"),
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TupleDeclaration()
+        {
+            await TestInMethodAsync("(int, string) x",
+                TestOptions.Regular.WithTuplesFeature(),
+                Options.Script.WithTuplesFeature(),
+                Punctuation.OpenParen,
+                Keyword("int"),
+                Punctuation.Comma,
+                Keyword("string"),
+                Punctuation.CloseParen,
+                Identifier("x"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TupleDeclarationWithNames()
+        {
+            await TestInMethodAsync("(int a, string b) x",
+                TestOptions.Regular.WithTuplesFeature(),
+                Options.Script.WithTuplesFeature(),
+                Punctuation.OpenParen,
+                Keyword("int"),
+                Identifier("a"),
+                Punctuation.Comma,
+                Keyword("string"),
+                Identifier("b"),
+                Punctuation.CloseParen,
+                Identifier("x"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TupleLiteral()
+        {
+            await TestInMethodAsync("var values = (1, 2)",
+                TestOptions.Regular.WithTuplesFeature(),
+                Options.Script.WithTuplesFeature(),
+                Keyword("var"),
+                Identifier("values"),
+                Operators.Equals,
+                Punctuation.OpenParen,
+                Number("1"),
+                Punctuation.Comma,
+                Number("2"),
+                Punctuation.CloseParen);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task TupleLiteralWithNames()
+        {
+            await TestInMethodAsync("var values = (a: 1, b: 2)",
+                TestOptions.Regular.WithTuplesFeature(),
+                Options.Script.WithTuplesFeature(),
+                Keyword("var"),
+                Identifier("values"),
+                Operators.Equals,
+                Punctuation.OpenParen,
+                Identifier("a"),
+                Punctuation.Colon,
+                Number("1"),
+                Punctuation.Comma,
+                Identifier("b"),
+                Punctuation.Colon,
+                Number("2"),
+                Punctuation.CloseParen);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1295,7 +1295,7 @@ class C
     }
 }
 ";
-            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -1337,7 +1337,7 @@ class C
     }
 }
 ";
-            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -442,7 +442,8 @@ compareTokens: false);
 @"class Program { static void Main ( string [ ] args ) { [| (int, int) x = (1, 2); |]  System . Console . WriteLine ( x.Item1 ); } } ",
 @"class Program { static void Main ( string [ ] args ) { (int, int) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.Item1); } private static (int, int) NewMethod() { return (1, 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -452,7 +453,8 @@ parseOptions: TestOptions.Regular.WithTuplesFeature());
 @"class Program { static void Main ( string [ ] args ) { [| (int a, int b) x = (1, 2); |]  System . Console . WriteLine ( x.a ); } } ",
 @"class Program { static void Main ( string [ ] args ) { (int a, int b) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.a); } private static (int a, int b) NewMethod() { return (1, 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -462,7 +464,8 @@ parseOptions: TestOptions.Regular.WithTuplesFeature());
 @"class Program { static void Main ( string [ ] args ) { [| (int, int) x = (a: 1, b: 2); |]  System . Console . WriteLine ( x.Item1 ); } } ",
 @"class Program { static void Main ( string [ ] args ) { (int, int) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.Item1); } private static (int, int) NewMethod() { return (a: 1, b: 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -472,7 +475,8 @@ parseOptions: TestOptions.Regular.WithTuplesFeature());
 @"class Program { static void Main ( string [ ] args ) { [| (int a, int b) x = (c: 1, d: 2); |]  System . Console . WriteLine ( x.a ); } } ",
 @"class Program { static void Main ( string [ ] args ) { (int a, int b) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.a); } private static (int a, int b) NewMethod() { return (c: 1, d: 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -482,7 +486,8 @@ parseOptions: TestOptions.Regular.WithTuplesFeature());
 @"class Program { static void Main ( string [ ] args ) { [| var x = (c: 1, d: 2); |]  System . Console . WriteLine ( x.c ); } } ",
 @"class Program { static void Main ( string [ ] args ) { (int c, int d) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.c); } private static (int c, int d) NewMethod() { return (c: 1, d: 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -207,7 +207,8 @@ index: 2);
 @"class C : [||]B { } class B { public B((int, string) x) { } }",
 @"class C : B { public C((int, string) x) : base(x) { } } class B { public B((int, string) x) { } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -217,7 +218,8 @@ parseOptions: TestOptions.Regular.WithTuplesFeature());
 @"class C : [||]B { } class B { public B((int a, string b) x) { } }",
 @"class C : B { public C((int a, string b) x) : base(x) { } } class B { public B((int a, string b) x) { } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.GenerateFromMembers.AddConstructorParameters;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -66,6 +67,76 @@ index: 0);
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
 string.Format(FeaturesResources.AddOptionalParametersTo, "Program", "bool"),
 index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTuple()
+        {
+            await TestAsync(
+@"class Program { [|(int, string) i ; (string, int) s ;|] public Program ( (int, string) i ) { this . i = i ; } } ",
+@"class Program { (int, string) i ; (string, int) s ; public Program ( (int, string) i , (string, int) s ) { this . i = i ; this . s = s ; } } ",
+index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleWithNames()
+        {
+            await TestAsync(
+@"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int a, string b) i ) { this . i = i ; } } ",
+@"class Program { (int a, string b) i ; (string c, int d) s ; public Program ( (int a, string b) i , (string c, int d) s ) { this . i = i ; this . s = s ; } } ",
+index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleWithDifferentNames()
+        {
+            await TestMissingAsync(
+@"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int e, string f) i ) { this . i = i ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleOptional()
+        {
+            await TestAsync(
+@"class Program { [|(int, string) i ; (string, int) s ;|] public Program ( (int, string) i ) { this . i = i ; } } ",
+@"class Program { (int, string) i ; (string, int) s ; public Program ( (int, string) i , (string, int) s = default((string, int)) ) { this . i = i ; this . s = s ; } } ",
+index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleOptionalWithNames()
+        {
+            await TestAsync(
+@"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int a, string b) i ) { this . i = i ; } } ",
+@"class Program { (int a, string b) i ; (string c, int d) s ; public Program ( (int a, string b) i , (string c, int d) s = default((string c, int d)) ) { this . i = i ; this . s = s ; } } ",
+index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleOptionalWithDifferentNames()
+        {
+            await TestMissingAsync(
+@"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int e, string f) i ) { this . i = i ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleWithNullable()
+        {
+            await TestAsync(
+@"class Program { [|(int?, bool?) i ; (byte?, long?) s ;|] public Program ( (int?, bool?) i ) { this . i = i ; } } ",
+@"class Program { (int?, bool?) i ; (byte?, long?) s ; public Program ( (int?, bool?) i , (byte?, long?) s ) { this . i = i ; this . s = s ; } } ",
+index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
+        public async Task TestTupleWithGenericss()
+        {
+            await TestAsync(
+@"class Program { [|(List<int>, List<bool>) i ; (List<byte>, List<long>) s ;|] public Program ( (List<int>, List<bool>) i ) { this . i = i ; } } ",
+@"class Program { (List<int>, List<bool>) i ; (List<byte>, List<long>) s ; public Program ( (List<int>, List<bool>) i , (List<byte>, List<long>) s ) { this . i = i ; this . s = s ; } } ",
+index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructor/GenerateConstructorTests.cs
@@ -190,7 +190,8 @@ index: 1);
 @"using System . Collections . Generic ; class Z { [|(int, string) a ;|] } ",
 @"using System . Collections . Generic ; class Z { (int, string) a ; public Z ( (int, string) a ) { this . a = a ; } } ",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.GenerateFromMembers.GenerateEqualsAndGetHashCode;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -174,6 +175,56 @@ index: 1);
 @"using System . Collections . Generic ; class Program { [|bool b ; HashSet < string > s ;|] public Program ( bool b ) { this . b = b ; } } ",
 FeaturesResources.GenerateBoth,
 index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task Tuple_Disabled()
+        {
+            await TestAsync(@"using System . Collections . Generic ; class C { [|(int, string) a ;|] } ",
+@"using System . Collections . Generic ; class C { (int, string) a ; public override bool Equals ( object obj ) { var c = obj as C ; return c != null && EqualityComparer < (int, string) > . Default . Equals ( a , c . a ) ; } } ",
+index: 0,
+                parseOptions: TestOptions.Regular.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp6));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task Tuples_Equals()
+        {
+            await TestAsync(
+@"using System . Collections . Generic ; class C { [|(int, string) a ;|] } ",
+@"using System . Collections . Generic ; class C { (int, string) a ; public override bool Equals ( object obj ) { var c = obj as C ; return c != null && EqualityComparer < (int, string) > . Default . Equals ( a , c . a ) ; } } ",
+index: 0,
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TupleWithNames_Equals()
+        {
+            await TestAsync(
+@"using System . Collections . Generic ; class C { [|(int x, string y) a ;|] } ",
+@"using System . Collections . Generic ; class C { (int x, string y) a ; public override bool Equals ( object obj ) { var c = obj as C ; return c != null && EqualityComparer < (int x, string y) > . Default . Equals ( a , c . a ) ; } } ",
+index: 0,
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task Tuple_HashCode()
+        {
+            await TestAsync(
+@"using System . Collections . Generic ; class Program { [|(int, string) i ;|] } ",
+@"using System . Collections . Generic ; class Program { (int, string) i ; public override int GetHashCode ( ) { return EqualityComparer < (int, string) > . Default . GetHashCode ( i ) ; } } ",
+index: 1,
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
+        public async Task TupleWithNames_HashCode()
+        {
+            await TestAsync(
+@"using System . Collections . Generic ; class Program { [|(int x, string y) i ;|] } ",
+@"using System . Collections . Generic ; class Program { (int x, string y) i ; public override int GetHashCode ( ) { return EqualityComparer < (int x, string y) > . Default . GetHashCode ( i ) ; } } ",
+index: 1,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.InlineTemporary;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.InlineTemporary
 {
@@ -79,7 +80,7 @@ class C
         ref int [||]x = ref arr[2];
         return ref x;
     }
-}", 
+}",
                 // TODO: propagating features to the project is currently NYI
                 parseOptions: ExperimentalParseOptions);
         }
@@ -3949,6 +3950,103 @@ class C
 }";
 
             await TestAsync(initial, expected, compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task Tuples_Disabled()
+        {
+            var code = @"
+using System;
+class C
+{
+    public void M()
+    {
+        (int, string) [||]x = (1, ""hello"");
+        x.ToString();
+    }
+}";
+
+            await TestMissingAsync(code, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task Tuples()
+        {
+            var code = @"
+using System;
+class C
+{
+    public void M()
+    {
+        (int, string) [||]x = (1, ""hello"");
+        x.ToString();
+    }
+}";
+
+            var expected = @"
+using System;
+class C
+{
+    public void M()
+    {
+        ((1, ""hello"")).ToString();
+    }
+}";
+
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task TuplesWithNames()
+        {
+            var code = @"
+using System;
+class C
+{
+    public void M()
+    {
+        (int a, string b) [||]x = (a: 1, b: ""hello"");
+        x.ToString();
+    }
+}";
+
+            var expected = @"
+using System;
+class C
+{
+    public void M()
+    {
+        ((a: 1, b: ""hello"")).ToString();
+    }
+}";
+
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(11028, "https://github.com/dotnet/roslyn/issues/11028")]
+        public async Task TuplesWithDifferentNames()
+        {
+            var code = @"
+class C
+{
+    public void M()
+    {
+        (int a, string b) [||]x = (c: 1, d: ""hello"");
+        x.a.ToString();
+    }
+}";
+
+            var expected = @"
+class C
+{
+    public void M()
+    {
+        (((int a, string b))((c: 1, d: ""hello""))).a.ToString();
+    }
+}";
+
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -2,6 +2,7 @@
 
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.CodeRefactorings.MoveDeclarationNearReference;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -365,6 +366,28 @@ class Program
         Console.WriteLine(foo);
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task Tuple()
+        {
+            await TestAsync(
+@"class C { void M() { (int, string) [||]x; { Console.WriteLine(x); } } }",
+@"class C { void M() { { (int, string) x; Console.WriteLine(x); } } }",
+index: 0,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveDeclarationNearReference)]
+        public async Task TupleWithNames()
+        {
+            await TestAsync(
+@"class C { void M() { (int a, string b) [||]x; { Console.WriteLine(x); } } }",
+@"class C { void M() { { (int a, string b) x; Console.WriteLine(x); } } }",
+index: 0,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings;
 using Microsoft.CodeAnalysis.ReplaceMethodWithProperty;
 using Roslyn.Test.Utilities;
@@ -420,6 +421,51 @@ index: 1);
 @"using System; class C { int [||]getFoo() { } void setFoo(int i) { } }",
 @"using System; class C { int Foo { get { } set { } } }",
 index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task Tuple()
+        {
+            await TestAsync(
+@"class C { (int, string) [||]GetFoo() { } }",
+@"class C { (int, string) Foo { get { } } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task Tuple_GetAndSet()
+        {
+            await TestAsync(
+@"using System; class C { (int, string) [||]getFoo() { } void setFoo((int, string) i) { } }",
+@"using System; class C { (int, string) Foo { get { } set { } } }",
+index: 1,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TupleWithNames_GetAndSet()
+        {
+            await TestAsync(
+@"using System; class C { (int a, string b) [||]getFoo() { } void setFoo((int a, string b) i) { } }",
+@"using System; class C { (int a, string b) Foo { get { } set { } } }",
+index: 1,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TupleWithDifferentNames_GetAndSet()
+        {
+            // Cannot refactor tuples with different names together
+            await Assert.ThrowsAsync<Xunit.Sdk.InRangeException>(() =>
+                TestAsync(
+@"using System; class C { (int a, string b) [||]getFoo() { } void setFoo((int c, string d) i) { } }",
+@"",
+index: 1,
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true));
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.FullyQualify;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -458,6 +459,26 @@ public class Program { static void M() { [|Xaml|] } }",
 @"namespace MS.Internal.Xaml { public class A { } }
 namespace System.Xaml { public class A { } }
 public class Program { static void M() { MS.Internal.Xaml } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        public async Task TupleTest()
+        {
+            await TestAsync(
+@"class Class { ([|IDictionary|], string) Method() { Foo(); } }",
+@"class Class { (System.Collections.IDictionary, string) Method() { Foo(); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsFullyQualify)]
+        public async Task TupleWithOneName()
+        {
+            await TestAsync(
+@"class Class { ([|IDictionary|] a, string) Method() { Foo(); } }",
+@"class Class { (System.Collections.IDictionary a, string) Method() { Foo(); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateConversionTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateConversionTests.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.GenerateMethod
+{
+    public class GenerateConversionTest : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new GenerateConversionCodeFixProvider());
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateImplicitConversionGenericClass()
+        {
+            await TestAsync(
+@"class Program { void Test ( int [ ] a ) { C < int > x1 = [|1|] ; } } class C < T > { } ",
+@"using System ; class Program { void Test ( int [ ] a ) { C < int > x1 = 1 ; } } class C < T > { public static implicit operator C < T > ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateImplicitConversionClass()
+        {
+            await TestAsync(
+@"class Program { void Test ( int [ ] a ) { C x1 = [|1|] ; } } class C { } ",
+@"using System ; class Program { void Test ( int [ ] a ) { C x1 = 1 ; } } class C { public static implicit operator C ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateImplicitConversionAwaitExpression()
+        {
+            await TestAsync(
+@"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = [|await a|] ; } } ",
+@"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = await a ; } public static implicit operator Program ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateImplicitConversionTargetTypeNotInSource()
+        {
+            await TestAsync(
+@"class Digit { public Digit ( double d ) { val = d ; } public double val ; } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = [|dig|] ; } } ",
+@"using System ; class Digit { public Digit ( double d ) { val = d ; } public double val ; public static implicit operator double ( Digit v ) { throw new NotImplementedException ( ) ; } } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = dig ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateExplicitConversionGenericClass()
+        {
+            await TestAsync(
+@"class Program { void Test ( int [ ] a ) { C < int > x1 = [|( C < int > ) 1|] ; } } class C < T > { } ",
+@"using System ; class Program { void Test ( int [ ] a ) { C < int > x1 = ( C < int > ) 1 ; } } class C < T > { public static explicit operator C < T > ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateExplicitConversionClass()
+        {
+            await TestAsync(
+@"class Program { void Test ( int [ ] a ) { C x1 = [|( C ) 1|] ; } } class C { } ",
+@"using System ; class Program { void Test ( int [ ] a ) { C x1 = ( C ) 1 ; } } class C { public static explicit operator C ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateExplicitConversionAwaitExpression()
+        {
+            await TestAsync(
+@"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = [|( Program ) await a|] ; } } ",
+@"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = ( Program ) await a ; } public static explicit operator Program ( int v ) { throw new NotImplementedException ( ) ; } } ");
+        }
+
+        [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateExplicitConversionTargetTypeNotInSource()
+        {
+            await TestAsync(
+@"class Digit { public Digit ( double d ) { val = d ; } public double val ; } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = [|( double ) dig|] ; } } ",
+@"using System ; class Digit { public Digit ( double d ) { val = d ; } public double val ; public static explicit operator double ( Digit v ) { throw new NotImplementedException ( ) ; } } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = ( double ) dig ; } } ");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -2879,84 +2880,34 @@ class Program
 }");
         }
 
-        public class GenerateConversionTest : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task MethodWithTuple()
         {
-            internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
-            {
-                return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(null, new GenerateConversionCodeFixProvider());
-            }
+            await TestAsync(
+@"class Class { void Method() { (int, string) d = [|NewMethod|]((1, ""hello"")); } }",
+@"using System; class Class { void Method() { (int, string) d = NewMethod((1, ""hello"")); } private (int, string) NewMethod((int, string) p) { throw new NotImplementedException(); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
 
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateImplicitConversionGenericClass()
-            {
-                await TestAsync(
-    @"class Program { void Test ( int [ ] a ) { C < int > x1 = [|1|] ; } } class C < T > { } ",
-    @"using System ; class Program { void Test ( int [ ] a ) { C < int > x1 = 1 ; } } class C < T > { public static implicit operator C < T > ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task MethodWithTupleWithNames()
+        {
+            await TestAsync(
+@"class Class { void Method() { (int a, string b) d = [|NewMethod|]((c: 1, d: ""hello"")); } }",
+@"using System; class Class { void Method() { (int a, string b) d = NewMethod((c: 1, d: ""hello"")); } private (int a, string b) NewMethod((int c, string d) p) { throw new NotImplementedException(); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
 
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateImplicitConversionClass()
-            {
-                await TestAsync(
-    @"class Program { void Test ( int [ ] a ) { C x1 = [|1|] ; } } class C { } ",
-    @"using System ; class Program { void Test ( int [ ] a ) { C x1 = 1 ; } } class C { public static implicit operator C ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateImplicitConversionAwaitExpression()
-            {
-                await TestAsync(
-    @"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = [|await a|] ; } } ",
-    @"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = await a ; } public static implicit operator Program ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateImplicitConversionTargetTypeNotInSource()
-            {
-                await TestAsync(
-    @"class Digit { public Digit ( double d ) { val = d ; } public double val ; } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = [|dig|] ; } } ",
-    @"using System ; class Digit { public Digit ( double d ) { val = d ; } public double val ; public static implicit operator double ( Digit v ) { throw new NotImplementedException ( ) ; } } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = dig ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateExplicitConversionGenericClass()
-            {
-                await TestAsync(
-    @"class Program { void Test ( int [ ] a ) { C < int > x1 = [|( C < int > ) 1|] ; } } class C < T > { } ",
-    @"using System ; class Program { void Test ( int [ ] a ) { C < int > x1 = ( C < int > ) 1 ; } } class C < T > { public static explicit operator C < T > ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateExplicitConversionClass()
-            {
-                await TestAsync(
-    @"class Program { void Test ( int [ ] a ) { C x1 = [|( C ) 1|] ; } } class C { } ",
-    @"using System ; class Program { void Test ( int [ ] a ) { C x1 = ( C ) 1 ; } } class C { public static explicit operator C ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateExplicitConversionAwaitExpression()
-            {
-                await TestAsync(
-    @"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = [|( Program ) await a|] ; } } ",
-    @"using System ; using System . Threading . Tasks ; class Program { async void Test ( ) { var a = Task . FromResult ( 1 ) ; Program x1 = ( Program ) await a ; } public static explicit operator Program ( int v ) { throw new NotImplementedException ( ) ; } } ");
-            }
-
-            [WorkItem(774321, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/774321")]
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task TestGenerateExplicitConversionTargetTypeNotInSource()
-            {
-                await TestAsync(
-    @"class Digit { public Digit ( double d ) { val = d ; } public double val ; } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = [|( double ) dig|] ; } } ",
-    @"using System ; class Digit { public Digit ( double d ) { val = d ; } public double val ; public static explicit operator double ( Digit v ) { throw new NotImplementedException ( ) ; } } class Program { static void Main ( string [ ] args ) { Digit dig = new Digit ( 7 ) ; double num = ( double ) dig ; } } ");
-            }
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task MethodWithTupleWithOneName()
+        {
+            await TestAsync(
+@"class Class { void Method() { (int a, string) d = [|NewMethod|]((c: 1, ""hello"")); } }",
+@"using System; class Class { void Method() { (int a, string) d = NewMethod((c: 1, ""hello"")); } private (int a, string Item2) NewMethod((int c, string Item2) p) { throw new NotImplementedException(); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateVariable;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
@@ -2939,6 +2940,46 @@ class C
         [|_field|] = 42;
     }
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TupleRead()
+        {
+            await TestAsync(
+@"class Class { void Method((int, string) i) { Method([|tuple|]); } }",
+@"class Class { private (int, string) tuple; void Method((int, string) i) { Method(tuple); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TupleWithOneNameRead()
+        {
+            await TestAsync(
+@"class Class { void Method((int a, string) i) { Method([|tuple|]); } }",
+@"class Class { private (int a, string Item2) tuple; void Method((int a, string) i) { Method(tuple); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TupleWrite()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|tuple|] = (1, ""hello""); } }",
+@"class Class { private (int, string) tuple; void Method() { tuple = (1, ""hello""); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)]
+        public async Task TupleWithOneNameWrite()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|tuple|] = (a: 1, ""hello""); } }",
+@"class Class { private (int a, string Item2) tuple; void Method() { tuple = (a: 1, ""hello""); } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -2692,13 +2692,39 @@ index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
-        public async Task Tuple()
+        public async Task LongTuple()
         {
             await TestAsync(
-@"interface IInterface { void Method1 ( ) ; } class Class : [|IInterface|] { (int, string) x; } ",
-@"using System; interface IInterface { void Method1 ( ) ; } class Class : IInterface { (int, string) x; public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature());
+@"interface IInterface { (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) ; } class Class : [|IInterface|] { (int, string) x; } ",
+@"using System; interface IInterface { (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) ; } class Class : IInterface { (int, string) x; public (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) { throw new NotImplementedException ( ) ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task LongTupleWithNames()
+        {
+            await TestAsync(
+@"interface IInterface { (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) ; } class Class : [|IInterface|] { (int, string) x; } ",
+@"using System; interface IInterface { (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) ; } class Class : IInterface { (int, string) x; public (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) { throw new NotImplementedException ( ) ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task GenericWithTuple()
+        {
+            await TestAsync(
+@"interface IInterface<TA, TB> { (TA, TB) Method1 ((TA, TB) y) ; } class Class : [|IInterface<(int, string), int>|] { (int, string) x; } ",
+@"using System; interface IInterface<TA, TB> { (TA, TB) Method1 ((TA, TB) y) ; } class Class : IInterface<(int, string), int> { (int, string) x; public ((int, string), int) Method1 (((int, string), int) y) { throw new NotImplementedException ( ) ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task GenericWithTupleWithNamess()
+        {
+            await TestAsync(
+@"interface IInterface<TA, TB> { (TA a, TB b) Method1 ((TA a, TB b) y) ; } class Class : [|IInterface<(int, string), int>|] { (int, string) x; } ",
+@"using System; interface IInterface<TA, TB> { (TA a, TB b) Method1 ((TA a, TB b) y) ; } class Class : IInterface<(int, string), int> { (int, string) x; public ((int, string) a, int b) Method1 (((int, string) a, int b) y) { throw new NotImplementedException ( ) ; } } ",
+parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryCast;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.RemoveUnnecessaryCast;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -3834,6 +3835,26 @@ class Program
     public enum Directions { North, East, South, West }
 }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task Tuple()
+        {
+            await TestAsync(
+            @" class C { void Main() { (int, string) tuple = [|((int, string))(1, ""hello"")|]; } }",
+            @" class C { void Main() { (int, string) tuple = (1, ""hello""); } }",
+            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task TupleWithDifferentNames()
+        {
+            await TestAsync(
+            @" class C { void Main() { (int a, string) tuple = [|((int, string d))(1, f: ""hello"")|]; } }",
+            @" class C { void Main() { (int a, string) tuple = (1, f: ""hello""); } }",
+            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty;
 using Roslyn.Test.Utilities;
@@ -316,6 +317,65 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
 {
     int P { get; set; }
 }", compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task Tuple_SingleGetterFromField()
+        {
+            await TestAsync(
+@"class Class { [|(int, string) i|]; (int, string) P { get { return i; } } }",
+@"class Class { (int, string) P { get; } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task TupleWithNames_SingleGetterFromField()
+        {
+            await TestAsync(
+@"class Class { [|(int a, string b) i|]; (int a, string b) P { get { return i; } } }",
+@"class Class { (int a, string b) P { get; } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task TupleWithDifferentNames_SingleGetterFromField()
+        {
+            await TestMissingAsync(
+@"class Class { [|(int a, string b) i|]; (int c, string d) P { get { return i; } } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task TupleWithOneName_SingleGetterFromField()
+        {
+            await TestAsync(
+@"class Class { [|(int a, string) i|]; (int a, string) P { get { return i; } } }",
+@"class Class { (int a, string) P { get; } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task Tuple_Initializer()
+        {
+            await TestAsync(
+@"class Class { [|(int, string) i = (1, ""hello"")|]; (int, string) P { get { return i; } } }",
+@"class Class { (int, string) P { get; } = (1, ""hello""); }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseAutoProperty)]
+        public async Task Tuple_GetterAndSetter()
+        {
+            await TestAsync(
+@"class Class { [|(int, string) i|]; (int, string) P { get { return i; } set { i = value; } } }",
+@"class Class { (int, string) P { get; set; } }",
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
@@ -1009,6 +1010,39 @@ class C
                 diagnosticCount: 1,
                 diagnosticId: IDEDiagnosticIds.UseExplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Error);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        public async Task SuggestExplicitTypeOnLocalWithIntrinsicTypeTuple()
+        {
+            await TestAsync(
+@"class C { static void M() { [|var|] s = (1, ""hello""); } }",
+@"class C { static void M() { (int, string) s = (1, ""hello""); }}",
+options: ExplicitTypeEverywhere(),
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        public async Task SuggestExplicitTypeOnLocalWithIntrinsicTypeTupleWithNames()
+        {
+            await TestAsync(
+@"class C { static void M() { [|var|] s = (a: 1, b: ""hello""); } }",
+@"class C { static void M() { (int a, string b) s = (a: 1, b: ""hello""); }}",
+options: ExplicitTypeEverywhere(),
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseExplicitType)]
+        public async Task SuggestExplicitTypeOnLocalWithIntrinsicTypeTupleWithOneName()
+        {
+            await TestAsync(
+@"class C { static void M() { [|var|] s = (a: 1, ""hello""); } }",
+@"class C { static void M() { (int a, string Item2) s = (a: 1, ""hello""); }}",
+options: ExplicitTypeEverywhere(),
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeFixes.TypeStyle;
 using Microsoft.CodeAnalysis.CSharp.CodeStyle;
 using Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Roslyn.Test.Utilities;
@@ -32,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseImplicit
         private readonly SimpleCodeStyleOption offWithError = new SimpleCodeStyleOption(false, NotificationOption.Error);
 
         // specify all options explicitly to override defaults.
-        private IDictionary<OptionKey, object> ImplicitTypeEverywhere() => 
+        private IDictionary<OptionKey, object> ImplicitTypeEverywhere() =>
             Options(CSharpCodeStyleOptions.UseImplicitTypeWherePossible, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent, onWithInfo)
             .With(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes, onWithInfo);
@@ -1397,10 +1398,10 @@ class C
         [|int|] s = 5;
     }
 }";
-            await TestDiagnosticSeverityAndCountAsync(source, 
-                options: ImplicitTypeEnforcements(), 
-                diagnosticCount: 1, 
-                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId, 
+            await TestDiagnosticSeverityAndCountAsync(source,
+                options: ImplicitTypeEnforcements(),
+                diagnosticCount: 1,
+                diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Info);
         }
 
@@ -1440,6 +1441,57 @@ class C
                 diagnosticCount: 1,
                 diagnosticId: IDEDiagnosticIds.UseImplicitTypeDiagnosticId,
                 diagnosticSeverity: DiagnosticSeverity.Error);
+        }
+
+        private static string trivial2uple =
+                    @"
+namespace System
+{
+    public class ValueTuple
+    {
+        public static ValueTuple<T1, T2> Create<T1, T2>(T1 item1, T2 item2) => new ValueTuple<T1, T2>(item1, item2);
+    }
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2) { }
+    }
+} ";
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        [WorkItem(11094, "https://github.com/dotnet/roslyn/issues/11094")]
+        public async Task SuggestVarOnLocalWithIntrinsicTypeTuple()
+        {
+            var before = @"class C { static void M() { [|(int a, string)|] s = (a: 1, ""hello""); } }";
+            var after = @"class C { static void M() { var s = (a: 1, ""hello""); } }";
+
+            await TestAsync(before, after, options: ImplicitTypeEverywhere(), parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+
+            // We would rather this refactoring also worked. See https://github.com/dotnet/roslyn/issues/11094
+            await TestMissingAsync(before, options: ImplicitTypeWhereApparent(), parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+        }
+
+        [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/11154"), Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task ValueTupleCreate()
+        {
+            await TestAsync(
+@"using System; class C { static void M() { [|ValueTuple<int, int>|] s = ValueTuple.Create(1, 1); } }" + trivial2uple,
+@"using System; class C { static void M() { var s = ValueTuple.Create(1, 1); } }" + trivial2uple,
+options: ImplicitTypeWhereApparent(),
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
+        public async Task TupleWithDifferentNames()
+        {
+            await TestMissingAsync(
+@"class C { static void M() { [|(int, string)|] s = (c: 1, d: ""hello""); } }",
+options: ImplicitTypeEverywhere(),
+parseOptions: TestOptions.Regular.WithTuplesFeature(),
+withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/Test/BraceHighlighting/AbstractBraceHighlightingTests.cs
+++ b/src/EditorFeatures/Test/BraceHighlighting/AbstractBraceHighlightingTests.cs
@@ -2,6 +2,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Implementation.BraceMatching;
 using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -16,9 +17,9 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.BraceHighlighting
 {
     public abstract class AbstractBraceHighlightingTests
     {
-        protected async Task TestBraceHighlightingAsync(string markup)
+        protected async Task TestBraceHighlightingAsync(string markup, ParseOptions options = null)
         {
-            using (var workspace = await CreateWorkspaceAsync(markup))
+            using (var workspace = await CreateWorkspaceAsync(markup, options))
             {
                 WpfTestCase.RequireWpfFact($"{nameof(AbstractBraceHighlightingTests)}.{nameof(TestBraceHighlightingAsync)} creates asynchronous taggers");
 
@@ -42,6 +43,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.BraceHighlighting
             }
         }
 
-        protected abstract Task<TestWorkspace> CreateWorkspaceAsync(string markup);
+        protected abstract Task<TestWorkspace> CreateWorkspaceAsync(string markup, ParseOptions options);
     }
 }

--- a/src/EditorFeatures/Test/BraceMatching/AbstractBraceMatcherTests.cs
+++ b/src/EditorFeatures/Test/BraceMatching/AbstractBraceMatcherTests.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Editor;
 using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Text;
@@ -21,11 +20,11 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.BraceMatching
             return workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id);
         }
 
-        protected abstract Task<TestWorkspace> CreateWorkspaceFromCodeAsync(string code);
+        protected abstract Task<TestWorkspace> CreateWorkspaceFromCodeAsync(string code, ParseOptions options);
 
-        protected async Task TestAsync(string markup, string expectedCode)
+        protected async Task TestAsync(string markup, string expectedCode, ParseOptions options = null)
         {
-            using (var workspace = await CreateWorkspaceFromCodeAsync(markup))
+            using (var workspace = await CreateWorkspaceFromCodeAsync(markup, options))
             {
                 var position = workspace.Documents.Single().CursorPosition.Value;
                 var document = GetDocument(workspace);

--- a/src/EditorFeatures/Test/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             IList<TextSpan> expectedSpans,
             SyntaxNode fixedRoot,
             string annotationKind,
-            bool compareTokens, 
+            bool compareTokens,
             ParseOptions parseOptions = null)
         {
             expectedSpans = expectedSpans ?? new List<TextSpan>();
@@ -66,14 +66,20 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             await TestMissingAsync(initialMarkup, parseOptions: GetScriptOptions(), options: options, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey, fixProviderData: fixProviderData);
         }
 
-        protected Task TestMissingAsync(
+        protected async Task TestMissingAsync(
             string initialMarkup,
             ParseOptions parseOptions,
             IDictionary<OptionKey, object> options = null,
             string fixAllActionEquivalenceKey = null,
-            object fixProviderData = null)
+            object fixProviderData = null,
+            bool withScriptOption = false)
         {
-            return TestMissingAsync(initialMarkup, parseOptions, compilationOptions: null, options: options, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey, fixProviderData: fixProviderData);
+            await TestMissingAsync(initialMarkup, parseOptions, compilationOptions: null, options: options, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey, fixProviderData: fixProviderData);
+
+            if (withScriptOption)
+            {
+                await TestMissingAsync(initialMarkup, parseOptions.WithKind(SourceCodeKind.Script), compilationOptions: null, options: options, fixAllActionEquivalenceKey: fixAllActionEquivalenceKey, fixProviderData: fixProviderData);
+            }
         }
 
         protected async Task TestMissingAsync(
@@ -157,15 +163,21 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
             await TestAsync(initialMarkup, expectedMarkup, GetScriptOptions(), index, compareTokens, options, fixAllActionEquivalenceKey, fixProviderData);
         }
 
-        protected Task TestAsync(
+        protected async Task TestAsync(
             string initialMarkup, string expectedMarkup,
             ParseOptions parseOptions,
             int index = 0, bool compareTokens = true,
             IDictionary<OptionKey, object> options = null,
             string fixAllActionEquivalenceKey = null,
-            object fixProviderData = null)
+            object fixProviderData = null,
+            bool withScriptOption = false)
         {
-            return TestAsync(initialMarkup, expectedMarkup, parseOptions, null, index, compareTokens, options, fixAllActionEquivalenceKey, fixProviderData);
+            await TestAsync(initialMarkup, expectedMarkup, parseOptions, null, index, compareTokens, options, fixAllActionEquivalenceKey, fixProviderData);
+
+            if (withScriptOption)
+            {
+                await TestAsync(initialMarkup, expectedMarkup, parseOptions.WithKind(SourceCodeKind.Script), null, index, compareTokens, options, fixAllActionEquivalenceKey, fixProviderData);
+            }
         }
 
         protected async Task TestAsync(
@@ -261,7 +273,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
         private static Document GetDocumentToVerify(DocumentId expectedChangedDocumentId, Solution oldSolution, Solution newSolution)
         {
             Document document;
-            // If the expectedChangedDocumentId is not mentioned then we expect only single document to be changed 
+            // If the expectedChangedDocumentId is not mentioned then we expect only single document to be changed
             if (expectedChangedDocumentId == null)
             {
                 var projectDifferences = SolutionUtilities.GetSingleChangedProjectChanges(oldSolution, newSolution);

--- a/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/BraceMatching/VisualBasicBraceMatcherTests.vb
@@ -8,7 +8,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.BraceMatching
     Public Class VisualBasicBraceMatcherTests
         Inherits AbstractBraceMatcherTests
 
-        Protected Overrides Function CreateWorkspaceFromCodeAsync(code As String) As Task(Of TestWorkspace)
+        Protected Overrides Function CreateWorkspaceFromCodeAsync(code As String, options As ParseOptions) As Task(Of TestWorkspace)
             Return TestWorkspace.CreateVisualBasicAsync(code)
         End Function
 
@@ -658,6 +658,5 @@ End Class
 
             Await TestAsync(code, expected)
         End Function
-
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs
@@ -575,7 +575,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 
         private static string GetParameterName(ITypeSymbol type)
         {
-            if (type == null || type.IsAnonymousType())
+            if (type == null || type.IsAnonymousType() || type.IsTupleType)
             {
                 return DefaultParameterName;
             }


### PR DESCRIPTION
I'm going down the list of folders in `CSharpEditorServicesTest` and adding IDE tests for tuples for all the relevant refactorings. I skipped over `Completion` and taking a break at `EditAndContinue`. Additional test suggestions within this range are appreciated.

There are four spots marked as "note" in comments. I plan to remove those before merging, but I want to discuss the expectations on this thread (leave as-is, simple fix, or file issue).

The only non-test code is in two files (`src/Compilers/CSharp/Portable/Symbols/TupleTypeSymbol.cs`, `src/Workspaces/Core/Portable/Shared/Extensions/ITypeSymbolExtensions.cs`).

@dotnet/roslyn-ide and @VSadov for review.
I'll get sign-off from compiler team once the rest is sorted out.

Fixes #10566.