### PR TITLE
Fix reporting of EnC (and other) diagnostics

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -28,6 +28,7 @@
     <Compile Include="Collections\BoxesTest.cs" />
     <Compile Include="Collections\ByteSequenceComparerTests.cs" />
     <Compile Include="CryptoBlobParserTests.cs" />
+    <Compile Include="Diagnostics\CompilationWithAnalyzersTests.cs" />
     <Compile Include="Diagnostics\ErrorLoggerTests.cs" />
     <Compile Include="Diagnostics\AnalysisContextInfoTests.cs" />
     <Compile Include="Diagnostics\BoxingOperationAnalyzer.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Diagnostics/CompilationWithAnalyzersTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Test.Utilities;
+using Roslyn.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.Diagnostics
+{
+    using SimpleDiagnostic = Diagnostic.SimpleDiagnostic;
+
+    public class CompilationWithAnalyzersTests : TestBase
+    {
+        [Fact]
+        public void GetEffectiveDiagnostics_Errors()
+        {
+            var c = CSharpCompilation.Create("c");
+            var ds = new[] { default(Diagnostic) };
+
+            Assert.Throws<ArgumentNullException>(() => CompilationWithAnalyzers.GetEffectiveDiagnostics(default(ImmutableArray<Diagnostic>), c));
+            Assert.Throws<ArgumentNullException>(() => CompilationWithAnalyzers.GetEffectiveDiagnostics(default(IEnumerable<Diagnostic>), c));
+            Assert.Throws<ArgumentNullException>(() => CompilationWithAnalyzers.GetEffectiveDiagnostics(ds, null));
+        }
+
+        [Fact]
+        public void GetEffectiveDiagnostics()
+        {
+            var c = CSharpCompilation.Create("c", options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary).
+                WithSpecificDiagnosticOptions(
+                    new[] { KeyValuePair.Create($"CS{(int)ErrorCode.WRN_AlwaysNull:D4}", ReportDiagnostic.Suppress) }));
+
+            var d1 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlignmentMagnitude);
+            var d2 = SimpleDiagnostic.Create(MessageProvider.Instance, (int)ErrorCode.WRN_AlwaysNull);
+            var ds = new[] { default(Diagnostic), d1, d2 };
+
+            var filtered = CompilationWithAnalyzers.GetEffectiveDiagnostics(ds, c);
+
+            // overwrite the original value to test eagerness:
+            ds[1] = default(Diagnostic);
+
+            AssertEx.Equal(new[] { d1 }, filtered);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -735,6 +735,7 @@ override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitVariableDeclarati
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWhileUntilLoopStatement(Microsoft.CodeAnalysis.Semantics.IWhileUntilLoopStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWithStatement(Microsoft.CodeAnalysis.Semantics.IWithStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitYieldBreakStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation) -> void
+static Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetEffectiveDiagnostics(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Diagnostic> diagnostics, Microsoft.CodeAnalysis.Compilation compilation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.Diagnostic>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.Descendants(this Microsoft.CodeAnalysis.IOperation operation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.DescendantsAndSelf(this Microsoft.CodeAnalysis.IOperation operation) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.IOperation>
 static Microsoft.CodeAnalysis.Semantics.OperationExtensions.GetRootOperation(this Microsoft.CodeAnalysis.ISymbol symbol, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.IOperation

--- a/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
+++ b/src/EditorFeatures/Core/Implementation/EditAndContinue/EditAndContinueDiagnosticUpdateSource.cs
@@ -12,12 +12,22 @@ using Microsoft.CodeAnalysis.EditAndContinue;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
 {
+    internal sealed class EncErrorId : BuildToolId.Base<DebuggingSession, object>
+    {
+        public EncErrorId(DebuggingSession session, object errorId)
+            : base(session, errorId)
+        {
+        }
+
+        public override string BuildTool => PredefinedBuildTools.EnC;
+    }
+
     [Export(typeof(EditAndContinueDiagnosticUpdateSource))]
     [Shared]
     internal sealed class EditAndContinueDiagnosticUpdateSource : IDiagnosticUpdateSource
     {
-        internal static object DebuggerErrorId = new object();
-        internal static object EmitErrorId = new object();
+        internal static readonly object DebuggerErrorId = new object();
+        internal static readonly object EmitErrorId = new object();
 
         [ImportingConstructor]
         public EditAndContinueDiagnosticUpdateSource(IDiagnosticUpdateSourceRegistrationService registrationService)
@@ -25,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             registrationService.Register(this);
         }
 
-        public bool SupportGetDiagnostics { get { return false; } }
+        public bool SupportGetDiagnostics => false;
 
         public event EventHandler<DiagnosticsUpdatedArgs> DiagnosticsUpdated;
 
@@ -34,100 +44,94 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.EditAndContinue
             return ImmutableArray<DiagnosticData>.Empty;
         }
 
-        public void ClearDiagnostics(DebuggingSession session, Workspace workspace, object kind, ProjectId projectId, ImmutableArray<DocumentId> documentIds)
+        public void ClearDiagnostics(EncErrorId errorId, Solution solution, ProjectId projectId, ImmutableArray<DocumentId> documentIds)
         {
-            if (documentIds.IsDefault)
+            // clear project diagnostics:
+            ClearDiagnostics(errorId, solution, projectId, null);
+
+            // clear document diagnostics:
+            foreach (var documentIdOpt in documentIds)
             {
-                return;
-            }
-
-            foreach (var documentId in documentIds)
-            {
-                ClearDiagnostics(session, workspace, kind, projectId, documentId);
-            }
-        }
-
-        public void ClearDiagnostics(DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId)
-        {
-            RaiseDiagnosticsUpdated(MakeRemovedArgs(session, workspace, errorId, projectId, documentId));
-        }
-
-        public ImmutableArray<DocumentId> ReportDiagnostics(DebuggingSession session, object errorId, ProjectId projectId, Solution solution, IEnumerable<Diagnostic> diagnostics)
-        {
-            var argsByDocument = ImmutableArray.CreateRange(
-                from diagnostic in diagnostics
-                let document = solution.GetDocument(diagnostic.Location.SourceTree, projectId)
-                where document != null
-                let item = MakeDiagnosticData(projectId, document, solution, diagnostic)
-                group item by document.Id into itemsByDocumentId
-                select MakeCreatedArgs(session, errorId, solution.Workspace, solution, projectId, itemsByDocumentId.Key, ImmutableArray.CreateRange(itemsByDocumentId)));
-
-            foreach (var args in argsByDocument)
-            {
-                RaiseDiagnosticsUpdated(args);
-            }
-
-            return argsByDocument.SelectAsArray(args => args.DocumentId);
-        }
-
-        private static DiagnosticData MakeDiagnosticData(ProjectId projectId, Document document, Solution solution, Diagnostic d)
-        {
-            if (document != null)
-            {
-                return DiagnosticData.Create(document, d);
-            }
-            else
-            {
-                var project = solution.GetProject(projectId);
-                Debug.Assert(project != null);
-                return DiagnosticData.Create(project, d);
+                ClearDiagnostics(errorId, solution, projectId, documentIdOpt);
             }
         }
 
-        private DiagnosticsUpdatedArgs MakeCreatedArgs(
-            DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
+        public void ClearDiagnostics(EncErrorId errorId, Solution solution, ProjectId projectId, DocumentId documentIdOpt)
         {
-            return MakeCreatedArgs(session, errorId, workspace, solution: null, projectId: projectId, documentId: documentId, items: items);
+            DiagnosticsUpdated?.Invoke(this, DiagnosticsUpdatedArgs.DiagnosticsRemoved(
+                errorId,
+                solution.Workspace,
+                solution: solution,
+                projectId: projectId,
+                documentId: documentIdOpt));
         }
 
-        private DiagnosticsUpdatedArgs MakeRemovedArgs(
-            DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, DocumentId documentId)
+        public ImmutableArray<DocumentId> ReportDiagnostics(object errorId, Solution solution, ProjectId projectId, IEnumerable<Diagnostic> diagnostics)
         {
-            return MakeRemovedArgs(session, errorId, workspace, solution: null, projectId: projectId, documentId: documentId);
-        }
+            Debug.Assert(errorId != null);
+            Debug.Assert(solution != null);
+            Debug.Assert(projectId != null);
 
-        private DiagnosticsUpdatedArgs MakeCreatedArgs(
-            DebuggingSession session, object errorId, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId, ImmutableArray<DiagnosticData> items)
-        {
-            return DiagnosticsUpdatedArgs.DiagnosticsCreated(
-                CreateId(session, errorId), workspace, solution, projectId, documentId, items);
-        }
+            var updateEvent = DiagnosticsUpdated;
+            var documentIds = ArrayBuilder<DocumentId>.GetInstance();
+            var documentDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
+            var projectDiagnosticData = ArrayBuilder<DiagnosticData>.GetInstance();
+            var project = solution.GetProject(projectId);
 
-        private DiagnosticsUpdatedArgs MakeRemovedArgs(
-            DebuggingSession session, object errorId, Workspace workspace, Solution solution, ProjectId projectId, DocumentId documentId)
-        {
-            return DiagnosticsUpdatedArgs.DiagnosticsRemoved(
-                CreateId(session, errorId), workspace, solution, projectId, documentId);
-        }
-
-        private static EnCId CreateId(DebuggingSession session, object errorId) => new EnCId(session, errorId);
-
-        private void RaiseDiagnosticsUpdated(DiagnosticsUpdatedArgs args)
-        {
-            this.DiagnosticsUpdated?.Invoke(this, args);
-        }
-
-        private class EnCId : BuildToolId.Base<DebuggingSession, object>
-        {
-            public EnCId(DebuggingSession session, object errorId) :
-                base(session, errorId)
+            foreach (var diagnostic in diagnostics)
             {
+                var documentOpt = solution.GetDocument(diagnostic.Location.SourceTree, projectId);
+
+                if (documentOpt != null)
+                {
+                    if (updateEvent != null)
+                    {
+                        documentDiagnosticData.Add(DiagnosticData.Create(documentOpt, diagnostic));
+                    }
+
+                    documentIds.Add(documentOpt.Id);
+                }
+                else if (updateEvent != null)
+                {
+                    projectDiagnosticData.Add(DiagnosticData.Create(project, diagnostic));
+                }
             }
 
-            public override string BuildTool
+            foreach (var documentDiagnostics in documentDiagnosticData.ToDictionary(data => data.DocumentId))
             {
-                get { return PredefinedBuildTools.EnC; }
+                updateEvent(this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                    errorId,
+                    solution.Workspace,
+                    solution,
+                    projectId,
+                    documentId: documentDiagnostics.Key,
+                    diagnostics: documentDiagnostics.Value));
             }
+
+            if (projectDiagnosticData.Count > 0)
+            {
+                updateEvent(this, DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                    errorId,
+                    solution.Workspace,
+                    solution,
+                    projectId,
+                    documentId: null,
+                    diagnostics: projectDiagnosticData.ToImmutable()));
+            }
+
+            documentDiagnosticData.Free();
+            projectDiagnosticData.Free();
+            return documentIds.ToImmutableAndFree();
+        }
+
+        internal ImmutableArray<DocumentId> ReportDiagnostics(DebuggingSession session, object errorId, ProjectId projectId, Solution solution, IEnumerable<Diagnostic> diagnostics)
+        {
+            return ReportDiagnostics(new EncErrorId(session, errorId), solution, projectId, diagnostics);
+        }
+
+        internal void ClearDiagnostics(DebuggingSession session, Workspace workspace, object errorId, ProjectId projectId, ImmutableArray<DocumentId> documentIds)
+        {
+            ClearDiagnostics(new EncErrorId(session, errorId), workspace.CurrentSolution, projectId, documentIds);
         }
     }
 }

--- a/src/EditorFeatures/Test/Workspaces/NoCompilationDocumentDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Test/Workspaces/NoCompilationDocumentDiagnosticAnalyzer.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 {
@@ -17,16 +18,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
 
-        public override Task AnalyzeSemanticsAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
+        public override Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.FromResult(true);
+            return SpecializedTasks.EmptyImmutableArray<Diagnostic>();
         }
 
-        public override Task AnalyzeSyntaxAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
+        public override Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
         {
-            addDiagnostic(Diagnostic.Create(Descriptor,
-                Location.Create(document.FilePath, default(TextSpan), default(LinePositionSpan))));
-            return Task.FromResult(true);
+            return Task.FromResult(ImmutableArray.Create(
+                Diagnostic.Create(Descriptor, Location.Create(document.FilePath, default(TextSpan), default(LinePositionSpan)))));
         }
     }
 }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDocumentDiagnosticAnalyzer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,8 +13,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal abstract class DocumentDiagnosticAnalyzer : DiagnosticAnalyzer
     {
         // REVIEW: why DocumentDiagnosticAnalyzer doesn't have span based analysis?
-        public abstract Task AnalyzeSyntaxAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken);
-        public abstract Task AnalyzeSemanticsAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken);
+        public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken);
+        public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken);
 
         /// <summary>
         /// it is not allowed one to implement both DocumentDiagnosticAnalzyer and DiagnosticAnalyzer

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDocumentDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDocumentDiagnosticAnalyzer.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
@@ -13,8 +14,33 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     internal abstract class DocumentDiagnosticAnalyzer : DiagnosticAnalyzer
     {
         // REVIEW: why DocumentDiagnosticAnalyzer doesn't have span based analysis?
-        public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken);
-        public abstract Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken);
+        // TODO: Make abstract once TypeScript and F# move over to the overloads above
+        public async virtual Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
+        {
+            var builder = ArrayBuilder<Diagnostic>.GetInstance();
+            await AnalyzeSyntaxAsync(document, builder.Add, cancellationToken).ConfigureAwait(false);
+            return builder.ToImmutableAndFree();
+        }
+
+        // TODO: Make abstract once TypeScript and F# move over to the overloads above
+        public async virtual Task<ImmutableArray<Diagnostic>> AnalyzeSemanticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            var builder = ArrayBuilder<Diagnostic>.GetInstance();
+            await AnalyzeSemanticsAsync(document, builder.Add, cancellationToken).ConfigureAwait(false);
+            return builder.ToImmutableAndFree();
+        }
+
+        // TODO: Remove once TypeScript and F# move over to the overloads above
+        public virtual Task AnalyzeSyntaxAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        // TODO: Remove once TypeScript and F# move over to the overloads above
+        public virtual Task AnalyzeSemanticsAsync(Document document, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
 
         /// <summary>
         /// it is not allowed one to implement both DocumentDiagnosticAnalzyer and DiagnosticAnalyzer

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -79,7 +79,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
         private EmitBaseline _pendingBaseline;
         private Project _projectBeingEmitted;
 
-        private ImmutableArray<DocumentId> _documentsWithEmitError;
+        private ImmutableArray<DocumentId> _documentsWithEmitError = ImmutableArray<DocumentId>.Empty;
 
         /// <summary>
         /// Initialized when the project switches to debug state.
@@ -251,11 +251,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
 
                         var descriptor = new DiagnosticDescriptor("Metadata", "Metadata", ServicesVSResources.ErrorWhileReading, DiagnosticCategory.EditAndContinue, DiagnosticSeverity.Error, isEnabledByDefault: true, customTags: DiagnosticCustomTags.EditAndContinue);
 
-                        _diagnosticProvider.ReportDiagnostics(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.DebuggerErrorId, _vsProject.Id, _encService.DebuggingSession.InitialSolution,
-                            new[]
-                            {
-                                Diagnostic.Create(descriptor, Location.None, outputPath, e.Message)
-                            });
+                        _diagnosticProvider.ReportDiagnostics(
+                            new EncErrorId(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.DebuggerErrorId),
+                            _encService.DebuggingSession.InitialSolution,
+                            _vsProject.Id,
+                            new[] { Diagnostic.Create(descriptor, Location.None, outputPath, e.Message) });
                     }
                 }
                 else
@@ -322,7 +322,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 else
                 {
                     // an error might have been reported:
-                    _diagnosticProvider.ClearDiagnostics(_encService.DebuggingSession, _vsProject.Workspace, EditAndContinueDiagnosticUpdateSource.DebuggerErrorId, _vsProject.Id, documentId: null);
+                    var errorId = new EncErrorId(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.DebuggerErrorId);
+                    _diagnosticProvider.ClearDiagnostics(errorId, _vsProject.Workspace.CurrentSolution, _vsProject.Id, documentIdOpt: null);
                 }
 
                 _activeMethods = null;
@@ -908,8 +909,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     Debug.Assert(s_breakStateProjectCount >= 0);
 
                     _changesApplied = false;
-                    _diagnosticProvider.ClearDiagnostics(_encService.DebuggingSession, _vsProject.Workspace, EditAndContinueDiagnosticUpdateSource.EmitErrorId, _vsProject.Id, _documentsWithEmitError);
-                    _documentsWithEmitError = default(ImmutableArray<DocumentId>);
+
+                    _diagnosticProvider.ClearDiagnostics(
+                        new EncErrorId(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.EmitErrorId), 
+                        _vsProject.Workspace.CurrentSolution,
+                        _vsProject.Id, 
+                        _documentsWithEmitError);
+
+                    _documentsWithEmitError = ImmutableArray<DocumentId>.Empty;
                 }
 
                 // HResult ignored by the debugger
@@ -971,25 +978,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                     delta = emitTask.Result;
                 }
 
+                var errorId = new EncErrorId(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.EmitErrorId);
+                
                 // Clear diagnostics, in case the project was built before and failed due to errors.
-                _diagnosticProvider.ClearDiagnostics(_encService.DebuggingSession, _vsProject.Workspace, EditAndContinueDiagnosticUpdateSource.EmitErrorId, _vsProject.Id, _documentsWithEmitError);
+                _diagnosticProvider.ClearDiagnostics(errorId, _projectBeingEmitted.Solution, _vsProject.Id, _documentsWithEmitError);
 
                 if (!delta.EmitResult.Success)
                 {
                     var errors = delta.EmitResult.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error);
-                    _documentsWithEmitError = _diagnosticProvider.ReportDiagnostics(
-                        _encService.DebuggingSession,
-                        EditAndContinueDiagnosticUpdateSource.EmitErrorId,
-                        _vsProject.Id,
-                        _projectBeingEmitted.Solution,
-                        errors);
-
+                    _documentsWithEmitError = _diagnosticProvider.ReportDiagnostics(errorId, _projectBeingEmitted.Solution, _vsProject.Id, errors);
                     _encService.EditSession.LogEmitProjectDeltaErrors(errors.Select(e => e.Id));
 
                     return VSConstants.E_FAIL;
                 }
 
-                _documentsWithEmitError = default(ImmutableArray<DocumentId>);
+                _documentsWithEmitError = ImmutableArray<DocumentId>.Empty;
                 SetFileUpdates(updater, delta.LineEdits);
 
                 updater.SetDeltaIL(delta.IL.Value, (uint)delta.IL.Value.Length);


### PR DESCRIPTION
Fixes issues with reporting diagnostics from EnC. Rude edits were sometimes not reported, EnC delta emit errors that didn't have a location were never reported.

There were a couple of bugs in the code base:
1) Logic that grouped diagnostics by document dropped ones that have no document (project-level)
2) Compiler API ```CompilationWithAnalyzers.GetEffectiveDiagnostics``` was implemented as an iterator and incorrectly used in analyzer executor. The usage pattern was:

```C#
using (var pooledList = GetListFromPool())
{
    Populate(pooledList);
    return CompilationWithAnalyzers.GetEffectiveDiagnostics(pooledList);
}
```

The caller returned before pulling on the iterator. As a result the enumerator was actually iterating over a released ```pooledList``` instance.

This change refactors the code to use ImmutableArray instead of IEnumerable and changes the public API to eagerly read the input IEnumerable (it seems that that was the original intent). This is slightly breaking change to the API (from lazy to eager) but it's imo more likely to fix lingering issues
than to actually break code.

Fixes https://github.com/dotnet/roslyn/issues/11152, https://github.com/dotnet/roslyn/issues/10040, https://github.com/dotnet/roslyn/issues/3634.