### PR TITLE
Fix the "Unused parameter" sample analyzers to ignore compiler genera…

### DIFF
--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.cs
@@ -78,8 +78,9 @@ namespace CSharpAnalyzers
             public UnusedParametersAnalyzer(IMethodSymbol method)
             {
                 // Initialization: Assume all parameters are unused.
-                _unusedParameters = new HashSet<IParameterSymbol>(method.Parameters);
-                _unusedParameterNames = new HashSet<string>(method.Parameters.Select(p => p.Name));
+                var parameters = method.Parameters.Where(p => !p.IsImplicitlyDeclared);
+                _unusedParameters = new HashSet<IParameterSymbol>(parameters);
+                _unusedParameterNames = new HashSet<string>(parameters.Select(p => p.Name));
             }
 
             #endregion

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.cs
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers/StatelessAnalyzers/CodeBlockAnalyzer.cs
@@ -46,8 +46,8 @@ namespace CSharpAnalyzers
 
             // Report diagnostic for void non-virtual methods with empty method bodies.
             var method = (IMethodSymbol)codeBlockContext.OwningSymbol;
-            var block = (BlockSyntax)codeBlockContext.CodeBlock.ChildNodes().First(n => n.Kind() == SyntaxKind.Block);
-            if (method.ReturnsVoid && !method.IsVirtual && block.Statements.Count == 0)
+            var block = (BlockSyntax)codeBlockContext.CodeBlock.ChildNodes().FirstOrDefault(n => n.Kind() == SyntaxKind.Block);
+            if (method.ReturnsVoid && !method.IsVirtual && block != null && block.Statements.Count == 0)
             {
                 var tree = block.SyntaxTree;
                 var location = method.Locations.First(l => tree.Equals(l.SourceTree));

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.vb
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers/StatefulAnalyzers/CodeBlockStartedAnalyzer.vb
@@ -67,8 +67,9 @@ Namespace BasicAnalyzers
 #Region "State intialization"
             Public Sub New(method As IMethodSymbol)
                 ' Initialization: Assume all parameters are unused.
-                _unusedParameters = New HashSet(Of IParameterSymbol)(method.Parameters)
-                _unusedParameterNames = New HashSet(Of String)(method.Parameters.Select(Function(p) p.Name))
+                Dim parameters = method.Parameters.Where(Function(p) Not p.IsImplicitlyDeclared)
+                _unusedParameters = New HashSet(Of IParameterSymbol)(parameters)
+                _unusedParameterNames = New HashSet(Of String)(parameters.Select(Function(p) p.Name))
             End Sub
 #End Region
 


### PR DESCRIPTION
…ted parameters with no locations.

Note that the corresponding FxCop analyzer (CA1801) is based on IOperation and hence doesn't hit this situation (https://github.com/dotnet/roslyn-analyzers/blob/master/src/Microsoft.Maintainability.Analyzers/Core/ReviewUnusedParameters.cs#L128)

Fixes #10314