### PR TITLE
Ignore .userprefs files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # User-specific files
 *.suo
 *.user
+*.userprefs
 *.sln.docstates
 .vs/
 


### PR DESCRIPTION
MonoDevelop / Xamarin Studio creates this file constantly and there is no reason to include it.