### PR TITLE
Allow generic type parameters to be the same type in method generation

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -2879,6 +2879,46 @@ class Program
 }");
         }
 
+        [WorkItem(10004, "https://github.com/dotnet/roslyn/issues/10004")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task TestGenerateMethodWithMultipleOfSameGenericType()
+        {
+            await TestAsync(
+@"using System;
+
+public class C
+{
+}
+
+public static class Ex
+{
+    public static T M1<T>(this T t) where T : C
+    {
+        return [|t.M<T, T>()|];
+    }
+}
+",
+@"using System;
+
+public class C
+{
+    internal T2 M<T1, T2>()
+        where T1 : C
+        where T2 : C
+    {
+    }
+}
+
+public static class Ex
+{
+    public static T M1<T>(this T t) where T : C
+    {
+        return t.M<T, T>();
+    }
+}
+");
+        }
+
         public class GenerateConversionTest : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
         {
             internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -2200,6 +2200,38 @@ NewLines("Imports System \n Imports System.Collections.Generic \n Module Program
 NewLines("Imports System \n Imports System.Collections.Generic \n Module Program \n Sub M() \n Dim x = New Dictionary ( Of Integer , Boolean ) From { { 1, T() } } \n End Sub \n Private Function T() As Boolean \n Throw New NotImplementedException() \n End Function \n End Module"))
         End Function
 
+        <WorkItem(10004, "https://github.com/dotnet/roslyn/issues/10004")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        Public Async Function TestGenerateMethodWithMultipleOfSameGenericType() As Task
+            Await TestAsync(
+<text>
+Namespace TestClasses
+    Public Class C
+    End Class
+
+    Module Ex
+        Public Function M(Of T As C)(a As T) As T
+            Return [|a.Test(Of T, T)()|]
+        End Function
+    End Module
+End Namespace
+</text>.Value.Replace(vbLf, vbCrLf),
+<text>
+Namespace TestClasses
+    Public Class C
+        Friend Function Test(Of T1 As C, T2 As C)() As T2
+        End Function
+    End Class
+
+    Module Ex
+        Public Function M(Of T As C)(a As T) As T
+            Return a.Test(Of T, T)()
+        End Function
+    End Module
+End Namespace
+</text>.Value.Replace(vbLf, vbCrLf))
+        End Function
+
         Public Class GenerateConversionTests
             Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
@@ -2484,7 +2516,6 @@ Class Digit
 End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
             End Function
-
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -67,7 +67,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             var mapping = new Dictionary<ITypeSymbol, ITypeSymbol>();
             for (int i = 0; i < method.TypeParameters.Length; i++)
             {
-                mapping.Add(method.TypeParameters[i], updatedTypeParameters[i]);
+                mapping[method.TypeParameters[i]] = updatedTypeParameters[i];
             }
 
             return CodeGenerationSymbolFactory.CreateMethodSymbol(
@@ -131,7 +131,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     typeParameter.Ordinal);
 
                 newTypeParameters.Add(newTypeParameter);
-                mapping.Add(typeParameter, newTypeParameter);
+                mapping[typeParameter] = newTypeParameter;
             }
 
             // Now we update the constraints.


### PR DESCRIPTION
Previouly we assumed that the type parameters in a method would not be of
the same `TypeSymbol` when generating a method and put them in a dictionary.
This causes exceptions when attempting to add to the dictionary and the
`TypeSymbol` is already added as a key. Now we use a list of instead of a
dictionary.

Fixes #10004