### PR TITLE
Automate share monitoring

### DIFF
--- a/src/Test/Perf/infra/MonitorShareTask.bat
+++ b/src/Test/Perf/infra/MonitorShareTask.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+call "%VS140COMNTOOLS%VsDevCmd.bat"
+
+pushd %~dp0
+
+:: Create a task which passes the location of the share to monitor as the parameter to look for new binary
+start csi %~dp0fetch_build.csx %1  %~dp0..\..\..\..\Binaries\Release
+
+popd

--- a/src/Test/Perf/infra/TriggerAutomation.bat
+++ b/src/Test/Perf/infra/TriggerAutomation.bat
@@ -5,10 +5,13 @@ call "%VS140COMNTOOLS%VsDevCmd.bat"
 
 pushd %~dp0
 
-:: Fetch the signed master release binaries and copy it to open binaries release folder
-csi fetch_build.csx Master %~dp0..\..\..\..\Binaries\Release
-
 :: Start Test Automation from the binaries directory
 csi %~dp0..\..\..\..\Binaries\Release\Perf\infra\automation.csx --verbose
+
+:: Write the successful build number
+csi persist_successful_build.csx %1 %2
+
+:: Start Share Monitor
+start "Monitoring share" MonitorShareTask.bat %3
 
 popd

--- a/src/Test/Perf/infra/persist_successful_build.csx
+++ b/src/Test/Perf/infra/persist_successful_build.csx
@@ -1,0 +1,14 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+
+string fileToUpdate = Args[0];
+string successfulBuildNumber = Args[1];
+
+var directoryName = Path.GetDirectoryName(fileToUpdate);
+if (!Directory.Exists(directoryName))
+{
+    Directory.CreateDirectory(directoryName);
+}
+
+File.WriteAllText(fileToUpdate, successfulBuildNumber);

--- a/src/Test/PerformanceTesting.csproj
+++ b/src/Test/PerformanceTesting.csproj
@@ -98,8 +98,12 @@
     <Content Include="Perf\tests\helloworld\hello_world.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="Perf\infra\MonitorShareTask.bat" />
-    <None Include="Perf\infra\persist_successful_build.csx" />
+    <Content Include="Perf\infra\MonitorShareTask.bat">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Perf\infra\persist_successful_build.csx">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="Perf\infra\TriggerAutomation.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/Test/PerformanceTesting.csproj
+++ b/src/Test/PerformanceTesting.csproj
@@ -98,6 +98,8 @@
     <Content Include="Perf\tests\helloworld\hello_world.csx">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="Perf\infra\MonitorShareTask.bat" />
+    <None Include="Perf\infra\persist_successful_build.csx" />
     <None Include="Perf\infra\TriggerAutomation.bat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
With this change we can have a task look for a new build in the specified share(Eg: Roslyn-Master-Signed-Release) and start testing as soon as the binaries get dropped in. After the testing is done, the results are reported and task is started to monitor the share again.

We also make sure not to run tests on previously run binaries.

Tagging @KevinH-MS @rchande @TyOverby for review