### PR TITLE
Source Generators: Entered tracking issues on Source Generators and removed "PROTOTYPE" remarks

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1816,7 +1816,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         var replacedProperty = (PropertySymbol)replaced;
                         Debug.Assert((object)replacedProperty != null);
-                        if (replacedProperty.IsIndexer || replacedProperty.IsIndexedProperty) // PROTOTYPE(generators): Test indexed property.
+                        if (replacedProperty.IsIndexer || replacedProperty.IsIndexedProperty) 
                         {
                             return new BoundPropertyGroup(
                                 syntax,

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -446,8 +446,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 if (replaced.IsImplicitlyDeclared &&
                                     (replaced.MethodKind == MethodKind.EventAdd || replaced.MethodKind == MethodKind.EventRemove))
                                 {
-                                    // PROTOTYPE(generators): Not handling field-like event accessors.
-                                    // (See EventHandler E in ReplaceOriginalTests.MultipleReplaces.)
                                     continue;
                                 }
                                 CompileMethod(replaced, extendedOrdinal, ref processedInitializers, synthesizedSubmissionFields, compilationState);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2349,7 +2349,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         case SymbolKind.Method:
                             if (((MethodSymbol)member).IsAsync)
                             {
-                                // PROTOTYPE(generators): Allow replacing async methods.
                                 continue;
                             }
                             goto case SymbolKind.Property;
@@ -2382,7 +2381,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         var method = member as SourceMethodSymbol;
                         if ((object)method != null && method.IsPartial)
                         {
-                            // PROTOTYPE(generators): Allow replacing partial methods.
                             continue; 
                         }
                         if ((object)last == null)
@@ -2406,10 +2404,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (next.IsReplace)
                             {
                                 diagnostics.Add(ErrorCode.ERR_DuplicateReplace, member.Locations[0], member);
-                                // PROTOTYPE(generators): May see multiple "replace" members before seeing the
-                                // original. Should call SetReplaced on all "replace" members when the original
-                                // is seen. (See EventHandler E in ReplaceOriginalTests.MultipleReplaces.)
-                                //Debug.Assert((object)last.Replaced != null);
                                 next.SetReplaced(last.Replaced);
                             }
                             else if ((object)last.Replaced == null)
@@ -2418,8 +2412,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 // That duplicate member will be reported elsewhere.
                                 last.SetReplaced(next);
                                 next.SetReplacedBy(last);
-                                // PROTOTYPE(generators): Remove all at once rather than one at a time so
-                                // this is O(n) where n is number of replaced members with same name.
                                 membersByName[name] = Remove(membersByName[name], next);
                             }
                         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/UnsafeTests.cs
@@ -2962,8 +2962,7 @@ public unsafe struct S
                 Diagnostic(ErrorCode.ERR_ManagedAddr, "Alias*").WithArguments("S"));
         }
 
-        // PROTOTYPE(generators): 
-        [Fact(Skip = "PROTOTYPE(generators)")]
+        [Fact()]
         public void ERR_ManagedAddr_Members()
         {
             var text = @"

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class ReplaceOriginalTests : CSharpTestBase
     {
+        [WorkItem(11123, "https://github.com/dotnet/roslyn/issues/11123")]
         [Fact]
         public void Members()
         {
@@ -46,8 +47,6 @@ partial struct S
 }";
             var compilation = CreateCompilationWithMscorlib(source);
             compilation.VerifyDiagnostics();
-            // PROTOTYPE(generators): Check ReplacedMethod/Property/Event.
-            // PROTOTYPE(generators): Check generated metadata includes replaced accessors but not replaced property or event.
         }
 
         [Fact]
@@ -314,6 +313,7 @@ struct S
                 Diagnostic(ErrorCode.ERR_OverrideFinalizeDeprecated, "Finalize").WithLocation(4, 37));
         }
 
+        [WorkItem(11122, "https://github.com/dotnet/roslyn/issues/11122")]
         [Fact]
         public void ExplicitImplementation()
         {
@@ -352,7 +352,6 @@ class C : I
     event EventHandler I.E { add { } remove { } }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            // PROTOTYPE(generators): Should note report any errors.
             compilation.VerifyDiagnostics(
                 // (19,22): error CS0539: 'C.this[int]' in explicit interface declaration is not a member of interface
                 //     replace object I.this[int index]
@@ -430,6 +429,7 @@ class C
                 Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(20, 24));
         }
 
+        [WorkItem(11124, "https://github.com/dotnet/roslyn/issues/11124")]
         [Fact]
         public void NoOriginal()
         {
@@ -486,10 +486,11 @@ class C
             {
                 var symbolInfo = model.GetSymbolInfo(expr);
                 var symbol = symbolInfo.Symbol;
-                // PROTOTYPE(generators): Assert this is the replace symbol.
+                // Assert this is the replace symbol.
             }
         }
 
+        [WorkItem(11125, "https://github.com/dotnet/roslyn/issues/11125")]
         [Fact]
         public void DifferentSignatures()
         {
@@ -519,9 +520,10 @@ class C
     static void M7(out object o) { o = null; }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics(); 
         }
 
+        [WorkItem(11126, "https://github.com/dotnet/roslyn/issues/11126")]
         [Fact]
         public void DifferentTypeParameters()
         {
@@ -534,9 +536,10 @@ class C
     replace static void N<T>() { }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics();
         }
 
+        [WorkItem(11127, "https://github.com/dotnet/roslyn/issues/11127")]
         [Fact]
         public void Abstract()
         {
@@ -549,7 +552,7 @@ class C
     replace internal virtual void F() { }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics(); 
         }
 
         [Fact]
@@ -673,6 +676,7 @@ class C
             compilation.VerifyDiagnostics();
         }
 
+        [WorkItem(11129, "https://github.com/dotnet/roslyn/issues/11129")]
         [Fact]
         public void DifferentAttributes()
         {
@@ -691,13 +695,14 @@ class C
     [A(F = 2)] replace void H() { }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics(); 
         }
 
+        [WorkItem(11130, "https://github.com/dotnet/roslyn/issues/11130")]
         [Fact]
         public void Modifiers()
         {
-            // PROTOTYPE(generators): Test extern, partial, unsafe, async
+            // Test extern, partial, unsafe, async
         }
 
         [Fact]
@@ -783,6 +788,7 @@ class C
             CompileAndVerify(compilation, expectedOutput: @"21");
         }
 
+        [WorkItem(11131, "https://github.com/dotnet/roslyn/issues/11131")]
         [Fact]
         public void MissingAccessors()
         {
@@ -795,9 +801,10 @@ class C
     replace object Q { set { } }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics();
         }
 
+        [WorkItem(11131, "https://github.com/dotnet/roslyn/issues/11131")]
         [Fact]
         public void AdditionalAccessors()
         {
@@ -810,9 +817,10 @@ class C
     replace object Q { get { return null; } set { } }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics(); 
         }
 
+        [WorkItem(11131, "https://github.com/dotnet/roslyn/issues/11131")]
         [Fact]
         public void DifferentAccessors()
         {
@@ -825,7 +833,7 @@ class C
     replace object Q { get { return null; } }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            compilation.VerifyDiagnostics(); // PROTOTYPE(generators): Report errors.
+            compilation.VerifyDiagnostics(); 
         }
 
         [Fact]
@@ -930,6 +938,7 @@ class C
                 Diagnostic(ErrorCode.ERR_BadArgType, "2").WithArguments("2", "int", "U").WithLocation(9, 21));
         }
 
+        [WorkItem(11132, "https://github.com/dotnet/roslyn/issues/11132")]
         [Fact]
         public void OriginalMethodExplicitTypeArguments()
         {
@@ -946,7 +955,7 @@ class C
     }
 }";
             var compilation = CreateCompilationWithMscorlib(source);
-            // PROTOTYPE(generators): We might be able to report better errors if 'original'
+            // We might be able to report better errors if 'original'
             // is not treated as a (contextual) keyword by the parser.
             // (ParseTerm is not calling ParseAliasQualifiedName in this case.)
             compilation.VerifyDiagnostics(
@@ -1011,7 +1020,7 @@ class C
                 Diagnostic(ErrorCode.ERR_MemberAlreadyExists, "M4").WithArguments("M4", "C").WithLocation(18, 26));
         }
 
-        // PROTOTYPE(generators): Should allow replacing partial methods.
+        [WorkItem(11117, "https://github.com/dotnet/roslyn/issues/11117")]
         [Fact]
         public void ReplacePartial()
         {
@@ -1145,10 +1154,11 @@ class C
 }");
         }
 
+        [WorkItem(11134, "https://github.com/dotnet/roslyn/issues/11134")]
         [Fact]
         public void UseSiteDiagnostics()
         {
-            // PROTOTYPE(generators): Can we test useSiteDiagnostics in BindInvocationExpression?
+            // Can we test useSiteDiagnostics in BindInvocationExpression?
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/ReplaceOriginalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/ReplaceOriginalTests.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class ReplaceOriginalTests
     {
-        [Fact(Skip = "PROTOTYPE(generators): Incremental parsing")]
+        [WorkItem(11121, "https://github.com/dotnet/roslyn/issues/11121")]
+        [Fact(Skip = "11121")]
         public void AddReplace()
         {
             string oldText =
@@ -23,7 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotEqual(default(SyntaxNodeOrToken), newTree.FindNodeOrTokenByKind(SyntaxKind.OriginalExpression));
         }
 
-        [Fact(Skip = "PROTOTYPE(generators): Incremental parsing")]
+        [WorkItem(11121, "https://github.com/dotnet/roslyn/issues/11121")]
+        [Fact(Skip = "11121")]
         public void RemoveReplace()
         {
             string oldText =

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -383,14 +383,10 @@ namespace Microsoft.CodeAnalysis
 
                 if (!sourceGenerators.IsEmpty)
                 {
-                    // PROTOTYPE(generators): Generated source path should include a "GeneratedFiles" subdirectory
-                    // so that "build clean" can be modified to delete the entire directory.
                     var trees = compilation.GenerateSource(sourceGenerators, this.Arguments.OutputDirectory, writeToDisk: true, cancellationToken: cancellationToken);
                     if (!trees.IsEmpty)
                     {
                         compilation = compilation.AddSyntaxTrees(trees);
-                        // PROTOTYPE(generators): If there are parse warnings, we'll report warnings
-                        // from the previous GetParseDiagnostics() call again here.
                         if (ReportErrors(compilation.GetParseDiagnostics(), consoleOutput, errorLogger))
                         {
                             return Failed;
@@ -398,7 +394,6 @@ namespace Microsoft.CodeAnalysis
                     }
                 }
 
-                // PROTOTYPE(generators): Are we missing parse events?
                 ConcurrentSet<Diagnostic> analyzerExceptionDiagnostics = null;
 
                 if (!analyzers.IsEmpty)


### PR DESCRIPTION
Entered tracking issues on Source Generators and removed "PROTOTYPE" remarks.
Very mechanical change.

The issues:
https://github.com/dotnet/roslyn/issues/11111
https://github.com/dotnet/roslyn/issues/11112
https://github.com/dotnet/roslyn/issues/11113
https://github.com/dotnet/roslyn/issues/11114
https://github.com/dotnet/roslyn/issues/11115
https://github.com/dotnet/roslyn/issues/11116
https://github.com/dotnet/roslyn/issues/11117
https://github.com/dotnet/roslyn/issues/11118
https://github.com/dotnet/roslyn/issues/11120
https://github.com/dotnet/roslyn/issues/11121
https://github.com/dotnet/roslyn/issues/11122
https://github.com/dotnet/roslyn/issues/11123
https://github.com/dotnet/roslyn/issues/11124
https://github.com/dotnet/roslyn/issues/11125
https://github.com/dotnet/roslyn/issues/11126
https://github.com/dotnet/roslyn/issues/11127
https://github.com/dotnet/roslyn/issues/11129
https://github.com/dotnet/roslyn/issues/11130
https://github.com/dotnet/roslyn/issues/11131
https://github.com/dotnet/roslyn/issues/11132
https://github.com/dotnet/roslyn/issues/11134
