### PR TITLE
Improve /errlog JSON escaping logic and add tests

### DIFF
--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -141,7 +141,7 @@ public class C
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);
@@ -236,7 +236,7 @@ public class C
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Emit\CustomDebugInfoTests.cs" />
     <Compile Include="FileSystem\PathUtilitiesTests.cs" />
     <Compile Include="InternalUtilities\StreamExtensionsTests.cs" />
+    <Compile Include="InternalUtilities\JsonWriterTests.cs" />
     <Compile Include="InternalUtilities\StringExtensionsTests.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityExtensions.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityMapTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/JsonWriterTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/JsonWriterTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Roslyn.Utilities.UnitTests.InternalUtilities
+{
+    public class JsonWriterTests
+    {
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        public void Boolean(string expected, bool value)
+        {
+            Assert.StrictEqual(expected, WriteToString(value));
+        }
+
+        [Theory]
+        [InlineData("-2147483648", int.MinValue)]
+        [InlineData("-42", -42)]
+        [InlineData("-1", -1)]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("42", 42)]
+        [InlineData("2147483647", int.MaxValue)]
+        public void Integer(string expected, int value)
+        {
+            Assert.StrictEqual(expected, WriteToString(value));
+        }
+
+        [Theory]
+        // escaped
+        [InlineData(@"\\", '\\')]
+        [InlineData(@"\""", '"')] 
+        // unsecaped
+        [InlineData(@"'", '\'')]
+        [InlineData(@"/", '/')]
+        //
+        // There are 5 ranges of characters that have output in the form of "\u<code>".
+        // The following tests the start and end character and at least one character in each range
+        // and also in between the ranges.
+        //
+        // #1. 0x0000 - 0x001F
+        [InlineData(@"\u0000", (char)0x00)]
+        [InlineData(@"\u0010", (char)0x10)]
+        [InlineData(@"\u001f", (char)0x1f)]
+        // Between #1 and #2
+        [InlineData(@"a", (char)0x61)]
+        // #2. 0x0085 NEXT LINE
+        [InlineData(@"\u0085", (char)0x85)]
+        // Between #2 and #3
+        [InlineData(@"ñ", (char)0xF1)]
+        // #3. 0x2028 LINE SEPARATOR - 0x2029 PARAGRAPH SEPARATOR
+        [InlineData(@"\u2028", (char)0x2028)]
+        [InlineData(@"\u2029", (char)0x2029)]
+        // Between #3 and #4
+        [InlineData(@"漢", (char)0x6F22)]
+        // #4. 0xD800 - 0xDFFF
+        [InlineData(@"\ud800", (char)0xd800)]
+        [InlineData(@"\udabc", (char)0xdabc)]
+        [InlineData(@"\udfff", (char)0xdfff)]
+        // Between #4 and #5
+        [InlineData("\ueabc", (char)0xeabc)]
+        // #5. 0xFFFE - 0xFFFF
+        [InlineData(@"\ufffe", (char)0xfffe)]
+        [InlineData(@"\uffff", (char)0xffff)]
+        public void Character(string expected, char value)
+        {
+            WriteInMultiplePositionsAndCheck(expected, value.ToString());
+        }
+
+        [Theory]
+        [InlineData(@"\ud83d\udc4d", "👍")]
+        public void String(string expected, string value)
+        {
+            WriteInMultiplePositionsAndCheck(expected, value);
+        }
+
+        private static void WriteInMultiplePositionsAndCheck(string expected, string value)
+        {
+            Assert.StrictEqual($"\"{expected}\"", WriteToString(value));
+            Assert.StrictEqual($"\"{expected}_after\"", WriteToString($"{value}_after"));
+            Assert.StrictEqual($"\"before_{expected}\"", WriteToString($"before_{value}"));
+            Assert.StrictEqual($"\"before_{expected}_after\"", WriteToString($"before_{value}_after"));
+        }
+
+        private static string WriteToString(Action<JsonWriter> action)
+        {
+            var stringWriter = new StringWriter();
+
+            using (var jsonWriter = new JsonWriter(stringWriter))
+            {
+                action(jsonWriter);
+            }
+
+            return stringWriter.ToString();
+        }
+
+        private static string WriteToString(bool value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+
+        private static string WriteToString(int value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+
+        private static string WriteToString(string value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
@@ -160,9 +160,6 @@ namespace Roslyn.Utilities
         //
         //   - Avoid intermediate StringBuilder and send escaped output directly to the destination.
         //
-        //   - Stop escaping '/': it is is optional per JSON spec and several users have expressed
-        //     that they don't like the way '\/' looks.
-        //
         private static string EscapeString(string value)
         {
             PooledStringBuilder pooledBuilder = null;
@@ -179,7 +176,7 @@ namespace Roslyn.Utilities
             {
                 char c = value[i];
 
-                if (c == '\"' || c == '\'' || c == '/' || c == '\\' || ShouldAppendAsUnicode(c))
+                if (c == '\"' || c == '\'' || c == '\\' || ShouldAppendAsUnicode(c))
                 {
                     if (b == null)
                     {
@@ -204,9 +201,6 @@ namespace Roslyn.Utilities
                         break;
                     case '\\':
                         b.Append("\\\\");
-                        break;
-                    case '/':
-                        b.Append("\\/");
                         break;
                     case '\'':
                         b.Append("\'");

--- a/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
@@ -162,10 +162,6 @@ namespace Roslyn.Utilities
         //
         // https://github.com/dotnet/corefx/blob/master/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptString.cs
         //
-        // Possible future improvements: https://github.com/dotnet/roslyn/issues/9769
-        //
-        //   - Avoid intermediate StringBuilder and send escaped output directly to the destination.
-        //
         private static string EscapeString(string value)
         {
             PooledStringBuilder pooledBuilder = null;
@@ -182,7 +178,7 @@ namespace Roslyn.Utilities
             {
                 char c = value[i];
 
-                if (c == '\"' || c == '\'' || c == '\\' || ShouldAppendAsUnicode(c))
+                if (c == '\"' || c == '\\' || ShouldAppendAsUnicode(c))
                 {
                     if (b == null)
                     {
@@ -207,9 +203,6 @@ namespace Roslyn.Utilities
                         break;
                     case '\\':
                         b.Append("\\\\");
-                        break;
-                    case '\'':
-                        b.Append("\'");
                         break;
                     default:
                         if (ShouldAppendAsUnicode(c))

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -147,7 +147,7 @@ End Class
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)
@@ -247,7 +247,7 @@ End Class
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
-                var filePath = GetEscapedUriForPath(tree.FilePath);
+                var filePath = GetUriForPath(tree.FilePath);
 
                 return @"
       ""results"": [
@@ -149,9 +149,9 @@ namespace Microsoft.CodeAnalysis
 }";
             }
 
-            public static string GetEscapedUriForPath(string path)
+            public static string GetUriForPath(string path)
             {
-                return new Uri(path, UriKind.RelativeOrAbsolute).ToString().Replace("/", "\\/");
+                return new Uri(path, UriKind.RelativeOrAbsolute).ToString();
             }
         }
 


### PR DESCRIPTION
Warming up for pending update to latest SARIF draft by fixing #9769 first

1. Stop escaping forward slashes (optional per spec and users don't want it)
2. Add tests converted from DataContractSerializer tests that stress the code we borrowed from there for escaping.
3. Let the underlying TextWriter handle all newlines

@dotnet/roslyn-compiler @lgolding @srivatsn  @mavasani @michaelcfanning 