### PR TITLE
Add missed code hooking up the option for /**/ comments

### DIFF
--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -31,6 +31,12 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(FeatureOnOffOptions.AutoXmlDocCommentGeneration, value); }
         }
 
+        public int AutoInsertAsteriskForNewLinesOfBlockComments
+        {
+            get { return GetBooleanOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString); }
+            set { SetBooleanOption(FeatureOnOffOptions.AutoInsertBlockCommentStartString, value); }
+        }
+
         public int BringUpOnIdentifier
         {
             get { return GetBooleanOption(CompletionOptions.TriggerOnTypingLetters); }

--- a/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/CSharpSettingsManagerOptionSerializer.cs
@@ -164,6 +164,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
                    option == FeatureOnOffOptions.KeywordHighlighting ||
                    option == FeatureOnOffOptions.FormatOnPaste ||
                    option == FeatureOnOffOptions.AutoXmlDocCommentGeneration ||
+                   option == FeatureOnOffOptions.AutoInsertBlockCommentStartString ||
                    option == FeatureOnOffOptions.RefactoringVerification ||
                    option == FeatureOnOffOptions.RenameTracking ||
                    option == FeatureOnOffOptions.RenameTrackingPreview;


### PR DESCRIPTION
Fixes #11264. Plus a property in the `AutomationObject`, don't know where it will be used though.

I can not find existing tests for persisting individual options. So I'm not sure how to properly prevent this from happening again.