### PR TITLE
Completion improvements

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/GlobalAssemblyCacheCompletionHelperTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/GlobalAssemblyCacheCompletionHelperTests.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.IntelliSense.Completion
                               select completion;
 
             Assert.True(systemsColl.Any(
-                completion => CommonCompletionItem.GetDescription(completion).Text == typeof(System.Diagnostics.Process).Assembly.FullName));
+                completion => completion.GetDescription().Text == typeof(System.Diagnostics.Process).Assembly.FullName));
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]

--- a/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionProvider.cs
@@ -30,9 +30,9 @@ namespace Microsoft.CodeAnalysis.Completion
 
         public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
         {
-            if (CommonCompletionItem.HasDescription(item))
+            if (item.HasDescription())
             {
-                return Task.FromResult(CommonCompletionItem.GetDescription(item));
+                return Task.FromResult(item.GetDescription());
             }
             else
             {

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.Completion
             Optional<string> displayText = default(Optional<string>),
             Optional<string> filterText = default(Optional<string>),
             Optional<string> sortText = default(Optional<string>),
-            Optional<ImmutableDictionary<string, string>> properties = default(Optional<ImmutableDictionary<string,string>>),
+            Optional<ImmutableDictionary<string, string>> properties = default(Optional<ImmutableDictionary<string, string>>),
             Optional<ImmutableArray<string>> tags = default(Optional<ImmutableArray<string>>),
             Optional<CompletionItemRules> rules = default(Optional<CompletionItemRules>))
         {
@@ -194,6 +194,44 @@ namespace Microsoft.CodeAnalysis.Completion
         public CompletionItem WithTags(ImmutableArray<string> tags)
         {
             return With(tags: tags);
+        }
+
+        internal const string DescriptionKey = nameof(DescriptionKey);
+
+        public CompletionItem WithDescription(string description)
+        {
+            var descriptionTags = ImmutableArray.Create(new TaggedText(TextTags.Text, description));
+
+            return WithDescription(descriptionTags);
+        }
+
+        public CompletionItem WithDescription(ImmutableArray<TaggedText> description)
+        {
+            var properties = Properties ?? ImmutableDictionary<string, string>.Empty;
+
+            // encode description
+
+
+            return With(properties: properties);
+        }
+
+        public bool HasDescription()
+        {
+            return Properties.ContainsKey(DescriptionKey);
+        }
+
+        public CompletionDescription GetDescription()
+        {
+            string encoded;
+            if (!Properties.TryGetValue(DescriptionKey, out encoded))
+            {
+                return CompletionDescription.Empty;
+            }
+
+            // decode
+            var decoded = ImmutableArray<TaggedText>.Empty;
+
+            return CompletionDescription.Create(decoded);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -196,7 +196,6 @@ namespace Microsoft.CodeAnalysis.Completion
             return With(tags: tags);
         }
 
-        internal const string DescriptionKey = nameof(DescriptionKey);
 
         public CompletionItem WithDescription(string description)
         {
@@ -209,27 +208,26 @@ namespace Microsoft.CodeAnalysis.Completion
         {
             var properties = Properties ?? ImmutableDictionary<string, string>.Empty;
 
-            // encode description
+            var encoded = CommonCompletionUtilities.EncodeDescription(description);
 
-
+            properties = properties.Add(CommonCompletionUtilities.DescriptionKey, encoded);
             return With(properties: properties);
         }
 
         public bool HasDescription()
         {
-            return Properties.ContainsKey(DescriptionKey);
+            return Properties.ContainsKey(CommonCompletionUtilities.DescriptionKey);
         }
 
         public CompletionDescription GetDescription()
         {
             string encoded;
-            if (!Properties.TryGetValue(DescriptionKey, out encoded))
+            if (!Properties.TryGetValue(CommonCompletionUtilities.DescriptionKey, out encoded))
             {
                 return CompletionDescription.Empty;
             }
 
-            // decode
-            var decoded = ImmutableArray<TaggedText>.Empty;
+            var decoded = CommonCompletionUtilities.DecodeDescription(encoded);
 
             return CompletionDescription.Create(decoded);
         }

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -358,9 +358,9 @@ namespace Microsoft.CodeAnalysis.Completion
 
         public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (CommonCompletionItem.HasDescription(item))
+            if (item.HasDescription())
             {
-                return Task.FromResult(CommonCompletionItem.GetDescription(item));
+                return Task.FromResult(item.GetDescription());
             }
 
             var provider = GetProvider(item);

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -35,11 +35,15 @@ Microsoft.CodeAnalysis.Completion.CompletionItem.AddProperty(string name, string
 Microsoft.CodeAnalysis.Completion.CompletionItem.AddTag(string tag) -> Microsoft.CodeAnalysis.Completion.CompletionItem
 Microsoft.CodeAnalysis.Completion.CompletionItem.DisplayText.get -> string
 Microsoft.CodeAnalysis.Completion.CompletionItem.FilterText.get -> string
+Microsoft.CodeAnalysis.Completion.CompletionItem.GetDescription() -> Microsoft.CodeAnalysis.Completion.CompletionDescription
+Microsoft.CodeAnalysis.Completion.CompletionItem.HasDescription() -> bool
 Microsoft.CodeAnalysis.Completion.CompletionItem.Properties.get -> System.Collections.Immutable.ImmutableDictionary<string, string>
 Microsoft.CodeAnalysis.Completion.CompletionItem.Rules.get -> Microsoft.CodeAnalysis.Completion.CompletionItemRules
 Microsoft.CodeAnalysis.Completion.CompletionItem.SortText.get -> string
 Microsoft.CodeAnalysis.Completion.CompletionItem.Span.get -> Microsoft.CodeAnalysis.Text.TextSpan
 Microsoft.CodeAnalysis.Completion.CompletionItem.Tags.get -> System.Collections.Immutable.ImmutableArray<string>
+Microsoft.CodeAnalysis.Completion.CompletionItem.WithDescription(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.TaggedText> description) -> Microsoft.CodeAnalysis.Completion.CompletionItem
+Microsoft.CodeAnalysis.Completion.CompletionItem.WithDescription(string description) -> Microsoft.CodeAnalysis.Completion.CompletionItem
 Microsoft.CodeAnalysis.Completion.CompletionItem.WithDisplayText(string text) -> Microsoft.CodeAnalysis.Completion.CompletionItem
 Microsoft.CodeAnalysis.Completion.CompletionItem.WithFilterText(string text) -> Microsoft.CodeAnalysis.Completion.CompletionItem
 Microsoft.CodeAnalysis.Completion.CompletionItem.WithProperties(System.Collections.Immutable.ImmutableDictionary<string, string> properties) -> Microsoft.CodeAnalysis.Completion.CompletionItem

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/CrefCompletionProvider.vb
@@ -194,8 +194,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         End Function
 
         Public Overrides Function GetDescriptionAsync(document As Document, item As CompletionItem, cancellationToken As CancellationToken) As Task(Of CompletionDescription)
-            If CommonCompletionItem.HasDescription(item) Then
-                Return Task.FromResult(CommonCompletionItem.GetDescription(item))
+            If item.HasDescription() Then
+                Return Task.FromResult(item.GetDescription())
             Else
                 Return SymbolCompletionItem.GetDescriptionAsync(item, document, cancellationToken)
             End If


### PR DESCRIPTION
This adds a WithDescription method on the CompletionItem, this makes it easy to add synchronously created completion descriptions to a completion item. e.g. in the case of Snippets.

@CyrusNajmabadi, @mattwar 
