### PR TITLE
Do not crash if we are passed a null compilation in EnumerateSymbols

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
@@ -63,6 +63,10 @@ namespace Microsoft.CodeAnalysis
             private static IEnumerable<ValueTuple<TSymbol, int>> EnumerateSymbols(Compilation compilation, ISymbol containingSymbol, string name, CancellationToken cancellationToken)
             {
                 int ordinal = 0;
+                if (compilation == null)
+                {
+                    yield break;
+                }
 
                 foreach (var declaringLocation in containingSymbol.DeclaringSyntaxReferences)
                 {


### PR DESCRIPTION
Fixes #11092