### PR TITLE
/errorlog improvements, fixes, and marking as v1.0.0

### DIFF
--- a/docs/compilers/Error Log Format.md
+++ b/docs/compilers/Error Log Format.md
@@ -1,31 +1,6 @@
-Introduction
-============
 The C# and Visual Basic compilers support a /errorlog:<file> switch on
 the command line to log all diagnostics in a structured, JSON format.
 
-The log format is SARIF (Static Analysis Results Interchange Format)
-and is defined by https://github.com/sarif-standard/sarif-spec
-
-Note that the format has not been finalized and the specification is
-still a draft. It will remain subject to breaking changes until the
-`version` property is emitted with a value of "1.0" or greater.
-
-This document does not repeat the details of the SARIF format, but
-rather adds information that is specific to the implementation provided
-by the C# and Visual Basic Compilers.
-
-
-Result Properties
-================
-The SARIF standard allows the `properties` property of `result` objects
-to contain arbitrary (string, string) key-value pairs.
-
-The keys and values used by the C# and VB compilers are serialized from
-the corresponding `Microsoft.CodeAnalysis.Diagnostic` as follows:
-
-Key                      | Value
------------------------- | ------------
-"warningLevel"           | `Diagnostic.WarningLevel`
-"category"               | `Diagnostic.Category`
-"isEnabledByDefault"     | `Diagnostic.IsEnabledByDefault
-"customProperties"       | `Diagnostic.Properties` 
+The log format is SARIF (Static Analysis Results Interchange Format):
+See https://sarifweb.azurewebsites.net/ for the format specification,
+JSON schema, and other related resources.

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -36,8 +36,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
             string expected =
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
-  ""version"": ""1.0.0-beta.5"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""version"": ""1.0.0"",
   ""runs"": [
     {
       ""tool"": {
@@ -146,8 +146,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
 
             string expected = 
 @"{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
-  ""version"": ""1.0.0-beta.5"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""version"": ""1.0.0"",
   ""runs"": [
     {
       ""tool"": {

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -111,11 +111,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void DescriptorIdCollision()
         {
             var descriptors = new[] {
-                // Toughest case: generation of TST001.001 collides with with actual TST001.001 and must be bumped to TST001.002
-                new DiagnosticDescriptor("TST001.001",    "_TST001.001_",     "", "", DiagnosticSeverity.Warning, true),
+                // Toughest case: generation of TST001-001 collides with with actual TST001-001 and must be bumped to TST001-002
+                new DiagnosticDescriptor("TST001-001",    "_TST001-001_",     "", "", DiagnosticSeverity.Warning, true),
                 new DiagnosticDescriptor("TST001",        "_TST001_",         "", "", DiagnosticSeverity.Warning, true),
-                new DiagnosticDescriptor("TST001",        "_TST001.002_",     "", "", DiagnosticSeverity.Warning, true),
-                new DiagnosticDescriptor("TST001",        "_TST001.003_",     "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST001",        "_TST001-002_",     "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST001",        "_TST001-003_",     "", "", DiagnosticSeverity.Warning, true),
 
                 // Descriptors with same values should not get distinct entries in log
                 new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Warning, true),
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
       },
       ""results"": [
         {
-          ""ruleId"": ""TST001.001"",
+          ""ruleId"": ""TST001-001"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -174,7 +174,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST001"",
-          ""ruleKey"": ""TST001.002"",
+          ""ruleKey"": ""TST001-002"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST001"",
-          ""ruleKey"": ""TST001.003"",
+          ""ruleKey"": ""TST001-003"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -212,7 +212,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.001"",
+          ""ruleKey"": ""TST002-001"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -220,7 +220,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.002"",
+          ""ruleKey"": ""TST002-002"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -228,12 +228,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.003"",
+          ""ruleKey"": ""TST002-003"",
           ""level"": ""error""
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.004"",
+          ""ruleKey"": ""TST002-004"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -241,21 +241,14 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.005"",
+          ""ruleKey"": ""TST002-005"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
           }
         },
         {
-          ""ruleId"": ""TST001.001"",
-          ""level"": ""warning"",
-          ""properties"": {
-            ""warningLevel"": 1
-          }
-        },
-        {
-          ""ruleId"": ""TST001"",
+          ""ruleId"": ""TST001-001"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -263,7 +256,6 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST001"",
-          ""ruleKey"": ""TST001.002"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -271,7 +263,15 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST001"",
-          ""ruleKey"": ""TST001.003"",
+          ""ruleKey"": ""TST001-002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST001"",
+          ""ruleKey"": ""TST001-003"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.001"",
+          ""ruleKey"": ""TST002-001"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.002"",
+          ""ruleKey"": ""TST002-002"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -317,12 +317,12 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.003"",
+          ""ruleKey"": ""TST002-003"",
           ""level"": ""error""
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.004"",
+          ""ruleKey"": ""TST002-004"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -330,7 +330,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         },
         {
           ""ruleId"": ""TST002"",
-          ""ruleKey"": ""TST002.005"",
+          ""ruleKey"": ""TST002-005"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -346,25 +346,25 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             ""isEnabledByDefault"": true
           }
         },
-        ""TST001.001"": {
-          ""id"": ""TST001.001"",
-          ""shortDescription"": ""_TST001.001_"",
+        ""TST001-001"": {
+          ""id"": ""TST001-001"",
+          ""shortDescription"": ""_TST001-001_"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
             ""isEnabledByDefault"": true
           }
         },
-        ""TST001.002"": {
+        ""TST001-002"": {
           ""id"": ""TST001"",
-          ""shortDescription"": ""_TST001.002_"",
+          ""shortDescription"": ""_TST001-002_"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
             ""isEnabledByDefault"": true
           }
         },
-        ""TST001.003"": {
+        ""TST001-003"": {
           ""id"": ""TST001"",
-          ""shortDescription"": ""_TST001.003_"",
+          ""shortDescription"": ""_TST001-003_"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
             ""isEnabledByDefault"": true
@@ -377,7 +377,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             ""isEnabledByDefault"": true
           }
         },
-        ""TST002.001"": {
+        ""TST002-001"": {
           ""id"": ""TST002"",
           ""shortDescription"": ""title_001"",
           ""defaultLevel"": ""warning"",
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             ""isEnabledByDefault"": true
           }
         },
-        ""TST002.002"": {
+        ""TST002-002"": {
           ""id"": ""TST002"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
@@ -393,21 +393,21 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             ""isEnabledByDefault"": true
           }
         },
-        ""TST002.003"": {
+        ""TST002-003"": {
           ""id"": ""TST002"",
           ""defaultLevel"": ""error"",
           ""properties"": {
             ""isEnabledByDefault"": true
           }
         },
-        ""TST002.004"": {
+        ""TST002-004"": {
           ""id"": ""TST002"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
             ""isEnabledByDefault"": false
           }
         },
-        ""TST002.005"": {
+        ""TST002-005"": {
           ""id"": ""TST002"",
           ""fullDescription"": ""description_005"",
           ""defaultLevel"": ""warning"",

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void AdditionalLocationsAsRelatedLocations()
         {
             var stream = new MemoryStream();
-            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), CultureInfo.InvariantCulture))
+            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("fr-CA")))
             {
                 var span = new TextSpan(0, 0);
                 var position = new LinePositionSpan(LinePosition.Zero, LinePosition.Zero);
@@ -44,7 +44,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         ""name"": ""toolName"",
         ""version"": ""1.2.3.4"",
         ""fileVersion"": ""1.2.3.4"",
-        ""semanticVersion"": ""1.2.3""
+        ""semanticVersion"": ""1.2.3"",
+        ""language"": ""fr-CA""
       },
       ""results"": [
         {
@@ -132,7 +133,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
             };
 
             var stream = new MemoryStream();
-            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), CultureInfo.InvariantCulture))
+            using (var logger = new ErrorLogger(stream, "toolName", "1.2.3.4", new Version(1, 2, 3, 4), new CultureInfo("en-US")))
             {
                 for (int i = 0; i < 2; i++)
                 {
@@ -153,7 +154,8 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         ""name"": ""toolName"",
         ""version"": ""1.2.3.4"",
         ""fileVersion"": ""1.2.3.4"",
-        ""semanticVersion"": ""1.2.3""
+        ""semanticVersion"": ""1.2.3"",
+        ""language"": ""en-US""
       },
       ""results"": [
         {

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/ErrorLoggerTests.cs
@@ -93,10 +93,25 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         public void DescriptorIdCollision()
         {
             var descriptors = new[] {
+                // Toughest case: generation of TST001.001 collides with with actual TST001.001 and must be bumped to TST00.002
                 new DiagnosticDescriptor("TST001.001",    "_TST001.001_",     "", "", DiagnosticSeverity.Warning, true),
                 new DiagnosticDescriptor("TST001",        "_TST001_",         "", "", DiagnosticSeverity.Warning, true),
                 new DiagnosticDescriptor("TST001",        "_TST001.002_",     "", "", DiagnosticSeverity.Warning, true),
                 new DiagnosticDescriptor("TST001",        "_TST001.003_",     "", "", DiagnosticSeverity.Warning, true),
+
+                // Descriptors with same values should not get distinct entries in log
+                new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Warning, true),
+
+                // Changing only the message format (which we do not write out) should not produce a distinct entry in log.
+                new DiagnosticDescriptor("TST002", "", "messageFormat", "", DiagnosticSeverity.Warning, true),
+
+                // Changing any property that we do write out should create a distinct entry
+                new DiagnosticDescriptor("TST002", "title_001", "", "", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST002", "", "", "category_002", DiagnosticSeverity.Warning, true),
+                new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Error /*003*/, true),
+                new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Warning, isEnabledByDefault: false /*004*/),
+                new DiagnosticDescriptor("TST002", "", "", "", DiagnosticSeverity.Warning, true, "description_005"),
             };
 
             var stream = new MemoryStream();
@@ -155,6 +170,65 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
           }
         },
         {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""message"": ""messageFormat"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.003"",
+          ""level"": ""error""
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.004"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.005"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
           ""ruleId"": ""TST001.001"",
           ""level"": ""warning"",
           ""properties"": {
@@ -179,6 +253,65 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         {
           ""ruleId"": ""TST001"",
           ""ruleKey"": ""TST001.003"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""level"": ""warning"",
+          ""message"": ""messageFormat"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.001"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.002"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.003"",
+          ""level"": ""error""
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.004"",
+          ""level"": ""warning"",
+          ""properties"": {
+            ""warningLevel"": 1
+          }
+        },
+        {
+          ""ruleId"": ""TST002"",
+          ""ruleKey"": ""TST002.005"",
           ""level"": ""warning"",
           ""properties"": {
             ""warningLevel"": 1
@@ -213,6 +346,51 @@ namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
         ""TST001.003"": {
           ""id"": ""TST001"",
           ""shortDescription"": ""_TST001.003_"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST002"": {
+          ""id"": ""TST002"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST002.001"": {
+          ""id"": ""TST002"",
+          ""shortDescription"": ""title_001"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST002.002"": {
+          ""id"": ""TST002"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""category"": ""category_002"",
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST002.003"": {
+          ""id"": ""TST002"",
+          ""defaultLevel"": ""error"",
+          ""properties"": {
+            ""isEnabledByDefault"": true
+          }
+        },
+        ""TST002.004"": {
+          ""id"": ""TST002"",
+          ""defaultLevel"": ""warning"",
+          ""properties"": {
+            ""isEnabledByDefault"": false
+          }
+        },
+        ""TST002.005"": {
+          ""id"": ""TST002"",
+          ""fullDescription"": ""description_005"",
           ""defaultLevel"": ""warning"",
           ""properties"": {
             ""isEnabledByDefault"": true

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -84,6 +84,11 @@ namespace Microsoft.CodeAnalysis
             return typeof(CommonCompiler).GetTypeInfo().Assembly.GetName().Version;
         }
 
+        internal string GetCultureName()
+        {
+            return Culture.Name;
+        }
+
         internal virtual Func<string, MetadataReferenceProperties, PortableExecutableReference> GetMetadataProvider()
         {
             return (path, properties) => MetadataReference.CreateFromFile(path, properties);

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -42,19 +42,15 @@ namespace Microsoft.CodeAnalysis
             _writer.WriteArrayStart("runs");
             _writer.WriteObjectStart(); // run
 
-            WriteToolInfo(toolName, toolFileVersion, toolAssemblyVersion);
+            _writer.WriteObjectStart("tool");
+            _writer.Write("name", toolName);
+            _writer.Write("version", toolAssemblyVersion.ToString());
+            _writer.Write("fileVersion", toolFileVersion);
+            _writer.Write("semanticVersion", toolAssemblyVersion.ToString(fieldCount: 3));
+            _writer.Write("language", culture.Name);
+            _writer.WriteObjectEnd(); // tool
 
             _writer.WriteArrayStart("results");
-        }
-
-        private void WriteToolInfo(string name, string fileVersion, Version assemblyVersion)
-        {
-            _writer.WriteObjectStart("tool");
-            _writer.Write("name", name);
-            _writer.Write("version", assemblyVersion.ToString());
-            _writer.Write("fileVersion", fileVersion);
-            _writer.Write("semanticVersion", assemblyVersion.ToString(fieldCount: 3));
-            _writer.WriteObjectEnd();
         }
 
         public void LogDiagnostic(Diagnostic diagnostic)

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -363,7 +363,7 @@ namespace Microsoft.CodeAnalysis
                 do
                 {
                     _counters[descriptor.Id] = ++counter;
-                    key = descriptor.Id + "." + counter.ToString("000", CultureInfo.InvariantCulture);
+                    key = descriptor.Id + "-" + counter.ToString("000", CultureInfo.InvariantCulture);
                 } while (_counters.ContainsKey(key));
 
                 _keys.Add(descriptor, key);

--- a/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
+++ b/src/Compilers/Core/Portable/CommandLine/ErrorLogger.cs
@@ -37,8 +37,8 @@ namespace Microsoft.CodeAnalysis
             _culture = culture;
 
             _writer.WriteObjectStart(); // root
-            _writer.Write("$schema", "http://json.schemastore.org/sarif-1.0.0-beta.5");
-            _writer.Write("version", "1.0.0-beta.5");
+            _writer.Write("$schema", "http://json.schemastore.org/sarif-1.0.0");
+            _writer.Write("version", "1.0.0");
             _writer.WriteArrayStart("runs");
             _writer.WriteObjectStart(); // run
 

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -308,6 +308,7 @@ namespace Microsoft.CodeAnalysis
             var expectedVersion = compiler.GetAssemblyVersion();
             var expectedSemanticVersion = compiler.GetAssemblyVersion().ToString(fieldCount: 3);
             var expectedFileVersion = compiler.GetAssemblyFileVersion();
+            var expectedLanguage = compiler.GetCultureName();
 
             return string.Format(@"{{
   ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
@@ -318,8 +319,9 @@ namespace Microsoft.CodeAnalysis
         ""name"": ""{0}"",
         ""version"": ""{1}"",
         ""fileVersion"": ""{2}"",
-        ""semanticVersion"": ""{3}""
-      }},", expectedToolName, expectedVersion, expectedFileVersion, expectedSemanticVersion);
+        ""semanticVersion"": ""{3}"",
+        ""language"": ""{4}""
+      }},", expectedToolName, expectedVersion, expectedFileVersion, expectedSemanticVersion, expectedLanguage);
         }
 
         public static string Stringize(this Diagnostic e)

--- a/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/DiagnosticExtensions.cs
@@ -311,8 +311,8 @@ namespace Microsoft.CodeAnalysis
             var expectedLanguage = compiler.GetCultureName();
 
             return string.Format(@"{{
-  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0-beta.5"",
-  ""version"": ""1.0.0-beta.5"",
+  ""$schema"": ""http://json.schemastore.org/sarif-1.0.0"",
+  ""version"": ""1.0.0"",
   ""runs"": [
     {{
       ""tool"": {{


### PR DESCRIPTION
Five distinct changes in five commits

* 50f8500: Fix #11383 - prevent duplicate rule metadata   
* c664130: Fix URI escaping  
* f73fd4e: Log language 
* 82e584e: Change rule ID disambiguator from '.' to '-'  
* e090e14: Mark as v1.0.0 (schema update is pending and there will be no breaking changes to it)

@mavasani @agocke @lgolding @michaelcfanning 