### PR TITLE
Fix the MakeConstCS and MakeConstVB samples to specify the analyzer a…

### DIFF
--- a/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
@@ -36,5 +36,6 @@ governing permissions and limitations under the License.
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstCS.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstCS.dll" />
   </Assets>
 </PackageManifest>

--- a/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
@@ -36,5 +36,6 @@ governing permissions and limitations under the License.
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstVB.dll" />
+    <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstVB.dll" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
…sset.

I verified that make const diagnostics now show up when these projects are set as startup projects and deployed to dev hive.

Fixes #3215