### PR TITLE
Add InternalImplementationOnly and doc-comments on IOperation

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/IExpression.cs
+++ b/src/Compilers/Core/Portable/Compilation/IExpression.cs
@@ -4,6 +4,10 @@ using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.Semantics
 {
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IHasArgumentsExpression : IOperation
     {
         /// <summary>
@@ -23,6 +27,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# or VB method invocation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IInvocationExpression : IHasArgumentsExpression
     {
         /// <summary>
@@ -48,6 +56,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an argument in a method invocation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IArgument : IOperation
     {
         /// <summary>
@@ -100,6 +112,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to an array element.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IArrayElementReferenceExpression : IOperation
     {
         /// <summary>
@@ -115,6 +131,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference through a pointer.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPointerIndirectionReferenceExpression : IOperation
     {
         /// <summary>
@@ -126,6 +146,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a declared local variable.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILocalReferenceExpression : IOperation
     {
         /// <summary>
@@ -137,6 +161,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a parameter.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IParameterReferenceExpression : IOperation
     {
         /// <summary>
@@ -148,6 +176,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a local variable synthesized by language analysis.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISyntheticLocalReferenceExpression : IOperation
     {
         /// <summary>
@@ -180,6 +212,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# this or base expression, or a VB Me, MyClass, or MyBase expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IInstanceReferenceExpression : IOperation
     {
         ///
@@ -201,10 +237,14 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// <summary>Indicates an explicit MyClass expression.</summary>
         ThisClass = 0x4
     }
-    
+
     /// <summary>
     /// Represents a reference to a member of a class, struct, or interface.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IMemberReferenceExpression : IOperation
     {
         /// <summary>
@@ -213,14 +253,18 @@ namespace Microsoft.CodeAnalysis.Semantics
         IOperation Instance { get; }
 
         /// <summary>
-        /// Referenced member.  
-        /// </summary>  
+        /// Referenced member.
+        /// </summary>
         ISymbol Member { get; }
     }
 
     /// <summary>
     /// Represents a reference to a field.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IFieldReferenceExpression : IMemberReferenceExpression
     {
         /// <summary>
@@ -232,6 +276,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a method other than as the target of an invocation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IMethodBindingExpression : IMemberReferenceExpression
     {
         /// <summary>
@@ -248,6 +296,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to a property.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPropertyReferenceExpression : IMemberReferenceExpression
     {
         /// <summary>
@@ -259,6 +311,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to an indexed property.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IIndexedPropertyReferenceExpression : IPropertyReferenceExpression, IHasArgumentsExpression
     {
     }
@@ -266,6 +322,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a reference to an event.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IEventReferenceExpression : IMemberReferenceExpression
     {
         /// <summary>
@@ -277,6 +337,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a binding of an event.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IEventAssignmentExpression : IOperation
     {
         /// <summary>
@@ -303,6 +367,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an expression that includes a ? or ?. conditional access instance expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IConditionalAccessExpression : IOperation
     {
         /// <summary>
@@ -318,6 +386,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents the value of a conditionally-accessed expression within an expression containing a conditional access.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IConditionalAccessInstanceExpression : IOperation
     {
     }
@@ -326,6 +398,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// Represents a general placeholder when no more specific kind of placeholder is available.
     /// A placeholder is an expression whose meaning is inferred from context.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPlaceholderExpression : IOperation
     {
     }
@@ -333,6 +409,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a unary, binary, relational, or conversion operation that can use an operator method.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IHasOperatorMethodExpression : IOperation
     {
         /// <summary>
@@ -348,6 +428,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an operation with one operand.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IUnaryOperatorExpression : IHasOperatorMethodExpression
     {
         /// <summary>
@@ -473,10 +557,13 @@ namespace Microsoft.CodeAnalysis.Semantics
         Invalid = UnaryOperandKind.Invalid | SimpleUnaryOperationKind.Invalid
     }
 
-    
     /// <summary>
     /// Represents an operation with two operands that produces a result with the same type as at least one of the operands.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IBinaryOperatorExpression : IHasOperatorMethodExpression
     {
         /// <summary>
@@ -831,6 +918,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a conversion operation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IConversionExpression : IHasOperatorMethodExpression
     {
         /// <summary>
@@ -882,6 +973,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# ?: or VB If expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IConditionalChoiceExpression : IOperation
     {
         /// <summary>
@@ -901,6 +996,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a null-coalescing expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface INullCoalescingExpression : IOperation
     {
         /// <summary>
@@ -916,6 +1015,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an expression that tests if a value is of a specific type.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IIsTypeExpression : IOperation
     {
         /// <summary>
@@ -931,6 +1034,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an expression operating on a type.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITypeOperationExpression : IOperation
     {
         /// <summary>
@@ -942,6 +1049,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a SizeOf expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISizeOfExpression : ITypeOperationExpression
     {
     }
@@ -949,6 +1060,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a TypeOf expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITypeOfExpression : ITypeOperationExpression
     {
     }
@@ -956,6 +1071,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a lambda expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILambdaExpression : IOperation
     {
         /// <summary>
@@ -971,6 +1090,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a textual literal numeric, string, etc. expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILiteralExpression : IOperation
     {
         /// <summary>
@@ -982,6 +1105,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an await expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IAwaitExpression : IOperation
     {
         /// <summary>
@@ -993,6 +1120,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an expression that creates a pointer value by taking the address of a reference.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IAddressOfExpression : IOperation
     {
         /// <summary>
@@ -1004,6 +1135,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a new/New expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IObjectCreationExpression : IHasArgumentsExpression
     {
         /// <summary>
@@ -1019,6 +1154,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an initializer for a field, property, or parameter.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISymbolInitializer : IOperation
     {
         IOperation Value { get; }
@@ -1027,6 +1166,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an initialization of a field.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IFieldInitializer : ISymbolInitializer
     {
         /// <summary>
@@ -1038,6 +1181,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an initialization of a property.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IPropertyInitializer : ISymbolInitializer
     {
         /// <summary>
@@ -1049,6 +1196,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an initialization of a parameter at the point of declaration.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IParameterInitializer : ISymbolInitializer
     {
         /// <summary>
@@ -1060,6 +1211,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents the creation of an array instance.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IArrayCreationExpression : IOperation
     {
         /// <summary>
@@ -1079,6 +1234,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents the initialization of an array instance.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IArrayInitializer : IOperation
     {
         /// <summary>
@@ -1090,6 +1249,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an assignment expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IAssignmentExpression : IOperation
     {
         /// <summary>
@@ -1105,6 +1268,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an assignment expression that includes a binary operation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ICompoundAssignmentExpression : IAssignmentExpression, IHasOperatorMethodExpression
     {
         /// <summary>
@@ -1116,6 +1283,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an increment expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IIncrementExpression : ICompoundAssignmentExpression
     {
         /// <summary>
@@ -1127,6 +1298,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a parenthesized expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IParenthesizedExpression : IOperation
     {
         /// <summary>
@@ -1138,6 +1313,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a late-bound reference to a member of a class or struct.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILateBoundMemberReferenceExpression : IOperation
     {
         /// <summary>
@@ -1153,22 +1332,42 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an argument value that has been omitted in an invocation.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IOmittedArgumentExpression : IOperation
     {
     }
 
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IUnboundLambdaExpression : IOperation
     {
     }
 
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IDefaultValueExpression : IOperation
     {
     }
 
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITypeParameterObjectCreationExpression : IOperation
     {
     }
 
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IInvalidExpression : IOperation
     {
     }

--- a/src/Compilers/Core/Portable/Compilation/IOperation.cs
+++ b/src/Compilers/Core/Portable/Compilation/IOperation.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using Microsoft.CodeAnalysis.Semantics;
 
 namespace Microsoft.CodeAnalysis
@@ -7,6 +8,11 @@ namespace Microsoft.CodeAnalysis
     /// <summary>
     /// Root type for representing the abstract semantics of C# and VB statements and expressions.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
+    [InternalImplementationOnly]
     public interface IOperation
     {
         /// <summary>

--- a/src/Compilers/Core/Portable/Compilation/IStatement.cs
+++ b/src/Compilers/Core/Portable/Compilation/IStatement.cs
@@ -7,6 +7,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a block scope.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IBlockStatement : IOperation
     {
         /// <summary>
@@ -22,6 +26,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a local variable declaration statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IVariableDeclarationStatement : IOperation
     {
         /// <summary>
@@ -33,6 +41,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a local variable declaration.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IVariableDeclaration : IOperation
     {
         /// <summary>
@@ -48,6 +60,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# switch or VB Select Case statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISwitchStatement : IOperation
     {
         /// <summary>
@@ -63,6 +79,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# case or VB Case statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISwitchCase : IOperation
     {
         /// <summary>
@@ -78,6 +98,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a clause of a C# case or a VB Case.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ICaseClause : IOperation
     {
         /// <summary>
@@ -114,6 +138,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents case x in C# or Case x in VB.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ISingleValueCaseClause : ICaseClause
     {
         /// <summary>
@@ -129,6 +157,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents Case Is op x in VB.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IRelationalCaseClause : ICaseClause
     {
         /// <summary>
@@ -136,7 +168,7 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         IOperation Value { get; }
         /// <summary>
-        /// Relational operator used to compare the switch value with the case value. 
+        /// Relational operator used to compare the switch value with the case value.
         /// </summary>
         BinaryOperationKind Relation { get; }
     }
@@ -144,6 +176,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents Case x To y in VB.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IRangeCaseClause : ICaseClause
     {
         /// <summary>
@@ -159,6 +195,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents an if statement in C# or an If statement in VB.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IIfStatement : IOperation
     {
         /// <summary>
@@ -178,6 +218,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# while, for, foreach, or do statement, or a VB While, For, For Each, or Do statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILoopStatement : IOperation
     {
         /// <summary>
@@ -214,6 +258,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# while, for, or do statement, or a VB While, For, or Do statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IForWhileUntilLoopStatement : ILoopStatement
     {
         /// <summary>
@@ -225,6 +273,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# while or do statement, or a VB While or Do statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IWhileUntilLoopStatement : IForWhileUntilLoopStatement
     {
         /// <summary>
@@ -240,6 +292,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# for statement or a VB For statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IForLoopStatement : IForWhileUntilLoopStatement
     {
         /// <summary>
@@ -259,6 +315,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# foreach statement or a VB For Each staement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IForEachLoopStatement : ILoopStatement
     {
         /// <summary>
@@ -274,6 +334,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# or VB label statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILabelStatement : IOperation
     {
         /// <summary>
@@ -289,6 +353,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# goto, break, or continue statement, or a VB GoTo, Exit ***, or Continue *** statement
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IBranchStatement : IOperation
     {
         /// <summary>
@@ -312,6 +380,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# throw or a VB Throw statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IThrowStatement : IOperation
     {
         /// <summary>
@@ -323,6 +395,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# return or a VB Return statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IReturnStatement : IOperation
     {
         /// <summary>
@@ -334,6 +410,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# lock or a VB SyncLock statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ILockStatement : IOperation
     {
         /// <summary>
@@ -349,6 +429,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# try or a VB Try statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ITryStatement : IOperation
     {
         /// <summary>
@@ -368,6 +452,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# catch or VB Catch clause.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface ICatchClause : IOperation
     {
         /// <summary>
@@ -391,6 +479,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# using or VB Using statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IUsingStatement : IOperation
     {
         /// <summary>
@@ -408,10 +500,14 @@ namespace Microsoft.CodeAnalysis.Semantics
         /// </summary>
         IOperation Value { get; }
     }
-    
+
     /// <summary>
     /// Represents a C# fixed staement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IFixedStatement : IOperation
     {
         /// <summary>
@@ -427,6 +523,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a C# or VB statement that consists solely of an expression.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IExpressionStatement : IOperation
     {
         /// <summary>
@@ -438,6 +538,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a VB With statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IWithStatement : IOperation
     {
         /// <summary>
@@ -453,6 +557,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Reprsents an empty statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IEmptyStatement : IOperation
     {
     }
@@ -460,6 +568,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a VB Stop statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IStopStatement : IOperation
     {
     }
@@ -467,6 +579,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a VB End statemnt.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IEndStatement : IOperation
     {
     }
@@ -474,6 +590,10 @@ namespace Microsoft.CodeAnalysis.Semantics
     /// <summary>
     /// Represents a syntactically or semantically invalid C# or VB statement.
     /// </summary>
+    /// <remarks>
+    /// This interface is reserved for implementation by its associated APIs. We reserve the right to
+    /// change it in the future.
+    /// </remarks>
     public interface IInvalidStatement : IOperation
     {
     }

--- a/src/Compilers/Core/Portable/Symbols/ISourceAssemblySymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISourceAssemblySymbol.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis
     /// This interface is reserved for implementation by its associated APIs. We reserve the right to
     /// change it in the future.
     /// </remarks>
-    [InternalImplementationOnly]
     public interface ISourceAssemblySymbol : IAssemblySymbol
     {
         Compilation Compilation { get; }


### PR DESCRIPTION
This supports running an analyzer that warns when a user implements these interfaces.

A prerequisite to fix https://github.com/dotnet/roslyn-analyzers/issues/863.

- Copied the remark from `ISymbol` derivations on all public interfaces that derive from `IOperation`
- Added remark and `[InternalImplementationOnly]` on `IOperation`
- Removed `[InternalImplementationOnly]` from `ISourceAssemblySymbol` because it was only there, unneeded