### PR TITLE
Get to the current module's MVID using a mechanism that works for portable as well as desktop

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -63,7 +63,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private BoundStatement InitializeMVID(SyntheticBoundNodeFactory factory, DiagnosticBag diagnostics)
         {
-
             CSharpCompilation compilation = factory.Compilation;
             CSharpSyntaxNode syntax = factory.Syntax;
 
@@ -102,12 +101,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // MVID = moduleReference.ModuleVersionId;
-             return
-                factory.Assignment(
-                    factory.ModuleVersionId(),
-                    factory.Property(
-                        moduleReference,
-                        WellKnownMember.System_Reflection_Module__ModuleVersionId));
+            return
+               factory.Assignment(
+                   factory.ModuleVersionId(),
+                   factory.Property(
+                       moduleReference,
+                       WellKnownMember.System_Reflection_Module__ModuleVersionId));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -59,11 +59,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     factory.ModuleVersionId(),
                     factory.Property(
                         factory.Property(
-                            factory.Call(
-                                null,
-                                (MethodSymbol)Binder.GetWellKnownTypeMember(compilationState.Compilation, WellKnownMember.System_Reflection_IntrospectionExtensions__GetTypeInfo, diagnostics, syntax: syntax),
-                                factory.TypeOfPrivateImplementationDetails()),
-                            WellKnownMember.System_Reflection_TypeInfo__Module),
+                            factory.Convert(
+                                factory.WellKnownType(WellKnownType.System_Type),
+                                factory.Call(
+                                    null,
+                                    (MethodSymbol)Binder.GetWellKnownTypeMember(compilationState.Compilation, WellKnownMember.System_Reflection_IntrospectionExtensions__GetTypeInfo, diagnostics, syntax: syntax),
+                                    factory.TypeOfPrivateImplementationDetails()),
+                                ConversionKind.ImplicitReference),
+                            WellKnownMember.System_Type__Module),
                         WellKnownMember.System_Reflection_Module__ModuleVersionId));
 
             body.Add(mvidInitialization);

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -77,19 +77,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // which is available via a GetTypeInfo extension method.
             //
             // The Portable mechanism also works on Desktop, but not on versions prior to 4.5, so there is no one single mechanism that work on all platforms.
+
             BoundExpression moduleReference;
             Symbol system_Type__Module = compilation.GetWellKnownTypeMember(WellKnownMember.System_Type__Module);
             if (system_Type__Module != null)
             {
                 // moduleReference = TypeOf(PrivateImplementationDetails).Module;
-
                 moduleReference = factory.Property(typeInstance, WellKnownMember.System_Type__Module);
             }
 
             else
             {
                 // moduleReference = ((System.Reflection.MemberInfo)System.Reflection.IntrospectionExtensions.GetTypeInfo(TypeOf(PrivateImplementationDetails))).Module;
-
                 moduleReference =
                     factory.Property(
                         factory.Convert(
@@ -103,7 +102,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // MVID = moduleReference.ModuleVersionId;
-
              return
                 factory.Assignment(
                     factory.ModuleVersionId(),

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -582,12 +582,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(null, method, args);
         }
 
-        public BoundExpression StaticCall(TypeSymbol receiver, WellKnownMember method, params BoundExpression[] args)
+        public BoundExpression StaticCall(WellKnownMember method, params BoundExpression[] args)
         {
             MethodSymbol methodSymbol = WellKnownMethod(method);
-            Debug.Assert(methodSymbol.IsStatic);
-            Debug.Assert(receiver.GetMembers(methodSymbol.Name).OfType<MethodSymbol>().Contains(methodSymbol));
             Binder.ReportUseSiteDiagnostics(methodSymbol, Diagnostics, Syntax);
+            Debug.Assert(methodSymbol.IsStatic);
             return Call(null, methodSymbol, args);
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -582,6 +582,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(null, method, args);
         }
 
+        public BoundExpression StaticCall(TypeSymbol receiver, WellKnownMember method, params BoundExpression[] args)
+        {
+            MethodSymbol methodSymbol = WellKnownMethod(method);
+            Debug.Assert(methodSymbol.IsStatic);
+            Debug.Assert(receiver.GetMembers(methodSymbol.Name).OfType<MethodSymbol>().Contains(methodSymbol));
+            Binder.ReportUseSiteDiagnostics(methodSymbol, Diagnostics, Syntax);
+            return Call(null, methodSymbol, args);
+        }
+
         public BoundCall Call(BoundExpression receiver, MethodSymbol method)
         {
             return Call(receiver, method, ImmutableArray<BoundExpression>.Empty);

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -1370,15 +1370,15 @@ public class Program
 
             Assert.True(false);
         }
-        
-        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)
-        {
-            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_refs, options: options, emitOptions: emitOptions);
-        }
 
         private CompilationVerifier CompileWithNoFramework(string source, EmitOptions emitOptions, CompilationOptions options = null)
         {
             return base.CompileAndVerify(source, verify: false, options: options, emitOptions: emitOptions);
+        }
+
+        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)
+        {
+            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_refs, options: options, emitOptions: emitOptions);
         }
 
         private static readonly MetadataReference[] s_refs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -1077,11 +1077,112 @@ True
             CompileAndVerify(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"), expectedOutput: expectedOutput);
         }
 
-        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)
+        [Fact]
+        public void PortableCoverage()
         {
-            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_asyncRefs, options: options, emitOptions: emitOptions);
+            string source = @"
+namespace System
+{
+    public class Object { }  
+    public struct Int32 { }  
+    public struct Boolean { }  
+    public class String { }  
+    public class Exception { }  
+    public class ValueType { }  
+    public class Enum { }  
+    public struct Void { }  
+    public class Guid { }
+    public struct RuntimeTypeHandle { }
+
+    public class Type
+    {
+        public static Type GetTypeFromHandle(RuntimeTypeHandle handle) { return new Type(); }
+    }
+}
+
+public class Console
+{
+    public static void WriteLine(string s) { }
+    public static void WriteLine(int i) { }
+    public static void WriteLine(bool b) { }
+}
+
+namespace System.Reflection
+{
+    public class MemberInfo
+    {
+        public virtual Module Module => new Module();
+    }
+
+    public class TypeInfo : MemberInfo
+    {
+    }
+
+    public class Module
+    {
+        public virtual Guid ModuleVersionId => new Guid();
+    }
+
+    public static class IntrospectionExtensions
+    {
+        public static TypeInfo GetTypeInfo(System.Type t) { return new TypeInfo(); }
+    }
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        TestMain();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
+    }
+
+    static int TestMain()
+    {
+        return 3;
+    }
+}
+";
+
+            string expectedTestMainIL = @"{
+  // Code size       53 (0x35)
+  .maxstack  4
+  .locals init (bool[] V_0)
+  IL_0000:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_0005:  ldtoken    ""int Program.TestMain()""
+  IL_000a:  ldelem.ref
+  IL_000b:  stloc.0
+  IL_000c:  ldloc.0
+  IL_000d:  brtrue.s   IL_002f
+  IL_000f:  ldsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
+  IL_0014:  ldtoken    ""int Program.TestMain()""
+  IL_0019:  ldsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
+  IL_001e:  ldtoken    ""int Program.TestMain()""
+  IL_0023:  ldelema    ""bool[]""
+  IL_0028:  ldc.i4.1
+  IL_0029:  call       ""bool[] Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload(System.Guid, int, ref bool[], int)""
+  IL_002e:  stloc.0
+  IL_002f:  ldloc.0
+  IL_0030:  ldc.i4.0
+  IL_0031:  ldc.i4.1
+  IL_0032:  stelem.i1
+  IL_0033:  ldc.i4.3
+  IL_0034:  ret
+}";
+            CompilationVerifier verifier = CompileWithNoFramework(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"));
+            verifier.VerifyIL("Program.TestMain", expectedTestMainIL);
         }
 
-        private static readonly MetadataReference[] s_asyncRefs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };
+        private CompilationVerifier CompileWithNoFramework(string source, EmitOptions emitOptions, CompilationOptions options = null)
+        {
+            return base.CompileAndVerify(source, verify: false, options: options, emitOptions: emitOptions);
+        }
+
+        private CompilationVerifier CompileAndVerify(string source, EmitOptions emitOptions, string expectedOutput = null, CompilationOptions options = null)
+        {
+            return base.CompileAndVerify(source, expectedOutput: expectedOutput, additionalRefs: s_refs, options: options, emitOptions: emitOptions);
+        }
+
+        private static readonly MetadataReference[] s_refs = new[] { MscorlibRef_v4_0_30316_17626, SystemRef_v4_0_30319_17929, SystemCoreRef_v4_0_30319_17929 };
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.DynamicAnalysis.UnitTests
@@ -1281,10 +1282,15 @@ public class Program
             {
                 CompilationVerifier verifier = CompileWithNoFramework(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"));
             }
-            catch (SyntheticBoundNodeFactory.MissingPredefinedMember missing)
+            catch (EmitException exception)
             {
-                Assert.True(missing.Diagnostic.ToString().Contains("IntrospectionExtensions.GetTypeInfo"));
-                return;                
+                foreach (Diagnostic diagnostic in exception.Diagnostics)
+                {
+                    if (diagnostic.ToString().Contains("Missing compiler required member 'System.Reflection.IntrospectionExtensions.GetTypeInfo'"))
+                    {
+                        return;
+                    }
+                }           
             }
 
             Assert.True(false);
@@ -1360,10 +1366,15 @@ public class Program
             {
                 CompilationVerifier verifier = CompileWithNoFramework(source + InstrumentationHelperSource, emitOptions: EmitOptions.Default.WithInstrument("Test.Flag"));
             }
-            catch (SyntheticBoundNodeFactory.MissingPredefinedMember missing)
+            catch (EmitException exception)
             {
-                Assert.True(missing.Diagnostic.ToString().Contains("Module.ModuleVersionId"));
-                return;
+                foreach (Diagnostic diagnostic in exception.Diagnostics)
+                {
+                    if (diagnostic.ToString().Contains("Missing compiler required member 'System.Reflection.Module.ModuleVersionId'"))
+                    {
+                        return;
+                    }
+                }
             }
 
             Assert.True(false);

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -52,6 +52,7 @@ namespace Microsoft.CodeAnalysis
         System_Type__GetTypeFromCLSID,
         System_Type__GetTypeFromHandle,
         System_Type__Missing,
+        System_Type__Module,
 
         System_Reflection_AssemblyKeyFileAttribute__ctor,
         System_Reflection_AssemblyKeyNameAttribute__ctor,
@@ -67,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         System_Reflection_Missing__Value,
 
         System_Reflection_IntrospectionExtensions__GetTypeInfo,
-        System_Type__Module,
+        System_Reflection_MemberInfo__Module,
         System_Reflection_Module__ModuleVersionId,
 
         System_IEquatable_T__Equals,

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -52,7 +52,6 @@ namespace Microsoft.CodeAnalysis
         System_Type__GetTypeFromCLSID,
         System_Type__GetTypeFromHandle,
         System_Type__Missing,
-        System_Type__Module,
 
         System_Reflection_AssemblyKeyFileAttribute__ctor,
         System_Reflection_AssemblyKeyNameAttribute__ctor,
@@ -67,6 +66,8 @@ namespace Microsoft.CodeAnalysis
 
         System_Reflection_Missing__Value,
 
+        System_Reflection_IntrospectionExtensions__GetTypeInfo,
+        System_Reflection_TypeInfo__Module,
         System_Reflection_Module__ModuleVersionId,
 
         System_IEquatable_T__Equals,

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis
         System_Reflection_Missing__Value,
 
         System_Reflection_IntrospectionExtensions__GetTypeInfo,
-        System_Reflection_TypeInfo__Module,
+        System_Type__Module,
         System_Reflection_Module__ModuleVersionId,
 
         System_IEquatable_T__Equals,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -355,13 +355,6 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,                                    // Field Signature
 
-                // System_Type__Module
-                (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
-                (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    0,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_Module - WellKnownType.ExtSentinel),
-
                 // System_Reflection_AssemblyKeyFileAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)WellKnownType.System_Reflection_AssemblyKeyFileAttribute,                                             // DeclaringTypeId
@@ -447,6 +440,21 @@ namespace Microsoft.CodeAnalysis
                 (byte)WellKnownType.System_Reflection_Missing,                                                              // DeclaringTypeId
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Reflection_Missing,                      // Field Signature
+
+                // System_Reflection_IntrospectionExtensions__GetTypeInfo
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)(WellKnownType.System_Reflection_IntrospectionExtensions - WellKnownType.ExtSentinel),                // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    1,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
+
+                // System_Reflection_TypeInfo__Module
+                (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
+                (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),                               // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_Module - WellKnownType.ExtSentinel),
 
                 // System_Reflection_Module__ModuleVersionId
                 (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
@@ -2908,7 +2916,6 @@ namespace Microsoft.CodeAnalysis
                 "GetTypeFromCLSID",                         // System_Type__GetTypeFromCLSID
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
                 "Missing",                                  // System_Type__Missing
-                "Module",                                   // System_Type__Module
                 ".ctor",                                    // System_Reflection_AssemblyKeyFileAttribute__ctor
                 ".ctor",                                    // System_Reflection_AssemblyKeyNameAttribute__ctor
                 "GetMethodFromHandle",                      // System_Reflection_MethodBase__GetMethodFromHandle
@@ -2919,6 +2926,8 @@ namespace Microsoft.CodeAnalysis
                 "GetFieldFromHandle",                       // System_Reflection_FieldInfo__GetFieldFromHandle
                 "GetFieldFromHandle",                       // System_Reflection_FieldInfo__GetFieldFromHandle2
                 "Value",                                    // System_Reflection_Missing__Value
+                "GetTypeInfo",                              // System_Reflection_IntrospectionExtensions__GetTypeInfo
+                "Module",                                   // System_Reflection_TypeInfo__Module
                 "ModuleVersionId",                          // System_Reflection_Module__ModuleVersionId
                 "Equals",                                   // System_IEquatable_T__Equals
                 "Equals",                                   // System_Collections_Generic_EqualityComparer_T__Equals

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -443,15 +443,15 @@ namespace Microsoft.CodeAnalysis
 
                 // System_Reflection_IntrospectionExtensions__GetTypeInfo
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)(WellKnownType.System_Reflection_IntrospectionExtensions - WellKnownType.ExtSentinel),                // DeclaringTypeId
+                (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_IntrospectionExtensions - WellKnownType.ExtSentinel), // DeclaringTypeId
                 0,                                                                                                          // Arity
                     1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
 
-                // System_Reflection_TypeInfo__Module
+                // System_Type__Module
                 (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
-                (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),                               // DeclaringTypeId
+                (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_Module - WellKnownType.ExtSentinel),

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -355,6 +355,13 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Object,                                    // Field Signature
 
+                // System_Type__Module
+                (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
+                (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_Module - WellKnownType.ExtSentinel),
+
                 // System_Reflection_AssemblyKeyFileAttribute__ctor
                 (byte)MemberFlags.Constructor,                                                                              // Flags
                 (byte)WellKnownType.System_Reflection_AssemblyKeyFileAttribute,                                             // DeclaringTypeId
@@ -449,9 +456,9 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_TypeInfo - WellKnownType.ExtSentinel),
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Type,
 
-                // System_Type__Module
+                // System_Reflection_MemberInfo__Module
                 (byte)(MemberFlags.Property | MemberFlags.Virtual),                                                         // Flags
-                (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
+                (byte)WellKnownType.System_Reflection_MemberInfo,                                                           // DeclaringTypeId
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Reflection_Module - WellKnownType.ExtSentinel),
@@ -2916,6 +2923,7 @@ namespace Microsoft.CodeAnalysis
                 "GetTypeFromCLSID",                         // System_Type__GetTypeFromCLSID
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
                 "Missing",                                  // System_Type__Missing
+                "Module",                                   // System_Type__Module
                 ".ctor",                                    // System_Reflection_AssemblyKeyFileAttribute__ctor
                 ".ctor",                                    // System_Reflection_AssemblyKeyNameAttribute__ctor
                 "GetMethodFromHandle",                      // System_Reflection_MethodBase__GetMethodFromHandle
@@ -2927,7 +2935,7 @@ namespace Microsoft.CodeAnalysis
                 "GetFieldFromHandle",                       // System_Reflection_FieldInfo__GetFieldFromHandle2
                 "Value",                                    // System_Reflection_Missing__Value
                 "GetTypeInfo",                              // System_Reflection_IntrospectionExtensions__GetTypeInfo
-                "Module",                                   // System_Reflection_TypeInfo__Module
+                "Module",                                   // System_Reflection_MemberInfo__Module
                 "ModuleVersionId",                          // System_Reflection_Module__ModuleVersionId
                 "Equals",                                   // System_IEquatable_T__Equals
                 "Equals",                                   // System_Collections_Generic_EqualityComparer_T__Equals

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -257,6 +257,8 @@ namespace Microsoft.CodeAnalysis
 
         System_ValueTuple_TRest,
 
+        System_Reflection_TypeInfo,
+        System_Reflection_IntrospectionExtensions,
         System_Reflection_Module,
         Microsoft_CodeAnalysis_Runtime_Instrumentation,
 
@@ -514,6 +516,8 @@ namespace Microsoft.CodeAnalysis
 
             "System.ValueTuple`8",
 
+            "System.Reflection.TypeInfo",
+            "System.Reflection.IntrospectionExtensions",
             "System.Reflection.Module",
             "Microsoft.CodeAnalysis.Runtime.Instrumentation",
 

--- a/src/Test/PdbUtilities/Metadata/ILVisualizer.cs
+++ b/src/Test/PdbUtilities/Metadata/ILVisualizer.cs
@@ -380,13 +380,24 @@ namespace Roslyn.Test.MetadataUtilities
                         case OperandType.InlineTok:
                         case OperandType.InlineType:
                             {
-                                uint pseudoToken = ReadUInt32(ilBytes, ref curIndex);
-                                // Check for a raw token value, encoded with a 1 high-order bit.
-                                if (opCode.OperandType == OperandType.InlineTok && (pseudoToken & 0x80000000) != 0 && pseudoToken != 0xffffffff)
-                                {
-                                    pseudoToken &= 0x7fffffff;
-                                }
                                 sb.Append(' ');
+                                uint pseudoToken = ReadUInt32(ilBytes, ref curIndex);
+                                if (opCode.OperandType == OperandType.InlineTok)
+                                {
+                                    // Check of an encoding of the maximum method token index value.
+                                    if ((pseudoToken & 0xff000000) == 0x40000000)
+                                    {
+                                        sb.Append("Max Method Token Index");
+                                        break;
+                                    }
+
+                                    // Check for a raw token value, encoded with a 1 high-order bit.
+                                    if ((pseudoToken & 0x80000000) != 0 && pseudoToken != 0xffffffff)
+                                    {
+                                        pseudoToken &= 0x7fffffff;
+                                    }
+                                }
+                               
                                 sb.Append(VisualizeSymbol(pseudoToken));
                                 break;
                             }


### PR DESCRIPTION
@dotnet/roslyn-compiler @dotnet/testimpact @jcouv @AlekseyTs @tannergooding @ManishJayaswal @drognanar 