### PR TITLE
Hide replace/original functionality behind a feature flag.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -219,6 +219,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case MessageID.IDS_FeatureRefLocalsReturns:
                 case MessageID.IDS_FeaturePatternMatching:
                 case MessageID.IDS_FeatureTuples:
+                case MessageID.IDS_FeatureReplace:
                     // in "demo" mode enable proposed new C# 7 language features.
                     if (PreprocessorSymbols.Contains("__DEMO__"))
                     {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -9774,6 +9774,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to replaced members.
+        /// </summary>
+        internal static string IDS_FeatureReplace {
+            get {
+                return ResourceManager.GetString("IDS_FeatureReplace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to static classes.
         /// </summary>
         internal static string IDS_FeatureStaticClasses {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -240,6 +240,9 @@
   <data name="IDS_FeaturePartialMethod" xml:space="preserve">
     <value>partial method</value>
   </data>
+  <data name="IDS_FeatureReplace" xml:space="preserve">
+    <value>replaced members</value>
+  </data>  
   <data name="IDS_SK_METHOD" xml:space="preserve">
     <value>method</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -119,6 +119,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         IDS_FeatureRefLocalsReturns = MessageBase + 12710,
         IDS_FeatureTuples = MessageBase + 12711,
+        IDS_FeatureReplace = MessageBase + 12712,
     }
 
     // Message IDs may refer to strings that need to be localized.
@@ -174,6 +175,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "patterns";
                 case MessageID.IDS_FeatureTuples:
                     return "tuples";
+                case MessageID.IDS_FeatureReplace:
+                    return "replace";
                 default:
                     return null;
             }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -1400,6 +1400,7 @@ tryAgain:
                             if (ShouldCurrentContextualKeywordBeTreatedAsModifier())
                             {
                                 modTok = ConvertToKeyword(this.EatToken());
+                                modTok = CheckFeatureAvailability(modTok, MessageID.IDS_FeatureReplace);
                                 break;
                             }
                             return;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
@@ -14,6 +14,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
 {
     public class ReplaceOriginalTests : CSharpTestBase
     {
+        private static CSharpCompilation CreateCompilationWithMscorlib(string text)
+        {
+            return CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithReplaceFeature());
+        }
+
+        private static CSharpCompilation CreateCompilationWithMscorlib(string text, CSharpCompilationOptions options)
+        {
+            return CreateCompilationWithMscorlib(text, options: options, parseOptions: TestOptions.Regular.WithReplaceFeature());
+        }
+
         [WorkItem(11123, "https://github.com/dotnet/roslyn/issues/11123")]
         [Fact]
         public void Members()

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/TestOptions.cs
@@ -68,5 +68,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
             return options.WithFeature("patterns", "true");
         }
+
+        public static CSharpParseOptions WithReplaceFeature(this CSharpParseOptions options)
+        {
+            return options.WithFeature("replace", "true");
+        }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -69,5 +69,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
             return options.WithFeature("tuples", "true");
         }
+
+        public static CSharpParseOptions WithReplaceFeature(this CSharpParseOptions options)
+        {
+            return options.WithFeature("replace", "true");
+        }
     }
 }


### PR DESCRIPTION
Since "original" is by itself contextual on the presence of "replace", only "replace" actually needs to be keyed off a flag.