### PR TITLE
Bring /errorlog output up to SARIF draft 1.0.0-beta.5

### DIFF
--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -21,16 +21,11 @@ The SARIF standard allows the `properties` property of `result` objects
 to contain arbitrary (string, string) key-value pairs.
 
 The keys and values used by the C# and VB compilers are serialized from
-the corresponding `Microsoft.CodeAnalysis.Diagnostic` and its
-`Microsoft.CodeAnalysis.DiagnosticDescriptor` as follows:
+the corresponding `Microsoft.CodeAnalysis.Diagnostic` as follows:
 
 Key                      | Value
 ------------------------ | ------------
-"severity"               | `Diagnostic.Severity` ("Hidden", "Info", "Warning, or "Error")
-"warningLevel"           | `Diagnostic.WarningLevel` ("1", "2", "3", or "4" for "Warning" severity; omitted otherwise)
-"defaultSeverity"        | `Diagnostic.DefaultSeverity` ("Hidden", "Info", "Warning, "Error")
-"title"                  | `DiagnosticDesciptor.Title` (omitted if null or empty)
+"warningLevel"           | `Diagnostic.WarningLevel`
 "category"               | `Diagnostic.Category`
-"helpLink"               | `DiagnosticDescriptor.HelpLink` (omitted if null or empty)
-"isEnabledByDefault"     | `Diagnostic.IsEnabledByDefault` ("True" or "False")
-"customProperties.[key]" | `Diagnostic.Properties[key]` (for each key in the dictionary)
+"isEnabledByDefault"     | `Diagnostic.IsEnabledByDefault
+"customProperties"       | `Diagnostic.Properties` 

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -120,25 +120,25 @@ public class C
           ""defaultLevel"": ""warning"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry""
+            ]
+          }}
         }},
         ""CS5001"": {{
           ""id"": ""CS5001"",
           ""defaultLevel"": ""error"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry"",
-            ""NotConfigurable""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
         }}
       }}
     }}
@@ -220,25 +220,25 @@ public class C
           ""defaultLevel"": ""warning"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry""
+            ]
+          }}
         }},
         ""CS5001"": {{
           ""id"": ""CS5001"",
           ""defaultLevel"": ""error"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry"",
-            ""NotConfigurable""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
         }}
       }}
     }}

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -92,7 +92,7 @@ public class C
           ""message"": ""The field 'C.x' is never used"",
           ""locations"": [
             {{
-              ""analysisTarget"": {{
+              ""resultFile"": {{
                 ""uri"": ""{0}"",
                 ""region"": {{
                   ""startLine"": 4,
@@ -192,7 +192,7 @@ public class C
           ],
           ""locations"": [
             {{
-              ""analysisTarget"": {{
+              ""resultFile"": {{
                 ""uri"": ""{0}"",
                 ""region"": {{
                   ""startLine"": 5,

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -88,24 +88,21 @@ public class C
       ""results"": [
         {{
           ""ruleId"": ""CS0169"",
-          ""kind"": ""warning"",
+          ""level"": ""warning"",
           ""locations"": [
             {{
-              ""analysisTarget"": [
-                {{
-                  ""uri"": ""{0}"",
-                  ""region"": {{
-                    ""startLine"": 4,
-                    ""startColumn"": 17,
-                    ""endLine"": 4,
-                    ""endColumn"": 18
-                  }}
+              ""analysisTarget"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 4,
+                  ""startColumn"": 17,
+                  ""endLine"": 4,
+                  ""endColumn"": 18
                 }}
-              ]
+              }}
             }}
           ],
-          ""fullMessage"": ""The field 'C.x' is never used"",
-          ""isSuppressedInSource"": false,
+          ""message"": ""The field 'C.x' is never used"",
           ""tags"": [
             ""Compiler"",
             ""Telemetry""
@@ -121,11 +118,8 @@ public class C
         }},
         {{
           ""ruleId"": ""CS5001"",
-          ""kind"": ""error"",
-          ""locations"": [
-          ],
-          ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
-          ""isSuppressedInSource"": false,
+          ""level"": ""error"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point"",
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
@@ -183,24 +177,24 @@ public class C
       ""results"": [
         {{
           ""ruleId"": ""CS0169"",
-          ""kind"": ""warning"",
+          ""level"": ""warning"",
           ""locations"": [
             {{
-              ""analysisTarget"": [
-                {{
-                  ""uri"": ""{0}"",
-                  ""region"": {{
-                    ""startLine"": 5,
-                    ""startColumn"": 17,
-                    ""endLine"": 5,
-                    ""endColumn"": 18
-                  }}
+              ""analysisTarget"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 5,
+                  ""startColumn"": 17,
+                  ""endLine"": 5,
+                  ""endColumn"": 18
                 }}
-              ]
+              }}
             }}
           ],
-          ""fullMessage"": ""The field 'C.x' is never used"",
-          ""isSuppressedInSource"": true,
+          ""message"": ""The field 'C.x' is never used"",
+          ""suppressionStates"": [
+            ""suppressedInSource""
+          ],
           ""tags"": [
             ""Compiler"",
             ""Telemetry""
@@ -216,11 +210,8 @@ public class C
         }},
         {{
           ""ruleId"": ""CS5001"",
-          ""kind"": ""error"",
-          ""locations"": [
-          ],
-          ""fullMessage"": ""Program does not contain a static 'Main' method suitable for an entry point"",
-          ""isSuppressedInSource"": false,
+          ""level"": ""error"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point"",
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -89,6 +89,7 @@ public class C
         {{
           ""ruleId"": ""CS0169"",
           ""level"": ""warning"",
+          ""message"": ""The field 'C.x' is never used"",
           ""locations"": [
             {{
               ""analysisTarget"": {{
@@ -102,37 +103,44 @@ public class C
               }}
             }}
           ],
-          ""message"": ""The field 'C.x' is never used"",
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ],
           ""properties"": {{
-            ""severity"": ""Warning"",
-            ""warningLevel"": ""3"",
-            ""defaultSeverity"": ""Warning"",
-            ""title"": ""Field is never used"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
+            ""warningLevel"": 3
           }}
         }},
         {{
           ""ruleId"": ""CS5001"",
           ""level"": ""error"",
-          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
+        }}
+      ],
+      ""rules"": {{
+        ""CS0169"": {{
+          ""id"": ""CS0169"",
+          ""shortDescription"": ""Field is never used"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
+          ""tags"": [
+            ""Compiler"",
+            ""Telemetry""
+          ]
+        }},
+        ""CS5001"": {{
+          ""id"": ""CS5001"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
             ""NotConfigurable""
-          ],
-          ""properties"": {{
-            ""severity"": ""Error"",
-            ""defaultSeverity"": ""Error"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
-          }}
+          ]
         }}
-      ]
+      }}
     }}
   ]
 }}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
@@ -178,6 +186,10 @@ public class C
         {{
           ""ruleId"": ""CS0169"",
           ""level"": ""warning"",
+          ""message"": ""The field 'C.x' is never used"",
+          ""suppressionStates"": [
+            ""suppressedInSource""
+          ],
           ""locations"": [
             {{
               ""analysisTarget"": {{
@@ -191,40 +203,44 @@ public class C
               }}
             }}
           ],
-          ""message"": ""The field 'C.x' is never used"",
-          ""suppressionStates"": [
-            ""suppressedInSource""
-          ],
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ],
           ""properties"": {{
-            ""severity"": ""Warning"",
-            ""warningLevel"": ""3"",
-            ""defaultSeverity"": ""Warning"",
-            ""title"": ""Field is never used"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
+            ""warningLevel"": 3
           }}
         }},
         {{
           ""ruleId"": ""CS5001"",
           ""level"": ""error"",
-          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point"",
+          ""message"": ""Program does not contain a static 'Main' method suitable for an entry point""
+        }}
+      ],
+      ""rules"": {{
+        ""CS0169"": {{
+          ""id"": ""CS0169"",
+          ""shortDescription"": ""Field is never used"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
+          ""tags"": [
+            ""Compiler"",
+            ""Telemetry""
+          ]
+        }},
+        ""CS5001"": {{
+          ""id"": ""CS5001"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
             ""NotConfigurable""
-          ],
-          ""properties"": {{
-            ""severity"": ""Error"",
-            ""defaultSeverity"": ""Error"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
-          }}
+          ]
         }}
-      ]
+      }}
     }}
   ]
 }}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));

--- a/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/ErrorLoggerTests.cs
@@ -141,7 +141,7 @@ public class C
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);
@@ -236,7 +236,7 @@ public class C
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFile));
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFile));
 
             var expectedText = expectedHeader + expectedIssues;
             Assert.Equal(expectedText, actualOutput);

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -40,6 +40,7 @@
     <Compile Include="Emit\CustomDebugInfoTests.cs" />
     <Compile Include="FileSystem\PathUtilitiesTests.cs" />
     <Compile Include="InternalUtilities\StreamExtensionsTests.cs" />
+    <Compile Include="InternalUtilities\JsonWriterTests.cs" />
     <Compile Include="InternalUtilities\StringExtensionsTests.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityExtensions.cs" />
     <Compile Include="MetadataReferences\AssemblyIdentityMapTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -28,6 +28,7 @@
     <Compile Include="Collections\BoxesTest.cs" />
     <Compile Include="Collections\ByteSequenceComparerTests.cs" />
     <Compile Include="CryptoBlobParserTests.cs" />
+    <Compile Include="Diagnostics\ErrorLoggerTests.cs" />
     <Compile Include="Diagnostics\AnalysisContextInfoTests.cs" />
     <Compile Include="Diagnostics\BoxingOperationAnalyzer.cs" />
     <Compile Include="Diagnostics\CouldHaveMoreSpecificTypeAnalyzer.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Xunit;
+using System.IO;
+using System;
+using System.Globalization;
+using System.Text;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
+{
+    // See also VB and C# command line unit tests for additional coverage.
+    public class ErrorLoggerTests
+    {
+        [Fact]
+        public void AdditionalLocationsAsRelatedLocations()
+        {
+            var stream = new MemoryStream();
+            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), CultureInfo.InvariantCulture))
+            {
+                var mainLocation = Location.Create(@"Z:\MainLocation.cs", new TextSpan(0, 0), new LinePositionSpan(LinePosition.Zero, LinePosition.Zero));
+                var additionalLocation = Location.Create(@"Z:\AdditionalLocation.cs", new TextSpan(0, 0), new LinePositionSpan(LinePosition.Zero, LinePosition.Zero));
+                var descriptor = new DiagnosticDescriptor("TST", "_TST_", "", "", DiagnosticSeverity.Error, false);
+
+                IEnumerable<Location> additionalLocations = new[] { additionalLocation };
+                logger.LogDiagnostic(Diagnostic.Create(descriptor, mainLocation, additionalLocations));
+            }
+
+            string expected = 
+@"{
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
+  ""version"": ""1.0.0-beta.5"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""toolName"",
+        ""version"": ""1.2.3.4"",
+        ""fileVersion"": ""1.2.3.4"",
+        ""semanticVersion"": ""1.2.3""
+      },
+      ""results"": [
+        {
+          ""ruleId"": ""TST"",
+          ""level"": ""error"",
+          ""locations"": [
+            {
+              ""resultFile"": {
+                ""uri"": ""file:///Z:/MainLocation.cs"",
+                ""region"": {
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 1
+                }
+              }
+            }
+          ],
+          ""relatedLocations"": [
+            {
+              ""physicalLocation"": {
+                ""uri"": ""file:///Z:/AdditionalLocation.cs"",
+                ""region"": {
+                  ""startLine"": 1,
+                  ""startColumn"": 1,
+                  ""endLine"": 1,
+                  ""endColumn"": 1
+                }
+              }
+            }
+          ]
+        }
+      ],
+      ""rules"": {
+        ""TST"": {
+          ""id"": ""TST"",
+          ""shortDescription"": ""_TST_"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {
+            ""isEnabledByDefault"": false
+          }
+        }
+      }
+    }
+  ]
+}";
+            string actual = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void DescriptorIdCollision()
+        {
+            var descriptors = new[] {
+                new DiagnosticDescriptor("TST001.001",    "_TST001.001_",     "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST001",        "_TST001_",         "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST001",        "_TST001.002_",     "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST001",        "_TST001.003_",     "", "", DiagnosticSeverity.Warning, true),
+            };
+
+            var stream = new MemoryStream();
+            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), CultureInfo.InvariantCulture))
+            {
+                for (int i = 0; i < 2; i++)
+                {
+                    foreach (var descriptor in descriptors)
+                    {
+                        logger.LogDiagnostic(Diagnostic.Create(descriptor, Location.None));
+                    }
+                }
+            }
+
+            string expected = 
+@"{
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
+  ""version"": ""1.0.0-beta.5"",
+  ""runs"": [
+    {
+      ""tool"": {
+        ""name"": ""toolName"",
+        ""version"": ""1.2.3.4"",
+        ""fileVersion"": ""1.2.3.4"",
+        ""semanticVersion"": ""1.2.3""
+      },
+      ""results"": [
+        {
+          ""ruleId"": ""TST001.001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""ruleKey"": ""TST001.002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""ruleKey"": ""TST001.003"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001.001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""ruleKey"": ""TST001.002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""ruleKey"": ""TST001.003"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        }
+      ],
+      ""rules"": {
+        ""TST001"": {
+          ""id"": ""TST001"",
+          ""shortDescription"": ""_TST001_"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST001.001"": {
+          ""id"": ""TST001.001"",
+          ""shortDescription"": ""_TST001.001_"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST001.002"": {
+          ""id"": ""TST001"",
+          ""shortDescription"": ""_TST001.002_"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST001.003"": {
+          ""id"": ""TST001"",
+          ""shortDescription"": ""_TST001.003_"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        }
+      }
+    }
+  ]
+}";
+            string actual = Encoding.UTF8.GetString(stream.ToArray());
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/JsonWriterTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/InternalUtilities/JsonWriterTests.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Xunit;
+
+namespace Roslyn.Utilities.UnitTests.InternalUtilities
+{
+    public class JsonWriterTests
+    {
+        [Theory]
+        [InlineData("true", true)]
+        [InlineData("false", false)]
+        public void Boolean(string expected, bool value)
+        {
+            Assert.StrictEqual(expected, WriteToString(value));
+        }
+
+        [Theory]
+        [InlineData("-2147483648", int.MinValue)]
+        [InlineData("-42", -42)]
+        [InlineData("-1", -1)]
+        [InlineData("0", 0)]
+        [InlineData("1", 1)]
+        [InlineData("42", 42)]
+        [InlineData("2147483647", int.MaxValue)]
+        public void Integer(string expected, int value)
+        {
+            Assert.StrictEqual(expected, WriteToString(value));
+        }
+
+        [Theory]
+        // escaped
+        [InlineData(@"\\", '\\')]
+        [InlineData(@"\""", '"')] 
+        // unsecaped
+        [InlineData(@"'", '\'')]
+        [InlineData(@"/", '/')]
+        //
+        // There are 5 ranges of characters that have output in the form of "\u<code>".
+        // The following tests the start and end character and at least one character in each range
+        // and also in between the ranges.
+        //
+        // #1. 0x0000 - 0x001F
+        [InlineData(@"\u0000", (char)0x00)]
+        [InlineData(@"\u0010", (char)0x10)]
+        [InlineData(@"\u001f", (char)0x1f)]
+        // Between #1 and #2
+        [InlineData(@"a", (char)0x61)]
+        // #2. 0x0085 NEXT LINE
+        [InlineData(@"\u0085", (char)0x85)]
+        // Between #2 and #3
+        [InlineData(@"ñ", (char)0xF1)]
+        // #3. 0x2028 LINE SEPARATOR - 0x2029 PARAGRAPH SEPARATOR
+        [InlineData(@"\u2028", (char)0x2028)]
+        [InlineData(@"\u2029", (char)0x2029)]
+        // Between #3 and #4
+        [InlineData(@"漢", (char)0x6F22)]
+        // #4. 0xD800 - 0xDFFF
+        [InlineData(@"\ud800", (char)0xd800)]
+        [InlineData(@"\udabc", (char)0xdabc)]
+        [InlineData(@"\udfff", (char)0xdfff)]
+        // Between #4 and #5
+        [InlineData("\ueabc", (char)0xeabc)]
+        // #5. 0xFFFE - 0xFFFF
+        [InlineData(@"\ufffe", (char)0xfffe)]
+        [InlineData(@"\uffff", (char)0xffff)]
+        public void Character(string expected, char value)
+        {
+            WriteInMultiplePositionsAndCheck(expected, value.ToString());
+        }
+
+        [Theory]
+        [InlineData(@"\ud83d\udc4d", "👍")]
+        public void String(string expected, string value)
+        {
+            WriteInMultiplePositionsAndCheck(expected, value);
+        }
+
+        private static void WriteInMultiplePositionsAndCheck(string expected, string value)
+        {
+            Assert.StrictEqual($"\"{expected}\"", WriteToString(value));
+            Assert.StrictEqual($"\"{expected}_after\"", WriteToString($"{value}_after"));
+            Assert.StrictEqual($"\"before_{expected}\"", WriteToString($"before_{value}"));
+            Assert.StrictEqual($"\"before_{expected}_after\"", WriteToString($"before_{value}_after"));
+        }
+
+        private static string WriteToString(Action<JsonWriter> action)
+        {
+            var stringWriter = new StringWriter();
+
+            using (var jsonWriter = new JsonWriter(stringWriter))
+            {
+                action(jsonWriter);
+            }
+
+            return stringWriter.ToString();
+        }
+
+        private static string WriteToString(bool value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+
+        private static string WriteToString(int value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+
+        private static string WriteToString(string value)
+        {
+            return WriteToString(j => j.Write(value));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -207,13 +207,13 @@ namespace Microsoft.CodeAnalysis
 
                 // We want to report diagnostics with source suppression in the error log file.
                 // However, these diagnostics should not be reported on the console output.
-                errorLoggerOpt?.LogDiagnostic(diag, this.Culture);
+                errorLoggerOpt?.LogDiagnostic(diag);
                 if (diag.IsSuppressed)
                 {
                     continue;
                 }
 
-                consoleOutput.WriteLine(DiagnosticFormatter.Format(diag, this.Culture));
+                consoleOutput.WriteLine(DiagnosticFormatter.Format(diag));
 
                 if (diag.Severity == DiagnosticSeverity.Error)
                 {
@@ -240,7 +240,7 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     PrintError(diagnostic, consoleOutput);
-                    errorLoggerOpt?.LogDiagnostic(Diagnostic.Create(diagnostic), this.Culture);
+                    errorLoggerOpt?.LogDiagnostic(Diagnostic.Create(diagnostic));
 
                     if (diagnostic.Severity == DiagnosticSeverity.Error)
                     {
@@ -267,7 +267,7 @@ namespace Microsoft.CodeAnalysis
                 return null;
             }
 
-            return new ErrorLogger(errorLog, GetToolName(), GetAssemblyFileVersion(), GetAssemblyVersion());
+            return new ErrorLogger(errorLog, GetToolName(), GetAssemblyFileVersion(), GetAssemblyVersion(), Culture);
         }
 
         /// <summary>

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -37,7 +37,8 @@ namespace Microsoft.CodeAnalysis
             _culture = culture;
 
             _writer.WriteObjectStart(); // root
-            _writer.Write("version", "1.0.0-beta.4");
+            _writer.Write("$schema", "http://json.schemastore.org/sarif-1.0.0-beta.5");
+            _writer.Write("version", "1.0.0-beta.5");
             _writer.WriteArrayStart("runs");
             _writer.WriteObjectStart(); // run
 
@@ -50,8 +51,9 @@ namespace Microsoft.CodeAnalysis
         {
             _writer.WriteObjectStart("tool");
             _writer.Write("name", name);
-            _writer.Write("version", assemblyVersion.ToString(fieldCount: 3));
+            _writer.Write("version", assemblyVersion.ToString());
             _writer.Write("fileVersion", fileVersion);
+            _writer.Write("semanticVersion", assemblyVersion.ToString(fieldCount: 3));
             _writer.WriteObjectEnd();
         }
 
@@ -60,10 +62,10 @@ namespace Microsoft.CodeAnalysis
             _writer.WriteObjectStart(); // result
             _writer.Write("ruleId", diagnostic.Id);
 
-            string ruleIdKey = _descriptors.Add(diagnostic.Descriptor);
-            if (ruleIdKey != diagnostic.Id)
+            string ruleKey = _descriptors.Add(diagnostic.Descriptor);
+            if (ruleKey != diagnostic.Id)
             {
-                _writer.Write("ruleIdKey", ruleIdKey);
+                _writer.Write("ruleKey", ruleKey);
             }
 
             _writer.Write("level", GetLevel(diagnostic.Severity));
@@ -237,7 +239,6 @@ namespace Microsoft.CodeAnalysis
                     }
 
                     _writer.Write("isEnabledByDefault", descriptor.IsEnabledByDefault);
-                    _writer.WriteObjectEnd(); // properties
 
                     if (descriptor.CustomTags.Any())
                     {
@@ -251,6 +252,7 @@ namespace Microsoft.CodeAnalysis
                         _writer.WriteArrayEnd(); // tags
                     }
 
+                    _writer.WriteObjectEnd(); // properties
                     _writer.WriteObjectEnd(); // rule
                 }
 

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis
             {
                 _writer.WriteArrayStart("locations");
                 _writer.WriteObjectStart(); // location
-                _writer.WriteKey("analysisTarget");
+                _writer.WriteKey("resultFile");
 
                 WritePhysicalLocation(location);
 

--- a/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
@@ -160,9 +160,6 @@ namespace Roslyn.Utilities
         //
         //   - Avoid intermediate StringBuilder and send escaped output directly to the destination.
         //
-        //   - Stop escaping '/': it is is optional per JSON spec and several users have expressed
-        //     that they don't like the way '\/' looks.
-        //
         private static string EscapeString(string value)
         {
             PooledStringBuilder pooledBuilder = null;
@@ -179,7 +176,7 @@ namespace Roslyn.Utilities
             {
                 char c = value[i];
 
-                if (c == '\"' || c == '\'' || c == '/' || c == '\\' || ShouldAppendAsUnicode(c))
+                if (c == '\"' || c == '\'' || c == '\\' || ShouldAppendAsUnicode(c))
                 {
                     if (b == null)
                     {
@@ -204,9 +201,6 @@ namespace Roslyn.Utilities
                         break;
                     case '\\':
                         b.Append("\\\\");
-                        break;
-                    case '/':
-                        b.Append("\\/");
                         break;
                     case '\'':
                         b.Append("\'");

--- a/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
@@ -162,10 +162,6 @@ namespace Roslyn.Utilities
         //
         // https://github.com/dotnet/corefx/blob/master/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JavaScriptString.cs
         //
-        // Possible future improvements: https://github.com/dotnet/roslyn/issues/9769
-        //
-        //   - Avoid intermediate StringBuilder and send escaped output directly to the destination.
-        //
         private static string EscapeString(string value)
         {
             PooledStringBuilder pooledBuilder = null;
@@ -182,7 +178,7 @@ namespace Roslyn.Utilities
             {
                 char c = value[i];
 
-                if (c == '\"' || c == '\'' || c == '\\' || ShouldAppendAsUnicode(c))
+                if (c == '\"' || c == '\\' || ShouldAppendAsUnicode(c))
                 {
                     if (b == null)
                     {
@@ -207,9 +203,6 @@ namespace Roslyn.Utilities
                         break;
                     case '\\':
                         b.Append("\\\\");
-                        break;
-                    case '\'':
-                        b.Append("\'");
                         break;
                     default:
                         if (ShouldAppendAsUnicode(c))

--- a/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/JsonWriter.cs
@@ -103,7 +103,7 @@ namespace Roslyn.Utilities
         public void Write(int value)
         {
             WritePending();
-            _output.Write(value);
+            _output.Write(value.ToString(CultureInfo.InvariantCulture));
             _pending = Pending.CommaNewLineAndIndent;
         }
 

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -125,13 +125,13 @@ End Class
           ""defaultLevel"": ""error"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry"",
-            ""NotConfigurable""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
         }},
         ""BC42024"": {{
           ""id"": ""BC42024"",
@@ -139,12 +139,12 @@ End Class
           ""defaultLevel"": ""warning"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry""
+            ]
+          }}
         }}
       }}
     }}
@@ -230,13 +230,13 @@ End Class
           ""defaultLevel"": ""error"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry"",
-            ""NotConfigurable""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry"",
+              ""NotConfigurable""
+            ]
+          }}
         }},
         ""BC42024"": {{
           ""id"": ""BC42024"",
@@ -244,12 +244,12 @@ End Class
           ""defaultLevel"": ""warning"",
           ""properties"": {{
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": true
-          }},
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ]
+            ""isEnabledByDefault"": true,
+            ""tags"": [
+              ""Compiler"",
+              ""Telemetry""
+            ]
+          }}
         }}
       }}
     }}

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -94,24 +94,21 @@ End Class
       ""results"": [
         {{
           ""ruleId"": ""BC42024"",
-          ""kind"": ""warning"",
+          ""level"": ""warning"",
           ""locations"": [
             {{
-              ""analysisTarget"": [
-                {{
-                  ""uri"": ""{0}"",
-                  ""region"": {{
-                    ""startLine"": 4,
-                    ""startColumn"": 13,
-                    ""endLine"": 4,
-                    ""endColumn"": 14
-                  }}
+              ""analysisTarget"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 4,
+                  ""startColumn"": 13,
+                  ""endLine"": 4,
+                  ""endColumn"": 14
                 }}
-              ]
+              }}
             }}
           ],
-          ""fullMessage"": ""Unused local variable: 'x'."",
-          ""isSuppressedInSource"": false,
+          ""message"": ""Unused local variable: 'x'."",
           ""tags"": [
             ""Compiler"",
             ""Telemetry""
@@ -127,11 +124,8 @@ End Class
         }},
         {{
           ""ruleId"": ""BC30420"",
-          ""kind"": ""error"",
-          ""locations"": [
-          ],
-          ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
-          ""isSuppressedInSource"": false,
+          ""level"": ""error"",
+          ""message"": ""'Sub Main' was not found in '{1}'."",
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
@@ -194,24 +188,24 @@ End Class
       ""results"": [
         {{
           ""ruleId"": ""BC42024"",
-          ""kind"": ""warning"",
+          ""level"": ""warning"",
           ""locations"": [
             {{
-              ""analysisTarget"": [
-                {{
-                  ""uri"": ""{0}"",
-                  ""region"": {{
-                    ""startLine"": 5,
-                    ""startColumn"": 13,
-                    ""endLine"": 5,
-                    ""endColumn"": 14
-                  }}
+              ""analysisTarget"": {{
+                ""uri"": ""{0}"",
+                ""region"": {{
+                  ""startLine"": 5,
+                  ""startColumn"": 13,
+                  ""endLine"": 5,
+                  ""endColumn"": 14
                 }}
-              ]
+              }}
             }}
           ],
-          ""fullMessage"": ""Unused local variable: 'x'."",
-          ""isSuppressedInSource"": true,
+          ""message"": ""Unused local variable: 'x'."",
+          ""suppressionStates"": [
+            ""suppressedInSource""
+          ],
           ""tags"": [
             ""Compiler"",
             ""Telemetry""
@@ -227,11 +221,8 @@ End Class
         }},
         {{
           ""ruleId"": ""BC30420"",
-          ""kind"": ""error"",
-          ""locations"": [
-          ],
-          ""fullMessage"": ""'Sub Main' was not found in '{1}'."",
-          ""isSuppressedInSource"": false,
+          ""level"": ""error"",
+          ""message"": ""'Sub Main' was not found in '{1}'."",
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -98,7 +98,7 @@ End Class
           ""message"": ""Unused local variable: 'x'."",
           ""locations"": [
             {{
-              ""analysisTarget"": {{
+              ""resultFile"": {{
                 ""uri"": ""{0}"",
                 ""region"": {{
                   ""startLine"": 4,
@@ -203,7 +203,7 @@ End Class
           ],
           ""locations"": [
             {{
-              ""analysisTarget"": {{
+              ""resultFile"": {{
                 ""uri"": ""{0}"",
                 ""region"": {{
                   ""startLine"": 5,

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -95,6 +95,7 @@ End Class
         {{
           ""ruleId"": ""BC42024"",
           ""level"": ""warning"",
+          ""message"": ""Unused local variable: 'x'."",
           ""locations"": [
             {{
               ""analysisTarget"": {{
@@ -108,37 +109,44 @@ End Class
               }}
             }}
           ],
-          ""message"": ""Unused local variable: 'x'."",
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ],
           ""properties"": {{
-            ""severity"": ""Warning"",
-            ""warningLevel"": ""1"",
-            ""defaultSeverity"": ""Warning"",
-            ""title"": ""Unused local variable"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
+            ""warningLevel"": 1
           }}
         }},
         {{
           ""ruleId"": ""BC30420"",
           ""level"": ""error"",
-          ""message"": ""'Sub Main' was not found in '{1}'."",
+          ""message"": ""'Sub Main' was not found in '{1}'.""
+        }}
+      ],
+      ""rules"": {{
+        ""BC30420"": {{
+          ""id"": ""BC30420"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
             ""NotConfigurable""
-          ],
+          ]
+        }},
+        ""BC42024"": {{
+          ""id"": ""BC42024"",
+          ""shortDescription"": ""Unused local variable"",
+          ""defaultLevel"": ""warning"",
           ""properties"": {{
-            ""severity"": ""Error"",
-            ""defaultSeverity"": ""Error"",
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
-          }}
+            ""isEnabledByDefault"": true
+          }},
+          ""tags"": [
+            ""Compiler"",
+            ""Telemetry""
+          ]
         }}
-      ]
+      }}
     }}
   ]
 }}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
@@ -189,6 +197,10 @@ End Class
         {{
           ""ruleId"": ""BC42024"",
           ""level"": ""warning"",
+          ""message"": ""Unused local variable: 'x'."",
+          ""suppressionStates"": [
+            ""suppressedInSource""
+          ],
           ""locations"": [
             {{
               ""analysisTarget"": {{
@@ -202,40 +214,44 @@ End Class
               }}
             }}
           ],
-          ""message"": ""Unused local variable: 'x'."",
-          ""suppressionStates"": [
-            ""suppressedInSource""
-          ],
-          ""tags"": [
-            ""Compiler"",
-            ""Telemetry""
-          ],
           ""properties"": {{
-            ""severity"": ""Warning"",
-            ""warningLevel"": ""1"",
-            ""defaultSeverity"": ""Warning"",
-            ""title"": ""Unused local variable"",
-            ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
+            ""warningLevel"": 1
           }}
         }},
         {{
           ""ruleId"": ""BC30420"",
           ""level"": ""error"",
-          ""message"": ""'Sub Main' was not found in '{1}'."",
+          ""message"": ""'Sub Main' was not found in '{1}'.""
+        }}
+      ],
+      ""rules"": {{
+        ""BC30420"": {{
+          ""id"": ""BC30420"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {{
+            ""category"": ""Compiler"",
+            ""isEnabledByDefault"": true
+          }},
           ""tags"": [
             ""Compiler"",
             ""Telemetry"",
             ""NotConfigurable""
-          ],
+          ]
+        }},
+        ""BC42024"": {{
+          ""id"": ""BC42024"",
+          ""shortDescription"": ""Unused local variable"",
+          ""defaultLevel"": ""warning"",
           ""properties"": {{
-            ""severity"": ""Error"",
-            ""defaultSeverity"": ""Error"",
             ""category"": ""Compiler"",
-            ""isEnabledByDefault"": ""True""
-          }}
+            ""isEnabledByDefault"": true
+          }},
+          ""tags"": [
+            ""Compiler"",
+            ""Telemetry""
+          ]
         }}
-      ]
+      }}
     }}
   ]
 }}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))

--- a/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/ErrorLoggerTests.vb
@@ -147,7 +147,7 @@ End Class
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)
@@ -247,7 +247,7 @@ End Class
       ]
     }}
   ]
-}}", AnalyzerForErrorLogTest.GetEscapedUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
+}}", AnalyzerForErrorLogTest.GetUriForPath(sourceFilePath), Path.GetFileNameWithoutExtension(sourceFilePath))
 
             Dim expectedText = expectedHeader + expectedIssues
             Assert.Equal(expectedText, actualOutput)

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CodeAnalysis
           ""message"": """ + Descriptor1.MessageFormat + @""",
           ""locations"": [
             {
-              ""analysisTarget"": {
+              ""resultFile"": {
                 ""uri"": """ + filePath + @""",
                 ""region"": {
                   ""startLine"": " + (expectedLineSpan.StartLinePosition.Line + 1) + @",

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis
                 var tree = compilation.SyntaxTrees.First();
                 var root = tree.GetRoot();
                 var expectedLineSpan = root.GetLocation().GetLineSpan();
-                var filePath = GetEscapedUriForPath(tree.FilePath);
+                var filePath = GetUriForPath(tree.FilePath);
 
                 return @"
       ""results"": [
@@ -149,9 +149,9 @@ namespace Microsoft.CodeAnalysis
 }";
             }
 
-            public static string GetEscapedUriForPath(string path)
+            public static string GetUriForPath(string path)
             {
-                return new Uri(path, UriKind.RelativeOrAbsolute).ToString().Replace("/", "\\/");
+                return new Uri(path, UriKind.RelativeOrAbsolute).ToString();
             }
         }
 

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -66,14 +66,22 @@ namespace Microsoft.CodeAnalysis
 
             private static string GetExpectedPropertiesMapText()
             {
-                var expectedText = "";
+                var expectedText = @"
+            ""customProperties"": {";
 
                 foreach (var kvp in s_properties.OrderBy(kvp => kvp.Key))
                 {
-                    expectedText += ",";
+                    if (!expectedText.EndsWith("{"))
+                    {
+                        expectedText += ",";
+                    }
+
                     expectedText += string.Format(@"
-            ""customProperties.{0}"": ""{1}""", kvp.Key, kvp.Value);
+              ""{0}"": ""{1}""", kvp.Key, kvp.Value);
                 }
+
+                expectedText += @"
+            }";
 
                 return expectedText;
             }
@@ -90,6 +98,7 @@ namespace Microsoft.CodeAnalysis
         {
           ""ruleId"": """ + Descriptor1.Id + @""",
           ""level"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""message"": """ + Descriptor1.MessageFormat + @""",
           ""locations"": [
             {
               ""analysisTarget"": {
@@ -103,39 +112,49 @@ namespace Microsoft.CodeAnalysis
               }
             }
           ],
-          ""message"": """ + Descriptor1.MessageFormat + @""",
-          ""tags"": [
-            " + String.Join("," + Environment.NewLine + "            ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
-          ],
           ""properties"": {
-            ""severity"": """ + Descriptor1.DefaultSeverity + @""",
-            ""warningLevel"": ""1"",
-            ""defaultSeverity"": """ + Descriptor1.DefaultSeverity + @""",
-            ""title"": """ + Descriptor1.Title + @""",
-            ""category"": """ + Descriptor1.Category + @""",
-            ""helpLink"": """ + Descriptor1.HelpLinkUri + @""",
-            ""isEnabledByDefault"": """ + Descriptor1.IsEnabledByDefault + @"""" +
-            GetExpectedPropertiesMapText() + @"
+            ""warningLevel"": 1," + GetExpectedPropertiesMapText() + @"
           }
         },
         {
           ""ruleId"": """ + Descriptor2.Id + @""",
           ""level"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
           ""message"": """ + Descriptor2.MessageFormat + @""",
-          ""tags"": [
-            " + String.Join("," + Environment.NewLine + "            ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
-          ],
-          ""properties"": {
-            ""severity"": """ + Descriptor2.DefaultSeverity + @""",
-            ""defaultSeverity"": """ + Descriptor2.DefaultSeverity + @""",
-            ""title"": """ + Descriptor2.Title + @""",
-            ""category"": """ + Descriptor2.Category + @""",
-            ""helpLink"": """ + Descriptor2.HelpLinkUri + @""",
-            ""isEnabledByDefault"": """ + Descriptor2.IsEnabledByDefault + @"""" +
-            GetExpectedPropertiesMapText() + @"
+          ""properties"": {" +
+             GetExpectedPropertiesMapText() + @"
           }
         }
-      ]
+      ],
+      ""rules"": {
+        """ + Descriptor1.Id + @""": {
+          ""id"": """ + Descriptor1.Id + @""",
+          ""shortDescription"": """ + Descriptor1.Title + @""",
+          ""fullDescription"": """ + Descriptor1.Description + @""",
+          ""defaultLevel"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""helpUri"": """ + Descriptor1.HelpLinkUri + @""",
+          ""properties"": {
+            ""category"": """ + Descriptor1.Category + @""",
+            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @"
+          },
+          ""tags"": [
+            " + String.Join("," + Environment.NewLine + "            ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
+          ]
+        },
+        """ + Descriptor2.Id + @""": {
+          ""id"": """ + Descriptor2.Id + @""",
+          ""shortDescription"": """ + Descriptor2.Title + @""",
+          ""fullDescription"": """ + Descriptor2.Description + @""",
+          ""defaultLevel"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""helpUri"": """ + Descriptor2.HelpLinkUri + @""",
+          ""properties"": {
+            ""category"": """ + Descriptor2.Category + @""",
+            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @"
+          },
+          ""tags"": [
+            " + String.Join("," + Environment.NewLine + "            ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
+          ]
+        }
+      }
     }
   ]
 }";

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -89,25 +89,21 @@ namespace Microsoft.CodeAnalysis
       ""results"": [
         {
           ""ruleId"": """ + Descriptor1.Id + @""",
-          ""kind"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""level"": """ + (Descriptor1.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
           ""locations"": [
             {
-              ""analysisTarget"": [
-                {
-                  ""uri"": """ + filePath + @""",
-                  ""region"": {
-                    ""startLine"": " + (expectedLineSpan.StartLinePosition.Line + 1) + @",
-                    ""startColumn"": " + (expectedLineSpan.StartLinePosition.Character + 1) + @",
-                    ""endLine"": " + (expectedLineSpan.EndLinePosition.Line + 1) + @",
-                    ""endColumn"": " + (expectedLineSpan.EndLinePosition.Character + 1) + @"
-                  }
+              ""analysisTarget"": {
+                ""uri"": """ + filePath + @""",
+                ""region"": {
+                  ""startLine"": " + (expectedLineSpan.StartLinePosition.Line + 1) + @",
+                  ""startColumn"": " + (expectedLineSpan.StartLinePosition.Character + 1) + @",
+                  ""endLine"": " + (expectedLineSpan.EndLinePosition.Line + 1) + @",
+                  ""endColumn"": " + (expectedLineSpan.EndLinePosition.Character + 1) + @"
                 }
-              ]
+              }
             }
           ],
-          ""shortMessage"": """ + Descriptor1.MessageFormat + @""",
-          ""fullMessage"": """ + Descriptor1.Description + @""",
-          ""isSuppressedInSource"": false,
+          ""message"": """ + Descriptor1.MessageFormat + @""",
           ""tags"": [
             " + String.Join("," + Environment.NewLine + "            ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
           ],
@@ -124,12 +120,8 @@ namespace Microsoft.CodeAnalysis
         },
         {
           ""ruleId"": """ + Descriptor2.Id + @""",
-          ""kind"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
-          ""locations"": [
-          ],
-          ""shortMessage"": """ + Descriptor2.MessageFormat + @""",
-          ""fullMessage"": """ + Descriptor2.Description + @""",
-          ""isSuppressedInSource"": false,
+          ""level"": """ + (Descriptor2.DefaultSeverity == DiagnosticSeverity.Error ? "error" : "warning") + @""",
+          ""message"": """ + Descriptor2.MessageFormat + @""",
           ""tags"": [
             " + String.Join("," + Environment.NewLine + "            ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
           ],

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -134,11 +134,11 @@ namespace Microsoft.CodeAnalysis
           ""helpUri"": """ + Descriptor1.HelpLinkUri + @""",
           ""properties"": {
             ""category"": """ + Descriptor1.Category + @""",
-            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @"
-          },
-          ""tags"": [
-            " + String.Join("," + Environment.NewLine + "            ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
-          ]
+            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @",
+            ""tags"": [
+              " + String.Join("," + Environment.NewLine + "              ", Descriptor1.CustomTags.Select(s => $"\"{s}\"")) + @"
+            ]
+          }
         },
         """ + Descriptor2.Id + @""": {
           ""id"": """ + Descriptor2.Id + @""",
@@ -148,11 +148,11 @@ namespace Microsoft.CodeAnalysis
           ""helpUri"": """ + Descriptor2.HelpLinkUri + @""",
           ""properties"": {
             ""category"": """ + Descriptor2.Category + @""",
-            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @"
-          },
-          ""tags"": [
-            " + String.Join("," + Environment.NewLine + "            ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
-          ]
+            ""isEnabledByDefault"": " + (Descriptor2.IsEnabledByDefault ? "true" : "false") + @",
+            ""tags"": [
+              " + String.Join("," + Environment.NewLine + "              ", Descriptor2.CustomTags.Select(s => $"\"{s}\"")) + @"
+            ]
+          }
         }
       }
     }

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -310,9 +310,9 @@ namespace Microsoft.CodeAnalysis
 
             return string.Format(@"{{
   ""version"": ""{0}"",
-  ""runLogs"": [
+  ""runs"": [
     {{
-      ""toolInfo"": {{
+      ""tool"": {{
         ""name"": ""{1}"",
         ""version"": ""{2}"",
         ""fileVersion"": ""{3}""

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -309,14 +309,14 @@ namespace Microsoft.CodeAnalysis
             var expectedFileVersion = compiler.GetAssemblyFileVersion();
 
             return string.Format(@"{{
-  ""version"": ""{0}"",
+  ""version"": ""1.0.0-beta.4"",
   ""runs"": [
     {{
       ""tool"": {{
-        ""name"": ""{1}"",
-        ""version"": ""{2}"",
-        ""fileVersion"": ""{3}""
-      }},", ErrorLogger.OutputFormatVersion, expectedToolName, expectedProductVersion, expectedFileVersion);
+        ""name"": ""{0}"",
+        ""version"": ""{1}"",
+        ""fileVersion"": ""{2}""
+      }},", expectedToolName, expectedProductVersion, expectedFileVersion);
         }
 
         public static string Stringize(this Diagnostic e)

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -305,18 +305,21 @@ namespace Microsoft.CodeAnalysis
         internal static string GetExpectedErrorLogHeader(string actualOutput, CommonCompiler compiler)
         {
             var expectedToolName = compiler.GetToolName();
-            var expectedProductVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
+            var expectedVersion = compiler.GetAssemblyVersion();
+            var expectedSemanticVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
             var expectedFileVersion = compiler.GetAssemblyFileVersion();
 
             return string.Format(@"{{
-  ""version"": ""1.0.0-beta.4"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
+  ""version"": ""1.0.0-beta.5"",
   ""runs"": [
     {{
       ""tool"": {{
         ""name"": ""{0}"",
         ""version"": ""{1}"",
-        ""fileVersion"": ""{2}""
-      }},", expectedToolName, expectedProductVersion, expectedFileVersion);
+        ""fileVersion"": ""{2}"",
+        ""semanticVersion"": ""{3}""
+      }},", expectedToolName, expectedVersion, expectedFileVersion, expectedSemanticVersion);
         }
 
         public static string Stringize(this Diagnostic e)


### PR DESCRIPTION
Bring /errorlog output up to SARIF draft 1.0.0-beta.5

Also fix #9769

1. Stop escaping forward slashes (optional per spec and users don't want it)
2. Add tests converted from DataContractSerializer tests that stress the code we borrowed from there for escaping.
3 .Let the underlying TextWriter handle all newlines

@dotnet/roslyn-compiler @mavasani @lgolding @michaelcfanning 