### PR TITLE
Correct intellisense and indentation for fixed statements

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartTokenFormatterFormatRangeTests.cs
@@ -2922,6 +2922,147 @@ class Program{
         }
 
         [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task UsingStatementWithNestedFixedStatement()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        using (null)
+        fixed (void* ptr = &i)
+        {
+        }$$
+    }
+}";
+
+            var expected = @"class C
+{
+    public void M()
+    {
+        using (null)
+            fixed (void* ptr = &i)
+            {
+            }
+    }
+}";
+
+            await AutoFormatTokenAsync(code, expected);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task FixedStatementWithNestedUsingStatement()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr = &i)
+        using (null)$$
+    }
+}";
+
+            var expected = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr = &i)
+            using (null)
+    }
+}";
+
+            await AutoFormatTokenAsync(code, expected);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task FixedStatementWithNestedFixedStatement()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr1 = &i)
+            fixed (void* ptr2 = &i)
+            {
+            }$$
+    }
+}";
+
+            var expected = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr1 = &i)
+        fixed (void* ptr2 = &i)
+        {
+        }
+    }
+}";
+
+            await AutoFormatTokenAsync(code, expected);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task FixedStatementWithNestedNotFixedStatement()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr = &i)
+        if (false)
+        {
+        }$$
+    }
+}";
+
+            var expected = @"class C
+{
+    public void M()
+    {
+        fixed (void* ptr = &i)
+            if (false)
+            {
+            }
+    }
+}";
+
+            await AutoFormatTokenAsync(code, expected);
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task NotFixedStatementWithNestedFixedStatement()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        if (false)
+        fixed (void* ptr = &i)
+        {
+        }$$
+    }
+}";
+
+            var expected = @"class C
+{
+    public void M()
+    {
+        if (false)
+            fixed (void* ptr = &i)
+            {
+            }
+    }
+}";
+
+            await AutoFormatTokenAsync(code, expected);
+        }
+
+        [WpfFact]
         [WorkItem(954386, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/954386")]
         [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
         public async Task FormattingRangeForFirstStatementOfBlock()

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -93,6 +93,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // using (expr)
             //   |
 
+            // fixed (void* v = &expr)
+            //   |
+
             // lock (expr)
             //   |
 
@@ -170,7 +173,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     parent.IsKind(SyntaxKind.WhileStatement) ||
                     parent.IsKind(SyntaxKind.IfStatement) ||
                     parent.IsKind(SyntaxKind.LockStatement) ||
-                    parent.IsKind(SyntaxKind.UsingStatement))
+                    parent.IsKind(SyntaxKind.UsingStatement) ||
+                    parent.IsKind(SyntaxKind.FixedStatement))
                 {
                     return true;
                 }

--- a/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/FormattingHelpers.cs
@@ -321,6 +321,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return usingStatement.CloseParenToken.Equals(token);
             }
 
+            var fixedStatement = statement as FixedStatementSyntax;
+            if (fixedStatement != null)
+            {
+                return fixedStatement.CloseParenToken.Equals(token);
+            }
+
             return false;
         }
 
@@ -386,6 +392,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                    node is ForStatementSyntax ||
                    node is ForEachStatementSyntax ||
                    node is UsingStatementSyntax ||
+                   node is FixedStatementSyntax ||
                    node is LockStatementSyntax;
         }
 

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -259,6 +259,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return;
             }
 
+            var fixedStatement = node as FixedStatementSyntax;
+            if (fixedStatement != null && fixedStatement.Statement != null && !(fixedStatement.Statement is BlockSyntax || fixedStatement.Statement is FixedStatementSyntax))
+            {
+                AddEmbeddedStatementsIndentationOperation(list, fixedStatement.Statement);
+                return;
+            }
+
             var doStatement = node as DoStatementSyntax;
             if (doStatement != null && doStatement.Statement != null && !(doStatement.Statement is BlockSyntax))
             {

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                     parent.Kind() == SyntaxKind.ForStatement || parent.Kind() == SyntaxKind.TryStatement ||
                     parent.Kind() == SyntaxKind.CatchClause || parent.Kind() == SyntaxKind.FinallyClause ||
                     parent.Kind() == SyntaxKind.LockStatement || parent.Kind() == SyntaxKind.CheckedStatement ||
-                    parent.Kind() == SyntaxKind.UncheckedStatement || parent.Kind() == SyntaxKind.SwitchSection));
+                    parent.Kind() == SyntaxKind.UncheckedStatement || parent.Kind() == SyntaxKind.SwitchSection ||
+                    parent.Kind() == SyntaxKind.FixedStatement));
         }
 
         public override AdjustSpacesOperation GetAdjustSpacesOperation(SyntaxToken previousToken, SyntaxToken currentToken, OptionSet optionSet, NextOperation<AdjustSpacesOperation> nextOperation)

--- a/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
+++ b/src/Workspaces/CSharp/Portable/Utilities/FormattingRangeHelper.cs
@@ -359,7 +359,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
                 node.Kind() == SyntaxKind.CatchClause ||
                 node.Kind() == SyntaxKind.FinallyClause ||
                 node.Kind() == SyntaxKind.LabeledStatement ||
-                node.Kind() == SyntaxKind.LockStatement;
+                node.Kind() == SyntaxKind.LockStatement ||
+                node.Kind() == SyntaxKind.FixedStatement;
         }
 
         private static SyntaxNode GetTopContainingNode(SyntaxNode node)


### PR DESCRIPTION
Ensures the IDE treats `fixed` statements as statement contexts so IntelliSense will be shown after the closing parenthesis.

This also adds some missing "magic" to correct the indentation of `fixed` statements. With this change, they're treated similar to `using`.

Fixes #11213.