### PR TITLE
Add API for consuming solution and document-specific options

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -58,11 +58,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         public bool SupportsFormattingOnTypedCharacter(Document document, char ch)
         {
-            var options = document.Project.Solution.Workspace.Options;
-            var smartIndentOn = options.GetOption(FormattingOptions.SmartIndent, document.Project.Language) == FormattingOptions.IndentStyle.Smart;
+            var options = document.Options;
+            var smartIndentOn = options.GetOption(FormattingOptions.SmartIndent) == FormattingOptions.IndentStyle.Smart;
 
-            if ((ch == '}' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language) && !smartIndentOn) ||
-                (ch == ';' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnSemicolon, document.Project.Language)))
+            if ((ch == '}' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace) && !smartIndentOn) ||
+                (ch == ';' && !options.GetOption(FeatureOnOffOptions.AutoFormattingOnSemicolon)))
             {
                 return false;
             }
@@ -182,12 +182,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                 return null;
             }
 
-            var options = document.Project.Solution.Workspace.Options;
-
             // don't attempt to format on close brace if autoformat on close brace feature is off, instead just smart indent
             bool smartIndentOnly =
                 token.IsKind(SyntaxKind.CloseBraceToken) &&
-                !options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace, document.Project.Language);
+                !document.Options.GetOption(FeatureOnOffOptions.AutoFormattingOnCloseBrace);
 
             if (!smartIndentOnly)
             {
@@ -216,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
         private async Task<IList<TextChange>> FormatTokenAsync(Document document, SyntaxToken token, IEnumerable<IFormattingRule> formattingRules, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var formatter = CreateSmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, root);
+            var formatter = CreateSmartTokenFormatter(document.Options, formattingRules, root);
             var changes = await formatter.FormatTokenAsync(document.Project.Solution.Workspace, token, cancellationToken).ConfigureAwait(false);
             return changes;
         }
@@ -247,7 +245,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var formatter = new SmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, (CompilationUnitSyntax)root);
+            var formatter = new SmartTokenFormatter(document.Options, formattingRules, (CompilationUnitSyntax)root);
 
             var changes = formatter.FormatRange(document.Project.Solution.Workspace, tokenRange.Value.Item1, tokenRange.Value.Item2, cancellationToken);
             return changes;

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
             var smartTokenformattingRules = (new SmartTokenFormattingRule()).Concat(_formattingRules);
             var adjustedStartPosition = previousToken.SpanStart;
-            var indentStyle = workspace.Options.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp);
+            var indentStyle = _optionSet.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp);
             if (token.IsKind(SyntaxKind.OpenBraceToken) && token.IsFirstTokenOnLine(token.SyntaxTree.GetText()) && indentStyle != FormattingOptions.IndentStyle.Smart)
             {
                 adjustedStartPosition = token.SpanStart;

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/AbstractCSharpCompletionProviderTests.cs
@@ -141,9 +141,7 @@ text;
                 var completionList = await GetCompletionListAsync(document, position, CompletionTrigger.Default);
                 var item = completionList.Items.First(i => i.DisplayText.StartsWith(textTypedSoFar));
 
-                var optionService = workspace.Services.GetService<IOptionService>();
-                var options = optionService.GetOptions().WithChangedOption(CSharpCompletionOptions.AddNewLineOnEnterAfterFullyTypedWord, sendThroughEnterEnabled);
-                optionService.SetOptions(options);
+                workspace.Options = workspace.Options.WithChangedOption(CSharpCompletionOptions.AddNewLineOnEnterAfterFullyTypedWord, sendThroughEnterEnabled);
 
                 var completionRules = CompletionHelper.GetHelper(document);
                 Assert.Equal(expected, completionRules.SendEnterThroughToEditor(item, textTypedSoFar, workspace.Options));

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodBase.cs
@@ -111,9 +111,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
             Assert.NotNull(document);
 
-            var options = document.Project.Solution.Workspace.Options
-                                  .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration)
-                                  .WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct);
+            var options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration)
+                                          .WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct);
 
             var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
             var validator = new CSharpSelectionValidator(semanticDocument, testDocument.SelectedSpans.Single(), options);
@@ -145,8 +144,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 var document = workspace.CurrentSolution.GetDocument(testDocument.Id);
                 Assert.NotNull(document);
 
-                var options = document.Project.Solution.Workspace.Options
-                                      .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, true);
+                var options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, true);
 
                 var semanticDocument = await SemanticDocument.CreateAsync(document, CancellationToken.None);
                 var validator = new CSharpSelectionValidator(semanticDocument, namedSpans["b"].Single(), options);
@@ -172,8 +170,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
                 var root = await document.GetSyntaxRootAsync();
                 var iterator = root.DescendantNodesAndSelf().Cast<SyntaxNode>();
 
-                var options = document.Project.Solution.Workspace.Options
-                                      .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, true);
+                var options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, true);
 
                 foreach (var node in iterator)
                 {

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -225,10 +225,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
                 // get original buffer
                 var buffer = workspace.Documents.First().GetTextBuffer();
 
-                var optionService = workspace.Services.GetService<IOptionService>();
                 if (isPaste)
                 {
-                    optionService.SetOptions(optionService.GetOptions().WithChangedOption(FeatureOnOffOptions.FormatOnPaste, LanguageNames.CSharp, true));
                     var commandHandler = new FormatCommandHandler(TestWaitIndicator.Default, null, null);
                     var commandArgs = new PasteCommandArgs(view, view.TextBuffer);
                     commandHandler.ExecuteCommand(commandArgs, () => { });

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
 
             var rules = formattingRuleProvider.CreateRule(document, position).Concat(Formatter.GetDefaultFormattingRules(document));
 
-            var formatter = new SmartTokenFormatter(workspace.Options, rules, root);
+            var formatter = new SmartTokenFormatter(document.Options, rules, root);
             var changes = await formatter.FormatTokenAsync(workspace, token, CancellationToken.None);
 
             ApplyChanges(buffer, changes);

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1365,7 +1365,7 @@ class C
                 Assert.True(
                     CSharpIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(
                         Formatter.GetDefaultFormattingRules(workspace, root.Language),
-                        root, line, workspace.Options, CancellationToken.None));
+                        root, line, document.Options, CancellationToken.None));
 
                 var actualIndentation = await GetSmartTokenFormatterIndentationWorkerAsync(workspace, buffer, indentationLine, ch);
                 Assert.Equal(expectedIndentation.Value, actualIndentation);
@@ -1392,7 +1392,7 @@ class C
                 Assert.False(
                     CSharpIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(
                         Formatter.GetDefaultFormattingRules(workspace, root.Language),
-                        root, line, workspace.Options, CancellationToken.None));
+                        root, line, document.Options, CancellationToken.None));
 
                 await TestIndentationAsync(indentationLine, expectedIndentation, workspace);
             }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -3093,7 +3093,6 @@ class Program{
             {
                 var subjectDocument = workspace.Documents.Single();
 
-                var optionService = workspace.Services.GetService<IOptionService>();
                 var textUndoHistory = new Mock<ITextUndoHistoryRegistry>();
                 var editorOperationsFactory = new Mock<IEditorOperationsFactoryService>();
                 var editorOperations = new Mock<IEditorOperations>();

--- a/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/AutomaticCompletion/AbstractAutomaticLineEnderCommandHandler.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.AutomaticCompletion
             }
 
             // feature off
-            if (!document.Project.Solution.Workspace.Options.GetOption(InternalFeatureOnOffOptions.AutomaticLineEnder))
+            if (!document.Options.GetOption(InternalFeatureOnOffOptions.AutomaticLineEnder))
             {
                 NextAction(operations, nextHandler);
                 return;

--- a/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyDetail.cs
+++ b/src/EditorFeatures/Core/Implementation/CallHierarchy/CallHierarchyDetail.cs
@@ -102,7 +102,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.CallHierarchy
             if (document != null)
             {
                 var navigator = _workspace.Services.GetService<IDocumentNavigationService>();
-                var options = _workspace.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, true);
+                var options = document.Options.WithChangedOption(NavigationOptions.PreferProvisionalTab, true);
                 navigator.TryNavigateToSpan(_workspace, document.Id, _span, options);
             }
         }

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
         protected bool FormatToken(ITextView view, Document document, SyntaxToken token, IEnumerable<IFormattingRule> formattingRules, CancellationToken cancellationToken)
         {
             var root = document.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var formatter = CreateSmartTokenFormatter(document.Project.Solution.Workspace.Options, formattingRules, root);
+            var formatter = CreateSmartTokenFormatter(document.Options, formattingRules, root);
             var changes = formatter.FormatTokenAsync(document.Project.Solution.Workspace, token, cancellationToken).WaitAndGetResult(cancellationToken);
             if (changes.Count == 0)
             {
@@ -226,14 +226,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
                 return;
             }
 
-            var options = document.Project.Solution.Workspace.Options;
+            var options = document.Options;
 
             // and then, insert the text
             document.Project.Solution.Workspace.ApplyTextChanges(document.Id,
                 new TextChange(
                     new TextSpan(
                         lineInSubjectBuffer.Start.Position, firstNonWhitespaceIndex),
-                        indentation.CreateIndentationString(options.GetOption(FormattingOptions.UseTabs, document.Project.Language), options.GetOption(FormattingOptions.TabSize, document.Project.Language))),
+                        indentation.CreateIndentationString(options.GetOption(FormattingOptions.UseTabs), options.GetOption(FormattingOptions.TabSize))),
                         CancellationToken.None);
         }
 
@@ -296,7 +296,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
             var position = view.GetCaretPoint(subjectBuffer).Value;
             var line = position.GetContainingLine();
             var root = document.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var options = document.Project.Solution.Workspace.Options;
+            var options = document.Options;
             if (!UseSmartTokenFormatter(root, line, formattingRules, options, cancellationToken))
             {
                 return false;

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                 symbol = ((IMethodSymbol)symbol).PartialImplementationPart ?? symbol;
             }
 
-            var options = project.Solution.Workspace.Options;
+            var options = project.Solution.Options;
 
             var preferredSourceLocations = NavigableItemFactory.GetPreferredSourceLocations(solution, symbol).ToArray();
             var title = NavigableItemFactory.GetSymbolDisplayString(project, symbol);
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                     var externalSourceDefinitions = FindExternalDefinitionsAsync(symbol, project, externalDefinitionProviders, cancellationToken).WaitAndGetResult(cancellationToken).ToImmutableArray();
                     if (externalSourceDefinitions.Length > 0)
                     {
-                        return TryGoToDefinition(externalSourceDefinitions, title, project.Solution.Workspace.Options, presenters, throwOnHiddenDefinition);
+                        return TryGoToDefinition(externalSourceDefinitions, title, options, presenters, throwOnHiddenDefinition);
                     }
                 }
 
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
             }
 
             var navigableItems = preferredSourceLocations.Select(location => NavigableItemFactory.GetItemFromSymbolLocation(solution, symbol, location)).ToImmutableArray();
-            return TryGoToDefinition(navigableItems, title, project.Solution.Workspace.Options, presenters, throwOnHiddenDefinition);
+            return TryGoToDefinition(navigableItems, title, options, presenters, throwOnHiddenDefinition);
         }
 
         private static bool TryGoToDefinition(

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_ToggleCompletionMode.cs
@@ -25,11 +25,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             if (Workspace.TryGetWorkspace(args.SubjectBuffer.AsTextContainer(), out workspace))
             {
-                var optionService = workspace.Services.GetService<IOptionService>();
-                var optionSet = optionService.GetOptions();
-
-                var wasEnabled = optionService.GetOption(EditorCompletionOptions.UseSuggestionMode);
-                optionService.SetOptions(optionSet.WithChangedOption(EditorCompletionOptions.UseSuggestionMode, !wasEnabled));
+                var newState = !workspace.Options.GetOption(EditorCompletionOptions.UseSuggestionMode);
+                workspace.Options = workspace.Options.WithChangedOption(EditorCompletionOptions.UseSuggestionMode, newState);
 
                 // If we don't have a computation in progress, then we don't have to do anything here.
                 if (this.sessionOpt == null)
@@ -37,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     return;
                 }
 
-                this.sessionOpt.SetModelBuilderState(!wasEnabled);
+                this.sessionOpt.SetModelBuilderState(newState);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/KeywordHighlighting/HighlighterViewTaggerProvider.cs
@@ -61,8 +61,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Highlighting
                 return;
             }
 
-            var options = document.Project.Solution.Workspace.Options;
-            if (!options.GetOption(FeatureOnOffOptions.KeywordHighlighting, document.Project.Language))
+            if (!document.Options.GetOption(FeatureOnOffOptions.KeywordHighlighting))
             {
                 return;
             }

--- a/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTaggerProvider.cs
@@ -54,8 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
                 return;
             }
 
-            var options = document.Project.Solution.Workspace.Options;
-            if (!options.GetOption(FeatureOnOffOptions.LineSeparator, document.Project.Language))
+            if (!document.Options.GetOption(FeatureOnOffOptions.LineSeparator))
             {
                 return;
             }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.RenameTrackingCodeAction.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
 
             protected override async Task<IEnumerable<CodeActionOperation>> ComputePreviewOperationsAsync(CancellationToken cancellationToken)
             {
-                if (!_document.Project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.RenameTrackingPreview, _document.Project.Language) ||
+                if (!_document.Options.GetOption(FeatureOnOffOptions.RenameTrackingPreview) ||
                     !TryInitializeRenameTrackingCommitter(cancellationToken))
                 {
                     return await SpecializedTasks.EmptyEnumerable<CodeActionOperation>().ConfigureAwait(false);

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
@@ -42,15 +42,14 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             var lineToBeIndented = textSnapshot.GetLineFromLineNumber(lineNumber);
 
             var formattingRules = GetFormattingRules(document, lineToBeIndented.Start);
-            var optionSet = document.Project.Solution.Workspace.Options;
 
             // enter on a token case.
-            if (ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, root, lineToBeIndented, optionSet, cancellationToken))
+            if (ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, root, lineToBeIndented, document.Options, cancellationToken))
             {
                 return null;
             }
 
-            var indenter = await GetIndenterAsync(document, lineToBeIndented, formattingRules, optionSet, cancellationToken).ConfigureAwait(false);
+            var indenter = await GetIndenterAsync(document, lineToBeIndented, formattingRules, document.Options, cancellationToken).ConfigureAwait(false);
             return indenter.GetDesiredIndentation();
         }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -485,9 +485,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
             {
                 this.AssertIsForeground();
 
-                var optionService = workspace.Services.GetService<IOptionService>();
 
-                if (optionService.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                if (workspace.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
                     _owner._codeRefactoringService != null &&
                     supportsFeatureService.SupportsRefactorings(document) &&
                     requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
@@ -623,9 +622,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 SnapshotSpan range,
                 CancellationToken cancellationToken)
             {
-                var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
-
-                if (optionService.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                if (document.Project.Solution.Workspace.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
                     provider._codeRefactoringService != null &&
                     supportsFeatureService.SupportsRefactorings(document) &&
                     requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -486,7 +486,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 this.AssertIsForeground();
 
 
-                if (workspace.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                if (document.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
                     _owner._codeRefactoringService != null &&
                     supportsFeatureService.SupportsRefactorings(document) &&
                     requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 SnapshotSpan range,
                 CancellationToken cancellationToken)
             {
-                if (document.Project.Solution.Workspace.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
+                if (document.Options.GetOption(EditorComponentOnOffOptions.CodeRefactorings) &&
                     provider._codeRefactoringService != null &&
                     supportsFeatureService.SupportsRefactorings(document) &&
                     requestedActionCategories.Contains(PredefinedSuggestedActionCategoryNames.Refactoring))

--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -46,11 +46,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 
         public async Task AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
         {
-            Contract.ThrowIfFalse(document.IsFromPrimaryBranch());
-
             // it has an assumption that this will not be called concurrently for same document.
             // in fact, in current design, it won't be even called concurrently for different documents.
             // but, can be called concurrently for different documents in future if we choose to.
+            Contract.ThrowIfFalse(document.IsFromPrimaryBranch());
+
             if (!_optionService.GetOption(InternalFeatureOnOffOptions.TodoComments))
             {
                 return;

--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -22,14 +22,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 
         private readonly TodoCommentIncrementalAnalyzerProvider _owner;
         private readonly Workspace _workspace;
-        private readonly IOptionService _optionService;
         private readonly TodoCommentTokens _todoCommentTokens;
         private readonly TodoCommentState _state;
 
-        public TodoCommentIncrementalAnalyzer(Workspace workspace, IOptionService optionService, TodoCommentIncrementalAnalyzerProvider owner, TodoCommentTokens todoCommentTokens)
+        public TodoCommentIncrementalAnalyzer(Workspace workspace, TodoCommentIncrementalAnalyzerProvider owner, TodoCommentTokens todoCommentTokens)
         {
             _workspace = workspace;
-            _optionService = optionService;
 
             _owner = owner;
             _todoCommentTokens = todoCommentTokens;
@@ -51,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             // but, can be called concurrently for different documents in future if we choose to.
             Contract.ThrowIfFalse(document.IsFromPrimaryBranch());
 
-            if (!_optionService.GetOption(InternalFeatureOnOffOptions.TodoComments))
+            if (!document.Project.Solution.Workspace.Options.GetOption(InternalFeatureOnOffOptions.TodoComments))
             {
                 return;
             }

--- a/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/AbstractTodoCommentIncrementalAnalyzer.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
             // but, can be called concurrently for different documents in future if we choose to.
             Contract.ThrowIfFalse(document.IsFromPrimaryBranch());
 
-            if (!document.Project.Solution.Workspace.Options.GetOption(InternalFeatureOnOffOptions.TodoComments))
+            if (!document.Options.GetOption(InternalFeatureOnOffOptions.TodoComments))
             {
                 return;
             }
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
                 return;
             }
 
-            var comments = await service.GetTodoCommentsAsync(document, _todoCommentTokens.GetTokens(_workspace), cancellationToken).ConfigureAwait(false);
+            var comments = await service.GetTodoCommentsAsync(document, _todoCommentTokens.GetTokens(document), cancellationToken).ConfigureAwait(false);
             var items = await CreateItemsAsync(document, comments, cancellationToken).ConfigureAwait(false);
 
             var data = new Data(textVersion, syntaxVersion, items);

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentIncrementalAnalyzerProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
         public IIncrementalAnalyzer CreateIncrementalAnalyzer(Workspace workspace)
         {
             return s_analyzers.GetValue(workspace, w =>
-               new TodoCommentIncrementalAnalyzer(w, w.Services.GetService<IOptionService>(), this, _todoCommentTokens));
+               new TodoCommentIncrementalAnalyzer(w, this, _todoCommentTokens));
         }
 
         internal void RaiseTaskListUpdated(object id, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<TodoItem> items)

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentTokens.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentTokens.cs
@@ -73,8 +73,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 
         public ImmutableArray<TodoCommentDescriptor> GetTokens(Workspace workspace)
         {
-            var optionService = workspace.Services.GetService<IOptionService>();
-            var optionText = optionService.GetOption(TodoCommentOptions.TokenList);
+            var optionText = workspace.Options.GetOption(TodoCommentOptions.TokenList);
 
             var lastInfo = _lastTokenInfo;
             if (lastInfo != null && lastInfo.OptionText == optionText)

--- a/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentTokens.cs
+++ b/src/EditorFeatures/Core/Implementation/TodoComment/TodoCommentTokens.cs
@@ -71,9 +71,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.TodoComments
 
         private TokenInfo _lastTokenInfo;
 
-        public ImmutableArray<TodoCommentDescriptor> GetTokens(Workspace workspace)
+        public ImmutableArray<TodoCommentDescriptor> GetTokens(Document document)
         {
-            var optionText = workspace.Options.GetOption(TodoCommentOptions.TokenList);
+            var optionText = document.Options.GetOption(TodoCommentOptions.TokenList);
 
             var lastInfo = _lastTokenInfo;
             if (lastInfo != null && lastInfo.OptionText == optionText)

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
@@ -12,19 +12,6 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 {
     internal static partial class ITextBufferExtensions
     {
-        public static IEnumerable<DocumentId> GetOpenDocumentIds(this ITextBuffer buffer)
-        {
-            var container = buffer.AsTextContainer();
-
-            Workspace workspace;
-            if (Workspace.TryGetWorkspace(container, out workspace))
-            {
-                return workspace.GetRelatedDocumentIds(container);
-            }
-
-            return SpecializedCollections.EmptyEnumerable<DocumentId>();
-        }
-
         internal static OptionSet TryGetOptions(this ITextBuffer textBuffer)
         {
             Workspace workspace;

--- a/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/ITextBufferExtensions.cs
@@ -18,12 +18,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
 
             if (Workspace.TryGetWorkspace(textBuffer.AsTextContainer(), out workspace))
             {
-                var service = workspace.Services.GetService<IOptionService>();
-
-                if (service != null)
-                {
-                    return service.GetOptions();
-                }
+                return workspace.Options;
             }
 
             return null;
@@ -52,14 +47,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
                     return option.DefaultValue;
                 }
 
-                var service = workspace.Services.GetService<IOptionService>();
-                if (service == null)
-                {
-                    return option.DefaultValue;
-                }
-
                 var language = workspace.Services.GetLanguageServices(buffer).Language;
-                return service.GetOption(option, language);
+                return workspace.Options.GetOption(option, language);
             }
             catch (Exception e) when (FatalError.Report(e))
             {

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -542,13 +542,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             using (var testWorkspace = await TestWorkspace.CreateAsync(xmlString))
             {
-                var optionsService = testWorkspace.Services.GetService<IOptionService>();
                 var position = testWorkspace.Documents.Single(d => d.Name == "SourceDocument").CursorPosition.Value;
                 var solution = testWorkspace.CurrentSolution;
                 var documentId = testWorkspace.Documents.Single(d => d.Name == "SourceDocument").Id;
                 var document = solution.GetDocument(documentId);
 
-                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers));
+                testWorkspace.Options = testWorkspace.Options.WithChangedOption(CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers);
 
                 var triggerInfo = CompletionTrigger.Default;
 
@@ -630,7 +629,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
         {
             using (var testWorkspace = await TestWorkspace.CreateAsync(xmlString))
             {
-                var optionsService = testWorkspace.Services.GetService<IOptionService>();
                 var position = testWorkspace.Documents.First().CursorPosition.Value;
                 var solution = testWorkspace.CurrentSolution;
                 var textContainer = testWorkspace.Documents.First().TextBuffer.AsTextContainer();

--- a/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
+++ b/src/EditorFeatures/Test/Completion/AbstractCompletionProviderTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Completion
 
         internal static async Task<CompletionContext> GetCompletionListContextAsync(CompletionProvider provider, Document document, int position, CompletionTrigger triggerInfo, OptionSet options = null)
         {
-            options = options ?? document.Project.Solution.Workspace.Options;
+            options = options ?? document.Options;
             var service = document.Project.LanguageServices.GetService<CompletionService>();
             var text = await document.GetTextAsync();
             var span = service.GetDefaultItemSpan(text, position);

--- a/src/EditorFeatures/Test/Extensions/WorkspaceExtensions.cs
+++ b/src/EditorFeatures/Test/Extensions/WorkspaceExtensions.cs
@@ -11,14 +11,13 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
         {
             if (options != null)
             {
-                var optionService = workspace.Services.GetService<IOptionService>();
-                var optionSet = optionService.GetOptions();
+                var optionSet = workspace.Options;
                 foreach (var option in options)
                 {
                     optionSet = optionSet.WithChangedOption(option.Key, option.Value);
                 }
 
-                optionService.SetOptions(optionSet);
+                workspace.Options = optionSet;
             }
         }
     }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -79,8 +79,6 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
                 OnAfterSymbolRenamedReturnValue = onAfterGlobalSymbolRenamedReturnValue
             };
 
-            var optionService = this.Workspace.Services.GetService<IOptionService>();
-
             // Mock the action taken by the workspace INotificationService
             var notificationService = Workspace.Services.GetService<INotificationService>() as INotificationServiceCallback;
             var callback = new Action<string, string, NotificationSeverity>((message, title, severity) => _notificationMessage = message);

--- a/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/Test/SignatureHelp/AbstractSignatureHelpProviderTests.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHelp.Presentation;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -351,13 +352,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp
         {
             using (var testWorkspace = await TestWorkspace.CreateAsync(xmlString))
             {
-                var optionsService = testWorkspace.Services.GetService<IOptionService>();
                 var cursorPosition = testWorkspace.Documents.First(d => d.Name == "SourceDocument").CursorPosition.Value;
                 var documentId = testWorkspace.Documents.First(d => d.Name == "SourceDocument").Id;
                 var document = testWorkspace.CurrentSolution.GetDocument(documentId);
                 var code = (await document.GetTextAsync()).ToString();
 
-                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(Microsoft.CodeAnalysis.Completion.CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers));
+                testWorkspace.Options = testWorkspace.Options.WithChangedOption(CompletionOptions.HideAdvancedMembers, document.Project.Language, hideAdvancedMembers);
 
                 IList<TextSpan> textSpans = null;
 

--- a/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
+++ b/src/EditorFeatures/Test/SolutionCrawler/WorkCoordinatorTests.cs
@@ -955,15 +955,13 @@ End Class";
 
         private static void SetOptions(Workspace workspace)
         {
-            var optionService = workspace.Services.GetService<IOptionService>();
-
             // override default timespan to make test run faster
-            optionService.SetOptions(optionService.GetOptions().WithChangedOption(InternalSolutionCrawlerOptions.ActiveFileWorkerBackOffTimeSpanInMS, 0)
-                                                               .WithChangedOption(InternalSolutionCrawlerOptions.AllFilesWorkerBackOffTimeSpanInMS, 0)
-                                                               .WithChangedOption(InternalSolutionCrawlerOptions.PreviewBackOffTimeSpanInMS, 0)
-                                                               .WithChangedOption(InternalSolutionCrawlerOptions.ProjectPropagationBackOffTimeSpanInMS, 0)
-                                                               .WithChangedOption(InternalSolutionCrawlerOptions.SemanticChangeBackOffTimeSpanInMS, 0)
-                                                               .WithChangedOption(InternalSolutionCrawlerOptions.EntireProjectWorkerBackOffTimeSpanInMS, 100));
+            workspace.Options = workspace.Options.WithChangedOption(InternalSolutionCrawlerOptions.ActiveFileWorkerBackOffTimeSpanInMS, 0)
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.AllFilesWorkerBackOffTimeSpanInMS, 0)
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.PreviewBackOffTimeSpanInMS, 0)
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.ProjectPropagationBackOffTimeSpanInMS, 0)
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.SemanticChangeBackOffTimeSpanInMS, 0)
+                                                 .WithChangedOption(InternalSolutionCrawlerOptions.EntireProjectWorkerBackOffTimeSpanInMS, 100);
         }
 
         private class WorkCoordinatorWorkspace : TestWorkspace

--- a/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
+++ b/src/EditorFeatures/Test/Tagging/AsynchronousTaggerTests.cs
@@ -123,13 +123,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Tagging
             return new TestTaggerEventSource();
         }
 
-        private static Mock<IOptionService> CreateFeatureOptionsMock()
-        {
-            var featureOptions = new Mock<IOptionService>(MockBehavior.Strict);
-            featureOptions.Setup(s => s.GetOption(EditorComponentOnOffOptions.Tagger)).Returns(true);
-            return featureOptions;
-        }
-
         private sealed class TaggerOperationListener : AsynchronousOperationListener
         {
         }

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticProviderTests.vb
@@ -277,11 +277,10 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
 
                 ' turn off diagnostic
                 If Not enabled Then
-                    Dim optionService = workspace.Services.GetService(Of IOptionService)()
-                    optionService.SetOptions(
-                        optionService.GetOptions().WithChangedOption(ServiceComponentOnOffOptions.DiagnosticProvider, False) _
+                    workspace.Options = workspace.Options _
+                                                  .WithChangedOption(ServiceComponentOnOffOptions.DiagnosticProvider, False) _
                                                   .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, False) _
-                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, False))
+                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, False)
                 End If
 
                 Dim registrationService = workspace.Services.GetService(Of ISolutionCrawlerRegistrationService)()

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -702,8 +702,7 @@ class AnonymousFunctions
                 Dim project = workspace.CurrentSolution.Projects.Single()
 
                 ' turn off heuristic
-                Dim options = workspace.Services.GetService(Of IOptionService)()
-                options.SetOptions(options.GetOptions.WithChangedOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic, False))
+                workspace.Options = workspace.Options.WithChangedOption(InternalDiagnosticsOptions.UseCompilationEndCodeFixHeuristic, False)
 
                 Dim analyzer = New CompilationEndedAnalyzer
                 Dim analyzerReference = New AnalyzerImageReference(ImmutableArray.Create(Of DiagnosticAnalyzer)(analyzer))

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicSignatureHelpCommandHandlerTests.vb
@@ -281,7 +281,7 @@ End Class
                               </Document>)
 
                 ' disable implicit sig help then type a trigger character -> no session should be available
-                state.Workspace.Options = state.Workspace.Options.WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, "Visual Basic", False)
+                state.Workspace.Options = state.Workspace.Options.WithChangedOption(SignatureHelpOptions.ShowSignatureHelp, LanguageNames.VisualBasic, False)
                 state.SendTypeChars("(")
                 Await state.AssertNoSignatureHelpSession()
 

--- a/src/EditorFeatures/Test2/Rename/DashboardTests.vb
+++ b/src/EditorFeatures/Test2/Rename/DashboardTests.vb
@@ -579,7 +579,7 @@ class D : B
                     Next
                 End If
 
-                workspace.Services.GetService(Of IOptionService)().SetOptions(optionSet)
+                workspace.Options = optionSet
 
                 Dim sessionInfo = renameService.StartInlineSession(
                     document, document.GetSyntaxTreeAsync().Result.GetRoot().FindToken(cursorPosition).Span, CancellationToken.None)

--- a/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
+++ b/src/EditorFeatures/Test2/Rename/InlineRenameTests.vb
@@ -102,9 +102,7 @@ Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Rename
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameOverloads, renameOverloads)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInStrings, renameInStrings)
             optionSet = optionSet.WithChangedOption(RenameOptions.RenameInComments, renameInComments)
-
-            Dim optionService = workspace.Services.GetService(Of IOptionService)()
-            optionService.SetOptions(optionSet)
+            workspace.Options = optionSet
 
             Dim session = StartSession(workspace)
 

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -45,8 +45,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     Return
                 End If
 
-                Dim optionService = document.Project.Solution.Workspace.Services.GetService(Of IOptionService)()
-                If Not (isExplicitFormat OrElse optionService.GetOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)) Then
+                If Not (isExplicitFormat OrElse document.Project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)) Then
                     Return
                 End If
 

--- a/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
+++ b/src/EditorFeatures/VisualBasic/LineCommit/CommitFormatter.vb
@@ -45,7 +45,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
                     Return
                 End If
 
-                If Not (isExplicitFormat OrElse document.Project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic)) Then
+                If Not (isExplicitFormat OrElse document.Options.GetOption(FeatureOnOffOptions.PrettyListing)) Then
                     Return
                 End If
 
@@ -228,13 +228,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.LineCommit
             Dim token = vbTree.GetRoot(cancellationToken).FindToken(Math.Min(endPosition, syntaxTree.GetRoot(cancellationToken).FullSpan.End))
 
             Dim node = token.Parent
-            Dim optionSet = document.Project.Solution.Workspace.Options
 
             ' collect all indent operation
             Dim operations = New List(Of IndentBlockOperation)()
             While node IsNot Nothing
                 operations.AddRange(FormattingOperations.GetIndentBlockOperations(
-                                    Formatter.GetDefaultFormattingRules(document), node, lastToken:=Nothing, optionSet:=optionSet))
+                                    Formatter.GetDefaultFormattingRules(document), node, lastToken:=Nothing, optionSet:=document.Options))
                 node = node.Parent
             End While
 

--- a/src/EditorFeatures/VisualBasic/NavigationBar/AbstractGenerateCodeItem.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/AbstractGenerateCodeItem.vb
@@ -43,7 +43,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
 
             Return Formatter.FormatAsync(newDocument,
                                          Formatter.Annotation,
-                                         options:=newDocument.Project.Solution.Workspace.Options,
+                                         options:=newDocument.Options,
                                          cancellationToken:=cancellationToken,
                                          rules:=formatterRules).WaitAndGetResult(cancellationToken)
         End Function

--- a/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
+++ b/src/EditorFeatures/VisualBasic/NavigationBar/VisualBasicNavigationBarItemService.vb
@@ -511,7 +511,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.NavigationBar
             Dim newDocument = generateCodeItem.GetGeneratedDocumentAsync(document, cancellationToken).WaitAndGetResult(cancellationToken)
             Dim generatedTree = newDocument.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken)
             Dim generatedNode = generatedTree.GetAnnotatedNodes(AbstractGenerateCodeItem.GeneratedSymbolAnnotation).Single().FirstAncestorOrSelf(Of MethodBlockBaseSyntax)
-            Dim indentSize = document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.IndentationSize, LanguageNames.VisualBasic)
+            Dim indentSize = newDocument.Options.GetOption(FormattingOptions.IndentationSize)
             Dim navigationPoint = NavigationPointHelpers.GetNavigationPoint(generatedTree.GetText(text.Encoding), indentSize, generatedNode)
 
             Using transaction = New CaretPreservingEditTransaction(VBEditorResources.GenerateMember, textView, _textUndoHistoryRegistry, _editorOperationsFactoryService)

--- a/src/EditorFeatures/VisualBasic/Utilities/CommandHandlers/AbstractImplementAbstractClassOrInterfaceCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/Utilities/CommandHandlers/AbstractImplementAbstractClassOrInterfaceCommandHandler.vb
@@ -101,7 +101,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Utilities.CommandHandlers
                 Return False
             End If
 
-            If Not document.Project.Solution.Workspace.Options.GetOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic) Then
+            If Not document.Options.GetOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers) Then
                 Return False
             End If
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/AbstractVisualBasicCompletionProviderTests.vb
@@ -115,7 +115,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion.Complet
                 Dim item = completionList.Items.First(Function(i) i.DisplayText.StartsWith(textTypedSoFar))
 
                 Dim helper = CompletionHelper.GetHelper(document)
-                Assert.Equal(expected, helper.SendEnterThroughToEditor(item, textTypedSoFar, workspace.Options))
+                Assert.Equal(expected, helper.SendEnterThroughToEditor(item, textTypedSoFar, document.Options))
             End Using
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceCommandHandlerTests.vb
@@ -66,9 +66,7 @@ Interface IFoo
 End Interface")
 
                 Dim commandHandler = MoveCaretAndCreateCommandHandler(workspace)
-
-                Dim optionServices = workspace.Services.GetService(Of IOptionService)()
-                optionServices.SetOptions(optionServices.GetOptions().WithChangedOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic, False))
+                workspace.Options = workspace.Options.WithChangedOption(FeatureOnOffOptions.AutomaticInsertionOfAbstractOrInterfaceMembers, LanguageNames.VisualBasic, False)
 
                 Dim nextHandlerCalled = False
                 Dim view = workspace.Documents.Single().GetTextView()

--- a/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/EndConstructGeneration/EndConstructTestingHelpers.vb
@@ -38,9 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.EndConstructGenera
         End Property
 
         Private Sub DisableLineCommit(workspace As Workspace)
-            ' Disable line commit
-            Dim optionsService = workspace.Services.GetService(Of IOptionService)()
-            optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False))
+            workspace.Options = workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
         End Sub
 
         Private Async Function VerifyTypedCharAppliedAsync(doFunc As Func(Of VisualBasicEndConstructService, ITextView, ITextBuffer, Boolean),

--- a/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ExtractMethod/ExtractMethodTests.vb
@@ -97,9 +97,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
             Dim document = workspace.CurrentSolution.GetDocument(testDocument.Id)
             Assert.NotNull(document)
 
-            Dim options = document.Project.Solution.Workspace.Options.
-                                   WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration).
-                                   WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct)
+            Dim options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, allowMovingDeclaration) _
+                                          .WithChangedOption(ExtractMethodOptions.DontPutOutOrRefOnStruct, document.Project.Language, dontPutOutOrRefOnStruct)
 
             Dim sdocument = Await SemanticDocument.CreateAsync(document, CancellationToken.None)
             Dim validator = New VisualBasicSelectionValidator(sdocument, snapshotSpan.Span.ToTextSpan(), options)
@@ -130,7 +129,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.ExtractMethod
                 Dim document = workspace.CurrentSolution.GetDocument(workspace.Documents.First().Id)
                 Assert.NotNull(document)
 
-                Dim options = document.Project.Solution.Workspace.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, True)
+                Dim options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, True)
                 Dim sdocument = Await SemanticDocument.CreateAsync(document, CancellationToken.None)
                 Dim validator = New VisualBasicSelectionValidator(sdocument, namedSpans("b").Single(), options)
                 Dim result = Await validator.GetValidSelectionAsync(CancellationToken.None)
@@ -164,8 +163,7 @@ End Class</text>
                 Dim root = Await document.GetSyntaxRootAsync()
                 Dim iterator = root.DescendantNodesAndSelf()
 
-                Dim options = document.Project.Solution.Workspace.Options _
-                                      .WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, True)
+                Dim options = document.Options.WithChangedOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language, True)
 
                 For Each node In iterator
                     Try

--- a/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/FormattingTestBase.vb
@@ -38,7 +38,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting
                 Dim changes = Formatter.GetFormattedTextChanges(
                     Await syntaxTree.GetRootAsync(),
                     workspace.Documents.First(Function(d) d.SelectedSpans.Any()).SelectedSpans,
-                    workspace, workspace.Options, rules, CancellationToken.None)
+                    workspace, document.Options, rules, CancellationToken.None)
                 AssertResult(expected, clonedBuffer, changes)
             End Using
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -39,9 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent2()
             Using workspace = New TestWorkspace()
-                Dim optionsService = workspace.Services.GetService(Of IOptionService)()
-                Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
-                Assert.Equal(True, initialState)
+                Assert.Equal(True, workspace.Options.GetOption(InternalFeatureOnOffOptions.SmartIndenter))
 
                 Dim provider = New SmartIndentProvider()
 
@@ -63,11 +61,9 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent3()
             Using workspace = New TestWorkspace()
-                Dim optionsService = workspace.Services.GetService(Of IOptionService)()
-                Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
-                Assert.Equal(True, initialState)
+                Assert.Equal(True, workspace.Options.GetOption(InternalFeatureOnOffOptions.SmartIndenter))
 
-                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False))
+                workspace.Options = workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False)
 
                 Dim provider = New SmartIndentProvider()
 
@@ -80,8 +76,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
                 textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
 
                 Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
-
-                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, True))
 
                 Assert.Null(smartIndenter)
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -15,17 +15,6 @@ Imports Moq
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indentation
     Public Class SmartIndentProviderTests
-        Private Class MockWaitIndicator
-            Implements IWaitIndicator
-            Public Function StartWait(title As String, message As String, allowCancel As Boolean, showProgress As Boolean) As IWaitContext Implements IWaitIndicator.StartWait
-                Throw New NotImplementedException()
-            End Function
-
-            Public Function Wait(title As String, message As String, allowCancel As Boolean, showProgress As Boolean, action As Action(Of IWaitContext)) As WaitIndicatorResult Implements IWaitIndicator.Wait
-                Throw New NotImplementedException()
-            End Function
-        End Class
-
         <Fact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent1()
@@ -35,47 +24,29 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
                 Function() provider.CreateSmartIndent(Nothing))
         End Sub
 
-        <Fact>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
-        Public Sub GetSmartIndent2()
-            Using workspace = New TestWorkspace()
+        Public Async Sub GetSmartIndent2()
+            Using workspace = Await TestWorkspace.CreateCSharpAsync("")
                 Assert.Equal(True, workspace.Options.GetOption(InternalFeatureOnOffOptions.SmartIndenter))
 
+                Dim document = workspace.Projects.Single().Documents.Single()
                 Dim provider = New SmartIndentProvider()
+                Dim smartIndenter = provider.CreateSmartIndent(document.GetTextView())
 
-                ' connect things together
-                Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
-                Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
-                workspace.RegisterText(subjectBuffer.AsTextContainer())
-
-                textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
-                textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
-                textView.SetupGet(Function(x) x.Caret).Returns(New Mock(Of ITextCaret)(MockBehavior.Strict).Object)
-
-                Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
                 Assert.NotNull(smartIndenter)
             End Using
         End Sub
 
-        <Fact>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
-        Public Sub GetSmartIndent3()
-            Using workspace = New TestWorkspace()
-                Assert.Equal(True, workspace.Options.GetOption(InternalFeatureOnOffOptions.SmartIndenter))
-
+        Public Async Sub GetSmartIndent3()
+            Using workspace = Await TestWorkspace.CreateCSharpAsync("")
                 workspace.Options = workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False)
 
+                Dim document = workspace.Projects.Single().Documents.Single()
                 Dim provider = New SmartIndentProvider()
-
-                ' connect things together
-                Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
-                Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
-                workspace.RegisterText(subjectBuffer.AsTextContainer())
-
-                textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
-                textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
-
-                Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
+                Dim smartIndenter = provider.CreateSmartIndent(document.GetTextView())
 
                 Assert.Null(smartIndenter)
             End Using

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -29,8 +29,6 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
         <Fact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent1()
-            Dim workspace = New TestWorkspace()
-
             Dim provider = New SmartIndentProvider()
 
             Assert.ThrowsAny(Of ArgumentException)(
@@ -40,51 +38,53 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indenta
         <Fact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent2()
-            Dim workspace = New TestWorkspace()
-            Dim optionsService = workspace.Services.GetService(Of IOptionService)()
-            Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
-            Assert.Equal(True, initialState)
+            Using workspace = New TestWorkspace()
+                Dim optionsService = workspace.Services.GetService(Of IOptionService)()
+                Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
+                Assert.Equal(True, initialState)
 
-            Dim provider = New SmartIndentProvider()
+                Dim provider = New SmartIndentProvider()
 
-            ' connect things together
-            Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
-            Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
-            workspace.RegisterText(subjectBuffer.AsTextContainer())
+                ' connect things together
+                Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
+                Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
+                workspace.RegisterText(subjectBuffer.AsTextContainer())
 
-            textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
-            textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
-            textView.SetupGet(Function(x) x.Caret).Returns(New Mock(Of ITextCaret)(MockBehavior.Strict).Object)
+                textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
+                textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
+                textView.SetupGet(Function(x) x.Caret).Returns(New Mock(Of ITextCaret)(MockBehavior.Strict).Object)
 
-            Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
-            Assert.NotNull(smartIndenter)
+                Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
+                Assert.NotNull(smartIndenter)
+            End Using
         End Sub
 
         <Fact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent3()
-            Dim workspace = New TestWorkspace()
-            Dim optionsService = workspace.Services.GetService(Of IOptionService)()
-            Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
-            Assert.Equal(True, initialState)
+            Using workspace = New TestWorkspace()
+                Dim optionsService = workspace.Services.GetService(Of IOptionService)()
+                Dim initialState = optionsService.GetOption(InternalFeatureOnOffOptions.SmartIndenter)
+                Assert.Equal(True, initialState)
 
-            optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False))
+                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, False))
 
-            Dim provider = New SmartIndentProvider()
+                Dim provider = New SmartIndentProvider()
 
-            ' connect things together
-            Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
-            Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
-            workspace.RegisterText(subjectBuffer.AsTextContainer())
+                ' connect things together
+                Dim textView = New Mock(Of ITextView)(MockBehavior.Strict)
+                Dim subjectBuffer = workspace.ExportProvider.GetExportedValue(Of ITextBufferFactoryService)().CreateTextBuffer()
+                workspace.RegisterText(subjectBuffer.AsTextContainer())
 
-            textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
-            textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
+                textView.SetupGet(Function(x) x.Options).Returns(TestEditorOptions.Instance)
+                textView.SetupGet(Function(x) x.TextBuffer).Returns(subjectBuffer)
 
-            Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
+                Dim smartIndenter = provider.CreateSmartIndent(textView.Object)
 
-            optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, True))
+                optionsService.SetOptions(optionsService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.SmartIndenter, True))
 
-            Assert.Null(smartIndenter)
+                Assert.Null(smartIndenter)
+            End Using
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2924,9 +2924,8 @@ End Class
         End Function
 
         Friend Shared Sub SetIndentStyle(buffer As ITextBuffer, indentStyle As FormattingOptions.IndentStyle)
-            Dim optionService = buffer.GetWorkspace().Services.GetService(Of IOptionService)()
-            Dim optionSet = optionService.GetOptions()
-            optionService.SetOptions(optionSet.WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle))
+            Dim workspace = buffer.GetWorkspace()
+            workspace.Options = workspace.Options.WithChangedOption(FormattingOptions.SmartIndent, LanguageNames.VisualBasic, indentStyle)
         End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -195,7 +195,7 @@ End Class
 
                 Assert.True(VisualBasicIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, root, line, workspace.Options, Nothing, ignoreMissingToken))
 
-                Dim smartFormatter = New SmartTokenFormatter(workspace.Options, formattingRules, root)
+                Dim smartFormatter = New SmartTokenFormatter(document.Options, formattingRules, root)
                 Dim changes = Await smartFormatter.FormatTokenAsync(workspace, token, Nothing)
 
                 Using edit = buffer.CreateEdit()

--- a/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/LineCommit/CommitOnMiscellaneousCommandsTests.vb
@@ -132,11 +132,7 @@ End Module
                                                               </Workspace>)
 
                 ' Turn off pretty listing
-                Dim optionService = testData.Workspace.GetService(Of IOptionService)()
-                Dim optionSet = optionService.GetOptions()
-                Dim prettyListing = optionSet.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
-                optionService.SetOptions(prettyListing)
-
+                testData.Workspace.Options = testData.Workspace.Options.WithChangedOption(FeatureOnOffOptions.PrettyListing, LanguageNames.VisualBasic, False)
                 testData.CommandHandler.ExecuteCommand(New FormatDocumentCommandArgs(testData.View, testData.Buffer), Sub() Exit Sub)
                 Assert.Equal("    Sub Main()", testData.Buffer.CurrentSnapshot.GetLineFromLineNumber(1).GetText())
             End Using

--- a/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/AddImport/CSharpAddImportCodeFixProvider.cs
@@ -481,8 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.AddImport
                     .Single();
                 newRoot = newRoot.TrackNodes(newUsing);
                 var documentWithSyntaxRoot = document.WithSyntaxRoot(newRoot);
-                var options = document.Project.Solution.Workspace.Options;
-                var simplifiedDocument = await Simplifier.ReduceAsync(documentWithSyntaxRoot, newUsing.Span, options, cancellationToken).ConfigureAwait(false);
+                var simplifiedDocument = await Simplifier.ReduceAsync(documentWithSyntaxRoot, newUsing.Span, cancellationToken: cancellationToken).ConfigureAwait(false);
 
                 newRoot = (CompilationUnitSyntax)await simplifiedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
                 var simplifiedUsing = newRoot.GetCurrentNode(newUsing);

--- a/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.RemoveUnnecessaryCastFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.RemoveUnnecessaryCastFixAllProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.RemoveUnnecessaryCast
         {
             internal static new readonly RemoveUnnecessaryCastFixAllProvider Instance = new RemoveUnnecessaryCastFixAllProvider();
 
-            protected override SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Workspace workspace, out string codeActionId, CancellationToken cancellationToken)
+            protected override SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Document document, out string codeActionId, CancellationToken cancellationToken)
             {
                 codeActionId = null;
                 return GetCastNode(root, model, diagnostic.Location.SourceSpan, cancellationToken);

--- a/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames
         {
             internal static new readonly SimplifyTypeNamesFixAllProvider Instance = new SimplifyTypeNamesFixAllProvider();
 
-            protected override SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Workspace workspace, out string codeActionId, CancellationToken cancellationToken)
+            protected override SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Document document, out string codeActionId, CancellationToken cancellationToken)
             {
                 codeActionId = null;
                 string diagnosticId;
-                var node = SimplifyTypeNamesCodeFixProvider.GetNodeToSimplify(root, model, diagnostic.Location.SourceSpan, workspace.Options, out diagnosticId, cancellationToken);
+                var node = SimplifyTypeNamesCodeFixProvider.GetNodeToSimplify(root, model, diagnostic.Location.SourceSpan, document.Options, out diagnosticId, cancellationToken);
                 if (node != null)
                 {
                     codeActionId = GetCodeActionId(diagnosticId, node.ToString());

--- a/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.cs
@@ -65,9 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.SimplifyTypeNames
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var optionSet = document.Project.Solution.Workspace.Options;
             string diagnosticId;
-            var node = GetNodeToSimplify(root, model, span, optionSet, out diagnosticId, cancellationToken);
+            var node = GetNodeToSimplify(root, model, span, document.Options, out diagnosticId, cancellationToken);
             if (node == null)
             {
                 return;

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -820,8 +820,6 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                 return updatedSolution;
             }
 
-            var placeSystemNamespaceFirst = document.Project.Solution.Workspace.Options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst, document.Project.Language);
-
             SyntaxNode root = null;
             if (modifiedRoot == null)
             {
@@ -851,6 +849,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                     return updatedSolution;
                 }
 
+                var placeSystemNamespaceFirst = document.Options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst);
                 var addedCompilationRoot = compilationRoot.AddUsingDirectives(new[] { usingDirective }, placeSystemNamespaceFirst, Formatter.Annotation);
                 updatedSolution = updatedSolution.WithDocumentSyntaxRoot(document.Id, addedCompilationRoot, PreservationMode.PreserveIdentity);
             }

--- a/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
+++ b/src/Features/CSharp/Portable/IntroduceVariable/CSharpIntroduceVariableService_IntroduceLocal.cs
@@ -30,8 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             bool isConstant,
             CancellationToken cancellationToken)
         {
-            var options = document.Project.Solution.Workspace.Options;
-
             var newLocalNameToken = GenerateUniqueLocalName(document, expression, isConstant, cancellationToken);
             var newLocalName = SyntaxFactory.IdentifierName(newLocalNameToken);
 
@@ -42,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             var declarationStatement = SyntaxFactory.LocalDeclarationStatement(
                 modifiers,
                 SyntaxFactory.VariableDeclaration(
-                    this.GetTypeSyntax(document, expression, isConstant, options, cancellationToken),
+                    this.GetTypeSyntax(document, expression, isConstant, cancellationToken),
                     SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(
                         newLocalNameToken.WithAdditionalAnnotations(RenameAnnotation.Create()),
                         null,
@@ -120,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
             return null;
         }
 
-        private TypeSyntax GetTypeSyntax(SemanticDocument document, ExpressionSyntax expression, bool isConstant, OptionSet options, CancellationToken cancellationToken)
+        private TypeSyntax GetTypeSyntax(SemanticDocument document, ExpressionSyntax expression, bool isConstant, CancellationToken cancellationToken)
         {
             var typeSymbol = GetTypeSymbol(document, expression, cancellationToken);
             if (typeSymbol.ContainsAnonymousType())
@@ -130,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.IntroduceVariable
 
             if (!isConstant && 
                 CanUseVar(typeSymbol) && 
-                TypeStyleHelper.IsImplicitTypePreferred(expression, document.SemanticModel, options, cancellationToken))
+                TypeStyleHelper.IsImplicitTypePreferred(expression, document.SemanticModel, document.Document.Options, cancellationToken))
             {
                 return SyntaxFactory.IdentifierName("var");
             }

--- a/src/Features/CSharp/Portable/RemoveUnnecessaryImports/CSharpRemoveUnnecessaryImportsService.cs
+++ b/src/Features/CSharp/Portable/RemoveUnnecessaryImports/CSharpRemoveUnnecessaryImportsService.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.CSharp.RemoveUnnecessaryImports
         {
             var spans = new List<TextSpan>();
             AddFormattingSpans(newRoot, spans, cancellationToken);
-            return Formatter.FormatAsync(newRoot, spans, document.Project.Solution.Workspace, document.Project.Solution.Workspace.Options, cancellationToken: cancellationToken);
+            return Formatter.FormatAsync(newRoot, spans, document.Project.Solution.Workspace, document.Options, cancellationToken: cancellationToken);
         }
 
         private void AddFormattingSpans(

--- a/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/AddImport/AbstractAddImportCodeFixProvider.cs
@@ -79,9 +79,8 @@ namespace Microsoft.CodeAnalysis.CodeFixes.AddImport
                 return;
             }
 
-            var options = document.Project.Solution.Workspace.Options;
-            var placeSystemNamespaceFirst = options.GetOption(
-                OrganizerOptions.PlaceSystemNamespaceFirst, document.Project.Language);
+            var placeSystemNamespaceFirst = document.Options.GetOption(
+                OrganizerOptions.PlaceSystemNamespaceFirst);
 
             using (Logger.LogBlock(FunctionId.Refactoring_AddImport, cancellationToken))
             {

--- a/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/NamingStyle/AbstractNamingStyleCodeFixProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.NamingStyles
                             solution,
                             symbol,
                             fixedName,
-                            solution.Workspace.Options,
+                            document.Options,
                             c).ConfigureAwait(false), 
                         nameof(AbstractNamingStyleCodeFixProvider)), 
                     diagnostic);

--- a/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/ExtractMethod/AbstractExtractMethodCodeRefactoringProvider.cs
@@ -59,17 +59,15 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.ExtractMethod
             TextSpan textSpan,
             CancellationToken cancellationToken)
         {
-            var options = document.Project.Solution.Workspace.Options;
             var result = await ExtractMethodService.ExtractMethodAsync(
                 document,
                 textSpan,
-                options,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken: cancellationToken).ConfigureAwait(false);
             Contract.ThrowIfNull(result);
 
             if (result.Succeeded || result.SucceededWithSuggestion)
             {
-                var description = options.GetOption(ExtractMethodOptions.AllowMovingDeclaration, document.Project.Language) ?
+                var description = document.Options.GetOption(ExtractMethodOptions.AllowMovingDeclaration) ?
                                       FeaturesResources.ExtractMethodLocal : FeaturesResources.ExtractMethod;
 
                 var codeAction = new MyCodeAction(description, (c) => AddRenameAnnotationAsync(result.Document, result.InvocationNameToken, c));

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
             var defaultItemSpan = this.GetDefaultItemSpan(text, caretPosition);
 
-            options = options ?? document.Project.Solution.Workspace.Options;
+            options = options ?? document.Options;
             var providers = GetProviders(roles, trigger);
 
             var completionProviderToIndex = GetCompletionProviderToIndex(providers);

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -29,9 +29,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
 
         public IIncrementalAnalyzer CreateIncrementalAnalyzer(Workspace workspace)
         {
-            var optionService = workspace.Services.GetService<IOptionService>();
-
-            if (!optionService.GetOption(ServiceComponentOnOffOptions.DiagnosticProvider))
+            if (!workspace.Options.GetOption(ServiceComponentOnOffOptions.DiagnosticProvider))
             {
                 return null;
             }

--- a/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV1/DiagnosticIncrementalAnalyzer.cs
@@ -143,7 +143,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
         private bool CheckOptions(Project project, bool forceAnalysis)
         {
             var workspace = project.Solution.Workspace;
-            if (ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, project.Language) &&
+            if (ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project) &&
                 workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
             {
                 return true;
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV1
 
             Func<Exception, bool> analyzerExceptionFilter = ex =>
             {
-                if (project.Solution.Workspace.Options.GetOption(InternalDiagnosticsOptions.CrashOnAnalyzerException))
+                if (project.Solution.Options.GetOption(InternalDiagnosticsOptions.CrashOnAnalyzerException))
                 {
                     // if option is on, crash the host to get crash dump.
                     FatalError.ReportUnlessCanceled(ex);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -404,16 +404,13 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
             private static async Task<bool> FullAnalysisEnabledAsync(Project project, bool ignoreFullAnalysisOptions, CancellationToken cancellationToken)
             {
-                var workspace = project.Solution.Workspace;
-                var language = project.Language;
-
                 if (ignoreFullAnalysisOptions)
                 {
                     return await project.HasSuccessfullyLoadedAsync(cancellationToken).ConfigureAwait(false);
                 }
 
-                if (!ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, language) ||
-                    !workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
+                if (!ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project) ||
+                    !project.Solution.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
                 {
                     return false;
                 }

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -225,7 +225,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 var semantic = state.GetAnalysisData(AnalysisKind.Semantic);
 
                 var project = document.Project;
-                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project.Solution.Workspace, project.Language);
+                var fullAnalysis = ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project);
 
                 // keep from build flag if full analysis is off
                 var fromBuild = fullAnalysis ? false : lastResult.FromBuild;

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -228,7 +228,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             // if full analysis is off, remove state that is from build.
             // this will make sure diagnostics (converted from build to live) from build will never be cleared
             // until next build.
-            if (!ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project.Solution.Workspace, project.Language))
+            if (!ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(project))
             {
                 stateSets = stateSets.Where(s => !s.FromBuild(project.Id));
             }

--- a/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
+++ b/src/Features/Core/Portable/EncapsulateField/AbstractEncapsulateFieldService.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 var constructorSyntaxes = GetConstructorNodes(field.ContainingType).ToSet();
                 if (finalFieldName != field.Name && constructorSyntaxes.Count > 0)
                 {
-                    solution = await Renamer.RenameSymbolAsync(solution, field, finalFieldName, solution.Workspace.Options,
+                    solution = await Renamer.RenameSymbolAsync(solution, field, finalFieldName, solution.Options,
                         location => constructorSyntaxes.Any(c => c.Span.IntersectsWith(location.SourceSpan)), cancellationToken: cancellationToken).ConfigureAwait(false);
                     document = solution.GetDocument(document.Id);
 
@@ -249,13 +249,13 @@ namespace Microsoft.CodeAnalysis.EncapsulateField
                 }
 
                 // Outside the constructor we want to rename references to the field to final property name.
-                return await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Workspace.Options,
+                return await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Options,
                     location => !constructorSyntaxes.Any(c => c.Span.IntersectsWith(location.SourceSpan)), cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             else
             {
                 // Just rename everything.
-                return await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Workspace.Options, cancellationToken).ConfigureAwait(false);
+                return await Renamer.RenameSymbolAsync(solution, field, generatedPropertyName, solution.Options, cancellationToken).ConfigureAwait(false);
             }
         }
 

--- a/src/Features/Core/Portable/ExtractMethod/AbstractExtractMethodService.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractExtractMethodService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
             OptionSet options,
             CancellationToken cancellationToken)
         {
-            options = options ?? document.Project.Solution.Workspace.Options;
+            options = options ?? document.Options;
 
             var semanticDocument = await SemanticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateVariable/AbstractGenerateVariableService.GenerateLocalCodeAction.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateVariable
 
                 var semanticModel = await _document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-                if (_service.TryConvertToLocalDeclaration(_state.LocalType, _state.IdentifierToken, _document.Project.Solution.Workspace.Options, semanticModel, cancellationToken, out newRoot))
+                if (_service.TryConvertToLocalDeclaration(_state.LocalType, _state.IdentifierToken, _document.Options, semanticModel, cancellationToken, out newRoot))
                 {
                     return newRoot;
                 }

--- a/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.IntroduceVariableAllOccurrenceCodeAction.cs
+++ b/src/Features/Core/Portable/IntroduceVariable/AbstractIntroduceVariableService.IntroduceVariableAllOccurrenceCodeAction.cs
@@ -26,7 +26,6 @@ namespace Microsoft.CodeAnalysis.IntroduceVariable
 
             protected override async Task<Document> PostProcessChangesAsync(Document document, CancellationToken cancellationToken)
             {
-                var optionSet = document.Project.Solution.Workspace.Options.WithChangedOption(FormattingOptions.AllowDisjointSpanMerging, true);
                 document = await Simplifier.ReduceAsync(document, Simplifier.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
                 document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
                 document = await CaseCorrector.CaseCorrectAsync(document, CaseCorrector.Annotation, cancellationToken).ConfigureAwait(false);

--- a/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
+++ b/src/Features/Core/Portable/MakeMethodSynchronous/AbstractMakeMethodSynchronousCodeFixProvider.cs
@@ -65,13 +65,12 @@ namespace Microsoft.CodeAnalysis.MakeMethodSynchronous
             var name = methodSymbol.Name;
             var newName = name.Substring(0, name.Length - AsyncSuffix.Length);
             var solution = document.Project.Solution;
-            var options = solution.Workspace.Options;
 
             // Store the path to this node.  That way we can find it post rename.
             var syntaxPath = new SyntaxPath(node);
 
             // Rename the method to remove the 'Async' suffix, then remove the 'async' keyword.
-            var newSolution = await Renamer.RenameSymbolAsync(solution, methodSymbol, newName, options, cancellationToken).ConfigureAwait(false);
+            var newSolution = await Renamer.RenameSymbolAsync(solution, methodSymbol, newName, solution.Options, cancellationToken).ConfigureAwait(false);
             var newDocument = newSolution.GetDocument(document.Id);
             var newRoot = await newDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
+++ b/src/Features/Core/Portable/Shared/Extensions/DocumentExtensions.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
     {
         public static bool ShouldHideAdvancedMembers(this Document document)
         {
-            return document.Project.Solution.Workspace.Options
-                .GetOption(CompletionOptions.HideAdvancedMembers, document.Project.Language);
+            return document.Options.GetOption(CompletionOptions.HideAdvancedMembers);
         }
 
         public static async Task<Document> ReplaceNodeAsync<TNode>(this Document document, TNode oldNode, TNode newNode, CancellationToken cancellationToken) where TNode : SyntaxNode

--- a/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
+++ b/src/Features/Core/Portable/Shared/Options/ServiceFeatureOnOffOptions.cs
@@ -18,15 +18,14 @@ namespace Microsoft.CodeAnalysis.Shared.Options
         /// </summary>
         public static readonly PerLanguageOption<bool?> ClosedFileDiagnostic = new PerLanguageOption<bool?>(OptionName, "Closed File Diagnostic", defaultValue: null);
 
-        public static bool IsClosedFileDiagnosticsEnabled(Workspace workspace, string language)
+        public static bool IsClosedFileDiagnosticsEnabled(Project project)
         {
-            var optionsService = workspace.Services.GetService<IOptionService>();
-            return optionsService != null && IsClosedFileDiagnosticsEnabled(optionsService, language);
+            return IsClosedFileDiagnosticsEnabled(project.Solution.Options, project.Language);
         }
 
-        public static bool IsClosedFileDiagnosticsEnabled(IOptionService optionService, string language)
+        public static bool IsClosedFileDiagnosticsEnabled(OptionSet options, string language)
         {
-            var option = optionService.GetOption(ClosedFileDiagnostic, language);
+            var option = options.GetOption(ClosedFileDiagnostic, language);
             if (!option.HasValue)
             {
                 return language == LanguageNames.CSharp ?

--- a/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
+++ b/src/Features/Core/Portable/UseAutoProperty/AbstractUseAutoPropertyCodeFixProvider.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.UseAutoProperty
             var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
 
             var solution = context.Document.Project.Solution;
-            var fieldLocations = await Renamer.GetRenameLocationsAsync(solution, fieldSymbol, solution.Workspace.Options, cancellationToken).ConfigureAwait(false);
+            var fieldLocations = await Renamer.GetRenameLocationsAsync(solution, fieldSymbol, solution.Options, cancellationToken).ConfigureAwait(false);
 
             // First, create the updated property we want to replace the old property with
             var isWrittenToOutsideOfConstructor = IsWrittenToOutsideOfConstructorOrProperty(fieldSymbol, fieldLocations, property, cancellationToken);

--- a/src/Features/VisualBasic/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.RemoveUnnecessaryCastFixAllProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/RemoveUnnecessaryCast/RemoveUnnecessaryCastCodeFixProvider.RemoveUnnecessaryCastFixAllProvider.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.RemoveUnnecessaryCast
 
             Friend Shared Shadows ReadOnly Instance As RemoveUnnecessaryCastFixAllProvider = New RemoveUnnecessaryCastFixAllProvider()
 
-            Protected Overrides Function GetNodeToSimplify(root As SyntaxNode, model As SemanticModel, diagnostic As Diagnostic, workspace As Workspace, ByRef codeActionId As String, cancellationToken As CancellationToken) As SyntaxNode
+            Protected Overrides Function GetNodeToSimplify(root As SyntaxNode, model As SemanticModel, diagnostic As Diagnostic, document As Document, ByRef codeActionId As String, cancellationToken As CancellationToken) As SyntaxNode
                 codeActionId = Nothing
                 Return GetCastNode(root, model, diagnostic.Location.SourceSpan, cancellationToken)
             End Function

--- a/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.SimplifyTypeNamesFixAllProvider.vb
@@ -13,10 +13,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
 
             Friend Shared Shadows ReadOnly Instance As SimplifyTypeNamesFixAllProvider = New SimplifyTypeNamesFixAllProvider
 
-            Protected Overrides Function GetNodeToSimplify(root As SyntaxNode, model As SemanticModel, diagnostic As Diagnostic, workspace As Workspace, ByRef codeActionId As String, cancellationToken As CancellationToken) As SyntaxNode
+            Protected Overrides Function GetNodeToSimplify(root As SyntaxNode, model As SemanticModel, diagnostic As Diagnostic, document As Document, ByRef codeActionId As String, cancellationToken As CancellationToken) As SyntaxNode
                 codeActionId = Nothing
                 Dim diagnosticId As String = Nothing
-                Dim node = SimplifyTypeNamesCodeFixProvider.GetNodeToSimplify(root, model, diagnostic.Location.SourceSpan, workspace.Options, diagnosticId, cancellationToken)
+                Dim node = SimplifyTypeNamesCodeFixProvider.GetNodeToSimplify(root, model, diagnostic.Location.SourceSpan, document.Options, diagnosticId, cancellationToken)
                 If node IsNot Nothing Then
                     codeActionId = GetCodeActionId(diagnosticId, node.ToString)
                 End If

--- a/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/SimplifyTypeNames/SimplifyTypeNamesCodeFixProvider.vb
@@ -50,10 +50,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.SimplifyTypeNames
             Dim cancellationToken = context.CancellationToken
 
             Dim root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)
-            Dim optionSet = document.Project.Solution.Workspace.Options
             Dim model = Await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(False)
             Dim diagnosticId As String = Nothing
-            Dim node = GetNodeToSimplify(root, model, span, optionSet, diagnosticId, cancellationToken)
+            Dim node = GetNodeToSimplify(root, model, span, document.Options, diagnosticId, cancellationToken)
             If node Is Nothing Then
                 Return
             End If

--- a/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
@@ -628,7 +628,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
                 Return updatedSolution
             End If
 
-            Dim placeSystemNamespaceFirst = document.Project.Solution.Workspace.Options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst, document.Project.Language)
+            Dim placeSystemNamespaceFirst = document.Options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst)
             Dim root As SyntaxNode = Nothing
             If (modifiedRoot Is Nothing) Then
                 root = Await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(False)

--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -139,8 +139,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
             if (name == "CSharp-Specific")
             {
                 var workspace = this.ComponentModel.GetService<VisualStudioWorkspace>();
-                var optionService = workspace.Services.GetService<IOptionService>();
-                return new Options.AutomationObject(optionService);
+                return new Options.AutomationObject(workspace);
             }
 
             return base.GetAutomationObject(name);

--- a/src/VisualStudio/CSharp/Impl/DesignerAttribute/CSharpDesignerAttributeIncrementalAnalyzerProvider.cs
+++ b/src/VisualStudio/CSharp/Impl/DesignerAttribute/CSharpDesignerAttributeIncrementalAnalyzerProvider.cs
@@ -37,18 +37,16 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.DesignerAttribute
 
         public IIncrementalAnalyzer CreatePerLanguageIncrementalAnalyzer(Workspace workspace, IIncrementalAnalyzerProvider provider)
         {
-            var optionService = workspace.Services.GetService<IOptionService>();
-            return new DesignerAttributeIncrementalAnalyzer(_serviceProvider, optionService, _notificationService, _asyncListeners);
+            return new DesignerAttributeIncrementalAnalyzer(_serviceProvider, _notificationService, _asyncListeners);
         }
 
         private class DesignerAttributeIncrementalAnalyzer : AbstractDesignerAttributeIncrementalAnalyzer
         {
             public DesignerAttributeIncrementalAnalyzer(
                 IServiceProvider serviceProvider,
-                IOptionService optionService,
                 IForegroundNotificationService notificationService,
                 IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners) :
-                base(serviceProvider, optionService, notificationService, asyncListeners)
+                base(serviceProvider, notificationService, asyncListeners)
             {
             }
 

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -20,11 +20,11 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
     [ComVisible(true)]
     public class AutomationObject
     {
-        private readonly IOptionService _optionService;
+        private readonly Workspace _workspace;
 
-        internal AutomationObject(IOptionService optionService)
+        internal AutomationObject(Workspace workspace)
         {
-            _optionService = optionService;
+            _workspace = workspace;
         }
 
         public int AutoComment
@@ -142,15 +142,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpFormattingOptions.LabelPositioning);
+                var option = _workspace.Options.GetOption(CSharpFormattingOptions.LabelPositioning);
                 return option == LabelPositionOptions.LeftMost ? 1 : 0;
             }
 
             set
             {
-                var optionSet = _optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value == 1 ? LabelPositionOptions.LeftMost : LabelPositionOptions.NoIndent);
-                _optionService.SetOptions(optionSet);
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value == 1 ? LabelPositionOptions.LeftMost : LabelPositionOptions.NoIndent);
             }
         }
 
@@ -158,15 +156,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpFormattingOptions.LabelPositioning);
-                return (int)option;
+                return (int)_workspace.Options.GetOption(CSharpFormattingOptions.LabelPositioning);
             }
 
             set
             {
-                var optionSet = _optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value);
-                _optionService.SetOptions(optionSet);
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.LabelPositioning, value);
             }
         }
 
@@ -360,16 +355,14 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator);
+                var option = _workspace.Options.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator);
                 return option == BinaryOperatorSpacingOptions.Single ? 1 : 0;
             }
 
             set
             {
                 var option = value == 1 ? BinaryOperatorSpacingOptions.Single : BinaryOperatorSpacingOptions.Ignore;
-                var optionSet = _optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, option);
-                _optionService.SetOptions(optionSet);
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, option);
             }
         }
 
@@ -479,14 +472,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                return _optionService.GetOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp);
+                return _workspace.Options.GetOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp);
             }
 
             set
             {
-                var optionSet = _optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp, value);
-                _optionService.SetOptions(optionSet);
+                _workspace.Options = _workspace.Options.WithChangedOption(SimplificationOptions.NamingPreferences, LanguageNames.CSharp, value);
             }
         }
 
@@ -524,8 +515,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible);
-                return GetUseVarOption(option);
+                return GetUseVarOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible);
             }
             set
             {
@@ -537,8 +527,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
-                return GetUseVarOption(option);
+                return GetUseVarOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent);
             }
             set
             {
@@ -550,8 +539,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
-                return GetUseVarOption(option);
+                return GetUseVarOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes);
             }
             set
             {
@@ -563,15 +551,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         {
             get
             {
-                var option = _optionService.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator);
-                return (int)option;
+                return (int)_workspace.Options.GetOption(CSharpFormattingOptions.SpacingAroundBinaryOperator);
             }
 
             set
             {
-                var optionSet = _optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, value);
-                _optionService.SetOptions(optionSet);
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.SpacingAroundBinaryOperator, value);
             }
         }
 
@@ -595,31 +580,27 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         private int GetBooleanOption(Option<bool> key)
         {
-            return _optionService.GetOption(key) ? 1 : 0;
+            return _workspace.Options.GetOption(key) ? 1 : 0;
         }
 
         private int GetBooleanOption(PerLanguageOption<bool> key)
         {
-            return _optionService.GetOption(key, LanguageNames.CSharp) ? 1 : 0;
+            return _workspace.Options.GetOption(key, LanguageNames.CSharp) ? 1 : 0;
         }
 
         private void SetBooleanOption(Option<bool> key, int value)
         {
-            var optionSet = _optionService.GetOptions();
-            optionSet = optionSet.WithChangedOption(key, value != 0);
-            _optionService.SetOptions(optionSet);
+            _workspace.Options = _workspace.Options.WithChangedOption(key, value != 0);
         }
 
         private void SetBooleanOption(PerLanguageOption<bool> key, int value)
         {
-            var optionSet = _optionService.GetOptions();
-            optionSet = optionSet.WithChangedOption(key, LanguageNames.CSharp, value != 0);
-            _optionService.SetOptions(optionSet);
+            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.CSharp, value != 0);
         }
 
         private int GetBooleanOption(PerLanguageOption<bool?> key)
         {
-            var option = _optionService.GetOption(key, LanguageNames.CSharp);
+            var option = _workspace.Options.GetOption(key, LanguageNames.CSharp);
             if (!option.HasValue)
             {
                 return -1;
@@ -631,24 +612,18 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
         private void SetBooleanOption(PerLanguageOption<bool?> key, int value)
         {
             bool? boolValue = (value < 0) ? (bool?)null : (value > 0);
-            var optionSet = _optionService.GetOptions();
-            optionSet = optionSet.WithChangedOption(key, LanguageNames.CSharp, boolValue);
-            _optionService.SetOptions(optionSet);
+            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.CSharp, boolValue);
         }
 
-        private static string GetUseVarOption(SimpleCodeStyleOption option)
+        private string GetUseVarOption(Option<SimpleCodeStyleOption> option)
         {
-            return option.ToXElement().ToString();
+            return _workspace.Options.GetOption(option).ToXElement().ToString();
         }
 
         private void SetUseVarOption(Option<SimpleCodeStyleOption> option, string value)
         {
-            SimpleCodeStyleOption convertedValue = SimpleCodeStyleOption.Default;
-            var optionSet = _optionService.GetOptions();
-
-            convertedValue = SimpleCodeStyleOption.FromXElement(XElement.Parse(value));
-            optionSet = optionSet.WithChangedOption(option, convertedValue);
-            _optionService.SetOptions(optionSet);
+            var convertedValue = SimpleCodeStyleOption.FromXElement(XElement.Parse(value));
+            _workspace.Options = _workspace.Options.WithChangedOption(option, convertedValue);
         }
     }
 }

--- a/src/VisualStudio/CSharp/Test/Options/OptionViewModelTests.cs
+++ b/src/VisualStudio/CSharp/Test/Options/OptionViewModelTests.cs
@@ -108,27 +108,5 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Options
                 }
             }
         }
-
-        [WpfFact, Trait(Traits.Feature, Traits.Features.Options)]
-        public async Task TestFeatureBasedSaving()
-        {
-            using (var workspace = await TestWorkspace.CreateCSharpAsync(""))
-            {
-                // Set an option for an unrelated feature
-                var optionService = workspace.GetService<IOptionService>();
-                var optionSet = optionService.GetOptions();
-                var expectedValue = !CSharpFormattingOptions.NewLineForCatch.DefaultValue;
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.NewLineForCatch, expectedValue);
-                optionService.SetOptions(optionSet);
-
-                // Save the options
-                var serviceProvider = new MockServiceProvider(workspace.ExportProvider);
-                using (var viewModel = new SpacingViewModel(workspace.Options, serviceProvider))
-                {
-                    var changedOptions = optionService.GetOptions();
-                    Assert.Equal(changedOptions.GetOption(CSharpFormattingOptions.NewLineForCatch), expectedValue);
-                }
-            }
-        }
     }
 }

--- a/src/VisualStudio/CSharp/Test/Options/OptionViewModelTests.cs
+++ b/src/VisualStudio/CSharp/Test/Options/OptionViewModelTests.cs
@@ -73,9 +73,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Options
         {
             using (var workspace = await TestWorkspace.CreateCSharpAsync(""))
             {
-                var optionService = workspace.GetService<IOptionService>();
-                var optionSet = optionService.GetOptions();
-                optionSet = optionSet.WithChangedOption(CSharpFormattingOptions.SpacingAfterMethodDeclarationName, true);
+                var optionSet = workspace.Options.WithChangedOption(CSharpFormattingOptions.SpacingAfterMethodDeclarationName, true);
 
                 var serviceProvider = new MockServiceProvider(workspace.ExportProvider);
                 using (var viewModel = new SpacingViewModel(optionSet, serviceProvider))
@@ -100,10 +98,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.Options
                     var initial = checkbox.IsChecked;
                     checkbox.IsChecked = !checkbox.IsChecked;
 
-                    var optionService = workspace.GetService<IOptionService>();
-                    var optionSet = optionService.GetOptions();
-
-                    var changedOptions = viewModel.ApplyChangedOptions(optionSet);
+                    var changedOptions = viewModel.ApplyChangedOptions(workspace.Options);
                     Assert.NotEqual(changedOptions.GetOption(CSharpFormattingOptions.SpacingAfterMethodDeclarationName), initial);
                 }
             }

--- a/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/DesignerAttribute/AbstractDesignerAttributeIncrementalAnalyzer.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 {
     internal abstract partial class AbstractDesignerAttributeIncrementalAnalyzer : ForegroundThreadAffinitizedObject
     {
-        private readonly IOptionService _optionService;
         private readonly IForegroundNotificationService _notificationService;
 
         private readonly IServiceProvider _serviceProvider;
@@ -37,14 +36,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
         public AbstractDesignerAttributeIncrementalAnalyzer(
             IServiceProvider serviceProvider,
-            IOptionService optionService,
             IForegroundNotificationService notificationService,
             IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
         {
             _serviceProvider = serviceProvider;
             Contract.ThrowIfNull(_serviceProvider);
 
-            _optionService = optionService;
             _notificationService = notificationService;
 
             _listener = new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.DesignerAttribute);
@@ -72,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.DesignerAttribu
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            if (!_optionService.GetOption(InternalFeatureOnOffOptions.DesignerAttributes))
+            if (!document.Project.Solution.Workspace.Options.GetOption(InternalFeatureOnOffOptions.DesignerAttributes))
             {
                 return;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/MiscellaneousDiagnosticAnalyzerService.cs
@@ -152,8 +152,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             private bool CheckOptions(Document document)
             {
-                if (ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_workspace, document.Project.Language) &&
-                    _workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
+                if (ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(document.Project) &&
+                    document.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
                 {
                     return true;
                 }

--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.cs
@@ -115,17 +115,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
             var commandHandlerFactory = Package.ComponentModel.GetService<ICommandHandlerServiceFactory>();
             var workspace = Package.ComponentModel.GetService<VisualStudioWorkspace>();
-            var optionsService = workspace.Services.GetService<IOptionService>();
 
             // The lifetime of CommandFilter is married to the view
             wpfTextView.GetOrCreateAutoClosingProperty(v =>
                 new StandaloneCommandFilter<TPackage, TLanguageService, TProject>(
-                    (TLanguageService)this, v, commandHandlerFactory, optionsService, EditorAdaptersFactoryService).AttachToVsTextView());
+                    (TLanguageService)this, v, commandHandlerFactory, EditorAdaptersFactoryService).AttachToVsTextView());
 
             var openDocument = wpfTextView.TextBuffer.AsTextContainer().GetRelatedDocuments().FirstOrDefault();
             var isOpenMetadataAsSource = openDocument != null && openDocument.Project.Solution.Workspace.Kind == WorkspaceKind.MetadataAsSource;
 
-            ConditionallyCollapseOutliningRegions(textView, wpfTextView, optionsService, isOpenMetadataAsSource);
+            ConditionallyCollapseOutliningRegions(textView, wpfTextView, workspace, isOpenMetadataAsSource);
 
             // If this is a metadata-to-source view, we want to consider the file read-only
             IVsTextLines vsTextLines;
@@ -144,7 +143,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
             }
         }
 
-        private void ConditionallyCollapseOutliningRegions(IVsTextView textView, IWpfTextView wpfTextView, IOptionService optionsService, bool isOpenMetadataAsSource)
+        private void ConditionallyCollapseOutliningRegions(IVsTextView textView, IWpfTextView wpfTextView, Workspace workspace, bool isOpenMetadataAsSource)
         {
             var outliningManagerService = this.Package.ComponentModel.GetService<IOutliningManagerService>();
             var outliningManager = outliningManagerService.GetOutliningManager(wpfTextView);
@@ -153,7 +152,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                 return;
             }
 
-            if (!optionsService.GetOption(FeatureOnOffOptions.Outlining, this.RoslynLanguageName))
+            if (!workspace.Options.GetOption(FeatureOnOffOptions.Outlining, this.RoslynLanguageName))
             {
                 outliningManager.Enabled = false;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Options/AbstractLanguageSettingsSerializer.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Options/AbstractLanguageSettingsSerializer.cs
@@ -231,8 +231,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
                 var componentModel = (IComponentModel)_serviceProvider.GetService(typeof(SComponentModel));
                 var visualStudioWorkspace = componentModel.GetService<VisualStudioWorkspace>();
 
-                var optionService = visualStudioWorkspace.Services.GetService<IOptionService>();
-                optionService.SetOptions(optionService.GetOptions().WithChangedOption(optionKey, value));
+                visualStudioWorkspace.Options = visualStudioWorkspace.Options.WithChangedOption(optionKey, value);
             }
         }
     }

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -174,8 +174,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                     var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                     if (document != null)
                     {
-                        var options = document.Project.Solution.Workspace.Options;
-                        var tabSize = options.GetOption(FormattingOptions.TabSize, document.Project.Language);
+                        var tabSize = document.Options.GetOption(FormattingOptions.TabSize);
                         indentDepth = lineText.GetColumnFromLineOffset(lineText.Length, tabSize);
                     }
                     else
@@ -525,8 +524,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return;
             }
 
-            var options = documentWithImports.Project.Solution.Workspace.Options;
-            var placeSystemNamespaceFirst = options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst, documentWithImports.Project.Language);
+            var placeSystemNamespaceFirst = documentWithImports.Options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst);
             documentWithImports = AddImports(documentWithImports, snippetNode, placeSystemNamespaceFirst, cancellationToken);
             AddReferences(documentWithImports.Project, snippetNode);
         }

--- a/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Snippets/AbstractSnippetExpansionClient.cs
@@ -174,8 +174,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                     var document = this.SubjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
                     if (document != null)
                     {
-                        var optionService = document.Project.Solution.Workspace.Services.GetService<IOptionService>();
-                        var tabSize = optionService.GetOption(FormattingOptions.TabSize, document.Project.Language);
+                        var options = document.Project.Solution.Workspace.Options;
+                        var tabSize = options.GetOption(FormattingOptions.TabSize, document.Project.Language);
                         indentDepth = lineText.GetColumnFromLineOffset(lineText.Length, tabSize);
                     }
                     else
@@ -525,8 +525,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Snippets
                 return;
             }
 
-            var optionService = documentWithImports.Project.Solution.Workspace.Services.GetService<IOptionService>();
-            var placeSystemNamespaceFirst = optionService.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst, documentWithImports.Project.Language);
+            var options = documentWithImports.Project.Solution.Workspace.Options;
+            var placeSystemNamespaceFirst = options.GetOption(OrganizerOptions.PlaceSystemNamespaceFirst, documentWithImports.Project.Language);
             documentWithImports = AddImports(documentWithImports, snippetNode, placeSystemNamespaceFirst, cancellationToken);
             AddReferences(documentWithImports.Project, snippetNode);
         }

--- a/src/VisualStudio/Core/Def/Implementation/StandaloneCommandFilter.cs
+++ b/src/VisualStudio/Core/Def/Implementation/StandaloneCommandFilter.cs
@@ -23,14 +23,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         /// </summary>
         /// <param name="wpfTextView">The IWpfTextView of the view.</param>
         /// <param name="commandHandlerServiceFactory">The MEF imported ICommandHandlerServiceFactory.</param>
-        /// <param name="featureOptionsService">The feature options service.</param>
         /// <param name="editorAdaptersFactoryService">The editor adapter</param>
         /// <param name="languageService">The language service</param>
         internal StandaloneCommandFilter(
             TLanguageService languageService,
             IWpfTextView wpfTextView,
             ICommandHandlerServiceFactory commandHandlerServiceFactory,
-            IOptionService featureOptionsService,
             IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
             : base(languageService, wpfTextView, editorAdaptersFactoryService, commandHandlerServiceFactory)
         {

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedDocument.cs
@@ -66,7 +66,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         private readonly IComponentModel _componentModel;
         private readonly Workspace _workspace;
         private readonly ITextDifferencingSelectorService _differenceSelectorService;
-        private readonly IOptionService _optionService;
         private readonly HostType _hostType;
         private readonly ReiteratedVersionSnapshotTracker _snapshotTracker;
         private readonly IFormattingRule _vbHelperFormattingRule;
@@ -95,7 +94,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
             _sourceCodeKind = sourceCodeKind;
             _componentModel = componentModel;
             _workspace = workspace;
-            _optionService = _workspace.Services.GetService<IOptionService>();
             _hostType = GetHostType();
 
             string filePath;
@@ -1008,7 +1006,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
         {
             if (_hostType == HostType.HTML)
             {
-                return _optionService.GetOption(FormattingOptions.IndentationSize, this.Project.Language);
+                return _workspace.Options.GetOption(FormattingOptions.IndentationSize, this.Project.Language);
             }
 
             if (_hostType == HostType.Razor)
@@ -1066,7 +1064,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
                         }
                     }
 
-                    return _optionService.GetOption(FormattingOptions.IndentationSize, this.Project.Language);
+                    return _workspace.Options.GetOption(FormattingOptions.IndentationSize, this.Project.Language);
                 }
             }
 

--- a/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Venus/ContainedLanguageCodeSupport.cs
@@ -217,8 +217,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Venus
 
             var formattingRules = additionalFormattingRule.Concat(Formatter.GetDefaultFormattingRules(targetDocument));
 
-            var workspace = targetDocument.Project.Solution.Workspace;
-            newRoot = Formatter.FormatAsync(newRoot, Formatter.Annotation, workspace, workspace.Options, formattingRules, cancellationToken).WaitAndGetResult_Venus(cancellationToken);
+            newRoot = Formatter.FormatAsync(
+                newRoot,
+                Formatter.Annotation,
+                targetDocument.Project.Solution.Workspace,
+                targetDocument.Options,
+                formattingRules,
+                cancellationToken).WaitAndGetResult_Venus(cancellationToken);
 
             var newMember = newRoot.GetAnnotatedNodesAndTokens(annotation).Single();
             var newMemberText = newMember.ToFullString();

--- a/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
+++ b/src/VisualStudio/Core/Def/Implementation/VirtualMemoryNotificationListener.cs
@@ -85,7 +85,7 @@ namespace Microsoft.VisualStudio.LanguageServices
                             _workspace.Options.GetOption(InternalFeatureOnOffOptions.FullSolutionAnalysisMemoryMonitor) &&
                             _workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis))
                         {
-                            _workspace.Services.GetService<IOptionService>().SetOptions(_workspace.Options.WithChangedOption(RuntimeOptions.FullSolutionAnalysis, false));
+                            _workspace.Options = _workspace.Options.WithChangedOption(RuntimeOptions.FullSolutionAnalysis, false);
 
                             // let user know full analysis is turned off due to memory concern
                             // no close info bar action

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -548,7 +548,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
             }
 
             // Rename symbol.
-            var newSolution = Renamer.RenameSymbolAsync(solution, symbol, newName, workspace.Options).WaitAndGetResult_CodeModel(CancellationToken.None);
+            var newSolution = Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Options).WaitAndGetResult_CodeModel(CancellationToken.None);
             var changedDocuments = newSolution.GetChangedDocuments(solution);
 
             // Notify third parties of the coming rename operation and let exceptions propagate out

--- a/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/AbstractCodeModelService.cs
@@ -547,10 +547,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel
                 nodeKeyValidation.AddProject(project);
             }
 
-            var optionSet = workspace.Services.GetService<IOptionService>().GetOptions();
-
             // Rename symbol.
-            var newSolution = Renamer.RenameSymbolAsync(solution, symbol, newName, optionSet).WaitAndGetResult_CodeModel(CancellationToken.None);
+            var newSolution = Renamer.RenameSymbolAsync(solution, symbol, newName, workspace.Options).WaitAndGetResult_CodeModel(CancellationToken.None);
             var changedDocuments = newSolution.GetChangedDocuments(solution);
 
             // Notify third parties of the coming rename operation and let exceptions propagate out

--- a/src/VisualStudio/Core/Impl/Options/AbstractCheckBoxViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractCheckBoxViewModel.cs
@@ -17,12 +17,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         internal virtual string GetPreview() => _isChecked ? _truePreview : _falsePreview;
 
-        public AbstractCheckBoxViewModel(IOption option, string description, string preview, AbstractOptionPreviewViewModel info, OptionSet options)
-            : this(option, description, preview, preview, info, options)
+        public AbstractCheckBoxViewModel(IOption option, string description, string preview, AbstractOptionPreviewViewModel info)
+            : this(option, description, preview, preview, info)
         {
         }
 
-        public AbstractCheckBoxViewModel(IOption option, string description, string truePreview, string falsePreview, AbstractOptionPreviewViewModel info, OptionSet options)
+        public AbstractCheckBoxViewModel(IOption option, string description, string truePreview, string falsePreview, AbstractOptionPreviewViewModel info)
         {
             _truePreview = truePreview;
             _falsePreview = falsePreview;

--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPreviewViewModel.cs
@@ -43,10 +43,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         public ObservableCollection<AbstractCodeStyleOptionViewModel> CodeStyleItems { get; set; }
 
         public OptionSet Options { get; set; }
+        private readonly OptionSet _originalOptions;
 
         protected AbstractOptionPreviewViewModel(OptionSet options, IServiceProvider serviceProvider, string language)
         {
             this.Options = options;
+            _originalOptions = options;
             this.Items = new List<object>();
             this.CodeStyleItems = new ObservableCollection<AbstractCodeStyleOptionViewModel>();
 
@@ -64,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         internal OptionSet ApplyChangedOptions(OptionSet optionSet)
         {
-            foreach (var optionKey in this.Options.GetAccessedOptions())
+            foreach (var optionKey in this.Options.GetChangedOptions(_originalOptions))
             {
                 if (ShouldPersistOption(optionKey))
                 {

--- a/src/VisualStudio/Core/Impl/Options/CheckBoxViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/CheckBoxViewModel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         }
 
         public CheckBoxOptionViewModel(IOption option, string description, string truePreview, string falsePreview, AbstractOptionPreviewViewModel info, OptionSet options)
-            : base(option, description, truePreview, falsePreview, info, options)
+            : base(option, description, truePreview, falsePreview, info)
         {
             SetProperty(ref _isChecked, (bool)options.GetOption(new OptionKey(option, option.IsPerLanguage ? info.Language : null)));
         }

--- a/src/VisualStudio/Core/Impl/Options/CheckBoxWithComboViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/CheckBoxWithComboViewModel.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         }
 
         public CheckBoxWithComboOptionViewModel(IOption option, string description, string truePreview, string falsePreview, AbstractOptionPreviewViewModel info, OptionSet options, IList<NotificationOptionViewModel> items)
-            : base(option, description, truePreview, falsePreview, info, options)
+            : base(option, description, truePreview, falsePreview, info)
         {
             NotificationOptions = items;
 

--- a/src/VisualStudio/Core/Impl/Options/FullSolutionAnalysisOptionBinding.cs
+++ b/src/VisualStudio/Core/Impl/Options/FullSolutionAnalysisOptionBinding.cs
@@ -26,7 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         {
             get
             {
-                return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_optionService, _languageName) &&
+                return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_optionService.GetOptions(), _languageName) &&
                        _optionService.GetOption(_fullSolutionAnalysis);
             }
 

--- a/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/CSharpSnippetExpansionClientTests.vb
@@ -276,12 +276,10 @@ using G=   H.I;
             Using workspace = Await TestWorkspace.CreateAsync(workspaceXml)
                 Dim document = workspace.Documents.Single()
 
-                Dim optionService = workspace.Services.GetService(Of IOptionService)()
-                Dim optionSet = optionService.GetOptions()
-                optionSet = optionSet.WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True)
-                optionSet = optionSet.WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize)
-                optionSet = optionSet.WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
-                optionService.SetOptions(optionSet)
+                workspace.Options = workspace.Options _
+                    .WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True) _
+                    .WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize) _
+                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
 
                 Dim snippetExpansionClient = New SnippetExpansionClient(
                     Guids.CSharpLanguageServiceId,

--- a/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
+++ b/src/VisualStudio/Core/Test/Snippets/SnippetTestState.vb
@@ -33,8 +33,8 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Snippets
         Public Sub New(workspaceElement As XElement, languageName As String, startActiveSession As Boolean, extraParts As IEnumerable(Of Type), Optional workspaceKind As String = Nothing)
             MyBase.New(workspaceElement, extraParts:=CreatePartCatalog(extraParts), workspaceKind:=workspaceKind)
 
-            Dim optionService = Workspace.Services.GetService(Of IOptionService)()
-            optionService.SetOptions(optionService.GetOptions().WithChangedOption(InternalFeatureOnOffOptions.Snippets, True))
+            Workspace.Options = Workspace.Options.WithChangedOption(InternalFeatureOnOffOptions.Snippets, True)
+
             Dim mockEditorAdaptersFactoryService = New Mock(Of IVsEditorAdaptersFactoryService)
             Dim mockSVsServiceProvider = New Mock(Of SVsServiceProvider)
             SnippetCommandHandler = If(languageName = LanguageNames.CSharp,

--- a/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
+++ b/src/VisualStudio/Core/Test/Snippets/VisualBasicSnippetExpansionClientTests.vb
@@ -355,12 +355,10 @@ End Class</Test>
             Using workspace = Await TestWorkspace.CreateAsync(workspaceXml)
                 Dim document = workspace.Documents.Single()
 
-                Dim optionService = workspace.Services.GetService(Of IOptionService)()
-                Dim optionSet = optionService.GetOptions()
-                optionSet = optionSet.WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True)
-                optionSet = optionSet.WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize)
-                optionSet = optionSet.WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
-                optionService.SetOptions(optionSet)
+                workspace.Options = workspace.Options _
+                    .WithChangedOption(FormattingOptions.UseTabs, document.Project.Language, True) _
+                    .WithChangedOption(FormattingOptions.TabSize, document.Project.Language, tabSize) _
+                    .WithChangedOption(FormattingOptions.IndentationSize, document.Project.Language, tabSize)
 
                 Dim snippetExpansionClient = New SnippetExpansionClient(
                     Guids.CSharpLanguageServiceId,

--- a/src/VisualStudio/VisualBasic/Impl/DesignerAttribute/BasicDesignerAttributeIncrementalAnalyzerProvider.vb
+++ b/src/VisualStudio/VisualBasic/Impl/DesignerAttribute/BasicDesignerAttributeIncrementalAnalyzerProvider.vb
@@ -30,8 +30,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.DesignerAttribute
         End Sub
 
         Public Function CreatePerLanguageIncrementalAnalyzer(workspace As Workspace, provider As IIncrementalAnalyzerProvider) As IIncrementalAnalyzer Implements IPerLanguageIncrementalAnalyzerProvider.CreatePerLanguageIncrementalAnalyzer
-            Dim optionService = workspace.Services.GetService(Of IOptionService)()
-            Return New DesignerAttributeIncrementalAnalyzer(Me._serviceProvider, optionService, Me._notificationService, Me._asyncListeners)
+            Return New DesignerAttributeIncrementalAnalyzer(Me._serviceProvider, Me._notificationService, Me._asyncListeners)
         End Function
 
         Private Class DesignerAttributeIncrementalAnalyzer
@@ -39,10 +38,9 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.DesignerAttribute
 
             Public Sub New(
                 serviceProvider As IServiceProvider,
-                optionService As IOptionService,
                 notificationService As IForegroundNotificationService,
                 asyncListeners As IEnumerable(Of Lazy(Of IAsynchronousOperationListener, FeatureMetadata)))
-                MyBase.New(serviceProvider, optionService, notificationService, asyncListeners)
+                MyBase.New(serviceProvider, notificationService, asyncListeners)
             End Sub
 
             Protected Overrides Function GetAllTopLevelTypeDefined(node As SyntaxNode) As IEnumerable(Of SyntaxNode)

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -133,8 +133,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
         Protected Overrides Function GetAutomationObject(name As String) As Object
             If name = "Basic-Specific" Then
                 Dim workspace = Me.ComponentModel.GetService(Of VisualStudioWorkspace)()
-                Dim optionService = workspace.Services.GetService(Of IOptionService)()
-                Return New AutomationObject(optionService)
+                Return New AutomationObject(workspace)
             End If
 
             Return MyBase.GetAutomationObject(name)

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -11,10 +11,10 @@ Imports Microsoft.CodeAnalysis.Simplification
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
     <ComVisible(True)>
     Public Class AutomationObject
-        Private ReadOnly _optionService As IOptionService
+        Private ReadOnly _workspace As Workspace
 
-        Friend Sub New(optionService As IOptionService)
-            _optionService = optionService
+        Friend Sub New(workspace As Workspace)
+            _workspace = workspace
         End Sub
 
         Public Property AutoComment As Boolean
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         <Obsolete("This SettingStore option has now been deprecated in favor of BasicClosedFileDiagnostics")>
         Public Property ClosedFileDiagnostics As Boolean
             Get
-                Return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_optionService, LanguageNames.VisualBasic)
+                Return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_workspace, LanguageNames.VisualBasic)
             End Get
             Set(value As Boolean)
                 ' Even though this option has been deprecated, we want to respect the setting if the user has explicitly turned off closed file diagnostics (which is the non-default value for 'ClosedFileDiagnostics').
@@ -221,27 +221,23 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         End Property
 
         Private Function GetBooleanOption(key As [Option](Of Boolean)) As Boolean
-            Return _optionService.GetOption(key)
+            Return _workspace.Options.GetOption(key)
         End Function
 
         Private Sub SetBooleanOption(key As [Option](Of Boolean), value As Boolean)
-            Dim optionSet = _optionService.GetOptions()
-            optionSet = optionSet.WithChangedOption(key, value)
-            _optionService.SetOptions(optionSet)
+            _workspace.Options = _workspace.Options.WithChangedOption(key, value)
         End Sub
 
         Private Function GetBooleanOption(key As [PerLanguageOption](Of Boolean)) As Boolean
-            Return _optionService.GetOption(key, LanguageNames.VisualBasic)
+            Return _workspace.Options.GetOption(key, LanguageNames.VisualBasic)
         End Function
 
         Private Sub SetBooleanOption(key As [PerLanguageOption](Of Boolean), value As Boolean)
-            Dim optionSet = _optionService.GetOptions()
-            optionSet = optionSet.WithChangedOption(key, LanguageNames.VisualBasic, value)
-            _optionService.SetOptions(optionSet)
+            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.VisualBasic, value)
         End Sub
 
         Private Function GetBooleanOption(key As PerLanguageOption(Of Boolean?)) As Integer
-            Dim [option] = _optionService.GetOption(key, LanguageNames.VisualBasic)
+            Dim [option] = _workspace.Options.GetOption(key, LanguageNames.VisualBasic)
             If Not [option].HasValue Then
                 Return -1
             End If
@@ -251,9 +247,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
 
         Private Sub SetBooleanOption(key As PerLanguageOption(Of Boolean?), value As Integer)
             Dim boolValue As Boolean? = If(value < 0, Nothing, value > 0)
-            Dim optionSet = _optionService.GetOptions()
-            optionSet = optionSet.WithChangedOption(key, LanguageNames.VisualBasic, boolValue)
-            _optionService.SetOptions(optionSet)
+            _workspace.Options = _workspace.Options.WithChangedOption(key, LanguageNames.VisualBasic, boolValue)
         End Sub
     End Class
 End Namespace

--- a/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Options/AutomationObject.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Options
         <Obsolete("This SettingStore option has now been deprecated in favor of BasicClosedFileDiagnostics")>
         Public Property ClosedFileDiagnostics As Boolean
             Get
-                Return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_workspace, LanguageNames.VisualBasic)
+                Return ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(_workspace.Options, LanguageNames.VisualBasic)
             End Get
             Set(value As Boolean)
                 ' Even though this option has been deprecated, we want to respect the setting if the user has explicitly turned off closed file diagnostics (which is the non-default value for 'ClosedFileDiagnostics').

--- a/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/AddImportsTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Editing
         private async Task TestAsync(string initialText, string importsAddedText, string simplifiedText, OptionSet options = null)
         {
             var doc = GetDocument(initialText);
-            options = options ?? doc.Project.Solution.Workspace.Options;
+            options = options ?? doc.Options;
 
             var imported = await ImportAdder.AddImportsAsync(doc, options);
 

--- a/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
+++ b/src/Workspaces/Core/Portable/CodeFixes/FixAllOccurrences/BatchSimplificationFixAllProvider.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
         /// <summary>
         /// Get node on which to add simplifier and formatter annotation for fixing the given diagnostic.
         /// </summary>
-        protected virtual SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Workspace workspace, out string codeActionEquivalenceKey, CancellationToken cancellationToken)
+        protected virtual SyntaxNode GetNodeToSimplify(SyntaxNode root, SemanticModel model, Diagnostic diagnostic, Document document, out string codeActionEquivalenceKey, CancellationToken cancellationToken)
         {
             codeActionEquivalenceKey = null;
             var span = diagnostic.Location.SourceSpan;
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
 
         /// <summary>
         /// By default, this property returns false and <see cref="AddSimplifierAnnotationsAsync(Document, ImmutableArray{Diagnostic}, FixAllState, CancellationToken)"/> will just add <see cref="Simplifier.Annotation"/> to each node to simplify
-        /// returned by <see cref="GetNodeToSimplify(SyntaxNode, SemanticModel, Diagnostic, Workspace, out string, CancellationToken)"/>.
+        /// returned by <see cref="GetNodeToSimplify(SyntaxNode, SemanticModel, Diagnostic, Document, out string, CancellationToken)"/>.
         /// 
         /// Override this property to return true if the fix all provider needs to add simplify annotations/fixup any of the parent nodes of the nodes to simplify.
         /// This could be the case if simplifying certain nodes can enable cascaded simplifications, such as parentheses removal on parenting node.
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes
             foreach (var diagnostic in diagnostics)
             {
                 string codeActionEquivalenceKey;
-                var node = GetNodeToSimplify(root, model, diagnostic, fixAllState.Solution.Workspace, out codeActionEquivalenceKey, cancellationToken);
+                var node = GetNodeToSimplify(root, model, diagnostic, document, out codeActionEquivalenceKey, cancellationToken);
                 if (node != null && fixAllState.CodeActionEquivalenceKey == codeActionEquivalenceKey)
                 {
                     nodesToSimplify.Add(node);

--- a/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
+++ b/src/Workspaces/Core/Portable/Editing/ImportAdderService.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Editing
     {
         public async Task<Document> AddImportsAsync(Document document, IEnumerable<TextSpan> spans, OptionSet options, CancellationToken cancellationToken)
         {
-            options = options ?? document.Project.Solution.Workspace.Options;
+            options = options ?? document.Options;
 
             var model = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);

--- a/src/Workspaces/Core/Portable/Formatting/Formatter.cs
+++ b/src/Workspaces/Core/Portable/Formatting/Formatter.cs
@@ -133,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            return document.WithSyntaxRoot(await FormatAsync(root, spans, document.Project.Solution.Workspace, options, rules, cancellationToken).ConfigureAwait(false));
+            return document.WithSyntaxRoot(await FormatAsync(root, spans, document.Project.Solution.Workspace, options ?? document.Options, rules, cancellationToken).ConfigureAwait(false));
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Microsoft.CodeAnalysis.Formatting
             }
 
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            return document.WithSyntaxRoot(await FormatAsync(root, annotation, document.Project.Solution.Workspace, options, rules, cancellationToken).ConfigureAwait(false));
+            return document.WithSyntaxRoot(await FormatAsync(root, annotation, document.Project.Solution.Workspace, options ?? document.Options, rules, cancellationToken).ConfigureAwait(false));
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/DocumentOptionSet.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    /// <summary>
+    /// An <see cref="OptionSet"/> that comes from <see cref="Document.Options"/>. It behaves just like a normal
+    /// <see cref="OptionSet"/> but remembers which language the <see cref="Document"/> is, so you don't have to
+    /// pass that information redundantly when calling <see cref="GetOption{T}(PerLanguageOption{T})"/>.
+    /// </summary>
+    public sealed class DocumentOptionSet : OptionSet
+    {
+        private readonly OptionSet _backingOptionSet;
+        private readonly string _language;
+
+        internal DocumentOptionSet(OptionSet backingOptionSet, string language)
+        {
+            _backingOptionSet = backingOptionSet;
+            _language = language;
+        }
+
+        public override object GetOption(OptionKey optionKey)
+        {
+            return _backingOptionSet.GetOption(optionKey);
+        }
+
+        public override T GetOption<T>(Option<T> option)
+        {
+            return _backingOptionSet.GetOption(option);
+        }
+
+        public T GetOption<T>(PerLanguageOption<T> option)
+        {
+            return _backingOptionSet.GetOption(option, _language);
+        }
+
+        public override T GetOption<T>(PerLanguageOption<T> option, string language)
+        {
+            return _backingOptionSet.GetOption(option, language);
+        }
+
+        public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object value)
+        {
+            return new DocumentOptionSet(_backingOptionSet.WithChangedOption(optionAndLanguage, value), _language);
+        }
+
+        public override OptionSet WithChangedOption<T>(Option<T> option, T value)
+        {
+            return new DocumentOptionSet(_backingOptionSet.WithChangedOption(option, value), _language);
+        }
+
+        public override OptionSet WithChangedOption<T>(PerLanguageOption<T> option, string language, T value)
+        {
+            return new DocumentOptionSet(_backingOptionSet.WithChangedOption(option, language, value), _language);
+        }
+
+        internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
+        {
+            return _backingOptionSet.GetChangedOptions(optionSet);
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Options/OptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionService.cs
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Options
 
         public OptionSet GetOptions()
         {
-            return new OptionSet(this);
+            return new WorkspaceOptionSet(this);
         }
 
         public T GetOption<T>(Option<T> option)
@@ -131,11 +131,18 @@ namespace Microsoft.CodeAnalysis.Options
                 throw new ArgumentNullException(nameof(optionSet));
             }
 
+            var workspaceOptionSet = optionSet as WorkspaceOptionSet;
+
+            if (workspaceOptionSet == null)
+            {
+                throw new ArgumentException(WorkspacesResources.OptionsDidNotComeFromWorkspace, paramName: nameof(optionSet));
+            }
+
             var changedOptions = new List<OptionChangedEventArgs>();
 
             lock (_gate)
             {
-                foreach (var optionKey in optionSet.GetAccessedOptions())
+                foreach (var optionKey in workspaceOptionSet.GetAccessedOptions())
                 {
                     var setValue = optionSet.GetOption(optionKey);
                     object currentValue = this.GetOption(optionKey);

--- a/src/Workspaces/Core/Portable/Options/OptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/OptionSet.cs
@@ -1,110 +1,41 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Options
 {
-    public sealed class OptionSet
+    public abstract class OptionSet
     {
-        private readonly IOptionService _service;
-
-        private readonly object _gate = new object();
-        private ImmutableDictionary<OptionKey, object> _values;
-
-        internal OptionSet(IOptionService service)
-        {
-            _service = service;
-            _values = ImmutableDictionary.Create<OptionKey, object>();
-        }
-
-        private OptionSet(IOptionService service, ImmutableDictionary<OptionKey, object> values)
-        {
-            _service = service;
-            _values = values;
-        }
+        /// <summary>
+        /// Gets the value of the option.
+        /// </summary>
+        public abstract object GetOption(OptionKey optionKey);
 
         /// <summary>
         /// Gets the value of the option.
         /// </summary>
-        public T GetOption<T>(Option<T> option)
-        {
-            return (T)GetOption(new OptionKey(option, language: null));
-        }
+        public abstract T GetOption<T>(Option<T> option);
 
         /// <summary>
         /// Gets the value of the option.
         /// </summary>
-        public T GetOption<T>(PerLanguageOption<T> option, string language)
-        {
-            return (T)GetOption(new OptionKey(option, language));
-        }
-
-        /// <summary>
-        /// Gets the value of the option.
-        /// </summary>
-        public object GetOption(OptionKey optionKey)
-        {
-            lock (_gate)
-            {
-                object value;
-
-                if (!_values.TryGetValue(optionKey, out value))
-                {
-                    value = _service != null ? _service.GetOption(optionKey) : optionKey.Option.DefaultValue;
-                    _values = _values.Add(optionKey, value);
-                }
-
-                return value;
-            }
-        }
+        public abstract T GetOption<T>(PerLanguageOption<T> option, string language);
 
         /// <summary>
         /// Creates a new <see cref="OptionSet" /> that contains the changed value.
         /// </summary>
-        public OptionSet WithChangedOption<T>(Option<T> option, T value)
-        {
-            return WithChangedOption(new OptionKey(option, language: null), value);
-        }
+        public abstract OptionSet WithChangedOption(OptionKey optionAndLanguage, object value);
 
         /// <summary>
         /// Creates a new <see cref="OptionSet" /> that contains the changed value.
         /// </summary>
-        public OptionSet WithChangedOption<T>(PerLanguageOption<T> option, string language, T value)
-        {
-            return WithChangedOption(new OptionKey(option, language), value);
-        }
+        public abstract OptionSet WithChangedOption<T>(Option<T> option, T value);
 
         /// <summary>
         /// Creates a new <see cref="OptionSet" /> that contains the changed value.
         /// </summary>
-        public OptionSet WithChangedOption(OptionKey optionAndLanguage, object value)
-        {
-            // make sure we first load this in current optionset
-            this.GetOption(optionAndLanguage);
+        public abstract OptionSet WithChangedOption<T>(PerLanguageOption<T> option, string language, T value);
 
-            return new OptionSet(_service, _values.SetItem(optionAndLanguage, value));
-        }
-
-        /// <summary>
-        /// Gets a list of all the options that were accessed.
-        /// </summary>
-        internal IEnumerable<OptionKey> GetAccessedOptions()
-        {
-            var optionSet = _service.GetOptions();
-            return GetChangedOptions(optionSet);
-        }
-
-        internal IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
-        {
-            foreach (var kvp in _values)
-            {
-                var currentValue = optionSet.GetOption(kvp.Key);
-                if (!object.Equals(currentValue, kvp.Value))
-                {
-                    yield return kvp.Key;
-                }
-            }
-        }
+        internal abstract IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet);
     }
 }

--- a/src/Workspaces/Core/Portable/Options/WorkspaceOptionSet.cs
+++ b/src/Workspaces/Core/Portable/Options/WorkspaceOptionSet.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.Options
+{
+    /// <summary>
+    /// An implementation of <see cref="OptionSet"/> that fetches values it doesn't know about to the workspace's option service. It ensures a contract
+    /// that values are immutable from this instance once observed.
+    /// </summary>
+    internal sealed class WorkspaceOptionSet : OptionSet
+    {
+        private readonly IOptionService _service;
+
+        private readonly object _gate = new object();
+        private ImmutableDictionary<OptionKey, object> _values;
+
+        internal WorkspaceOptionSet(IOptionService service)
+        {
+            _service = service;
+            _values = ImmutableDictionary.Create<OptionKey, object>();
+        }
+
+        private WorkspaceOptionSet(IOptionService service, ImmutableDictionary<OptionKey, object> values)
+        {
+            _service = service;
+            _values = values;
+        }
+
+        public override T GetOption<T>(Option<T> option)
+        {
+            return (T)GetOption(new OptionKey(option, language: null));
+        }
+
+        public override T GetOption<T>(PerLanguageOption<T> option, string language)
+        {
+            return (T)GetOption(new OptionKey(option, language));
+        }
+
+        public override object GetOption(OptionKey optionKey)
+        {
+            lock (_gate)
+            {
+                object value;
+
+                if (!_values.TryGetValue(optionKey, out value))
+                {
+                    value = _service != null ? _service.GetOption(optionKey) : optionKey.Option.DefaultValue;
+                    _values = _values.Add(optionKey, value);
+                }
+
+                return value;
+            }
+        }
+
+        public override OptionSet WithChangedOption<T>(Option<T> option, T value)
+        {
+            return WithChangedOption(new OptionKey(option, language: null), value);
+        }
+
+        public override OptionSet WithChangedOption<T>(PerLanguageOption<T> option, string language, T value)
+        {
+            return WithChangedOption(new OptionKey(option, language), value);
+        }
+
+        public override OptionSet WithChangedOption(OptionKey optionAndLanguage, object value)
+        {
+            // make sure we first load this in current optionset
+            this.GetOption(optionAndLanguage);
+
+            return new WorkspaceOptionSet(_service, _values.SetItem(optionAndLanguage, value));
+        }
+
+        /// <summary>
+        /// Gets a list of all the options that were accessed.
+        /// </summary>
+        internal IEnumerable<OptionKey> GetAccessedOptions()
+        {
+            var optionSet = _service.GetOptions();
+            return GetChangedOptions(optionSet);
+        }
+
+        internal override IEnumerable<OptionKey> GetChangedOptions(OptionSet optionSet)
+        {
+            foreach (var kvp in _values)
+            {
+                var currentValue = optionSet.GetOption(kvp.Key);
+                if (!object.Equals(currentValue, kvp.Value))
+                {
+                    yield return kvp.Key;
+                }
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Shipped.txt
@@ -502,12 +502,12 @@ Microsoft.CodeAnalysis.Options.OptionKey.Language.get -> string
 Microsoft.CodeAnalysis.Options.OptionKey.Option.get -> Microsoft.CodeAnalysis.Options.IOption
 Microsoft.CodeAnalysis.Options.OptionKey.OptionKey(Microsoft.CodeAnalysis.Options.IOption option, string language = null) -> void
 Microsoft.CodeAnalysis.Options.OptionSet
-Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
-Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option) -> T
-Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language) -> T
-Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption(Microsoft.CodeAnalysis.Options.OptionKey optionAndLanguage, object value) -> Microsoft.CodeAnalysis.Options.OptionSet
-Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
-Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
+abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option) -> T
+abstract Microsoft.CodeAnalysis.Options.OptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language) -> T
+abstract Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption(Microsoft.CodeAnalysis.Options.OptionKey optionAndLanguage, object value) -> Microsoft.CodeAnalysis.Options.OptionSet
+abstract Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
+abstract Microsoft.CodeAnalysis.Options.OptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
 Microsoft.CodeAnalysis.Options.PerLanguageOption<T>
 Microsoft.CodeAnalysis.Options.PerLanguageOption<T>.DefaultValue.get -> T
 Microsoft.CodeAnalysis.Options.PerLanguageOption<T>.Feature.get -> string

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -2,7 +2,17 @@ Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddSwitchSections(Microsoft.CodeA
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement) -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.SyntaxNode>
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.InsertSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, int index, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool
+Microsoft.CodeAnalysis.Document.Options.get -> Microsoft.CodeAnalysis.Options.DocumentOptionSet
+Microsoft.CodeAnalysis.Options.DocumentOptionSet
+Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option) -> T
+Microsoft.CodeAnalysis.Solution.Options.get -> Microsoft.CodeAnalysis.Options.OptionSet
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NameOfExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption(Microsoft.CodeAnalysis.Options.OptionKey optionKey) -> object
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option) -> T
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language) -> T
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption(Microsoft.CodeAnalysis.Options.OptionKey optionAndLanguage, object value) -> Microsoft.CodeAnalysis.Options.OptionSet
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
+override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.NamingPreferences.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<string>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyEventAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyFieldAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>

--- a/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
+++ b/src/Workspaces/Core/Portable/Rename/ConflictEngine/RenamedSpansTracker.cs
@@ -203,8 +203,7 @@ namespace Microsoft.CodeAnalysis.Rename.ConflictEngine
 
                     if (replacementTextValid)
                     {
-                        var optionSet = solution.Workspace.Options;
-                        document = await Simplifier.ReduceAsync(document, Simplifier.Annotation, optionSet, cancellationToken).ConfigureAwait(false);
+                        document = await Simplifier.ReduceAsync(document, Simplifier.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
                         document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
                     }
 

--- a/src/Workspaces/Core/Portable/Rename/Renamer.cs
+++ b/src/Workspaces/Core/Portable/Rename/Renamer.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Rename
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            options = options ?? solution.Workspace.Options;
+            options = options ?? solution.Options;
             return RenameLocations.FindAsync(symbol, solution, options, cancellationToken);
         }
 

--- a/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
+++ b/src/Workspaces/Core/Portable/Simplification/AbstractSimplificationService.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Simplification
                     return document;
                 }
 
-                optionSet = optionSet ?? document.Project.Solution.Workspace.Options;
+                optionSet = optionSet ?? document.Options;
 
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
@@ -424,6 +425,19 @@ namespace Microsoft.CodeAnalysis
         private string GetDebuggerDisplay()
         {
             return this.Name;
+        }
+
+        /// <summary>
+        /// Returns the options that should be applied to this document. This consists of global options from <see cref="Solution.Options"/>,
+        /// merged with any settings the user has specified at the solution, project, and document levels.
+        /// </summary>
+        public DocumentOptionSet Options
+        {
+            get
+            {
+                // TODO: merge with document-specific options
+                return new DocumentOptionSet(Project.Solution.Options, Project.Language);
+            }
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Project.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Collections.Immutable;
 using Roslyn.Utilities;

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Collections.Immutable;
@@ -2281,6 +2282,19 @@ namespace Microsoft.CodeAnalysis
             if (!this.ContainsAdditionalDocument(documentId))
             {
                 throw new InvalidOperationException(WorkspacesResources.DocumentNotInSolution);
+            }
+        }
+
+        /// <summary>
+        /// Returns the options that should be applied to this solution. This consists of global options from <see cref="Workspace.Options"/>,
+        /// merged with any settings the user has specified at the solution level.
+        /// </summary>
+        public OptionSet Options
+        {
+            get
+            {
+                // TODO: merge with solution-specific options
+                return this.Workspace.Options;
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -395,6 +395,8 @@
     <Compile Include="FindSymbols\DeclaredSymbolInfo.cs" />
     <Compile Include="FindSymbols\FindReferences\Finders\ILanguageServiceReferenceFinder.cs" />
     <Compile Include="LinkedFileDiffMerging\LinkedFileDiffMergingLogger.cs" />
+    <Compile Include="Options\DocumentOptionSet.cs" />
+    <Compile Include="Options\OptionSet.cs" />
     <Compile Include="Packaging\IPackageInstallerService.cs" />
     <Compile Include="SymbolSearch\ISymbolSearchService.cs" />
     <Compile Include="FindSymbols\SymbolTree\ISymbolTreeInfoCacheService.cs" />
@@ -653,7 +655,7 @@
     <Compile Include="Options\OptionChangedEventArgs.cs" />
     <Compile Include="Options\OptionKey.cs" />
     <Compile Include="Options\OptionService.cs" />
-    <Compile Include="Options\OptionSet.cs" />
+    <Compile Include="Options\WorkspaceOptionSet.cs" />
     <Compile Include="Options\OptionsServiceFactory.cs" />
     <Compile Include="Options\PerLanguageOption.cs" />
     <Compile Include="Options\Providers\ExportOptionProviderAttribute.cs" />

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -800,6 +800,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The options being set didn&apos;t originate from a workspace..
+        /// </summary>
+        internal static string OptionsDidNotComeFromWorkspace {
+            get {
+                return ResourceManager.GetString("OptionsDidNotComeFromWorkspace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Specified path must be absolute..
         /// </summary>
         internal static string PathMustBeAbsolute {

--- a/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
+++ b/src/Workspaces/CoreTest/WorkspaceServiceTests/OptionServiceTests.cs
@@ -156,7 +156,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.WorkspaceServices
             var newOptionSet = optionSet.WithChangedOption(optionKey, false);
             Assert.NotSame(optionSet, newOptionSet);
             Assert.NotEqual(optionSet, newOptionSet);
-            Assert.NotEqual(optionSet.GetAccessedOptions().Count(), newOptionSet.GetAccessedOptions().Count());
         }
     }
 }


### PR DESCRIPTION
This is a large change to introduce an API to consume document- and project-level options. Just like `Workspace.Options` today gives you an `OptionSet`, this introduces `Document.Options` and `Solution.Options`. Right now they just return the workspace-level values, but this gives us the ability to make those do something else in upcoming days/weeks.

*Review:* @dotnet/roslyn-ide, @dotnet/roslyn-analysis