### PR TITLE
Fix error reporting race in cmd line compilers

### DIFF
--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -64,6 +64,7 @@
     <Compile Include="CodeGen\ILEmitStyle.cs" />
     <Compile Include="DiagnosticAnalyzer\AnalysisResult.cs" />
     <Compile Include="InternalUtilities\EmptyComparer.cs" />
+    <Compile Include="InternalUtilities\ConcurrentBag.cs" />
     <Compile Include="InternalUtilities\StringOrdinalComparer.cs" />
     <Compile Include="MetadataReference\AssemblyIdentityMap.cs" />
     <Compile Include="Compilation\OperationVisitor.cs" />

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="file">Source file information.</param>
         /// <param name="diagnostics">Storage for diagnostics.</param>
         /// <returns>File content or null on failure.</returns>
-        internal SourceText ReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics)
+        internal SourceText ReadFileContent(CommandLineSourceFile file, ICollection<DiagnosticInfo> diagnostics)
         {
             string discarded;
             return ReadFileContent(file, diagnostics, out discarded);
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="diagnostics">Storage for diagnostics.</param>
         /// <param name="normalizedFilePath">If given <paramref name="file"/> opens successfully, set to normalized absolute path of the file, null otherwise.</param>
         /// <returns>File content or null on failure.</returns>
-        internal SourceText ReadFileContent(CommandLineSourceFile file, IList<DiagnosticInfo> diagnostics, out string normalizedFilePath)
+        internal SourceText ReadFileContent(CommandLineSourceFile file, ICollection<DiagnosticInfo> diagnostics, out string normalizedFilePath)
         {
             var filePath = file.Path;
             try

--- a/src/Compilers/Core/Portable/InternalUtilities/ConcurrentBag.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/ConcurrentBag.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.InternalUtilities
+{
+    internal class ConcurrentBag<T>
+        : System.Collections.Concurrent.ConcurrentBag<T>, ICollection<T>
+    {
+        public bool IsReadOnly
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Clear()
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Contains(T item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool Remove(T item)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Both C# and VB command line compilers parse input files in parallel
if parallelism is enabled. However, they previously attempted to
report errors by writing to the same TextWriter concurrently. Accessing
a text writer can only be done on a single thread. This change
collects all the diagnostics in a concurrent collection, then reports
them in a single thread.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/217749?fullScreen=false