### PR TITLE
Deconstruction-assignment for tuples

### DIFF
--- a/docs/features/deconstruction.md
+++ b/docs/features/deconstruction.md
@@ -36,17 +36,18 @@ In short, what this does is find a `Deconstruct` method on the expression on the
 The existing assignment binding currently checks if the variable on its left-hand-side can be assigned to and if the two sides are compatible.
 It will be updated to support deconstruction-assignment, ie. when the left-hand-side is a tuple-literal/tuple-expression:
 
-- Each item on the left needs to be assignable and needs to be compatible with corresponding position on the right
+- Needs to break the right-hand-side into items. That step is un-necessary if the right-hand-side is already a tuple though.
+- Each item on the left needs to be assignable and needs to be compatible with corresponding position on the right (resulting from previous step).
 - Needs to handle nesting case such as `(x, (y, z)) = M();`, but note that the second item in the top-level group has no discernable type.
 
-The lowering for deconstruction-assignment would translate: `(expressionX, expressionY, expressionZ) = (expressionA, expressionB, expressionC)` into:
+In the general case, the lowering for deconstruction-assignment would translate: `(expressionX, expressionY, expressionZ) = expressionRight` into:
 
 ```
 tempX = &evaluate expressionX
 tempY = &evaluate expressionY
 tempZ = &evaluate expressionZ
 
-tempRight = evaluate right and evaluate Deconstruct
+tempRight = evaluate right and evaluate Deconstruct in three parts
 
 tempX = tempRight.A (including conversions)
 tempY = tempRight.B (including conversions)
@@ -80,23 +81,16 @@ evaluate side-effect on the left-hand-side variables
 evaluate Deconstruct passing the references directly in
 ```
 
-Note that the feature is built around the `Deconstruct` mechanism for deconstructing types.
-`ValueTuple` and `System.Tuple` will rely on that same mechanism, except that the compiler may need to synthesize the proper `Deconstruct` methods.
+In the case where the expression on the right is a tuple, the evaluation order becomes:
+```
+evaluate side-effect on the left-hand-side variables
+evaluate the right-hand-side and do a tuple conversion
+assign element-wise from the right to the left
+```
 
+Note that tuples (`System.ValueTuple`) don't need to invoke Deconstruct.
+But `System.Tuple` will rely on the Deconstruct mechanism.
 
-**Work items, open issues and assumptions to confirm with LDM:**
-
-- I assume this should work even if `System.ValueTuple` is not present.
-- How is the Deconstruct method resolved?
-    - I assumed there can be no ambiguity. Only one `Deconstruct` is allowed (in nesting cases we have no type to guide the resolution process).
-    - But we may allow a little bit of ambiguity and preferring an instance over extension method.
-- Do the names matter? `int x, y; (a: x, b: y) = M();`
-- Can we deconstruct into a single out variable? I assume no.
-- I assume no compound assignment `(x, y) += M();`
-- [ ] Provide more details on the semantic of deconstruction-assignment, both static (The LHS of the an assignment-expression used be a L-value, but now it can be L-value -- which uses existing rules -- or tuple_literal. The new rules for tuple_literal on the LHS...) and dynamic.
-- [ ] Discuss with Aleksey about "Deconstruct and flow analysis for nullable ref type"
-- [ ] Validate any target typing or type inference scenarios.
-- The deconstruction-assignment is treated separately from deconstruction-declaration, which means it doesn't allow combinations such as `int x; (x, int y) = M();`.
 
 ###Deconstruction-declaration (deconstruction into new variables):
 
@@ -158,20 +152,11 @@ constant_declarator // not sure
     ;
 ```
 
-Treat deconstruction of a tuple into new variables as a new kind of node (AssignmentExpression).
+Treat deconstruction of a tuple into new variables as a new kind of node (not AssignmentExpression).
 It would pick up the behavior of each contexts where new variables can be declared (TODO: need to list). For instance, in LINQ, new variables go into a transparent identifiers.
 It is seen as deconstructing into separate variables (we don't introduce transparent identifiers in contexts where they didn't exist previously).
 
-Should we allow this?
-`var t = (x: 1, y: 2);    (x: var a, y: var b) = t;`
-or `var (x: a, y: b) = t;`
-(if not, tuple names aren't very useful?)
-
-- [ ] Add example: var (x, y) =
-- [ ] Semantic (cardinality should match, ordering including conversion,
-- [ ] What are the type rules? `(string s, int x) = (null, 3);`
-
-- Deconstruction for `System.ValueTuple`, `System.Tuple` and any other type involves a call to `Deconstruct`.
+Just like deconstruction-assignment, deconstruction-declaration does not need to invoke `Deconstruct` for tuple types.
 
 **References**
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1754,7 +1754,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (boundRHS.Type == null)
             {
                 Error(diagnostics, ErrorCode.ERR_DeconstructRequiresExpression, node);
-                return BadExpression(node, boundRHS);
+                return BadExpression(node, checkedVariables.Concat(boundRHS).ToArray());
             }
 
             return BindDeconstructWithDeconstruct(node, diagnostics, boundRHS, checkedVariables);

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -397,7 +397,7 @@
     <Field Name="LeftVariables" Type="ImmutableArray&lt;BoundExpression&gt;"/>
 
     <Field Name="Right" Type="BoundExpression"/>
-    <Field Name="DeconstructMember" Type="MethodSymbol" Null="allow"/>
+    <Field Name="DeconstructMemberOpt" Type="MethodSymbol" Null="allow"/>
 
     <!-- The assignments have placeholders for the left and right part of the assignment -->
     <Field Name="Assignments" Type="ImmutableArray&lt;BoundDeconstructionAssignmentOperator.AssignmentInfo&gt;" Null="NotApplicable" SkipInVisitor="true"/>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -397,7 +397,7 @@
     <Field Name="LeftVariables" Type="ImmutableArray&lt;BoundExpression&gt;"/>
 
     <Field Name="Right" Type="BoundExpression"/>
-    <Field Name="DeconstructMember" Type="MethodSymbol" Null="disallow"/>
+    <Field Name="DeconstructMember" Type="MethodSymbol" Null="allow"/>
 
     <!-- The assignments have placeholders for the left and right part of the assignment -->
     <Field Name="Assignments" Type="ImmutableArray&lt;BoundDeconstructionAssignmentOperator.AssignmentInfo&gt;" Null="NotApplicable" SkipInVisitor="true"/>

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2321,15 +2321,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot deconstruct null..
-        /// </summary>
-        internal static string ERR_CannotDeconstructNull {
-            get {
-                return ResourceManager.GetString("ERR_CannotDeconstructNull", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot pass null for friend assembly name.
         /// </summary>
         internal static string ERR_CannotPassNullForFriendAssembly {
@@ -3100,6 +3091,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_DecConstError {
             get {
                 return ResourceManager.GetString("ERR_DecConstError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deconstruct assignment requires an expression with a type on the right-hand-side..
+        /// </summary>
+        internal static string ERR_DeconstructRequiresExpression {
+            get {
+                return ResourceManager.GetString("ERR_DeconstructRequiresExpression", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2321,6 +2321,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot deconstruct null..
+        /// </summary>
+        internal static string ERR_CannotDeconstructNull {
+            get {
+                return ResourceManager.GetString("ERR_CannotDeconstructNull", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot pass null for friend assembly name.
         /// </summary>
         internal static string ERR_CannotPassNullForFriendAssembly {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4884,7 +4884,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_MissingDeconstruct" xml:space="preserve">
     <value>No Deconstruct instance or extension method was found for type '{0}'.</value>
   </data>
-  <data name="ERR_CannotDeconstructNull" xml:space="preserve">
-    <value>Cannot deconstruct null.</value>
+  <data name="ERR_DeconstructRequiresExpression" xml:space="preserve">
+    <value>Deconstruct assignment requires an expression with a type on the right-hand-side.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4884,4 +4884,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_MissingDeconstruct" xml:space="preserve">
     <value>No Deconstruct instance or extension method was found for type '{0}'.</value>
   </data>
+  <data name="ERR_CannotDeconstructNull" xml:space="preserve">
+    <value>Cannot deconstruct null.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1395,5 +1395,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AmbiguousDeconstruct = 8207,
         ERR_DeconstructRequiresOutParams = 8208,
         ERR_DeconstructWrongParams = 8209,
+        ERR_CannotDeconstructNull = 8210,
     }
 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1395,6 +1395,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_AmbiguousDeconstruct = 8207,
         ERR_DeconstructRequiresOutParams = 8208,
         ERR_DeconstructWrongParams = 8209,
-        ERR_CannotDeconstructNull = 8210,
+        ERR_DeconstructRequiresExpression = 8210,
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -102,7 +102,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert((object)node.DeconstructMemberOpt != null);
 
-            int numVariables = node.LeftVariables.Length;
             CSharpSyntaxNode syntax = node.Syntax;
 
             // prepare out parameters for Deconstruct
@@ -110,14 +109,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             var outParametersBuilder = ArrayBuilder<BoundExpression>.GetInstance(deconstructParameters.Length);
             Debug.Assert(deconstructParameters.Length == node.LeftVariables.Length);
 
-            for (int i = 0; i < numVariables; i++)
+            foreach (var deconstructParameter in deconstructParameters)
             {
-                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, deconstructParameters[i].Type, SynthesizedLocalKind.LoweringTemp);
+                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, deconstructParameter.Type, SynthesizedLocalKind.LoweringTemp);
 
                 var localBound = new BoundLocal(syntax,
                                                 localSymbol,
                                                 null,
-                                                deconstructParameters[i].Type
+                                                deconstructParameter.Type
                                                 )
                 { WasCompilerGenerated = true };
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp
@@ -9,9 +12,6 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
         {
-            CSharpSyntaxNode syntax = node.Syntax;
-            int numVariables = node.LeftVariables.Length;
-
             var temps = ArrayBuilder<LocalSymbol>.GetInstance();
             var stores = ArrayBuilder<BoundExpression>.GetInstance();
 
@@ -24,40 +24,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             BoundExpression loweredRight = VisitExpression(node.Right);
+            ImmutableArray<BoundExpression> rhsValues;
 
-            // prepare out parameters for Deconstruct
-            var deconstructParameters = node.DeconstructMember.Parameters;
-            var outParametersBuilder = ArrayBuilder<BoundExpression>.GetInstance(deconstructParameters.Length);
-            Debug.Assert(deconstructParameters.Length == node.LeftVariables.Length);
-
-            for (int i = 0; i < numVariables; i++)
+            // get or make right-hand-side values
+            if (node.Right.Type.IsTupleType)
             {
-                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, deconstructParameters[i].Type, SynthesizedLocalKind.LoweringTemp);
-
-                var localBound = new BoundLocal(syntax,
-                                                localSymbol,
-                                                null,
-                                                deconstructParameters[i].Type
-                                                ) { WasCompilerGenerated = true };
-
-                temps.Add(localSymbol);
-                outParametersBuilder.Add(localBound);
+                rhsValues = AccessTupleFields(node, loweredRight, temps, stores);
+            }
+            else
+            {
+                rhsValues = CallDeconstruct(node, loweredRight, temps, stores);
             }
 
-            var outParameters = outParametersBuilder.ToImmutableAndFree();
-
-            // invoke Deconstruct
-            var invokeDeconstruct = MakeCall(syntax, loweredRight, node.DeconstructMember, outParameters, node.DeconstructMember.ReturnType);
-            stores.Add(invokeDeconstruct);
-
-            // assign from out temps to lhs receivers
-            for (int i = 0; i < numVariables; i++)
+            // assign from rhs values to lhs receivers
+            int numAssignments = node.Assignments.Length;
+            for (int i = 0; i < numAssignments; i++)
             {
                 // lower the assignment and replace the placeholders for source and target in the process
                 var assignmentInfo = node.Assignments[i];
 
                 AddPlaceholderReplacement(assignmentInfo.LValuePlaceholder, lhsReceivers[i]);
-                AddPlaceholderReplacement(assignmentInfo.RValuePlaceholder, outParameters[i]);
+                AddPlaceholderReplacement(assignmentInfo.RValuePlaceholder, rhsValues[i]);
 
                 var assignment = VisitExpression(assignmentInfo.Assignment);
 
@@ -74,6 +61,71 @@ namespace Microsoft.CodeAnalysis.CSharp
             lhsReceivers.Free();
 
             return result;
+        }
+
+        private ImmutableArray<BoundExpression> AccessTupleFields(BoundDeconstructionAssignmentOperator node, BoundExpression loweredRight, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
+        {
+            var tupleType = TupleTypeSymbol.Create((NamedTypeSymbol)loweredRight.Type); // PROTOTYPE(tuples)
+            var tupleElementTypes = tupleType.TupleElementTypes;
+
+            var numElements = tupleElementTypes.Length;
+            Debug.Assert(numElements == node.LeftVariables.Length);
+
+            CSharpSyntaxNode syntax = node.Syntax;
+
+            // list the tuple fields
+            var fieldAccessorsBuilder = ArrayBuilder<BoundExpression>.GetInstance(numElements);
+
+            for (int i = 0; i < numElements; i++)
+            {
+                var fields = tupleType.GetMembers(TupleTypeSymbol.TupleMemberName(i + 1)).OfType<FieldSymbol>();
+                var field = fields.Single();
+                var fieldAccess = MakeTupleFieldAccess(syntax, field, loweredRight, null, LookupResultKind.Empty, tupleElementTypes[i]);
+                fieldAccessorsBuilder.Add(fieldAccess);
+            }
+
+            return fieldAccessorsBuilder.ToImmutableAndFree();
+        }
+
+        /// <summary>
+        /// Prepares local variables to be used in Deconstruct call
+        /// Adds a invocation of Deconstruct with those as out parameters onto the 'stores' sequence
+        /// Returns the expressions for those out parameters
+        /// </summary>
+        private ImmutableArray<BoundExpression> CallDeconstruct(BoundDeconstructionAssignmentOperator node, BoundExpression loweredRight, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
+        {
+            Debug.Assert((object)node.DeconstructMember != null);
+
+            int numVariables = node.LeftVariables.Length;
+            CSharpSyntaxNode syntax = node.Syntax;
+
+            // prepare out parameters for Deconstruct
+            var deconstructParameters = node.DeconstructMember.Parameters;
+            var outParametersBuilder = ArrayBuilder<BoundExpression>.GetInstance(deconstructParameters.Length);
+            Debug.Assert(deconstructParameters.Length == node.LeftVariables.Length);
+
+            for (int i = 0; i < numVariables; i++)
+            {
+                var localSymbol = new SynthesizedLocal(_factory.CurrentMethod, deconstructParameters[i].Type, SynthesizedLocalKind.LoweringTemp);
+
+                var localBound = new BoundLocal(syntax,
+                                                localSymbol,
+                                                null,
+                                                deconstructParameters[i].Type
+                                                )
+                { WasCompilerGenerated = true };
+
+                temps.Add(localSymbol);
+                outParametersBuilder.Add(localBound);
+            }
+
+            var outParameters = outParametersBuilder.ToImmutableAndFree();
+
+            // invoke Deconstruct
+            var invokeDeconstruct = MakeCall(syntax, loweredRight, node.DeconstructMember, outParameters, node.DeconstructMember.ReturnType);
+            stores.Add(invokeDeconstruct);
+
+            return outParameters;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private ImmutableArray<BoundExpression> AccessTupleFields(BoundDeconstructionAssignmentOperator node, BoundExpression loweredRight, ArrayBuilder<LocalSymbol> temps, ArrayBuilder<BoundExpression> stores)
         {
-            var tupleType = TupleTypeSymbol.Create((NamedTypeSymbol)loweredRight.Type); // PROTOTYPE(tuples)
+            var tupleType = loweredRight.Type.IsTupleType ? loweredRight.Type : TupleTypeSymbol.Create((NamedTypeSymbol)loweredRight.Type);
             var tupleElementTypes = tupleType.TupleElementTypes;
 
             var numElements = tupleElementTypes.Length;

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -397,6 +397,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /// <summary>
+        /// If this is a field of a tuple type,
+        /// id is an index of the element (zero-based).
+        /// Otherwise, a negative number.
+        /// </summary>
+        public virtual int TupleElementIndex
+        {
+            get
+            {
+                return -1;
+            }
+        }
+
         #region IFieldSymbol Members
 
         ISymbol IFieldSymbol.AssociatedSymbol

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -398,8 +398,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this is a field of a tuple type,
-        /// id is an index of the element (zero-based).
+        /// If this is a field representing a tuple element,
+        /// returns the index of the element (zero-based).
         /// Otherwise, a negative number.
         /// </summary>
         public virtual int TupleElementIndex

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
-        public int TupleFieldId
+        public override int TupleElementIndex
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -40,8 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If this field represents a tuple element (including the name match), 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
-        /// </summary>
-        public int TupleFieldId
+        /// </summary>i
+        public override int TupleElementIndex
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -685,12 +685,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<FieldSymbol> CollectTupleElementFields()
         {
-            var builder = ArrayBuilder<FieldSymbol>.GetInstance(_elementTypes.Length);
-            builder.SetItem(_elementTypes.Length - 1, null);
-            var members = GetMembers().Where(m => m.Kind == SymbolKind.Field);
+            var builder = ArrayBuilder<FieldSymbol>.GetInstance(_elementTypes.Length, null);
 
-            foreach (var member in members)
+            foreach (var member in GetMembers())
             {
+                if (member.Kind != SymbolKind.Field)
+                {
+                    continue;
+                }
+
                 var field = (FieldSymbol)member;
                 int index = field.TupleElementIndex;
                 if (index >= 0)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -620,6 +620,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public virtual ImmutableArray<string> TupleElementNames => default(ImmutableArray<string>);
 
         /// <summary>
+        /// If this symbol represents a tuple type, get the fields for the tuple's elements.
+        /// </summary>
+        public virtual ImmutableArray<FieldSymbol> TupleElementFields => default(ImmutableArray<FieldSymbol>);
+
+        /// <summary>
         /// Is this type a managed type (false for everything but enum, pointer, and
         /// some struct types).
         /// </summary>

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -621,6 +621,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// If this symbol represents a tuple type, get the fields for the tuple's elements.
+        /// Otherwise, returns default.
         /// </summary>
         public virtual ImmutableArray<FieldSymbol> TupleElementFields => default(ImmutableArray<FieldSymbol>);
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -886,9 +886,9 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithRefsFeature());
             comp.VerifyDiagnostics(
-                // (7,9): error CS8210: Cannot deconstruct null.
+                // (7,9): error CS8210: Deconstruct assignment requires an expression with a type on the right-hand-side.
                 //         (x, x) = null;
-                Diagnostic(ErrorCode.ERR_CannotDeconstructNull, "(x, x) = null").WithLocation(7, 9),
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "(x, x) = null").WithLocation(7, 9),
                 // (6,13): warning CS0168: The variable 'x' is declared but never used
                 //         int x;
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "x").WithArguments("x").WithLocation(6, 13)
@@ -939,7 +939,7 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact]
+        [Fact(Skip = "PROTOTYPE(tuples)")]
         public void DeconstructTuple2()
         {
             string source = @"
@@ -960,7 +960,7 @@ class C
     }
 }
 ";
-
+            // Should not give this error: (9,18): error CS0029: Cannot implicitly convert type '(int, string)' to '(long, string)'
             var comp = CompileAndVerify(source, expectedOutput: "1 hello", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics();
         }
@@ -984,6 +984,75 @@ class C
 
             var comp = CompileAndVerify(source, expectedOutput: "4 2", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size      141 (0x8d)
+  .maxstack  10
+  .locals init (long V_0, //x
+                int V_1) //y
+  IL_0000:  ldc.i4.1
+  IL_0001:  conv.i8
+  IL_0002:  ldc.i4.1
+  IL_0003:  conv.i8
+  IL_0004:  ldc.i4.1
+  IL_0005:  conv.i8
+  IL_0006:  ldc.i4.1
+  IL_0007:  conv.i8
+  IL_0008:  ldc.i4.1
+  IL_0009:  conv.i8
+  IL_000a:  ldc.i4.1
+  IL_000b:  conv.i8
+  IL_000c:  ldc.i4.1
+  IL_000d:  conv.i8
+  IL_000e:  ldc.i4.1
+  IL_000f:  conv.i8
+  IL_0010:  ldc.i4.4
+  IL_0011:  conv.i8
+  IL_0012:  ldc.i4.2
+  IL_0013:  newobj     ""System.ValueTuple<long, long, int>..ctor(long, long, int)""
+  IL_0018:  newobj     ""System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>..ctor(long, long, long, long, long, long, long, (long, long, int))""
+  IL_001d:  dup
+  IL_001e:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item1""
+  IL_0023:  stloc.0
+  IL_0024:  dup
+  IL_0025:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item2""
+  IL_002a:  stloc.0
+  IL_002b:  dup
+  IL_002c:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item3""
+  IL_0031:  stloc.0
+  IL_0032:  dup
+  IL_0033:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item4""
+  IL_0038:  stloc.0
+  IL_0039:  dup
+  IL_003a:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item5""
+  IL_003f:  stloc.0
+  IL_0040:  dup
+  IL_0041:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item6""
+  IL_0046:  stloc.0
+  IL_0047:  dup
+  IL_0048:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item7""
+  IL_004d:  stloc.0
+  IL_004e:  dup
+  IL_004f:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_0054:  ldfld      ""long System.ValueTuple<long, long, int>.Item1""
+  IL_0059:  stloc.0
+  IL_005a:  dup
+  IL_005b:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_0060:  ldfld      ""long System.ValueTuple<long, long, int>.Item2""
+  IL_0065:  stloc.0
+  IL_0066:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_006b:  ldfld      ""int System.ValueTuple<long, long, int>.Item3""
+  IL_0070:  stloc.1
+  IL_0071:  ldloc.0
+  IL_0072:  box        ""long""
+  IL_0077:  ldstr      "" ""
+  IL_007c:  ldloc.1
+  IL_007d:  box        ""int""
+  IL_0082:  call       ""string string.Concat(object, object, object)""
+  IL_0087:  call       ""void System.Console.WriteLine(string)""
+  IL_008c:  ret
+}
+");
         }
 
         [Fact(Skip = "PROTOTYPE(tuples)")]
@@ -1003,6 +1072,7 @@ class C
 }
 ";
 
+            // issue with return type
             var comp = CompileAndVerify(source, expectedOutput: "4 2", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics();
         }
@@ -1026,7 +1096,54 @@ class C
 
             var comp = CompileAndVerify(source, expectedOutput: "hello", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
             comp.VerifyDiagnostics();
+            comp.VerifyIL("C.Main", @"
+{
+  // Code size       48 (0x30)
+  .maxstack  3
+  .locals init (string V_0, //x
+                string V_1) //y
+  IL_0000:  ldstr      ""goodbye""
+  IL_0005:  stloc.0
+  IL_0006:  ldnull
+  IL_0007:  ldstr      ""hello""
+  IL_000c:  newobj     ""System.ValueTuple<string, string>..ctor(string, string)""
+  IL_0011:  dup
+  IL_0012:  ldfld      ""string System.ValueTuple<string, string>.Item1""
+  IL_0017:  stloc.0
+  IL_0018:  ldfld      ""string System.ValueTuple<string, string>.Item2""
+  IL_001d:  stloc.1
+  IL_001e:  ldstr      ""{0}{1}""
+  IL_0023:  ldloc.0
+  IL_0024:  ldloc.1
+  IL_0025:  call       ""string string.Format(string, object, object)""
+  IL_002a:  call       ""void System.Console.WriteLine(string)""
+  IL_002f:  ret
+}
+");
         }
 
+        [Fact]
+        public void TupleWithNoConversion()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        byte x;
+        string y;
+
+        (x, y) = (1, 2);
+    }
+}
+";
+            // PROTOTYPE(tuples) This error message is misleading
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            comp.VerifyDiagnostics(
+                // (9,18): error CS0029: Cannot implicitly convert type '(int, int)' to '(byte, string)'
+                //         (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_NoImplicitConv, "(1, 2)").WithArguments("(int, int)", "(byte, string)").WithLocation(9, 18)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -889,9 +889,9 @@ class C
                 // (7,9): error CS8210: Cannot deconstruct null.
                 //         (x, x) = null;
                 Diagnostic(ErrorCode.ERR_CannotDeconstructNull, "(x, x) = null").WithLocation(7, 9),
-                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
-                //         int x = 0;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13)
+                // (6,13): warning CS0168: The variable 'x' is declared but never used
+                //         int x;
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "x").WithArguments("x").WithLocation(6, 13)
                 );
         }
 


### PR DESCRIPTION
This PR mainly adds deconstruction-assignment with the right-hand-side being a tuple type or a tuple literal (with or without type).

This also adds tests for follow-ups from previous feedback:
- ref returning methods on the left. Check sideeffects.
- Foo()[Bar()] on the left, where all Foo, Bar and the indexer have sideeffects - print something
- check IL in simple/common cases
- Optimize the case where LHS variable is simple ref value

@dotnet/roslyn-compiler for review.

