### PR TITLE
Bugfix: NullReferenceException should not be thrown in SymbolKeyTestB

### DIFF
--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
                     body = (node as AccessorDeclarationSyntax).Body;
                 }
 
-                if (body != null || body.Statements.Any())
+                if (body != null && body.Statements.Any())
                 {
                     list.Add(body);
                 }


### PR DESCRIPTION
…ase.GetBlockSyntaxList