### PR TITLE
Fix Markdown list typography in Source Generators documentation

### DIFF
--- a/docs/features/generators.md
+++ b/docs/features/generators.md
@@ -142,6 +142,7 @@ replace.cs:
     }
 ```
 The following `class` and `struct` members can be replaced:
+
 1. Static and instance methods, properties, and events
 1. Explicit interface implementations of members
 1. User defined operators
@@ -153,6 +154,7 @@ The following `class` and `struct` members can be replaced:
 The default constructor can be added by a generator but not replaced.
 
 The following must match when replacing a member:
+
 1. Signature: name, accessibility, arity, return type, parameter number, parameter types and ref-ness
 1. Parameter names and default values (to prevent changing the interpretation of call-sites)
 1. Type parameters and constraints


### PR DESCRIPTION
To get a list to render in GitHub-flavored Markdown, there needs to be a
blank line before it.