### PR TITLE
Remove description check

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -358,11 +358,6 @@ namespace Microsoft.CodeAnalysis.Completion
 
         public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (CommonCompletionItem.HasDescription(item))
-            {
-                return Task.FromResult(CommonCompletionItem.GetDescription(item));
-            }
-
             var provider = GetProvider(item);
             if (provider != null)
             {


### PR DESCRIPTION
Remove check for description property from base CompletionServiceWithProviders class.  This is already handled in CommonCompletionProvider.

@CyrusNajmabadi please review
