### PR TITLE
Remove -anycpu RIDs in project.json files

### DIFF
--- a/src/Compilers/CSharp/csc/project.json
+++ b/src/Compilers/CSharp/csc/project.json
@@ -7,10 +7,7 @@
   },
   "runtimes": {
     "win7": { },
-    "win7-anycpu": { },
     "ubuntu.14.04": { },
-    "ubuntu.14.04-anycpu": { },
-    "osx.10.10": { },
-    "osx.10.10-anycpu": { }
+    "osx.10.10": { }
   }
 }

--- a/src/Compilers/Core/MSBuildTask/Desktop/project.json
+++ b/src/Compilers/Core/MSBuildTask/Desktop/project.json
@@ -4,7 +4,6 @@
     "net45": {}
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Compilers/Extension/project.json
+++ b/src/Compilers/Extension/project.json
@@ -7,7 +7,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Compilers/Server/VBCSCompiler/project.json
+++ b/src/Compilers/Server/VBCSCompiler/project.json
@@ -6,10 +6,7 @@
   },
   "runtimes": {
     "win7": { },
-    "win7-anycpu": { },
     "ubuntu.14.04": { },
-    "ubuntu.14.04-anycpu": { },
-    "osx.10.10": { },
-    "osx.10.10-anycpu": { }
+    "osx.10.10": { }
   }
 }

--- a/src/Compilers/VisualBasic/vbc/project.json
+++ b/src/Compilers/VisualBasic/vbc/project.json
@@ -7,10 +7,7 @@
   },
   "runtimes": {
     "win7": { },
-    "win7-anycpu": { },
     "ubuntu.14.04": { },
-    "ubuntu.14.04-anycpu": { },
-    "osx.10.10": { },
-    "osx.10.10-anycpu": { }
+    "osx.10.10": { }
   }
 }

--- a/src/EditorFeatures/Test/project.json
+++ b/src/EditorFeatures/Test/project.json
@@ -8,7 +8,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/ExpressionEvaluator/Package/project.json
+++ b/src/ExpressionEvaluator/Package/project.json
@@ -5,7 +5,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Interactive/Host/project.json
+++ b/src/Interactive/Host/project.json
@@ -4,7 +4,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Interactive/csi/project.json
+++ b/src/Interactive/csi/project.json
@@ -4,7 +4,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Interactive/vbi/project.json
+++ b/src/Interactive/vbi/project.json
@@ -4,7 +4,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Samples/CSharp/APISampleUnitTests/project.json
+++ b/src/Samples/CSharp/APISampleUnitTests/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ConsoleClassifier/project.json
+++ b/src/Samples/CSharp/ConsoleClassifier/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ConvertToAutoProperty/project.json
+++ b/src/Samples/CSharp/ConvertToAutoProperty/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ConvertToConditional/Impl/project.json
+++ b/src/Samples/CSharp/ConvertToConditional/Impl/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ConvertToConditional/Test/project.json
+++ b/src/Samples/CSharp/ConvertToConditional/Test/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/CopyPasteWithUsing/project.json
+++ b/src/Samples/CSharp/CopyPasteWithUsing/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/FormatSolution/project.json
+++ b/src/Samples/CSharp/FormatSolution/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/project.json
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/project.json
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Test/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/MakeConst/Impl/project.json
+++ b/src/Samples/CSharp/MakeConst/Impl/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/RefOutModifier/project.json
+++ b/src/Samples/CSharp/RefOutModifier/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/CSharp/TreeTransforms/project.json
+++ b/src/Samples/CSharp/TreeTransforms/project.json
@@ -5,8 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-x86" : {},
-    "win7-anycpu": {}
+    "win7-x86": {}
   }
 }

--- a/src/Samples/Shared/UnitTestFramework/project.json
+++ b/src/Samples/Shared/UnitTestFramework/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/APISampleUnitTests/project.json
+++ b/src/Samples/VisualBasic/APISampleUnitTests/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/ConsoleClassifier/project.json
+++ b/src/Samples/VisualBasic/ConsoleClassifier/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/project.json
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Test/project.json
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Test/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/FormatSolution/project.json
+++ b/src/Samples/VisualBasic/FormatSolution/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/project.json
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/project.json
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Test/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/MakeConst/Impl/project.json
+++ b/src/Samples/VisualBasic/MakeConst/Impl/project.json
@@ -5,7 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/RemoveByVal/Impl/project.json
+++ b/src/Samples/VisualBasic/RemoveByVal/Impl/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/RemoveByVal/Test/project.json
+++ b/src/Samples/VisualBasic/RemoveByVal/Test/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Samples/VisualBasic/TreeTransforms/project.json
+++ b/src/Samples/VisualBasic/TreeTransforms/project.json
@@ -5,8 +5,6 @@
     "net452": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-x86": {},
-    "win7-anycpu": {}
+    "win7-x86": {}
   }
 }

--- a/src/Test/DeployDesktopTestRuntime/project.json
+++ b/src/Test/DeployDesktopTestRuntime/project.json
@@ -4,7 +4,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Test/Utilities/Desktop/project.json
+++ b/src/Test/Utilities/Desktop/project.json
@@ -7,11 +7,8 @@
     "net45": { }
   },
   "runtimes": {
-    "win7-anycpu": { },
     "win7": { },
     "ubuntu.14.04": { },
-    "ubuntu.14.04-anycpu": { },
-    "osx.10.10": { },
-    "osx.10.10-anycpu": { }
+    "osx.10.10": { }
   }
 }

--- a/src/Test/Utilities/Portable.FX45/project.json
+++ b/src/Test/Utilities/Portable.FX45/project.json
@@ -7,10 +7,7 @@
   },
   "runtimes": {
     "win7": { },
-    "win7-anycpu": { },
     "ubuntu.14.04": { },
-    "ubuntu.14.04-anycpu": { },
-    "osx.10.10": { },
-    "osx.10.10-anycpu": { }
+    "osx.10.10": { }
   }
 }

--- a/src/Tools/ProcessWatchdog/project.json
+++ b/src/Tools/ProcessWatchdog/project.json
@@ -6,7 +6,6 @@
     "net45": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/Tools/Source/MetadataVisualizer/project.json
+++ b/src/Tools/Source/MetadataVisualizer/project.json
@@ -4,7 +4,6 @@
     "net45": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/Tools/Source/Pdb2Xml/project.json
+++ b/src/Tools/Source/Pdb2Xml/project.json
@@ -5,7 +5,6 @@
     "net45": {}
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": {}
+    "win7": { }
   }
 }

--- a/src/Tools/Source/RunTests/project.json
+++ b/src/Tools/Source/RunTests/project.json
@@ -7,7 +7,6 @@
     "net45": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/VisualStudio/Setup/project.json
+++ b/src/VisualStudio/Setup/project.json
@@ -6,7 +6,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }

--- a/src/VisualStudio/TestUtilities/project.json
+++ b/src/VisualStudio/TestUtilities/project.json
@@ -5,7 +5,6 @@
     "net46": {}
   },
   "runtimes": {
-    "win7": {},
-    "win7-anycpu": {}
+    "win7": {}
   }
 }

--- a/src/VisualStudio/VisualStudioInteractiveComponents/project.json
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/project.json
@@ -4,7 +4,6 @@
     "net46": { }
   },
   "runtimes": {
-    "win7": { },
-    "win7-anycpu": { }
+    "win7": { }
   }
 }


### PR DESCRIPTION
These were workarounds for building with Visual Studio 2015 RTM. We
don't support that anymore.

Fixes #8767.

*Review:* @dotnet/roslyn-infrastructure, @agocke, @jaredpar, @tannergooding