### PR TITLE
Monitor share to run automation

### DIFF
--- a/src/Test/Perf/infra/MonitorShareTask.bat
+++ b/src/Test/Perf/infra/MonitorShareTask.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+call "%VS140COMNTOOLS%VsDevCmd.bat"
+
+pushd %~dp0
+
+:: Create a task which passes the location of the share to monitor as the parameter to look for new binary
+start csi %~dp0monitor_and_start_test.csx %1
+
+popd

--- a/src/Test/Perf/infra/TriggerAutomation.bat
+++ b/src/Test/Perf/infra/TriggerAutomation.bat
@@ -6,7 +6,7 @@ call "%VS140COMNTOOLS%VsDevCmd.bat"
 pushd %~dp0
 
 :: Fetch the signed master release binaries and copy it to open binaries release folder
-csi fetch_build.csx Master %~dp0..\..\..\..\Binaries\Release
+csi fetch_build.csx %1 %~dp0..\..\..\..\Binaries\Release
 
 :: Start Test Automation from the binaries directory
 csi %~dp0..\..\..\..\Binaries\Release\Perf\infra\automation.csx

--- a/src/Test/Perf/infra/fetch_build.csx
+++ b/src/Test/Perf/infra/fetch_build.csx
@@ -9,10 +9,8 @@ using System.Linq;
 using System.Xml;
 
 // TODO: Use actual command line argument parser so we can have help text, etc...
-var branch = Args.Count() == 2 ? Args[0] : "master";
+var sourceFolder = Args[0];
 var destinationFolder = Args.Count() == 2 ? Args[1] : @"C:\Roslyn\Binaries\Release";
-
-var sourceFolder = $@"\\cpvsbuild\drops\Roslyn\Roslyn-{branch}-Signed-Release";
 
 string latestBuild = null;
 foreach (var folder in Directory.GetDirectories(sourceFolder, "????????.?").Reverse())

--- a/src/Test/Perf/infra/monitor_and_start_test.csx
+++ b/src/Test/Perf/infra/monitor_and_start_test.csx
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+Task.Run(() => StartWatching());
+Console.WriteLine("Press any key to continue");
+Console.Read();
+
+void StartWatching()
+{
+    FileSystemWatcher watcher = new FileSystemWatcher();
+    watcher.Path = Args[0];
+    watcher.Created += new FileSystemEventHandler(OnChanged);
+    watcher.IncludeSubdirectories = false;
+    watcher.EnableRaisingEvents = true;
+    while (true)
+    {
+        // Stay in loop
+    }
+}
+
+void OnChanged(object sender, FileSystemEventArgs e)
+{
+    // Wait for 120 seconds to make sure all the contents are copied over to the share
+    // If there is a better estimate then we can modify the wait time to be a little over the estimate.
+    Thread.Sleep(120000);
+    var processInfo = new ProcessStartInfo(@"TriggerAutomation.bat");
+    processInfo.Arguments = Args[0];
+
+    // Fire and forget
+    var process = Process.Start(processInfo);
+}

--- a/src/Test/PerformanceTesting.csproj
+++ b/src/Test/PerformanceTesting.csproj
@@ -98,6 +98,12 @@
     <Content Include="Perf\tests\helloworld\hello_world.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Perf\infra\MonitorShareTask.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Perf\infra\monitor_and_start_test.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Perf\infra\TriggerAutomation.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
We can now monitor any share and trigger an automated test run when we see a new build has been for a particular build share

The flow is,
1. MonitorShareTask starts a monitor_and_start_test process which is constantly listening for new binaries in the build output folder
2. When the new binaries arrive, we start the TriggerAutomation which will fetch the new binaries and start the autoamted tests.

MonitorShareTask mentions the share to monitor and it can be added a scheduled task in all the performance infra machines as a startup task.

Tagging @KevinH-MS @rchande @TyOverby for review