### PR TITLE
Tuples: adding tests for local functions and reserved element names

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -489,7 +489,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static bool CheckTupleMemberName(string name, int position, CSharpSyntaxNode syntax, DiagnosticBag diagnostics, PooledHashSet<string> uniqueFieldNames)
         {
-            int reserved = TupleTypeSymbol.IsMemberNameReserved(name);
+            int reserved = TupleTypeSymbol.IsElementNameReserved(name);
             if (reserved == 0)
             {
                 Error(diagnostics, ErrorCode.ERR_TupleReservedMemberNameAnyPosition, syntax, name);

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -493,17 +493,33 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return "Item" + position;
         }
 
+        // This array needs to be sorted for binary searching
+        private static readonly string[] reservedMemberNames = new[]
+        {
+            "CombineHashCodes",
+            "CompareTo",
+            "Create",
+            "Deconstruct",
+            "Equals",
+            "GetHashCode",
+            "GetHashCodeCore",
+            "Rest",
+            "Size",
+            "ToString",
+            "ToStringEnd"
+        };
+
         /// <summary>
         /// Checks whether the field name is reserved and tells us which position it's reserved for.
         ///
         /// For example:
         /// Returns 3 for "Item3".
-        /// Returns 0 for "Rest".
+        /// Returns 0 for "Rest", "ToString" and other members of System.ValueTuple.
         /// Returns -1 for names that aren't reserved.
         /// </summary>
         internal static int IsMemberNameReserved(string name)
         {
-            if (String.Equals(name, "Rest", StringComparison.Ordinal))
+            if (Array.BinarySearch(reservedMemberNames, name, StringComparer.Ordinal) >= 0)
             {
                 return 0;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -497,17 +497,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             switch (name)
             {
-                case "CombineHashCodes":
                 case "CompareTo":
-                case "Create":
                 case "Deconstruct":
                 case "Equals":
                 case "GetHashCode":
-                case "GetHashCodeCore":
                 case "Rest":
-                case "Size":
                 case "ToString":
-                case "ToStringEnd":
                     return true;
 
                 default:

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -94,8 +94,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static TupleTypeSymbol Create(NamedTypeSymbol tupleCompatibleType)
         {
             return Create(ImmutableArray<Location>.Empty,
-                          tupleCompatibleType, 
-                          default(ImmutableArray<Location>), 
+                          tupleCompatibleType,
+                          default(ImmutableArray<Location>),
                           default(ImmutableArray<string>));
         }
 
@@ -493,21 +493,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return "Item" + position;
         }
 
-        // This array needs to be sorted for binary searching
-        private static readonly string[] reservedMemberNames = new[]
+        private static bool IsElementNameForbidden(string name)
         {
-            "CombineHashCodes",
-            "CompareTo",
-            "Create",
-            "Deconstruct",
-            "Equals",
-            "GetHashCode",
-            "GetHashCodeCore",
-            "Rest",
-            "Size",
-            "ToString",
-            "ToStringEnd"
-        };
+            switch (name)
+            {
+                case "CombineHashCodes":
+                case "CompareTo":
+                case "Create":
+                case "Deconstruct":
+                case "Equals":
+                case "GetHashCode":
+                case "GetHashCodeCore":
+                case "Rest":
+                case "Size":
+                case "ToString":
+                case "ToStringEnd":
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
 
         /// <summary>
         /// Checks whether the field name is reserved and tells us which position it's reserved for.
@@ -517,9 +523,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Returns 0 for "Rest", "ToString" and other members of System.ValueTuple.
         /// Returns -1 for names that aren't reserved.
         /// </summary>
-        internal static int IsMemberNameReserved(string name)
+        internal static int IsElementNameReserved(string name)
         {
-            if (Array.BinarySearch(reservedMemberNames, name, StringComparer.Ordinal) >= 0)
+            if (IsElementNameForbidden(name))
             {
                 return 0;
             }
@@ -554,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(type.IsDefinition);
 
             MemberDescriptor relativeDescriptor = WellKnownMembers.GetDescriptor(relativeMember);
-            return CSharpCompilation.GetRuntimeMember(type, ref relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance, 
+            return CSharpCompilation.GetRuntimeMember(type, ref relativeDescriptor, CSharpCompilation.SpecialMembersSignatureComparer.Instance,
                                                       accessWithinOpt: null); // force lookup of public members only
         }
 
@@ -857,7 +863,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
 
                     members.Add(new TupleErrorFieldSymbol(this, name, i,
-                                                      _elementLocations.IsDefault ? null : _elementLocations[i], 
+                                                      _elementLocations.IsDefault ? null : _elementLocations[i],
                                                       _elementTypes[i],
                                                       diagnosticInfo));
                 }
@@ -891,7 +897,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // Go in reverse because we want members with default name, which precede the ones with
                     // friendly names, to be in the map.  
-                    for (int i = members.Length - 1; i >= 0; i--) 
+                    for (int i = members.Length - 1; i >= 0; i--)
                     {
                         var member = members[i];
                         switch (member.Kind)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -2364,6 +2364,57 @@ class C
         }
 
         [Fact]
+        public void TupleWithExistingUnderlyingMemberNames()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            comp.VerifyDiagnostics(
+                // (6,18): error CS8202: Tuple membername 'CombineHashCodes' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CombineHashCodes").WithArguments("CombineHashCodes").WithLocation(6, 18),
+                // (6,39): error CS8202: Tuple membername 'CompareTo' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CompareTo").WithArguments("CompareTo").WithLocation(6, 39),
+                // (6,53): error CS8202: Tuple membername 'Create' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Create").WithArguments("Create").WithLocation(6, 53),
+                // (6,64): error CS8202: Tuple membername 'Deconstruct' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Deconstruct").WithArguments("Deconstruct").WithLocation(6, 64),
+                // (6,80): error CS8202: Tuple membername 'Equals' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Equals").WithArguments("Equals").WithLocation(6, 80),
+                // (6,91): error CS8202: Tuple membername 'GetHashCode' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCode").WithArguments("GetHashCode").WithLocation(6, 91),
+                // (6,107): error CS8202: Tuple membername 'GetHashCodeCore' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCodeCore").WithArguments("GetHashCodeCore").WithLocation(6, 107),
+                // (6,127): error CS8202: Tuple membername 'Rest' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 127),
+                // (6,136): error CS8202: Tuple membername 'Size' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Size").WithArguments("Size").WithLocation(6, 136),
+                // (6,145): error CS8202: Tuple membername 'ToString' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToString").WithArguments("ToString").WithLocation(6, 145),
+                // (6,159): error CS8202: Tuple membername 'ToStringEnd' is disallowed at any position.
+                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToStringEnd").WithArguments("ToStringEnd").WithLocation(6, 159)
+                );
+        }
+
+        [Fact]
         public void LongTupleDeclaration()
         {
             var source = @"
@@ -5842,7 +5893,7 @@ class C
             Assert.Equal("(int, int)", m1Tuple.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("(int a2, int b2)", m2Tuple.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("public struct ValueTuple<T1, T2>", m1Tuple.TupleUnderlyingType.DeclaringSyntaxReferences.Single().GetSyntax().ToString().Substring(0, 32));
-                         
+
             AssertTupleTypeEquality(m2Tuple);
             AssertTupleTypeEquality(m6Tuple);
 
@@ -5923,7 +5974,7 @@ class C
 
             var members = tuple.GetMembers();
 
-            for(int i = 0; i < members.Length; i++)
+            for (int i = 0; i < members.Length; i++)
             {
                 for (int j = 0; j < members.Length; j++)
                 {
@@ -5937,7 +5988,7 @@ class C
             }
 
             var underlyingMembers = tuple.TupleUnderlyingType.GetMembers();
-            foreach(var m in members)
+            foreach (var m in members)
             {
                 Assert.False(underlyingMembers.Any(u => u.Equals(m)));
                 Assert.False(underlyingMembers.Any(u => m.Equals(u)));
@@ -6794,7 +6845,7 @@ class C
                     ".Item8"
                 );
         }
-        
+
         [Fact]
         public void DefaultAndFriendlyElementNames_08()
         {
@@ -7758,7 +7809,7 @@ namespace System
                              t13.ToTestDisplayString());
             }
 
-            var m3Tuple = (NamedTypeSymbol)c.GetMember<MethodSymbol>("M3").ReturnType;       
+            var m3Tuple = (NamedTypeSymbol)c.GetMember<MethodSymbol>("M3").ReturnType;
             {
                 var t1 = TupleTypeSymbol.Create(null, m3Tuple.TupleUnderlyingType, default(ImmutableArray<Location>), default(ImmutableArray<string>));
                 var t2 = TupleTypeSymbol.Create(null, m3Tuple.TupleUnderlyingType, default(ImmutableArray<Location>), default(ImmutableArray<string>));
@@ -9214,6 +9265,104 @@ class C
 
             Assert.True(xSymbol.TupleUnderlyingType.IsErrorType());
             Assert.False(xSymbol.IsReferenceType); // if no underlying type, then defaults to struct
+        }
+
+        [Fact]
+        public void LocalFunction()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int, int) Local((int, int) x) { return x; }
+        System.Console.WriteLine(Local((1, 2)));
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}", parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LocalFunctionWithNamedTuple()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int a, int b) Local((int c, int d) x) { return x; }
+        System.Console.WriteLine(Local((d: 1, c: 2)).b);
+    }
+}
+" + trivial2uple;
+
+            var comp = CompileAndVerify(source, expectedOutput: "2", parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LocalFunctionWithLongTuple()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        (int, string, int, string, int, string, int, string) Local((int, string, int, string, int, string, int, string) x) { return x; }
+        System.Console.WriteLine(Local((1, ""Alice"", 2, ""Brenda"", 3, ""Chloe"", 4, ""Dylan"")));
+    }
+}
+";
+
+            var comp = CompileAndVerify(source, expectedOutput: "(1, Alice, 2, Brenda, 3, Chloe, 4, Dylan)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TupleMembersInLambda()
+        {
+            var source = @"
+using System;
+class C
+{
+    static Action action;
+
+    static void Main()
+    {
+        var tuple = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8);
+        action += () => { Console.Write(tuple.Item1 + "" "" + tuple.a + "" "" + tuple.Rest + "" "" + tuple.Item8 + "" "" + tuple.h); };
+        action();
+    }
+}
+";
+
+            var comp = CompileAndVerify(source, expectedOutput: "1 1 (8) 8 8", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void LongTupleConstructor()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        var x = new (int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8);
+        System.Console.WriteLine(x);
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            comp.VerifyDiagnostics(
+                // (6,83): error CS1503: Argument 8: cannot convert from 'int' to '(int)'
+                //         var x = new (int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8);
+                Diagnostic(ErrorCode.ERR_BadArgType, "8").WithArguments("8", "int", "(int)").WithLocation(6, 83)
+                );
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -9267,7 +9267,7 @@ class C
             Assert.False(xSymbol.IsReferenceType); // if no underlying type, then defaults to struct
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.LocalFunctions)]
         public void LocalFunction()
         {
             var source = @"
@@ -9303,7 +9303,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [Fact, CompilerTrait(CompilerFeature.LocalFunctions)]
         public void LocalFunctionWithLongTuple()
         {
             var source = @"
@@ -9352,7 +9352,7 @@ class C
     void M()
     {
         var x = new (int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8);
-        System.Console.WriteLine(x);
+        var y = new (int, int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 }
 ";
@@ -9361,7 +9361,10 @@ class C
             comp.VerifyDiagnostics(
                 // (6,83): error CS1503: Argument 8: cannot convert from 'int' to '(int)'
                 //         var x = new (int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8);
-                Diagnostic(ErrorCode.ERR_BadArgType, "8").WithArguments("8", "int", "(int)").WithLocation(6, 83)
+                Diagnostic(ErrorCode.ERR_BadArgType, "8").WithArguments("8", "int", "(int)").WithLocation(6, 83),
+                // (7,21): error CS1729: '(int, int, int, int, int, int, int, int, int)' does not contain a constructor that takes 9 arguments
+                //         var y = new (int, int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8, 9);
+                Diagnostic(ErrorCode.ERR_BadCtorArgCount, "(int, int, int, int, int, int, int, int, int)").WithArguments("(int, int, int, int, int, int, int, int, int)", "9").WithLocation(7, 21)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -2371,47 +2371,50 @@ class C
 {
     static void Main()
     {
-        var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
+        var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
     }
 }
 ";
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics(
-                // (6,18): error CS8202: Tuple membername 'CombineHashCodes' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CombineHashCodes").WithArguments("CombineHashCodes").WithLocation(6, 18),
-                // (6,39): error CS8202: Tuple membername 'CompareTo' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CompareTo").WithArguments("CompareTo").WithLocation(6, 39),
-                // (6,53): error CS8202: Tuple membername 'Create' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Create").WithArguments("Create").WithLocation(6, 53),
-                // (6,64): error CS8202: Tuple membername 'Deconstruct' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Deconstruct").WithArguments("Deconstruct").WithLocation(6, 64),
-                // (6,80): error CS8202: Tuple membername 'Equals' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Equals").WithArguments("Equals").WithLocation(6, 80),
-                // (6,91): error CS8202: Tuple membername 'GetHashCode' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCode").WithArguments("GetHashCode").WithLocation(6, 91),
-                // (6,107): error CS8202: Tuple membername 'GetHashCodeCore' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCodeCore").WithArguments("GetHashCodeCore").WithLocation(6, 107),
-                // (6,127): error CS8202: Tuple membername 'Rest' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 127),
-                // (6,136): error CS8202: Tuple membername 'Size' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Size").WithArguments("Size").WithLocation(6, 136),
-                // (6,145): error CS8202: Tuple membername 'ToString' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToString").WithArguments("ToString").WithLocation(6, 145),
-                // (6,159): error CS8202: Tuple membername 'ToStringEnd' is disallowed at any position.
-                //         var x = (CombineHashCodes: 1, CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, GetHashCodeCore: 7, Rest: 8, Size: 9, ToString: 10, ToStringEnd: 11);
-                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToStringEnd").WithArguments("ToStringEnd").WithLocation(6, 159)
+                // (6,18): error CS8202: Tuple membername 'CompareTo' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CompareTo").WithArguments("CompareTo").WithLocation(6, 18),
+                // (6,43): error CS8202: Tuple membername 'Deconstruct' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Deconstruct").WithArguments("Deconstruct").WithLocation(6, 43),
+                // (6,59): error CS8202: Tuple membername 'Equals' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Equals").WithArguments("Equals").WithLocation(6, 59),
+                // (6,70): error CS8202: Tuple membername 'GetHashCode' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCode").WithArguments("GetHashCode").WithLocation(6, 70),
+                // (6,86): error CS8202: Tuple membername 'Rest' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 86),
+                // (6,95): error CS8202: Tuple membername 'ToString' is disallowed at any position.
+                //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
+                Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToString").WithArguments("ToString").WithLocation(6, 95)
                 );
+        }
+
+        [Fact]
+        public void TupleWithExistingInaccessibleUnderlyingMemberNames()
+        {
+            var source = @"
+class C
+{
+    static void Main()
+    {
+        var x = (CombineHashCodes: 1, Create: 2, GetHashCodeCore: 3, Size: 4, ToStringEnd: 5);
+        System.Console.WriteLine(x.CombineHashCodes + "" "" + x.Create + "" "" + x.GetHashCodeCore + "" "" + x.Size + "" "" + x.ToStringEnd);
+    }
+}
+";
+
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]


### PR DESCRIPTION
Adding reserved name behavior as discussed with Aleksey, to fix #10802.
We might consider checking the underlying type instead once we have the new conversion code (that will perform some checks on names/members as well).

Adding a few tests that came to my mind.

@dotnet/roslyn-compiler for review.