### PR TITLE
One TempDirectory For all tests

### DIFF
--- a/src/Test/Perf/runner.csx
+++ b/src/Test/Perf/runner.csx
@@ -58,7 +58,7 @@ foreach (var test in testInstances)
         }
         else
         {
-            traceManager.StartScenario(test.Name + i, test.MeasuredProc);
+            traceManager.StartScenario(test.Name, test.MeasuredProc);
             traceManager.StartEvent();
             test.Test();
             traceManager.EndEvent();

--- a/src/Test/Perf/tests/csharp/csharp_compiler.csx
+++ b/src/Test/Perf/tests/csharp/csharp_compiler.csx
@@ -28,11 +28,11 @@ class CSharpCompilerTest: PerfTest
     
     public override void Test() 
     {
-        string responseFile = "@" + Path.Combine(MyTempDirectory, "csharp", _rspFile);
-        string keyfileLocation = Path.Combine(MyTempDirectory, "csharp", "keyfile", "35MSSharedLib1024.snk");
+        string responseFile = "@" + Path.Combine(TempDirectory, "csharp", _rspFile);
+        string keyfileLocation = Path.Combine(TempDirectory, "csharp", "keyfile", "35MSSharedLib1024.snk");
         string args = $"{responseFile} /keyfile:{keyfileLocation}";
 
-        string workingDirectory = Path.Combine(MyTempDirectory, "csharp");
+        string workingDirectory = Path.Combine(TempDirectory, "csharp");
 
         ShellOutVital(Path.Combine(MyBinaries(), "csc.exe"), args, IsVerbose(), _logger, workingDirectory);
         _logger.Flush();

--- a/src/Test/Perf/tests/helloworld/hello_world.csx
+++ b/src/Test/Perf/tests/helloworld/hello_world.csx
@@ -26,7 +26,7 @@ class HelloWorldTest : PerfTest
     public override void Setup() 
     {
         _pathToHelloWorld = Path.Combine(MyWorkingDirectory, "HelloWorld.cs");
-        _pathToOutput = Path.Combine(MyArtifactsDirectory, "HelloWorld.exe");
+        _pathToOutput = Path.Combine(TempDirectory, "HelloWorld.exe");
     }
     
     public override void Test() 

--- a/src/Test/Perf/util/RelativeDirectory.cs
+++ b/src/Test/Perf/util/RelativeDirectory.cs
@@ -23,27 +23,13 @@ namespace Roslyn.Test.Performance.Utilities
 
         public string MyWorkingDirectory => _workingDir;
 
-
-        /// Returns the directory that you can put artifacts like
-        /// etl traces or compiled binaries
-        public string MyArtifactsDirectory
+        public string TempDirectory
         {
             get
             {
-                var path = Path.Combine(MyWorkingDirectory, "artifacts");
-                Directory.CreateDirectory(path);
-                return path;
-            }
-        }
-
-        public string MyTempDirectory
-        {
-            get
-            {
-                var workingDir = MyWorkingDirectory;
-                var path = Path.Combine(workingDir, "temp");
-                Directory.CreateDirectory(path);
-                return path;
+                var tempDirectory = Path.Combine(Environment.ExpandEnvironmentVariables("%SYSTEMDRIVE%")+@"\", "PerfTemp");
+                Directory.CreateDirectory(tempDirectory);
+                return tempDirectory;
             }
         }
 
@@ -111,7 +97,7 @@ namespace Roslyn.Test.Performance.Utilities
         public void DownloadProject(string name, int version, ILogger logger)
         {
             var zipFileName = $"{name}.{version}.zip";
-            var zipPath = Path.Combine(MyTempDirectory, zipFileName);
+            var zipPath = Path.Combine(TempDirectory, zipFileName);
             // If we've already downloaded the zip, assume that it
             // has been downloaded *and* extracted.
             if (File.Exists(zipPath))
@@ -121,7 +107,7 @@ namespace Roslyn.Test.Performance.Utilities
             }
 
             // Remove all .zip files that were downloaded before.
-            foreach (var path in Directory.EnumerateFiles(MyTempDirectory, $"{name}.*.zip"))
+            foreach (var path in Directory.EnumerateFiles(TempDirectory, $"{name}.*.zip"))
             {
                 logger.Log($"Removing old zip {path}");
                 File.Delete(path);
@@ -135,8 +121,8 @@ namespace Roslyn.Test.Performance.Utilities
             logger.Log($"Done Downloading");
 
             // Extract to temp directory
-            logger.Log($"Extracting {zipPath} to {MyTempDirectory}");
-            ZipFile.ExtractToDirectory(zipPath, MyTempDirectory);
+            logger.Log($"Extracting {zipPath} to {TempDirectory}");
+            ZipFile.ExtractToDirectory(zipPath, TempDirectory);
             logger.Log($"Done Extracting");
         }
     }

--- a/src/Test/Perf/util/RelativeDirectory.cs
+++ b/src/Test/Perf/util/RelativeDirectory.cs
@@ -27,7 +27,7 @@ namespace Roslyn.Test.Performance.Utilities
         {
             get
             {
-                var tempDirectory = Path.Combine(Environment.ExpandEnvironmentVariables("%SYSTEMDRIVE%")+@"\", "PerfTemp");
+                var tempDirectory = Environment.ExpandEnvironmentVariables(@"%SYSTEMDRIVE%\PerfTemp");
                 Directory.CreateDirectory(tempDirectory);
                 return tempDirectory;
             }


### PR DESCRIPTION
There are 2 reasons.
1. We are running into errors trying to unzip test solutions in the temp folder which is rooted deep inside the binaries folder
2. When trying to run the tests again, we need to delete the temp directories of each directory separately because we could pick up csx files from the test files.

We could solve the 2nd issue by cleaning up after the run. But the 1st issue still stands

Tagging @TyOverby @KevinH-MS @rchande for review