### PR TITLE
Fix formatting of ref/out parameters in Scripting

### DIFF
--- a/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatterImpl.cs
+++ b/src/Scripting/CSharp/Hosting/ObjectFormatter/CSharpObjectFormatterImpl.cs
@@ -18,13 +18,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
             Filter = new CSharpMemberFilter();
         }
 
-        protected override string FormatRefKind(ParameterInfo parameter)
-        {
-            return parameter.IsOut
-                ? parameter.IsIn
-                    ? "ref"
-                    : "out"
-                : "";
-        }
+        protected override string FormatRefKind(ParameterInfo parameter) => parameter.IsOut ? "out" : "ref";
     }
 }

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -994,6 +994,7 @@ $@"Exception of type 'System.Exception' was thrown.
             {
                 const string filePath = @"z:\Fixture.cs";
 
+                // TODO (DevDiv #173210): Should show ParametersFixture.Method<char>(ref char)
                 var expected =
 $@"Exception of type 'System.Exception' was thrown.
   + Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests.ObjectFormatterTests.ParametersFixture.Method<U>(ref U){string.Format(ScriptingResources.AtFileLine, filePath, 10161)}

--- a/src/Scripting/CSharpTest/ObjectFormatterTests.cs
+++ b/src/Scripting/CSharpTest/ObjectFormatterTests.cs
@@ -943,5 +943,65 @@ $@"'object' does not contain a definition for 'x'
                 Assert.Equal(expected, actual);
             }
         }
+
+        private static class ParametersFixture
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static void Method(ref char c, out DateTime d)
+            {
+                throw new Exception();
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public static void Method<U>(ref U u)
+            {
+                throw new Exception();
+            }
+        }
+
+        [Fact]
+        public void StackTrace_RefOutParameters()
+        {
+            try
+            {
+                char c = ' ';
+                DateTime date;
+                ParametersFixture.Method(ref c, out date);
+            }
+            catch (Exception e)
+            {
+                const string filePath = @"z:\Fixture.cs";
+
+                var expected =
+$@"Exception of type 'System.Exception' was thrown.
+  + Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests.ObjectFormatterTests.ParametersFixture.Method(ref char, out System.DateTime){string.Format(ScriptingResources.AtFileLine, filePath, 10155)}
+  + Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests.ObjectFormatterTests.StackTrace_RefOutParameters(){string.Format(ScriptingResources.AtFileLine, filePath, 10172)}
+";
+                var actual = s_formatter.FormatException(e);
+                Assert.Equal(expected, actual);
+            }
+        }
+
+        [Fact]
+        public void StackTrace_GenericRefParameter()
+        {
+            try
+            {
+                char c = ' ';
+                ParametersFixture.Method<char>(ref c);
+            }
+            catch (Exception e)
+            {
+                const string filePath = @"z:\Fixture.cs";
+
+                var expected =
+$@"Exception of type 'System.Exception' was thrown.
+  + Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests.ObjectFormatterTests.ParametersFixture.Method<U>(ref U){string.Format(ScriptingResources.AtFileLine, filePath, 10161)}
+  + Microsoft.CodeAnalysis.CSharp.Scripting.Hosting.UnitTests.ObjectFormatterTests.StackTrace_GenericRefParameter(){string.Format(ScriptingResources.AtFileLine, filePath, 10194)}
+";
+                var actual = s_formatter.FormatException(e);
+                Assert.Equal(expected, actual);
+            }
+        }
     }
 }

--- a/src/Scripting/Core/Hosting/ObjectFormatter/CommonObjectFormatter.cs
+++ b/src/Scripting/Core/Hosting/ObjectFormatter/CommonObjectFormatter.cs
@@ -131,8 +131,16 @@ namespace Microsoft.CodeAnalysis.Scripting.Hosting
                     builder.Append(", ");
                 }
 
-                builder.Append(FormatRefKind(parameter));
-                builder.Append(TypeNameFormatter.FormatTypeName(parameter.ParameterType, options));
+                if (parameter.ParameterType.IsByRef)
+                {
+                    builder.Append(FormatRefKind(parameter));
+                    builder.Append(' ');
+                    builder.Append(TypeNameFormatter.FormatTypeName(parameter.ParameterType.GetElementType(), options));
+                }
+                else
+                {
+                    builder.Append(TypeNameFormatter.FormatTypeName(parameter.ParameterType, options));
+                }
             }
 
             builder.Append(')');

--- a/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatterImpl.vb
+++ b/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatterImpl.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Sub
 
         Protected Overrides Function FormatRefKind(parameter As ParameterInfo) As String
-            Return "ByRef"
+            Return If(parameter.IsOut, "<Out> ByRef", "ByRef")
         End Function
     End Class
 

--- a/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatterImpl.vb
+++ b/src/Scripting/VisualBasic/Hosting/ObjectFormatter/VisualBasicObjectFormatterImpl.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         End Sub
 
         Protected Overrides Function FormatRefKind(parameter As ParameterInfo) As String
-            Return If(parameter.IsOut, "ByRef", "")
+            Return "ByRef"
         End Function
     End Class
 


### PR DESCRIPTION
This is used when displaying exceptions in csi.

Previously, ref/out parameters in stacktraces were shown incorrectly, and even threw `NullRerefenceException` when the type of the ref/out parameter was a type parameter.

Fixes the fixable part of #11284