### PR TITLE
Fix a bug with command line args on Windows+Mono, fixes #11316

### DIFF
--- a/src/Compilers/Core/CommandLine/BuildClient.cs
+++ b/src/Compilers/Core/CommandLine/BuildClient.cs
@@ -65,6 +65,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
     internal abstract class BuildClient
     {
         protected static bool IsRunningOnWindows => Path.DirectorySeparatorChar == '\\';
+        
+        protected static bool IsRunningOnMono => Type.GetType("Mono.Runtime") != null;
 
         /// <summary>
         /// Run a compilation through the compiler server and print the output
@@ -197,7 +199,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         protected static IEnumerable<string> GetCommandLineArgs(IEnumerable<string> args)
         {
-            if (IsRunningOnWindows)
+            if (IsRunningOnWindows && !IsRunningOnMono)
             {
                 return GetCommandLineWindows(args);
             }


### PR DESCRIPTION
We shouldn't invoke `GetCommandLineWindows` on Mono. Otherwise, arguments for `mono csc.exe Program.cs` will be equal to [`csc.exe`, `Program.cs`] instead of [`Program.cs`]. As a result, csc.exe will try to compile binary content of `csc.exe`. Original bug report: #11316.
