### PR TITLE
Get compilation from symbol instead of having it passed into SymbolKey.Create

### DIFF
--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyCompilationsTests.cs
@@ -71,7 +71,7 @@ namespace N1.N2
             var originalSymbols = GetSourceSymbols(comp1, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);
             var newSymbols = GetSourceSymbols(comp2, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);
 
-            ResolveAndVerifySymbolList(newSymbols, comp2, originalSymbols, comp1);
+            ResolveAndVerifySymbolList(newSymbols, originalSymbols, comp1);
         }
 
         [Fact, WorkItem(530171, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530171")]
@@ -101,7 +101,7 @@ public void Method()
             var originalSymbols = GetSourceSymbols(comp1, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);
             var newSymbols = GetSourceSymbols(comp2, SymbolCategory.DeclaredType | SymbolCategory.DeclaredNamespace).OrderBy(s => s.Name);
 
-            ResolveAndVerifySymbolList(newSymbols, comp2, originalSymbols, comp1);
+            ResolveAndVerifySymbolList(newSymbols, originalSymbols, comp1);
         }
 
         [Fact]
@@ -127,8 +127,8 @@ namespace NS
             var implementation = definition.PartialImplementationPart;
 
             // Assert that both the definition and implementation resolve back to themselves
-            Assert.Equal(definition, ResolveSymbol(definition, comp, comp, SymbolKeyComparison.None));
-            Assert.Equal(implementation, ResolveSymbol(implementation, comp, comp, SymbolKeyComparison.None));
+            Assert.Equal(definition, ResolveSymbol(definition, comp, SymbolKeyComparison.None));
+            Assert.Equal(implementation, ResolveSymbol(implementation, comp, SymbolKeyComparison.None));
         }
 
         [Fact]
@@ -170,10 +170,10 @@ class C<T> : I<T>, I
             var indexer1 = type.GetMembers().Where(m => m.MetadataName == "I.Item").Single() as IPropertySymbol;
             var indexer2 = type.GetMembers().Where(m => m.MetadataName == "I<T>.Item").Single() as IPropertySymbol;
 
-            AssertSymbolKeysEqual(indexer1, compilation, indexer2, compilation, SymbolKeyComparison.None, expectEqual: false);
+            AssertSymbolKeysEqual(indexer1, indexer2, SymbolKeyComparison.None, expectEqual: false);
 
-            Assert.Equal(indexer1, ResolveSymbol(indexer1, compilation, compilation, SymbolKeyComparison.None));
-            Assert.Equal(indexer2, ResolveSymbol(indexer2, compilation, compilation, SymbolKeyComparison.None));
+            Assert.Equal(indexer1, ResolveSymbol(indexer1, compilation, SymbolKeyComparison.None));
+            Assert.Equal(indexer2, ResolveSymbol(indexer2, compilation, SymbolKeyComparison.None));
         }
 
         #endregion
@@ -234,7 +234,7 @@ namespace N1.N2
             var originalSymbols = GetSourceSymbols(comp1, SymbolCategory.DeclaredType);
             var newSymbols = GetSourceSymbols(comp2, SymbolCategory.DeclaredType);
 
-            ResolveAndVerifySymbolList(newSymbols, comp2, originalSymbols, comp1);
+            ResolveAndVerifySymbolList(newSymbols, originalSymbols, comp1);
         }
 
         [Fact]
@@ -275,10 +275,10 @@ namespace NS
             var typeSym02 = namespace2.GetTypeMembers("C2").Single() as NamedTypeSymbol;
 
             // new C1 resolve to old C1
-            ResolveAndVerifySymbol(typeSym01, comp2, typeSym00, comp1);
+            ResolveAndVerifySymbol(typeSym01, typeSym00, comp1);
 
             // old C1 (new C2) NOT resolve to old C1
-            var symkey = SymbolKey.Create(typeSym02, comp1, CancellationToken.None);
+            var symkey = SymbolKey.Create(typeSym02, CancellationToken.None);
             var syminfo = symkey.Resolve(comp1);
             Assert.Null(syminfo.Symbol);
         }
@@ -320,7 +320,7 @@ public class Test
             var newSymbols = GetSourceSymbols(comp2, SymbolCategory.NonTypeMember | SymbolCategory.Parameter)
                                  .Where(s => !s.IsAccessor()).OrderBy(s => s.Name);
 
-            ResolveAndVerifySymbolList(newSymbols, comp2, originalSymbols, comp1);
+            ResolveAndVerifySymbolList(newSymbols, originalSymbols, comp1);
         }
 
         [WorkItem(542700, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542700")]
@@ -353,8 +353,8 @@ public class Test
             var typeSym2 = comp2.SourceModule.GlobalNamespace.GetTypeMembers("Test").Single() as NamedTypeSymbol;
             var newSymbols = typeSym2.GetMembers(WellKnownMemberNames.Indexer);
 
-            ResolveAndVerifySymbol(newSymbols.First(), comp2, originalSymbols.First(), comp1, SymbolKeyComparison.CaseSensitive);
-            ResolveAndVerifySymbol(newSymbols.Last(), comp2, originalSymbols.Last(), comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(newSymbols.First(), originalSymbols.First(), comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(newSymbols.Last(), originalSymbols.Last(), comp1, SymbolKeyComparison.CaseSensitive);
         }
 
         [Fact]
@@ -379,10 +379,10 @@ namespace NS
             var typeSym02 = namespace2.GetTypeMembers("C1").FirstOrDefault() as NamedTypeSymbol;
 
             // new C1 resolves to old C1 if we ignore assembly and module ids
-            ResolveAndVerifySymbol(typeSym02, comp2, typeSym01, comp1, SymbolKeyComparison.CaseSensitive | SymbolKeyComparison.IgnoreAssemblyIds);
+            ResolveAndVerifySymbol(typeSym02, typeSym01, comp1, SymbolKeyComparison.CaseSensitive | SymbolKeyComparison.IgnoreAssemblyIds);
 
             // new C1 DOES NOT resolve to old C1 if we don't ignore assembly and module ids
-            Assert.Null(ResolveSymbol(typeSym02, comp2, comp1, SymbolKeyComparison.CaseSensitive));
+            Assert.Null(ResolveSymbol(typeSym02,  comp1, SymbolKeyComparison.CaseSensitive));
         }
 
         [WpfFact(Skip = "530169"), WorkItem(530169, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530169")]
@@ -398,19 +398,19 @@ namespace NS
             Symbol sym2 = comp2.Assembly;
 
             // Not ignoreAssemblyAndModules
-            ResolveAndVerifySymbol(sym1, comp2, sym2, comp2);
+            ResolveAndVerifySymbol(sym1, sym2, comp2);
 
-            AssertSymbolKeysEqual(sym1, comp1, sym2, comp2, SymbolKeyComparison.IgnoreAssemblyIds, true);
-            Assert.NotNull(ResolveSymbol(sym1, comp1, comp2, SymbolKeyComparison.IgnoreAssemblyIds));
+            AssertSymbolKeysEqual(sym1, sym2, SymbolKeyComparison.IgnoreAssemblyIds, true);
+            Assert.NotNull(ResolveSymbol(sym1, comp2, SymbolKeyComparison.IgnoreAssemblyIds));
 
             // Module
             sym1 = comp1.Assembly.Modules[0];
             sym2 = comp2.Assembly.Modules[0];
 
-            ResolveAndVerifySymbol(sym1, comp1, sym2, comp2);
+            ResolveAndVerifySymbol(sym1, sym2, comp2);
 
-            AssertSymbolKeysEqual(sym2, comp2, sym1, comp1, SymbolKeyComparison.IgnoreAssemblyIds, true);
-            Assert.NotNull(ResolveSymbol(sym2, comp2, comp1, SymbolKeyComparison.IgnoreAssemblyIds));
+            AssertSymbolKeysEqual(sym2, sym1, SymbolKeyComparison.IgnoreAssemblyIds, true);
+            Assert.NotNull(ResolveSymbol(sym2, comp1, SymbolKeyComparison.IgnoreAssemblyIds));
         }
 
         [Fact, WorkItem(530170, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530170")]
@@ -427,25 +427,25 @@ namespace NS
             ISymbol assembly2 = compilation2.Assembly;
 
             // different
-            AssertSymbolKeysEqual(assembly2, compilation2, assembly1, compilation1, SymbolKeyComparison.CaseSensitive, expectEqual: false);
-            Assert.Null(ResolveSymbol(assembly2, compilation2, compilation1, SymbolKeyComparison.CaseSensitive));
+            AssertSymbolKeysEqual(assembly2, assembly1, SymbolKeyComparison.CaseSensitive, expectEqual: false);
+            Assert.Null(ResolveSymbol(assembly2, compilation1, SymbolKeyComparison.CaseSensitive));
 
             // ignore means ALL assembly/module symbols have same ID
-            AssertSymbolKeysEqual(assembly2, compilation2, assembly1, compilation1, SymbolKeyComparison.IgnoreAssemblyIds, expectEqual: true);
+            AssertSymbolKeysEqual(assembly2, assembly1, SymbolKeyComparison.IgnoreAssemblyIds, expectEqual: true);
 
             // But can NOT be resolved
-            Assert.Null(ResolveSymbol(assembly2, compilation2, compilation1, SymbolKeyComparison.IgnoreAssemblyIds));
+            Assert.Null(ResolveSymbol(assembly2, compilation1, SymbolKeyComparison.IgnoreAssemblyIds));
 
             // Module
             var module1 = compilation1.Assembly.Modules[0];
             var module2 = compilation2.Assembly.Modules[0];
 
             // different
-            AssertSymbolKeysEqual(module1, compilation1, module2, compilation2, SymbolKeyComparison.CaseSensitive, expectEqual: false);
-            Assert.Null(ResolveSymbol(module1, compilation1, compilation2, SymbolKeyComparison.CaseSensitive));
+            AssertSymbolKeysEqual(module1, module2, SymbolKeyComparison.CaseSensitive, expectEqual: false);
+            Assert.Null(ResolveSymbol(module1, compilation2, SymbolKeyComparison.CaseSensitive));
 
-            AssertSymbolKeysEqual(module2, compilation2, module1, compilation1, SymbolKeyComparison.IgnoreAssemblyIds);
-            Assert.Null(ResolveSymbol(module2, compilation2, compilation1, SymbolKeyComparison.IgnoreAssemblyIds));
+            AssertSymbolKeysEqual(module2, module1, SymbolKeyComparison.IgnoreAssemblyIds);
+            Assert.Null(ResolveSymbol(module2, compilation1, SymbolKeyComparison.IgnoreAssemblyIds));
         }
 
         [Fact, WorkItem(546254, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546254")]
@@ -471,12 +471,12 @@ public class C {}
             Symbol sym2 = comp2.Assembly;
 
             // comment is changed to compare Name ONLY
-            AssertSymbolKeysEqual(sym1, comp1, sym2, comp2, SymbolKeyComparison.CaseSensitive, expectEqual: true);
-            var resolved = ResolveSymbol(sym2, comp2, comp1, SymbolKeyComparison.CaseSensitive);
+            AssertSymbolKeysEqual(sym1, sym2, SymbolKeyComparison.CaseSensitive, expectEqual: true);
+            var resolved = ResolveSymbol(sym2, comp1, SymbolKeyComparison.CaseSensitive);
             Assert.Equal(sym1, resolved);
 
-            AssertSymbolKeysEqual(sym1, comp1, sym2, comp2, SymbolKeyComparison.IgnoreAssemblyIds);
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolKeyComparison.IgnoreAssemblyIds));
+            AssertSymbolKeysEqual(sym1, sym2, SymbolKeyComparison.IgnoreAssemblyIds);
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolKeyComparison.IgnoreAssemblyIds));
         }
 
         #endregion

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyMetadataVsSourceTests.cs
@@ -78,11 +78,11 @@ public class App : C
             // 'E'
             var member05 = (typesym.GetMembers(WellKnownMemberNames.Indexer).Single() as PropertySymbol).Type;
 
-            ResolveAndVerifySymbol(member03, comp2, originalSymbols[0], comp1, SymbolKeyComparison.CaseSensitive);
-            ResolveAndVerifySymbol(member01, comp2, originalSymbols[1], comp1, SymbolKeyComparison.CaseSensitive);
-            ResolveAndVerifySymbol(member05, comp2, originalSymbols[2], comp1, SymbolKeyComparison.CaseSensitive);
-            ResolveAndVerifySymbol(member02, comp2, originalSymbols[3], comp1, SymbolKeyComparison.CaseSensitive);
-            ResolveAndVerifySymbol(member04, comp2, originalSymbols[4], comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(member03, originalSymbols[0], comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(member01, originalSymbols[1], comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(member05, originalSymbols[2], comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(member02, originalSymbols[3], comp1, SymbolKeyComparison.CaseSensitive);
+            ResolveAndVerifySymbol(member04, originalSymbols[4], comp1, SymbolKeyComparison.CaseSensitive);
         }
 
         [WorkItem(542700, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542700")]
@@ -249,24 +249,21 @@ class Test
             foreach (var body in list)
             {
                 var df = model.AnalyzeDataFlow(body.Statements.First(), body.Statements.Last());
-                if (df.VariablesDeclared != null)
+                foreach (var local in df.VariablesDeclared)
                 {
-                    foreach (var local in df.VariablesDeclared)
-                    {
-                        var localType = ((LocalSymbol)local).Type;
+                    var localType = ((LocalSymbol)local).Type;
 
-                        if (local.Name == "fi")
-                        {
-                            ResolveAndVerifySymbol(localType, comp40, mtsym20_1, comp20, SymbolKeyComparison.CaseSensitive);
-                        }
-                        else if (local.Name == "ary")
-                        {
-                            ResolveAndVerifySymbol(localType, comp40, mtsym20_2, comp20, SymbolKeyComparison.CaseSensitive);
-                        }
-                        else if (local.Name == "dt")
-                        {
-                            ResolveAndVerifySymbol(localType, comp40, mtsym20_3, comp20, SymbolKeyComparison.CaseSensitive);
-                        }
+                    if (local.Name == "fi")
+                    {
+                        ResolveAndVerifySymbol(localType, mtsym20_1, comp20, SymbolKeyComparison.CaseSensitive);
+                    }
+                    else if (local.Name == "ary")
+                    {
+                        ResolveAndVerifySymbol(localType, mtsym20_2, comp20, SymbolKeyComparison.CaseSensitive);
+                    }
+                    else if (local.Name == "dt")
+                    {
+                        ResolveAndVerifySymbol(localType, mtsym20_3, comp20, SymbolKeyComparison.CaseSensitive);
                     }
                 }
             }

--- a/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/SymbolId/SymbolKeyTestBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
 
         #region "Verification"
 
-        internal static void ResolveAndVerifySymbolList(IEnumerable<ISymbol> newSymbols, Compilation newCompilation, IEnumerable<ISymbol> originalSymbols, CSharpCompilation originalComp)
+        internal static void ResolveAndVerifySymbolList(IEnumerable<ISymbol> newSymbols, IEnumerable<ISymbol> originalSymbols, CSharpCompilation originalComp)
         {
             var newlist = newSymbols.OrderBy(s => s.Name).ToList();
             var origlist = originalSymbols.OrderBy(s => s.Name).ToList();
@@ -44,28 +44,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
 
             for (int i = 0; i < newlist.Count; i++)
             {
-                ResolveAndVerifySymbol(newlist[i], newCompilation, origlist[i], originalComp);
+                ResolveAndVerifySymbol(newlist[i], origlist[i], originalComp);
             }
         }
 
         internal static void ResolveAndVerifyTypeSymbol(ExpressionSyntax node, ITypeSymbol sourceSymbol, SemanticModel model, CSharpCompilation sourceComp)
         {
             var typeinfo = model.GetTypeInfo(node);
-            ResolveAndVerifySymbol(typeinfo.Type ?? typeinfo.ConvertedType, model.Compilation, sourceSymbol, sourceComp);
+            ResolveAndVerifySymbol(typeinfo.Type ?? typeinfo.ConvertedType, sourceSymbol, sourceComp);
         }
 
         internal static void ResolveAndVerifySymbol(ExpressionSyntax node, ISymbol sourceSymbol, SemanticModel model, CSharpCompilation sourceComp, SymbolKeyComparison comparison = SymbolKeyComparison.None)
         {
             var syminfo = model.GetSymbolInfo(node);
-            ResolveAndVerifySymbol(syminfo.Symbol, model.Compilation, sourceSymbol, sourceComp, comparison);
+            ResolveAndVerifySymbol(syminfo.Symbol, sourceSymbol, sourceComp, comparison);
         }
 
-        internal static void ResolveAndVerifySymbol(ISymbol symbol1, Compilation compilation1, ISymbol symbol2, Compilation compilation2, SymbolKeyComparison comparison = SymbolKeyComparison.None)
+        internal static void ResolveAndVerifySymbol(ISymbol symbol1, ISymbol symbol2, Compilation compilation2, SymbolKeyComparison comparison = SymbolKeyComparison.None)
         {
             // same ID
-            AssertSymbolKeysEqual(symbol1, compilation1, symbol2, compilation2, comparison);
+            AssertSymbolKeysEqual(symbol1, symbol2, comparison);
 
-            var resolvedSymbol = ResolveSymbol(symbol1, compilation1, compilation2, comparison);
+            var resolvedSymbol = ResolveSymbol(symbol1, compilation2, comparison);
 
             Assert.NotNull(resolvedSymbol);
 
@@ -74,18 +74,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SymbolId
             Assert.Equal(symbol2.GetHashCode(), resolvedSymbol.GetHashCode());
         }
 
-        internal static ISymbol ResolveSymbol(ISymbol originalSymbol, Compilation originalCompilation, Compilation targetCompilation, SymbolKeyComparison comparison)
+        internal static ISymbol ResolveSymbol(ISymbol originalSymbol, Compilation targetCompilation, SymbolKeyComparison comparison)
         {
-            var sid = SymbolKey.Create(originalSymbol, originalCompilation, CancellationToken.None);
+            var sid = SymbolKey.Create(originalSymbol, CancellationToken.None);
             var symInfo = sid.Resolve(targetCompilation, (comparison & SymbolKeyComparison.IgnoreAssemblyIds) == SymbolKeyComparison.IgnoreAssemblyIds);
 
             return symInfo.Symbol;
         }
 
-        internal static void AssertSymbolKeysEqual(ISymbol symbol1, Compilation compilation1, ISymbol symbol2, Compilation compilation2, SymbolKeyComparison comparison, bool expectEqual = true)
+        internal static void AssertSymbolKeysEqual(ISymbol symbol1, ISymbol symbol2, SymbolKeyComparison comparison, bool expectEqual = true)
         {
-            var sid1 = SymbolKey.Create(symbol1, compilation1, CancellationToken.None);
-            var sid2 = SymbolKey.Create(symbol2, compilation2, CancellationToken.None);
+            var sid1 = SymbolKey.Create(symbol1, CancellationToken.None);
+            var sid2 = SymbolKey.Create(symbol2, CancellationToken.None);
 
             // default is Insensitive
             var isCaseSensitive = (comparison & SymbolKeyComparison.CaseSensitive) == SymbolKeyComparison.CaseSensitive;

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/MetadataAsSourceFileService.cs
@@ -88,7 +88,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             MetadataAsSourceGeneratedFileInfo fileInfo;
             Location navigateLocation = null;
             var topLevelNamedType = MetadataAsSourceHelpers.GetTopLevelContainingNamedType(symbol);
-            var symbolId = SymbolKey.Create(symbol, await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false), cancellationToken);
+            var symbolId = SymbolKey.Create(symbol, cancellationToken);
 
             using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
             {
@@ -244,11 +244,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
 
             if (peMetadataReference.FilePath != null)
             {
-                return new UniqueDocumentKey(peMetadataReference.FilePath, project.Language, SymbolKey.Create(topLevelNamedType, compilation, cancellationToken));
+                return new UniqueDocumentKey(peMetadataReference.FilePath, project.Language, SymbolKey.Create(topLevelNamedType, cancellationToken));
             }
             else
             {
-                return new UniqueDocumentKey(topLevelNamedType.ContainingAssembly.Identity, project.Language, SymbolKey.Create(topLevelNamedType, compilation, cancellationToken));
+                return new UniqueDocumentKey(topLevelNamedType.ContainingAssembly.Identity, project.Language, SymbolKey.Create(topLevelNamedType, cancellationToken));
             }
         }
 

--- a/src/EditorFeatures/Core/Implementation/MetadataAsSource/SymbolMappingServiceFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/MetadataAsSource/SymbolMappingServiceFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.MetadataAsSource
             public async Task<SymbolMappingResult> MapSymbolAsync(Document document, ISymbol symbol, CancellationToken cancellationToken)
             {
                 var compilation = await document.Project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                return await MapSymbolAsync(document, SymbolKey.Create(symbol, compilation, cancellationToken), cancellationToken).ConfigureAwait(false);
+                return await MapSymbolAsync(document, SymbolKey.Create(symbol, cancellationToken), cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
+++ b/src/EditorFeatures/Core/Implementation/Peek/PeekableItemFactory.cs
@@ -68,8 +68,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Peek
             }
             else
             {
-                var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var symbolKey = SymbolKey.Create(symbol, compilation, cancellationToken);
+                var symbolKey = SymbolKey.Create(symbol, cancellationToken);
 
                 var firstLocation = symbol.Locations.FirstOrDefault();
                 if (firstLocation != null)

--- a/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyCompilationsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyCompilationsTests.vb
@@ -119,8 +119,8 @@ End Namespace
                 Dim sym1 = origlist(i)
                 Dim sym2 = newlist(i)
 
-                AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.CaseSensitive, expectEqual:=False)
-                Dim resolvedSymbol = ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.CaseSensitive) ' ignored
+                AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.CaseSensitive, expectEqual:=False)
+                Dim resolvedSymbol = ResolveSymbol(sym2, comp1, SymbolIdComparison.CaseSensitive) ' ignored
                 Assert.NotNull(resolvedSymbol)
                 Assert.Equal(sym1, resolvedSymbol)
             Next
@@ -228,10 +228,10 @@ End Class
             Dim sym1 = comp1.SourceModule.GlobalNamespace.GetMembers("C").FirstOrDefault()
             Dim sym2 = comp2.SourceModule.GlobalNamespace.GetMembers("C").FirstOrDefault()
 
-            AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.CaseInsensitive, expectEqual:=False)
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.CaseInsensitive))
+            AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.CaseInsensitive, expectEqual:=False)
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolIdComparison.CaseInsensitive))
             ' ignore asm id 
-            ResolveAndVerifySymbol(sym2, comp2, sym1, comp1, SymbolIdComparison.CaseInsensitive Or SymbolIdComparison.IgnoreAssemblyIds)
+            ResolveAndVerifySymbol(sym2, sym1, comp1, SymbolIdComparison.CaseInsensitive Or SymbolIdComparison.IgnoreAssemblyIds)
         End Sub
 
         <Fact, WorkItem(530170, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530170")>
@@ -263,22 +263,22 @@ End Class
             Dim sym1 As ISymbol = comp1.Assembly
             Dim sym2 As ISymbol = comp2.Assembly
 
-            AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.CaseInsensitive, False)
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.CaseInsensitive))
+            AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.CaseInsensitive, False)
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolIdComparison.CaseInsensitive))
             ' ignore asm id 
             ' Same ID
-            AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.IgnoreAssemblyIds)
+            AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.IgnoreAssemblyIds)
             ' but can NOT resolve
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.CaseInsensitive Or SymbolIdComparison.IgnoreAssemblyIds))
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolIdComparison.CaseInsensitive Or SymbolIdComparison.IgnoreAssemblyIds))
 
             sym1 = comp1.Assembly.Modules(0)
             sym2 = comp2.Assembly.Modules(0)
 
-            AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.CaseInsensitive, False)
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.CaseInsensitive))
+            AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.CaseInsensitive, False)
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolIdComparison.CaseInsensitive))
 
-            AssertSymbolsIdsEqual(sym2, comp2, sym1, comp1, SymbolIdComparison.IgnoreAssemblyIds)
-            Assert.Null(ResolveSymbol(sym2, comp2, comp1, SymbolIdComparison.IgnoreAssemblyIds))
+            AssertSymbolsIdsEqual(sym2, sym1, comp1, SymbolIdComparison.IgnoreAssemblyIds)
+            Assert.Null(ResolveSymbol(sym2, comp1, SymbolIdComparison.IgnoreAssemblyIds))
         End Sub
 
 #End Region

--- a/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyMetadataVsSourceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyMetadataVsSourceTests.vb
@@ -88,11 +88,11 @@ End Class
             ' 'E'
             Dim mtSym05 = (TryCast(typesym.GetMembers("Item").[Single](), IPropertySymbol)).Type
 
-            ResolveAndVerifySymbol(mtSym03, comp2, originalSymbols(0), comp1, SymbolIdComparison.CaseSensitive)
-            ResolveAndVerifySymbol(mtSym01, comp2, originalSymbols(1), comp1, SymbolIdComparison.CaseSensitive)
-            ResolveAndVerifySymbol(mtSym05, comp2, originalSymbols(2), comp1, SymbolIdComparison.CaseSensitive)
-            ResolveAndVerifySymbol(mtSym02, comp2, originalSymbols(3), comp1, SymbolIdComparison.CaseInsensitive)
-            ResolveAndVerifySymbol(mtSym04, comp2, originalSymbols(4), comp1, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(mtSym03, originalSymbols(0), comp1, SymbolIdComparison.CaseSensitive)
+            ResolveAndVerifySymbol(mtSym01, originalSymbols(1), comp1, SymbolIdComparison.CaseSensitive)
+            ResolveAndVerifySymbol(mtSym05, originalSymbols(2), comp1, SymbolIdComparison.CaseSensitive)
+            ResolveAndVerifySymbol(mtSym02, originalSymbols(3), comp1, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(mtSym04, originalSymbols(4), comp1, SymbolIdComparison.CaseInsensitive)
         End Sub
 
         <Fact>
@@ -245,13 +245,13 @@ End Class
             Dim localSymbols = ver40Symbols.OrderBy(Function(s) s.Name).[Select](Function(s) DirectCast(s, ILocalSymbol)).ToList()
 
             ' a
-            ResolveAndVerifySymbol(localSymbols(0).Type, comp40, typeA, comp20, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(localSymbols(0).Type, typeA, comp20, SymbolIdComparison.CaseInsensitive)
             ' ary
-            ResolveAndVerifySymbol(localSymbols(1).Type, comp40, DirectCast(ver20Symbols(0), IParameterSymbol).Type, comp20, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(localSymbols(1).Type, DirectCast(ver20Symbols(0), IParameterSymbol).Type, comp20, SymbolIdComparison.CaseInsensitive)
             ' dt
-            ResolveAndVerifySymbol(localSymbols(2).Type, comp40, DirectCast(ver20Symbols(4), IParameterSymbol).Type, comp20, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(localSymbols(2).Type, DirectCast(ver20Symbols(4), IParameterSymbol).Type, comp20, SymbolIdComparison.CaseInsensitive)
             ' fi
-            ResolveAndVerifySymbol(localSymbols(3).Type, comp40, DirectCast(ver20Symbols(1), IMethodSymbol).ReturnType, comp20, SymbolIdComparison.CaseInsensitive)
+            ResolveAndVerifySymbol(localSymbols(3).Type, DirectCast(ver20Symbols(1), IMethodSymbol).ReturnType, comp20, SymbolIdComparison.CaseInsensitive)
 
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyTestBase.vb
+++ b/src/EditorFeatures/VisualBasicTest/SymbolId/SymbolKeyTestBase.vb
@@ -38,14 +38,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SymbolId
             Assert.Equal(origlist.Count, newlist.Count)
 
             For i = 0 To newlist.Count - 1
-                ResolveAndVerifySymbol(newlist(i), newCompilation, origlist(i), originalCompilation)
+                ResolveAndVerifySymbol(newlist(i), origlist(i), originalCompilation)
             Next
 
         End Sub
 
         Friend Shared Sub ResolveAndVerifyTypeSymbol(node As ExpressionSyntax, sourceSymbol As ITypeSymbol, model As SemanticModel, sourceComp As Compilation)
             Dim typeinfo = model.GetTypeInfo(node)
-            ResolveAndVerifySymbol(If(typeinfo.Type, typeinfo.ConvertedType), model.Compilation, sourceSymbol, sourceComp)
+            ResolveAndVerifySymbol(If(typeinfo.Type, typeinfo.ConvertedType), sourceSymbol, sourceComp)
         End Sub
 
         Friend Shared Sub ResolveAndVerifySymbol(node As ExpressionSyntax, sourceSymbol As ISymbol, model As SemanticModel, sourceComp As Compilation, Optional comparison As SymbolIdComparison = SymbolIdComparison.None)
@@ -56,29 +56,29 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.SymbolId
                 symbol = syminfo.CandidateSymbols.Single()
             End If
 
-            ResolveAndVerifySymbol(symbol, model.Compilation, sourceSymbol, sourceComp, comparison)
+            ResolveAndVerifySymbol(symbol, sourceSymbol, sourceComp, comparison)
         End Sub
 
-        Friend Shared Sub ResolveAndVerifySymbol(symbol1 As ISymbol, compilation1 As Compilation, symbol2 As ISymbol, compilation2 As Compilation, Optional comparison As SymbolIdComparison = SymbolIdComparison.None)
+        Friend Shared Sub ResolveAndVerifySymbol(symbol1 As ISymbol, symbol2 As ISymbol, compilation2 As Compilation, Optional comparison As SymbolIdComparison = SymbolIdComparison.None)
 
-            AssertSymbolsIdsEqual(symbol1, compilation1, symbol2, compilation2, comparison)
+            AssertSymbolsIdsEqual(symbol1, symbol2, compilation2, comparison)
 
-            Dim resolvedSymbol = ResolveSymbol(symbol1, compilation1, compilation2, comparison)
+            Dim resolvedSymbol = ResolveSymbol(symbol1, compilation2, comparison)
             Assert.NotNull(resolvedSymbol)
             Assert.Equal(symbol2, resolvedSymbol)
             Assert.Equal(symbol2.GetHashCode(), resolvedSymbol.GetHashCode())
         End Sub
 
-        Friend Shared Function ResolveSymbol(originalSymbol As ISymbol, originalCompilation As Compilation, targetCompilation As Compilation, comparison As SymbolIdComparison) As ISymbol
-            Dim sid = SymbolKey.Create(originalSymbol, originalCompilation, CancellationToken.None)
+        Friend Shared Function ResolveSymbol(originalSymbol As ISymbol, targetCompilation As Compilation, comparison As SymbolIdComparison) As ISymbol
+            Dim sid = SymbolKey.Create(originalSymbol, CancellationToken.None)
             Dim symInfo = sid.Resolve(targetCompilation, (comparison And SymbolIdComparison.IgnoreAssemblyIds) = SymbolIdComparison.IgnoreAssemblyIds)
             Return symInfo.Symbol
         End Function
 
-        Friend Shared Sub AssertSymbolsIdsEqual(symbol1 As ISymbol, compilation1 As Compilation, symbol2 As ISymbol, compilation2 As Compilation, comparison As SymbolIdComparison, Optional expectEqual As Boolean = True)
+        Friend Shared Sub AssertSymbolsIdsEqual(symbol1 As ISymbol, symbol2 As ISymbol, compilation2 As Compilation, comparison As SymbolIdComparison, Optional expectEqual As Boolean = True)
 
-            Dim sid1 = SymbolKey.Create(symbol1, compilation1, CancellationToken.None)
-            Dim sid2 = SymbolKey.Create(symbol2, compilation2, CancellationToken.None)
+            Dim sid1 = SymbolKey.Create(symbol1, CancellationToken.None)
+            Dim sid2 = SymbolKey.Create(symbol2, CancellationToken.None)
 
             Dim isCaseSensitive = (comparison And SymbolIdComparison.CaseSensitive) = SymbolIdComparison.CaseSensitive
             Dim ignoreAssemblyIds = (comparison And SymbolIdComparison.IgnoreAssemblyIds) = SymbolIdComparison.IgnoreAssemblyIds

--- a/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
+++ b/src/VisualStudio/Core/Impl/RoslynVisualStudioWorkspace.cs
@@ -156,7 +156,7 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
 
             var originalCompilation = project.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
-            var symbolId = SymbolKey.Create(symbol, originalCompilation, cancellationToken);
+            var symbolId = SymbolKey.Create(symbol, cancellationToken);
             var currentCompilation = currentProject.GetCompilationAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var symbolInfo = symbolId.Resolve(currentCompilation, cancellationToken: cancellationToken);
 

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
@@ -30,6 +30,9 @@ namespace Microsoft.CodeAnalysis
                 _containingKey = GetOrCreate(containingSymbol, visitor);
                 _localName = symbol.Name;
 
+                Contract.ThrowIfNull(
+                    visitor.Compilation,
+                    message: $"visitor cannot be created with a null compilation and visit a {nameof(NonDeclarationSymbolKey<TSymbol>)}.");
                 foreach (var possibleSymbol in EnumerateSymbols(visitor.Compilation, containingSymbol, _localName, visitor.CancellationToken))
                 {
                     if (possibleSymbol.Item1.Equals(symbol))

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.MethodSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.MethodSymbolKey.cs
@@ -87,13 +87,13 @@ namespace Microsoft.CodeAnalysis
                     // Is this a conversion operator? If so, we must also compare the return type.
                     if (_returnType != null)
                     {
-                        if (!_returnType.Equals(SymbolKey.Create(method.ReturnType, compilation, cancellationToken), comparisonOptions))
+                        if (!_returnType.Equals(SymbolKey.Create(method.ReturnType, cancellationToken), comparisonOptions))
                         {
                             continue;
                         }
                     }
 
-                    if (!ParametersMatch(comparisonOptions, compilation, method.OriginalDefinition.Parameters, _refKinds, _originalParameterTypeKeys, cancellationToken))
+                    if (!ParametersMatch(comparisonOptions, method.OriginalDefinition.Parameters, _refKinds, _originalParameterTypeKeys, cancellationToken))
                     {
                         continue;
                     }

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.PropertySymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.PropertySymbolKey.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis
 
                 var comparisonOptions = new ComparisonOptions(compilation.IsCaseSensitive, ignoreAssemblyKey, compareMethodTypeParametersByName: true);
                 var matchingProperties = properties.Where(p =>
-                    ParametersMatch(comparisonOptions, compilation, p.OriginalDefinition.Parameters, _refKinds, _originalParameterTypeKeys, cancellationToken));
+                    ParametersMatch(comparisonOptions, p.OriginalDefinition.Parameters, _refKinds, _originalParameterTypeKeys, cancellationToken));
 
                 return CreateSymbolInfo(matchingProperties);
             }

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.cs
@@ -103,9 +103,9 @@ namespace Microsoft.CodeAnalysis
         /// through GetOrCreate and not Create.
         /// </para>
         /// </summary>
-        internal static SymbolKey Create(ISymbol symbol, Compilation compilation = null, CancellationToken cancellationToken = default(CancellationToken))
+        internal static SymbolKey Create(ISymbol symbol, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return GetOrCreate(symbol, new Visitor(compilation, cancellationToken));
+            return GetOrCreate(symbol, new Visitor((symbol.ContainingAssembly as ISourceAssemblySymbol)?.Compilation, cancellationToken));
         }
 
         private static SymbolKey GetOrCreate(ISymbol symbol, Visitor visitor)
@@ -213,7 +213,6 @@ namespace Microsoft.CodeAnalysis
 
         private static bool ParametersMatch(
             ComparisonOptions options,
-            Compilation compilation,
             ImmutableArray<IParameterSymbol> parameters,
             RefKind[] refKinds,
             SymbolKey[] typeKeys,
@@ -243,7 +242,7 @@ namespace Microsoft.CodeAnalysis
                     options.IgnoreAssemblyKey,
                     compareMethodTypeParametersByName: true);
 
-                if (!typeKeys[i].Equals(SymbolKey.Create(parameter.Type, compilation, cancellationToken), newOptions))
+                if (!typeKeys[i].Equals(SymbolKey.Create(parameter.Type, cancellationToken), newOptions))
                 {
                     return false;
                 }

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKeyExtensions.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKeyExtensions.cs
@@ -8,14 +8,7 @@ namespace Microsoft.CodeAnalysis
     {
         public static SymbolKey GetSymbolKey(this ISymbol symbol)
         {
-            return SymbolKey.Create(symbol, null, CancellationToken.None);
+            return SymbolKey.Create(symbol, CancellationToken.None);
         }
-
-#if false
-        internal static SymbolKey GetSymbolKey(this ISymbol symbol, Compilation compilation, CancellationToken cancellationToken)
-        {
-            return SymbolKey.Create(symbol, compilation, cancellationToken);
-        }
-#endif
     }
 }


### PR DESCRIPTION
Before this change there was a rare case where we would visit `NonDeclarationSymbolKey` within the constructor of `SymbolKey` with a null compilation causing a crash.  We now get the compilation from the symbol itself so this case cannot happen. See [this](https://github.com/dotnet/roslyn/issues/11092#issuecomment-218362553) comment for more information.

Fixes #11092