### PR TITLE
uninstall previous vsixes

### DIFF
--- a/src/Test/Perf/infra/install_vsixes.csx
+++ b/src/Test/Perf/infra/install_vsixes.csx
@@ -25,6 +25,10 @@ var vsixes = new[]
 
 var installer = Path.Combine(binariesDirectory, "VSIXExpInstaller.exe");
 
+// Uninstall all previously installed VSIXes
+TestUtilities.ShellOutVital(installer, $"/rootSuffix:RoslynPerf /uninstallAll", IsVerbose(), logger, binariesDirectory);
+
+// Install the new VSIXes
 foreach (var vsix in vsixes)
 {
     TestUtilities.ShellOutVital(installer, $"/rootSuffix:RoslynPerf {vsix}", IsVerbose(), logger, binariesDirectory);


### PR DESCRIPTION
While installing the VSIXes using the install_vsixes.csx, uninstall the previous VSIXes before installing the new ones.

Tagging @KevinH-MS @rchande @TyOverby for review