### PR TITLE
Bootstrap builds Roslyn and runs test

### DIFF
--- a/src/Test/Perf/infra/automation.csx
+++ b/src/Test/Perf/infra/automation.csx
@@ -1,24 +1,13 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 #r "./../../Roslyn.Test.Performance.Utilities.dll"
 
-// IsVerbose()
-#load "../util/test_util.csx"
 // RunFile()
 #load "../util/runner_util.csx"
 
 using Roslyn.Test.Performance.Utilities;
 
 var directoryUtil = new RelativeDirectory();
-var logger = new ConsoleAndFileLogger();
 TestUtilities.InitUtilities();
-
-// Update the repository
-string branch = TestUtilities.StdoutFrom("git", IsVerbose(), logger, "rev-parse --abbrev-ref HEAD");
-TestUtilities.ShellOutVital("git", $"pull origin {branch}", IsVerbose(), logger);
-TestUtilities.ShellOutVital(Path.Combine(directoryUtil.RoslynDirectory, "Restore.cmd"), "", IsVerbose(), logger, workingDirectory: directoryUtil.RoslynDirectory);
-
-// Build Roslyn in Release Mode
-TestUtilities.ShellOutVital("msbuild", "./Roslyn.sln /p:Configuration=Release", IsVerbose(), logger, workingDirectory: directoryUtil.RoslynDirectory);
 
 // Install the Vsixes to RoslynPerf hive
 await RunFile(Path.Combine(directoryUtil.MyWorkingDirectory, "install_vsixes.csx"));

--- a/src/Test/Perf/util/RelativeDirectory.cs
+++ b/src/Test/Perf/util/RelativeDirectory.cs
@@ -89,6 +89,8 @@ namespace Roslyn.Test.Performance.Utilities
             throw new Exception("Couldn't find binaries. Are you running from the binaries directory?");
         }
 
+        public string TaoPath => Path.Combine(MyBinaries(), "Tao");
+
         public string PerfDirectory => Path.Combine(RoslynDirectory, "src", "Test", "Perf");
 
         public string BinDirectory => Path.Combine(RoslynDirectory, "Binaries");


### PR DESCRIPTION
Bootstrap will build whole of Roslyn both in Open and Closed depending on what the user has enlisted into.

Automated runs and Internal users will be able to build, run the perf tests and report the results by running bootstrap.bat(may be a different name given its purpose is different now).

Users using the open Roslyn will build Open Roslyn but they won't run the tests by running Bootstrap.bat. Once they run bootstrap.bat, they can run runner.csx to run the tests individually.

Tagging @rchande @KevinH-MS  @TyOverby for review