### PR TITLE
Add public API to enable/disable compiler diagnostics for custom work…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -71,12 +71,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal void StartSolutionCrawler()
         {
-            DiagnosticProvider.Enable(this, DiagnosticProvider.Options.Syntax);
+            DiagnosticServices.Enable(this, DiagnosticServiceOptions.Syntax);
         }
 
         internal void StopSolutionCrawler()
         {
-            DiagnosticProvider.Disable(this);
+            DiagnosticServices.Disable(this);
         }
 
         private LanguageInformation TryGetLanguageInformation(string filename)

--- a/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/DefaultDiagnosticUpdateSourceTests.vb
@@ -35,7 +35,7 @@ class 123 { }
                 Dim miscService = New DefaultDiagnosticAnalyzerService(diagnosticService)
                 Assert.False(miscService.SupportGetDiagnostics)
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Syntax)
 
                 Dim optionsService = workspace.Services.GetService(Of IOptionService)()
 
@@ -83,7 +83,7 @@ class A
                 Dim miscService = New DefaultDiagnosticAnalyzerService(diagnosticService)
                 Assert.False(miscService.SupportGetDiagnostics)
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Syntax)
 
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
@@ -120,7 +120,7 @@ class A
                 Dim miscService = New DefaultDiagnosticAnalyzerService(diagnosticService)
                 Assert.False(miscService.SupportGetDiagnostics)
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Semantic)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Semantic)
 
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
@@ -157,7 +157,7 @@ class A
                 Dim miscService = New DefaultDiagnosticAnalyzerService(diagnosticService)
                 Assert.False(miscService.SupportGetDiagnostics)
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Semantic Or DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Semantic Or DiagnosticServiceOptions.Syntax)
 
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
@@ -194,7 +194,7 @@ class A
                 Dim miscService = New DefaultDiagnosticAnalyzerService(diagnosticService)
                 Assert.False(miscService.SupportGetDiagnostics)
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Semantic Or DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Semantic Or DiagnosticServiceOptions.Syntax)
 
                 Dim document = workspace.CurrentSolution.Projects.First().Documents.First()
                 Dim analyzer = miscService.CreateIncrementalAnalyzer(workspace)
@@ -217,7 +217,7 @@ class 123 { }
             Using workspace = Await TestWorkspace.CreateCSharpAsync(code.Value)
                 Dim miscService = New DefaultDiagnosticAnalyzerService(New MockDiagnosticUpdateSourceRegistrationService())
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Syntax)
 
                 Dim buildTool = String.Empty
 
@@ -242,7 +242,7 @@ End Class
             Using workspace = Await TestWorkspace.CreateVisualBasicAsync(code.Value)
                 Dim miscService = New DefaultDiagnosticAnalyzerService(New MockDiagnosticUpdateSourceRegistrationService())
 
-                DiagnosticProvider.Enable(workspace, DiagnosticProvider.Options.Syntax)
+                DiagnosticServices.Enable(workspace, DiagnosticServiceOptions.Syntax)
 
                 Dim buildTool = String.Empty
 

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticProvider.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Provide a way for users to turn on and off analyzing workspace for compiler diagnostics
     /// </summary>
-    internal static class DiagnosticProvider
+    public static class DiagnosticProvider
     {
         public static void Enable(Workspace workspace, Options options)
         {

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticServiceOptions.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticServiceOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Flags to indicate which types of compiler diagnostics are reported by <see cref="DiagnosticServices"/>
+    /// </summary>
+    [Flags]
+    public enum DiagnosticServiceOptions
+    {
+        /// <summary>
+        /// Include syntax errors
+        /// </summary>
+        Syntax = 0x01,
+
+        /// <summary>
+        /// Include semantic errors
+        /// </summary>
+        Semantic = 0x02,
+    }
+}

--- a/src/Workspaces/Core/Portable/Diagnostics/DiagnosticServices.cs
+++ b/src/Workspaces/Core/Portable/Diagnostics/DiagnosticServices.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 
 namespace Microsoft.CodeAnalysis
@@ -9,9 +9,9 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Provide a way for users to turn on and off analyzing workspace for compiler diagnostics
     /// </summary>
-    public static class DiagnosticProvider
+    public static class DiagnosticServices
     {
-        public static void Enable(Workspace workspace, Options options)
+        public static void Enable(Workspace workspace, DiagnosticServiceOptions options)
         {
             var service = workspace.Services.GetService<ISolutionCrawlerRegistrationService>();
 
@@ -25,25 +25,11 @@ namespace Microsoft.CodeAnalysis
             service.Unregister(workspace);
         }
 
-        private static CodeAnalysis.Options.OptionSet GetOptions(Workspace workspace, Options options)
+        private static OptionSet GetOptions(Workspace workspace, DiagnosticServiceOptions options)
         {
             return workspace.Options
-                            .WithChangedOption(InternalRuntimeDiagnosticOptions.Syntax, (options & Options.Syntax) == Options.Syntax)
-                            .WithChangedOption(InternalRuntimeDiagnosticOptions.Semantic, (options & Options.Semantic) == Options.Semantic);
-        }
-
-        [Flags]
-        public enum Options
-        {
-            /// <summary>
-            /// Include syntax errors
-            /// </summary>
-            Syntax = 0x01,
-
-            /// <summary>
-            /// Include semantic errors
-            /// </summary>
-            Semantic = 0x02,
+                            .WithChangedOption(InternalRuntimeDiagnosticOptions.Syntax, (options & DiagnosticServiceOptions.Syntax) == DiagnosticServiceOptions.Syntax)
+                            .WithChangedOption(InternalRuntimeDiagnosticOptions.Semantic, (options & DiagnosticServiceOptions.Semantic) == DiagnosticServiceOptions.Semantic);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,2 +1,8 @@
-static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool
+Microsoft.CodeAnalysis.DiagnosticProvider
+Microsoft.CodeAnalysis.DiagnosticProvider.Options
+Microsoft.CodeAnalysis.DiagnosticProvider.Options.Semantic = 2 -> Microsoft.CodeAnalysis.DiagnosticProvider.Options
+Microsoft.CodeAnalysis.DiagnosticProvider.Options.Syntax = 1 -> Microsoft.CodeAnalysis.DiagnosticProvider.Options
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NameOfExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
+static Microsoft.CodeAnalysis.DiagnosticProvider.Disable(Microsoft.CodeAnalysis.Workspace workspace) -> void
+static Microsoft.CodeAnalysis.DiagnosticProvider.Enable(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DiagnosticProvider.Options options) -> void
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,8 +1,8 @@
-Microsoft.CodeAnalysis.DiagnosticProvider
-Microsoft.CodeAnalysis.DiagnosticProvider.Options
-Microsoft.CodeAnalysis.DiagnosticProvider.Options.Semantic = 2 -> Microsoft.CodeAnalysis.DiagnosticProvider.Options
-Microsoft.CodeAnalysis.DiagnosticProvider.Options.Syntax = 1 -> Microsoft.CodeAnalysis.DiagnosticProvider.Options
+Microsoft.CodeAnalysis.DiagnosticServiceOptions
+Microsoft.CodeAnalysis.DiagnosticServiceOptions.Semantic = 2 -> Microsoft.CodeAnalysis.DiagnosticServiceOptions
+Microsoft.CodeAnalysis.DiagnosticServiceOptions.Syntax = 1 -> Microsoft.CodeAnalysis.DiagnosticServiceOptions
+Microsoft.CodeAnalysis.DiagnosticServices
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.NameOfExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
-static Microsoft.CodeAnalysis.DiagnosticProvider.Disable(Microsoft.CodeAnalysis.Workspace workspace) -> void
-static Microsoft.CodeAnalysis.DiagnosticProvider.Enable(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DiagnosticProvider.Options options) -> void
+static Microsoft.CodeAnalysis.DiagnosticServices.Disable(Microsoft.CodeAnalysis.Workspace workspace) -> void
+static Microsoft.CodeAnalysis.DiagnosticServices.Enable(Microsoft.CodeAnalysis.Workspace workspace, Microsoft.CodeAnalysis.DiagnosticServiceOptions options) -> void
 static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -335,7 +335,8 @@
     <Compile Include="CodeGeneration\CodeGenerationSymbolFactory.cs" />
     <Compile Include="CodeGeneration\CodeGenerator.cs" />
     <Compile Include="Diagnostics\DiagnosticData.cs" />
-    <Compile Include="Diagnostics\DiagnosticProvider.cs" />
+    <Compile Include="Diagnostics\DiagnosticServices.cs" />
+    <Compile Include="Diagnostics\DiagnosticServiceOptions.cs" />
     <Compile Include="Diagnostics\Extensions.cs" />
     <Compile Include="Diagnostics\InternalDiagnosticsOptions.cs" />
     <Compile Include="Diagnostics\InternalRuntimeDiagnosticOptions.cs" />


### PR DESCRIPTION
…space.

this will let people who want to show compiler diagnostic squiggles on thier custom workspace to have 1 API
to enable/disable it.

this API is what misc workspace uses to show squiggles on files in misc project.

currently AnyCode requested this API and some other internal and external people also
wanted this so that they can create textview with custom workspace in VS that shows some C#/VB code snippet.