### PR TITLE
Use a pool that doesn't leak memory in highly concurrent scenarios.

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
+++ b/src/Workspaces/Core/Portable/Utilities/EditDistance.cs
@@ -627,7 +627,7 @@ namespace Roslyn.Utilities
     internal class SimplePool<T> where T : class
     {
         private readonly object _gate = new object();
-        private readonly List<T> _values = new List<T>();
+        private readonly Stack<T> _values = new Stack<T>();
         private readonly Func<T> _allocate;
 
         public SimplePool(Func<T> allocate)
@@ -639,14 +639,9 @@ namespace Roslyn.Utilities
         {
             lock (_gate)
             {
-                for (int i = 0, n = _values.Count; i < n; i++)
+                if (_values.Count > 0)
                 {
-                    var matrix = _values[i];
-                    if (matrix != null)
-                    {
-                        _values[i] = null;
-                        return matrix;
-                    }
+                    return _values.Pop();
                 }
 
                 return _allocate();
@@ -657,16 +652,7 @@ namespace Roslyn.Utilities
         {
             lock (_gate)
             {
-                for (int i = 0, n = _values.Count; i < n; i++)
-                {
-                    if (_values[i] == null)
-                    {
-                        _values[i] = value;
-                        return;
-                    }
-                }
-
-                _values.Add(value);
+                _values.Push(value);
             }
         }
     }


### PR DESCRIPTION
The xaml team reported a lot of arrays being created and destroyed during one of their scenarios.
Turns out this was due to us creating lots of arrays for computing the edit distances we use for
BKTrees.  While we were pooling these, we were getting and returning the arrays so quickly 
that we were exacerbating a known limitation of the pooling technology whereby highly concurrent allocatoin/frees actually cause objects to be leaked.

I've switched to a simple locked pool model which doesn't suffer from this.  