### PR TITLE
Fix for NRE in VSO Watson bug 217660

### DIFF
--- a/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/DocumentEventArgs.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -10,6 +11,7 @@ namespace Microsoft.CodeAnalysis
 
         public DocumentEventArgs(Document document)
         {
+            Contract.ThrowIfNull(document);
             this.Document = document;
         }
     }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Events.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis
         protected Task RaiseDocumentOpenedEventAsync(Document document)
         {
             var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentOpenedEventName);
-            if (ev.HasHandlers)
+            if (ev.HasHandlers && document != null)
             {
                 return this.ScheduleTask(() =>
                 {
@@ -142,7 +142,7 @@ namespace Microsoft.CodeAnalysis
         protected Task RaiseDocumentClosedEventAsync(Document document)
         {
             var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentClosedEventName);
-            if (ev.HasHandlers)
+            if (ev.HasHandlers && document != null)
             {
                 return this.ScheduleTask(() =>
                 {
@@ -176,7 +176,7 @@ namespace Microsoft.CodeAnalysis
         protected Task RaiseDocumentActiveContextChangedEventAsync(Document document)
         {
             var ev = _eventMap.GetEventHandlers<EventHandler<DocumentEventArgs>>(DocumentActiveContextChangedName);
-            if (ev.HasHandlers)
+            if (ev.HasHandlers && document != null)
             {
                 return this.ScheduleTask(() =>
                 {


### PR DESCRIPTION
Add null checks before raising events.

Fixes [217660](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=217660&triage=true)