### PR TITLE
Improve OrderPreservingMultiDictionary.

### DIFF
--- a/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
+++ b/src/Compilers/Core/Portable/Collections/OrderPreservingMultiDictionary.cs
@@ -166,10 +166,7 @@ namespace Microsoft.CodeAnalysis.Collections
             internal void Free()
             {
                 var arrayBuilder = _value as ArrayBuilder<V>;
-                if (arrayBuilder != null)
-                {
-                    arrayBuilder.Free();
-                }
+                arrayBuilder?.Free();
             }
 
             internal V this[int index]

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -41,6 +41,9 @@
     <Compile Include="..\..\..\Compilers\Core\Portable\Collections\ImmutableArrayExtensions.cs">
       <Link>InternalUtilities\ImmutableArrayExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\Compilers\Core\Portable\Collections\OrderPreservingMultiDictionary.cs">
+      <Link>Utilities\CompilerUtilities\OrderPreservingMultiDictionary.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\Compilers\Core\Portable\Collections\PooledStringBuilder.cs">
       <Link>Collections\PooledStringBuilder.cs</Link>
     </Compile>


### PR DESCRIPTION
1. Support allocation-free enumeration of the dictionary.
2. Pool internal data so that less garbage is churned when creating and releasing dictionaries.