### PR TITLE
create active file analyzers non-lazily.

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.IncrementalAnalyzerProcessor.cs
@@ -52,7 +52,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     _lazyDiagnosticAnalyzerService = new Lazy<IDiagnosticAnalyzerService>(() => GetDiagnosticAnalyzerService(analyzerProviders));
 
-                    var lazyActiveFileAnalyzers = new Lazy<ImmutableArray<IIncrementalAnalyzer>>(() => GetActiveFileIncrementalAnalyzers(_registration, analyzerProviders));
+                    // create active file analyzers right away
+                    var activeFileAnalyzers = GetActiveFileIncrementalAnalyzers(_registration, analyzerProviders);
+
+                    // create non active file analyzers lazily.
                     var lazyAllAnalyzers = new Lazy<ImmutableArray<IIncrementalAnalyzer>>(() => GetIncrementalAnalyzers(_registration, analyzerProviders));
 
                     // event and worker queues
@@ -60,7 +63,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                     var globalNotificationService = _registration.GetService<IGlobalOperationNotificationService>();
 
-                    _highPriorityProcessor = new HighPriorityProcessor(listener, this, lazyActiveFileAnalyzers, highBackOffTimeSpanInMs, shutdownToken);
+                    _highPriorityProcessor = new HighPriorityProcessor(listener, this, activeFileAnalyzers, highBackOffTimeSpanInMs, shutdownToken);
                     _normalPriorityProcessor = new NormalPriorityProcessor(listener, this, lazyAllAnalyzers, globalNotificationService, normalBackOffTimeSpanInMs, shutdownToken);
                     _lowPriorityProcessor = new LowPriorityProcessor(listener, this, lazyAllAnalyzers, globalNotificationService, lowBackOffTimeSpanInMs, shutdownToken);
                 }


### PR DESCRIPTION
we used to create all solution crawler analyzers lazily. which means all analyzers only register themselves once the very first solution crawler pass has run.

this caused ctrl+. for LB right after solution open sometimes not work since solution crawler didn't run its first pass yet so there is no analyzers registered to system.

now, we create solution crawler analyzers for active files non-lazily. those analyzers should be ready right away once solution is up.

fix https://github.com/dotnet/roslyn/issues/10877