### PR TITLE
Wire up /runtimemetadataversion to the build task

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
@@ -230,6 +230,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (ITaskItem[])_store[nameof(Resources)]; }
         }
 
+        public string RuntimeMetadataVersion
+        {
+            set { _store[nameof(RuntimeMetadataVersion)] = value; }
+            get { return (string)_store[nameof(RuntimeMetadataVersion)]; }
+        }
+
         public ITaskItem[] ResponseFiles
         {
             set { _store[nameof(ResponseFiles)] = value; }
@@ -691,6 +697,7 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         {
             commandLine.AppendPlusOrMinusSwitch("/deterministic", _store, nameof(Deterministic));
             commandLine.AppendPlusOrMinusSwitch("/publicsign", _store, nameof(PublicSign));
+            commandLine.AppendSwitchIfNotNull("/runtimemetadataversion:", RuntimeMetadataVersion);
 
             AddFeatures(commandLine, Features);
         }

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -77,6 +77,20 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void RuntimeMetadataVersionFlag()
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.RuntimeMetadataVersion = "v1234";
+            Assert.Equal("/out:test.exe /runtimemetadataversion:v1234 test.cs", csc.GenerateResponseFileContents());
+
+            csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.RuntimeMetadataVersion = null;
+            Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void TargetTypeDll()
         {
             var csc = new Csc();

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -74,6 +74,20 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void RuntimeMetadataVersionFlag()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.RuntimeMetadataVersion = "v1234";
+            Assert.Equal("/optionstrict:custom /out:test.exe /runtimemetadataversion:v1234 test.vb", vbc.GenerateResponseFileContents());
+
+            vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.RuntimeMetadataVersion = null;
+            Assert.Equal("/optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void TargetTypeDll()
         {
             var vbc = new Vbc();


### PR DESCRIPTION
Fixes #5608

/cc @tmat @jasonmalinowski @dotnet/roslyn-compiler 