### PR TITLE
Change contents of the TestSetup project

### DIFF
--- a/src/VisualStudio/TestSetup/BindingAttributes.cs
+++ b/src/VisualStudio/TestSetup/BindingAttributes.cs
@@ -1,0 +1,3 @@
+﻿﻿using Microsoft.VisualStudio.Shell;
+
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Roslyn.Hosting.Diagnostics.dll")]

--- a/src/VisualStudio/TestSetup/BindingPath.pkgdef
+++ b/src/VisualStudio/TestSetup/BindingPath.pkgdef
@@ -1,2 +1,0 @@
-﻿[$RootKey$\BindingPaths\{d0122878-51f1-4b36-95ec-dec2079a2a84}]
-"$PackageFolder$"=""

--- a/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
+++ b/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
@@ -64,6 +64,8 @@
     <ProjectReference Include="..\Setup\VisualStudioSetup.csproj">
       <Project>{201ec5b7-f91e-45e5-b9f2-67a266cce6fc}</Project>
       <Name>VisualStudioSetup</Name>
+      <Private>False</Private>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="..\TestUtilities\VisualStudioTestUtilities.csproj">
       <Project>{3bed15fd-d608-4573-b432-1569c1026f6d}</Project>

--- a/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
+++ b/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
@@ -34,6 +34,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="BindingAttributes.cs" />
     <Compile Include="IntegrationTestServiceCommands.cs" />
     <Compile Include="IntegrationTestServicePackage.cs" />
     <Compile Include="TestExtensionErrorHandler.cs" />

--- a/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
+++ b/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
@@ -59,6 +59,7 @@
     <ProjectReference Include="..\..\Workspaces\Core\Portable\Workspaces.csproj">
       <Project>{5f8d2414-064a-4b3a-9b42-8e2a04246be5}</Project>
       <Name>Workspaces</Name>
+      <Private>False</Private>
     </ProjectReference>
     <ProjectReference Include="..\Setup\VisualStudioSetup.csproj">
       <Project>{201ec5b7-f91e-45e5-b9f2-67a266cce6fc}</Project>

--- a/src/VisualStudio/TestSetup/source.extension.vsixmanifest
+++ b/src/VisualStudio/TestSetup/source.extension.vsixmanifest
@@ -17,7 +17,6 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Hosting.Diagnostics.dll" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-    <Asset Type="Microsoft.VisualStudio.VsPackage" Path="BindingPath.pkgdef" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
 </PackageManifest>


### PR DESCRIPTION
The main goal here is to add an explicit CodeBase for Roslyn.Hosting.Diagnostics.dll which I do in fb4ccbc. The other changes generally clean things up, and reduce the package size from a few megabytes to a few kilobytes.