### PR TITLE
Remove dependency on MetadataBuilder internals

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
@@ -51,7 +51,7 @@ public class C
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrument("Test.Flag"));
        
             var peReader = new PEReader(peImage);
-            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader);
+            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             VerifyDocuments(reader, reader.Documents,
                 @"'C:\myproject\doc1.cs' B8-F7-5B-45-79-BC-51-18-00-2B-11-40-B6-E8-E2-85-28-D9-11-0C (SHA1)");
@@ -165,7 +165,7 @@ public class C
             var peImage = c.EmitToArray(EmitOptions.Default.WithInstrument("Test.Flag"));
 
             var peReader = new PEReader(peImage);
-            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader);
+            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             VerifyDocuments(reader, reader.Documents,
                 @"'C:\myproject\doc1.cs' EE-A5-42-12-BD-ED-90-96-8D-12-54-DE-D0-F0-4F-EC-79-C6-2A-89 (SHA1)");
@@ -217,14 +217,14 @@ public class C
             var peImage = c.EmitToArray(EmitOptions.Default);
 
             var peReader = new PEReader(peImage);
-            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader);
+            var reader = DynamicAnalysisDataReader.TryCreateFromPE(peReader, "<DynamicAnalysisData>");
 
             Assert.Null(reader);
         }
 
         private static void VerifySpans(DynamicAnalysisDataReader reader, DynamicAnalysisMethod methodData, params string[] expected)
         {
-            AssertEx.Equal(expected, reader.GetSpans(methodData.Blob).Select(s => s.ToString()));
+            AssertEx.Equal(expected, reader.GetSpans(methodData.Blob).Select(s => $"({s.StartLine},{s.StartColumn})-({s.EndLine},{s.EndColumn})"));
         }
 
         private void VerifyDocuments(DynamicAnalysisDataReader reader, ImmutableArray<DynamicAnalysisDocument> documents, params string[] expected)

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -860,6 +860,8 @@ namespace Microsoft.CodeAnalysis.Emit
             }
         }
 
+        int Cci.IModule.DebugDocumentCount => _debugDocuments.Count;
+
         #endregion
 
         #region INamedEntity

--- a/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/FullMetadataWriter.cs
@@ -61,7 +61,10 @@ namespace Microsoft.Cci
                     break;
             }
 
-            var dynamicAnalysisDataWriterOpt = context.ModuleBuilder.EmitOptions.EmitDynamicAnalysisData ? new DynamicAnalysisDataWriter() : null;
+            var dynamicAnalysisDataWriterOpt = context.ModuleBuilder.EmitOptions.EmitDynamicAnalysisData ? 
+                new DynamicAnalysisDataWriter(context.Module.DebugDocumentCount, context.Module.HintNumberOfMethodDefinitions) : 
+                null;
+
             return new FullMetadataWriter(context, builder, debugBuilderOpt, dynamicAnalysisDataWriterOpt, messageProvider, allowMissingMethodBodies, deterministic, cancellationToken);
         }
 

--- a/src/Compilers/Core/Portable/PEWriter/Units.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Units.cs
@@ -205,6 +205,12 @@ namespace Microsoft.Cci
         // provide a basis for approximating the capacities of
         // various databases used during Emit.
         int HintNumberOfMethodDefinitions { get; }
+
+        /// <summary>
+        /// Number of debug documents in the module. 
+        /// Used to determine capacities of lists and indices when emitting debug info.
+        /// </summary>
+        int DebugDocumentCount { get; }
     }
 
     internal struct DefinitionWithLocation


### PR DESCRIPTION
Some APIs currently used for writing DynamicAnalysis resource are not gonna be exposed by the System.Reflection.Metadata.