### PR TITLE
Ensure that compiling is finished by the time we get to collect diagnostics.

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -1733,6 +1733,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
+            CompleteTrees(filterTree);
+        }
+
+        internal override void CompleteTrees(SyntaxTree filterTree)
+        {
             // By definition, a tree is complete when all of its compiler diagnostics have been reported.
             // Since unused imports are the last thing we compute and report, a tree is complete when
             // the unused imports have been reported.

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7729,12 +7729,13 @@ using System.Diagnostics; // Unused.
             return output;
         }
 
+        [WorkItem(11368, "https://github.com/dotnet/roslyn/issues/11368")]
         [WorkItem(899050, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/899050")]
         [WorkItem(981677, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/981677")]
         [WorkItem(998069, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/998069")]
         [WorkItem(998724, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/998724")]
         [WorkItem(1021115, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1021115")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/11368")]
+        [Fact]
         public void NoWarnAndWarnAsError_WarningDiagnostic()
         {
             // This assembly has a WarningDiagnosticAnalyzer type which should produce custom warning

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -501,12 +501,15 @@ namespace Microsoft.CodeAnalysis
                                             win32ResourceStreamOpt,
                                             diagnosticBag,
                                             cancellationToken);
-
-                                        if (success)
-                                        {
-                                            compilation.ReportUnusedImports(null, diagnosticBag, cancellationToken);
-                                        }
                                     }
+
+                                    // only report unused usings if we have success.
+                                    if (success)
+                                    {
+                                        compilation.ReportUnusedImports(null, diagnosticBag, cancellationToken);
+                                    }
+
+                                    compilation.CompleteTrees(null);
                                 }
                             }
 

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -1480,10 +1480,24 @@ namespace Microsoft.CodeAnalysis
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Reports all unused imports/usings so far (and thus it must be called as a last step of Emit)
+        /// </summary>
         internal abstract void ReportUnusedImports(
             SyntaxTree filterTree,
             DiagnosticBag diagnostics,
             CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Signals the event queue, if any, that we are done compiling.
+        /// There should not be more compiling actions after this step.
+        /// NOTE: once we signal about completion to analyzers they will cancel and thus in some cases we 
+        ///       may be effectively cutting off some diagnostics.
+        ///       It is not clear if behavior is desirable.
+        ///       See: https://github.com/dotnet/roslyn/issues/11470
+        /// </summary>
+        /// <param name="filterTree">What tree to complete. null means complete all trees. </param>
+        internal abstract void CompleteTrees(SyntaxTree filterTree);
 
         internal bool Compile(
             CommonPEModuleBuilder moduleBuilder,
@@ -1695,7 +1709,7 @@ namespace Microsoft.CodeAnalysis
                         {
                             ReportUnusedImports(null, diagnostics, cancellationToken);
                         }
-                    }
+                   }
                 }
                 finally
                 {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
@@ -177,6 +177,21 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             {
                 if (existingWaiters != null)
                 {
+                    // we have waiters and we have data.
+                    // allow some extra time to drain the queue before cancelling
+                    // but do not wait for too long.
+                    SpinWait.SpinUntil(() =>
+                    {
+                        lock (SyncObject)
+                        {
+                            return _data.Count == 0;
+                        }
+                    },
+                    10000);
+
+                    // cancel waiters.
+                    // NOTE: this could result in losing diagnostics
+                    //       see https://github.com/dotnet/roslyn/issues/11470
                     foreach (var tcs in existingWaiters)
                     {
                         tcs.SetCanceled();

--- a/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/VisualBasicCompilation.vb
@@ -1610,6 +1610,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
             End If
 
+            CompleteTrees(filterTree)
+        End Sub
+
+        Friend Overrides Sub CompleteTrees(filterTree As SyntaxTree)
             ' By definition, a tree Is complete when all of its compiler diagnostics have been reported.
             ' Since unused imports are the last thing we compute And report, a tree Is complete when
             ' the unused imports have been reported.


### PR DESCRIPTION
Ensure that compiling is finished by the time we get to collect diagnostics.

The last step in compiling is collecting and reporting using/imports diagnostics. Any compiling action after that would invalidate using/imports diagnostics.

That makes using/imports diagnostics a logical step to signal the event queue that we are done compiling and it is in fact the place where the signalling happens.
As a result reporting of using diagnostics is prerequisite before collecting all diagnostics (including analyzers).

This change renames the method to be ReportUnusedImportsAndFinishCompiling and ensures that we do call it before calling GetDiagnosticsAsync to collect all diagnostics.

Fixes: https://github.com/dotnet/roslyn/issues/11368


NOTE: this change fixes only what is explained above. 
There is a very small possibility of a race because in some cases we cancel waiting analyzers upon completion of compiling and that can lead to missing diagnostics if analyzers are being slow. 
That behavior is hard to get around if we also want to guarantee that compiler eventually exits. I will enter a separate bug on that behavior.
Bug: https://github.com/dotnet/roslyn/issues/11470