### PR TITLE
Call TestUtilities.InitUtilities appropriately

### DIFF
--- a/src/Test/Perf/infra/automation.csx
+++ b/src/Test/Perf/infra/automation.csx
@@ -7,7 +7,7 @@
 using Roslyn.Test.Performance.Utilities;
 
 var directoryUtil = new RelativeDirectory();
-TestUtilities.InitUtilities();
+TestUtilities.InitUtilitiesFromCsx();
 
 // Install the Vsixes to RoslynPerf hive
 await RunFile(Path.Combine(directoryUtil.MyWorkingDirectory, "install_vsixes.csx"));

--- a/src/Test/Perf/infra/install.csx
+++ b/src/Test/Perf/infra/install.csx
@@ -13,7 +13,7 @@ using System.IO;
 using Roslyn.Test.Performance.Utilities;
 using static Roslyn.Test.Performance.Utilities.TestUtilities;
 
-TestUtilities.InitUtilities();
+TestUtilities.InitUtilitiesFromCsx();
 
 // If we're being #load'ed by uninstall.csx, set the "uninstall" flag.
 var uninstall = Environment.GetCommandLineArgs()[1] == "uninstall.csx";

--- a/src/Test/Perf/infra/install_vsixes.csx
+++ b/src/Test/Perf/infra/install_vsixes.csx
@@ -7,7 +7,7 @@
 using System.IO;
 using Roslyn.Test.Performance.Utilities;
 
-TestUtilities.InitUtilities();
+TestUtilities.InitUtilitiesFromCsx();
 var directoryUtil = new RelativeDirectory();
 var logger = new ConsoleAndFileLogger();
 

--- a/src/Test/Perf/util/TestUtilities.cs
+++ b/src/Test/Perf/util/TestUtilities.cs
@@ -27,9 +27,9 @@ namespace Roslyn.Test.Performance.Utilities
         /// For Eg: If SomeLibarayFile.cs calls this method and if the library is built is some build machine where SomeLibarayFile.cs is saved at
         /// Y:/Project/SomeLibarayFile.cs then when the library is used in any machine where there is no Y: drive then we will see errors saying
         /// invalid directory path. Also note that <param name="sourceFilePath"/> will be set to "Y:/Project/SomeLibarayFile.cs" and not set to
-        /// the path of the file from where the call to SomeLibarayFile.cs which in turn called <see cref="InitUtilities(string)"/>
+        /// the path of the file from where the call to SomeLibarayFile.cs which in turn called <see cref="InitUtilitiesFromCsx(string)"/>
         /// </summary>
-        public static void InitUtilities([CallerFilePath] string sourceFilePath = "")
+        public static void InitUtilitiesFromCsx([CallerFilePath] string sourceFilePath = "")
         {
             _myWorkingFile = sourceFilePath;
         }
@@ -39,7 +39,7 @@ namespace Roslyn.Test.Performance.Utilities
         {
             if (_myWorkingFile == null)
             {
-                throw new Exception("Tests must call InitUtilities before doing any path-dependent operations.");
+                throw new Exception("Tests must call InitUtilitiesFromCsx before doing any path-dependent operations.");
             }
             return Directory.GetParent(_myWorkingFile).FullName;
         }
@@ -72,7 +72,7 @@ namespace Roslyn.Test.Performance.Utilities
 
         /// Shells out, and if the process fails, log the error
         /// and quit the script.
-        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilities(string)"/>
+        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilitiesFromCsx(string)"/>
         /// for more information
         public static void ShellOutVital(
                 string file,
@@ -90,7 +90,7 @@ namespace Roslyn.Test.Performance.Utilities
             }
         }
 
-        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilities(string)"/>
+        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilitiesFromCsx(string)"/>
         /// for more information
         public static ProcessResult ShellOut(
                 string file,

--- a/src/Test/Perf/util/TestUtilities.cs
+++ b/src/Test/Perf/util/TestUtilities.cs
@@ -20,6 +20,15 @@ namespace Roslyn.Test.Performance.Utilities
         //
         public static string _myWorkingFile = null;
 
+        /// <summary>
+        /// This method should be called *ONLY* by the csx scripts.
+        /// This method *MUST NOT* be called from within the library itself. If this method is called within the library instead of csx scripts
+        /// then <param name="sourceFilePath"/> will be set to the path of the file when the library is actual built.
+        /// For Eg: If SomeLibarayFile.cs calls this method and if the library is built is some build machine where SomeLibarayFile.cs is saved at
+        /// Y:/Project/SomeLibarayFile.cs then when the library is used in any machine where there is no Y: drive then we will see errors saying
+        /// invalid directory path. Also note that <param name="sourceFilePath"/> will be set to "Y:/Project/SomeLibarayFile.cs" and not set to
+        /// the path of the file from where the call to SomeLibarayFile.cs which in turn called <see cref="InitUtilities(string)"/>
+        /// </summary>
         public static void InitUtilities([CallerFilePath] string sourceFilePath = "")
         {
             _myWorkingFile = sourceFilePath;
@@ -33,97 +42,6 @@ namespace Roslyn.Test.Performance.Utilities
                 throw new Exception("Tests must call InitUtilities before doing any path-dependent operations.");
             }
             return Directory.GetParent(_myWorkingFile).FullName;
-        }
-
-        /// Returns the directory that you can put artifacts like
-        /// etl traces or compiled binaries
-        public static string MyArtifactsDirectory()
-        {
-            var path = Path.Combine(MyWorkingDirectory(), "artifacts");
-            Directory.CreateDirectory(path);
-            return path;
-        }
-
-        public static string MyTempDirectory()
-        {
-            var workingDir = MyWorkingDirectory();
-            var path = Path.Combine(workingDir, "temp");
-            Directory.CreateDirectory(path);
-            return path;
-        }
-
-        public static string RoslynDirectory()
-        {
-            var workingDir = MyWorkingDirectory();
-            var binaryDebug = Path.Combine("Binaries", "Debug").ToString();
-            int binaryDebugIndex = workingDir.IndexOf(binaryDebug, StringComparison.OrdinalIgnoreCase);
-            if (binaryDebugIndex != -1)
-            {
-                return workingDir.Substring(0, binaryDebugIndex);
-            }
-
-            var binaryRelease= Path.Combine("Binaries", "Release").ToString();
-            return workingDir.Substring(0, workingDir.IndexOf(binaryRelease, StringComparison.OrdinalIgnoreCase));
-        }
-
-        public static string CscPath()
-        {
-            return Path.Combine(MyBinaries(), "csc.exe");
-        }
-
-        public static string MyBinaries()
-        {
-            var workingDir = MyWorkingDirectory();
-            // We may be a release or debug build
-            var debug = workingDir.IndexOf("debug", StringComparison.CurrentCultureIgnoreCase);
-            if (debug != -1)
-                return workingDir.Substring(0, debug + "debug".Length);
-
-            var release = workingDir.IndexOf("release", StringComparison.CurrentCultureIgnoreCase);
-            if (release != -1)
-                return workingDir.Substring(0, release + "release".Length);
-
-            throw new Exception("You are attempting to run performance test from the src directory. Run it from binaries");
-        }
-
-        public static string PerfDirectory()
-        {
-            return Path.Combine(RoslynDirectory(), "src", "Test", "Perf");
-        }
-
-        public static string BinDirectory()
-        {
-            return Path.Combine(RoslynDirectory(), "Binaries");
-        }
-
-        public static string BinDebugDirectory()
-        {
-            return Path.Combine(BinDirectory(), "Debug");
-        }
-
-        public static string BinReleaseDirectory()
-        {
-            return Path.Combine(BinDirectory(), "Release");
-        }
-
-        public static string DebugCscPath()
-        {
-            return Path.Combine(BinDebugDirectory(), "csc.exe");
-        }
-
-        public static string ReleaseCscPath()
-        {
-            return Path.Combine(BinReleaseDirectory(), "csc.exe");
-        }
-
-        public static string DebugVbcPath()
-        {
-            return Path.Combine(BinDebugDirectory(), "vbc.exe");
-        }
-
-        public static string ReleaseVbcPath()
-        {
-            return Path.Combine(BinReleaseDirectory(), "vbc.exe");
         }
 
         public static string GetCPCDirectoryPath()
@@ -154,6 +72,8 @@ namespace Roslyn.Test.Performance.Utilities
 
         /// Shells out, and if the process fails, log the error
         /// and quit the script.
+        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilities(string)"/>
+        /// for more information
         public static void ShellOutVital(
                 string file,
                 string args,
@@ -170,6 +90,8 @@ namespace Roslyn.Test.Performance.Utilities
             }
         }
 
+        /// NOTE: <param name="workingDirectory"/> should be set when called inside the library and not from csx. see <see cref="InitUtilities(string)"/>
+        /// for more information
         public static ProcessResult ShellOut(
                 string file,
                 string args,
@@ -240,9 +162,9 @@ namespace Roslyn.Test.Performance.Utilities
             };
         }
 
-        public static string StdoutFrom(string program, bool verbose, ILogger logger, string args = "")
+        public static string StdoutFrom(string program, bool verbose, ILogger logger, string args = "", string workingDirectory = null)
         {
-            var result = ShellOut(program, args, verbose, logger);
+            var result = ShellOut(program, args, verbose, logger, workingDirectory);
             if (result.Failed)
             {
                 LogProcessResult(result, logger);

--- a/src/Test/Perf/util/Tools.cs
+++ b/src/Test/Perf/util/Tools.cs
@@ -119,7 +119,7 @@ namespace Roslyn.Test.Performance.Utilities
 
             arguments = arguments.Replace("\r\n", " ").Replace("\n", "");
 
-            ShellOutVital(Path.Combine(GetCPCDirectoryPath(), "ViBenchToJson.exe"), arguments, verbose, logger);
+            ShellOutVital(Path.Combine(GetCPCDirectoryPath(), "ViBenchToJson.exe"), arguments, verbose, logger, workingDirectory: "");
 
             return outJson;
         }
@@ -168,7 +168,7 @@ namespace Roslyn.Test.Performance.Utilities
 
         public static void CopyDirectory(string source, ILogger logger, string destination, string argument = @"/mir")
         {
-            var result = ShellOut("Robocopy", $"{argument} {source} {destination}", verbose: true, logger: logger);
+            var result = ShellOut("Robocopy", $"{argument} {source} {destination}", verbose: true, logger: logger, workingDirectory: "");
 
             // Robocopy has a success exit code from 0 - 7
             if (result.Code > 7)

--- a/src/Test/Perf/util/TraceManager.cs
+++ b/src/Test/Perf/util/TraceManager.cs
@@ -28,10 +28,6 @@ namespace Roslyn.Test.Performance.Utilities
             _scenarioGenerator = new ScenarioGenerator(scenarioPath);
             _verbose = verbose;
             _logger = logger;
-
-            // Since TraceManager.Setup() and few other functions use ShellOutVital,
-            // which requires the TestUtilities.InitUtilities() to be called
-            InitUtilities();
         }
 
         public bool HasWarmUpIteration
@@ -63,24 +59,24 @@ namespace Roslyn.Test.Performance.Utilities
 
         public void Setup()
         {
-            ShellOutVital(_cpcPath, "/Setup /DisableArchive", _verbose, _logger);
+            ShellOutVital(_cpcPath, "/Setup /DisableArchive", _verbose, _logger, workingDirectory: "");
         }
 
         public void Start()
         {
-            ShellOutVital(_cpcPath, "/Start /DisableArchive", _verbose, _logger);
+            ShellOutVital(_cpcPath, "/Start /DisableArchive", _verbose, _logger, workingDirectory: "");
         }
 
         public void Stop()
         {
             var scenariosXmlPath = Path.Combine(GetCPCDirectoryPath(), "scenarios.xml");
             var consumptionTempResultsPath = Path.Combine(GetCPCDirectoryPath(), "ConsumptionTempResults.xml");
-            ShellOutVital(_cpcPath, $"/Stop /DisableArchive /ScenarioPath=\"{scenariosXmlPath}\" /ConsumptionTempResultsPath=\"{consumptionTempResultsPath}\"", _verbose, _logger);
+            ShellOutVital(_cpcPath, $"/Stop /DisableArchive /ScenarioPath=\"{scenariosXmlPath}\" /ConsumptionTempResultsPath=\"{consumptionTempResultsPath}\"", _verbose, _logger, workingDirectory: "");
         }
 
         public void Cleanup()
         {
-            ShellOutVital(_cpcPath, "/Cleanup /DisableArchive", _verbose, _logger);
+            ShellOutVital(_cpcPath, "/Cleanup /DisableArchive", _verbose, _logger, workingDirectory: "");
         }
 
         public void StartScenarios()


### PR DESCRIPTION
Calling TestUtilities.InitUtilities from within the library, instead of a csx file, will result in the path of the file where the library was initially built to be passed to InitUtilities which is not the expected behavior. Fixing it in all occurence

Also removing some unnecessary and unused helpers

Tagging @KevinH-MS @rchande @TyOverby for review