### PR TITLE
Include Microsoft.Diagnostics.Runtime in the test setup VSIX

### DIFF
--- a/src/VisualStudio/TestSetup/BindingAttributes.cs
+++ b/src/VisualStudio/TestSetup/BindingAttributes.cs
@@ -1,3 +1,4 @@
 ﻿﻿using Microsoft.VisualStudio.Shell;
 
 [assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Roslyn.Hosting.Diagnostics.dll")]
+[assembly: ProvideCodeBase(CodeBase = @"$PackageFolder$\Microsoft.Diagnostics.Runtime.dll")]

--- a/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
+++ b/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
@@ -20,6 +20,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <UseCodebase>true</UseCodebase>
+    <CopyNuGetImplementations>true</CopyNuGetImplementations>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
@@ -71,6 +72,9 @@
       <Project>{3bed15fd-d608-4573-b432-1569c1026f6d}</Project>
       <Name>VisualStudioTestUtilities</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <NuGetPackageToIncludeInVsix Include="Microsoft.Diagnostics.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/VisualStudio/TestSetup/project.json
+++ b/src/VisualStudio/TestSetup/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "Microsoft.Diagnostics.Runtime": "0.8.31-beta"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
This allows us to properly deploy it into VS rather than rely on AssemblyResolve hackery.

*Review:* @dotnet/roslyn-ide