### PR TITLE
Fix #9719: Add Module kind to CLS Compliance checker

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -550,7 +550,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     ReportNonCompliantTypeArguments((DirectCast(type, ArrayTypeSymbol)).ElementType, context, diagnosticSymbol)
                 Case TypeKind.Error, TypeKind.TypeParameter
                     Return
-                Case TypeKind.Class, TypeKind.Structure, TypeKind.Interface, TypeKind.Delegate, TypeKind.Enum, TypeKind.Submission
+                Case TypeKind.Class, TypeKind.Structure, TypeKind.Interface, TypeKind.Delegate, TypeKind.Enum, TypeKind.Submission, TypeKind.Module
                     ReportNonCompliantTypeArguments(DirectCast(type, NamedTypeSymbol), context, diagnosticSymbol)
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(type.TypeKind)
@@ -572,7 +572,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return IsCompliantType((DirectCast(type, ArrayTypeSymbol)).ElementType, context)
                 Case TypeKind.Error, TypeKind.TypeParameter
                     Return True
-                Case TypeKind.Class, TypeKind.Structure, TypeKind.Interface, TypeKind.Delegate, TypeKind.Enum, TypeKind.Submission
+                Case TypeKind.Class, TypeKind.Structure, TypeKind.Interface, TypeKind.Delegate, TypeKind.Enum, TypeKind.Submission, TypeKind.Module
                     Return IsCompliantType(DirectCast(type, NamedTypeSymbol))
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(type.TypeKind)

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/Source/ClsComplianceTests.vb
@@ -3684,5 +3684,35 @@ End Namespace
             comp3.WithOptions(TestOptions.ReleaseModule.WithConcurrentBuild(True)).AssertNoDiagnostics()
         End Sub
 
+        <Fact, WorkItem(9719, "https://github.com/dotnet/roslyn/issues/9719")>
+        Public Sub Bug9719()
+            ' repro was simpler than what's on the github issue - before any fixes, the below snippit triggered the crash
+            Dim source =
+                <compilation>
+                    <file name="a.vb">
+                        <![CDATA[
+Imports System
+
+<Assembly: CLSCompliant(True)>
+
+Public Class C
+    Public Sub Problem(item As DummyModule)
+    End Sub
+End Class
+
+Public Module DummyModule
+
+End Module
+                        ]]>
+                    </file>
+                </compilation>
+
+            CreateCompilationWithMscorlib45AndVBRuntime(source).AssertTheseDiagnostics(<errors><![CDATA[
+BC30371: Module 'DummyModule' cannot be used as a type.
+    Public Sub Problem(item As DummyModule)
+                               ~~~~~~~~~~~
+]]></errors>)
+        End Sub
+
     End Class
 End Namespace


### PR DESCRIPTION
Looks like the CLS compliance checker wasn't handling modules alongside other type-ish things (classes, delegates, etc.). A simple add to two switches seems to handle it - even though I think VB doesn't allow modules with type arguments, I added it there for consistency. (Enums are there too)

The test case is simpler than the original reported issue - before I added Modules to the switches, the test in this PR caused the same crash (ExceptionUtilities.UnexpectedValue).

Ping @jaredpar @gafter - not sure who else to ping for review.