### PR TITLE
Properly generate a method off of a property in VB.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -2232,6 +2232,52 @@ End Namespace
 </text>.Value.Replace(vbLf, vbCrLf))
         End Function
 
+        <WorkItem(11461, "https://github.com/dotnet/roslyn/issues/11461")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        Public Async Function TestGenerateMethodOffOfExistingProperty() As Task
+            Await TestAsync(
+<text>
+Imports System
+
+Public NotInheritable Class Repository
+    Shared ReadOnly Property agreementtype As AgreementType
+        Get
+        End Get
+    End Property
+End Class
+
+Public Class Agreementtype
+End Class
+
+Class C
+    Shared Sub TestError()
+        [|Repository.AgreementType.NewFunction|]("", "")
+    End Sub
+End Class
+</text>.Value.Replace(vbLf, vbCrLf),
+<text>
+Imports System
+
+Public NotInheritable Class Repository
+    Shared ReadOnly Property agreementtype As AgreementType
+        Get
+        End Get
+    End Property
+End Class
+
+Public Class Agreementtype
+    Friend Sub NewFunction(v1 As String, v2 As String)
+        Throw New NotImplementedException()
+    End Sub
+End Class
+
+Class C
+    Shared Sub TestError()
+        Repository.AgreementType.NewFunction("", "")
+    End Sub
+End Class</text>.Value.Replace(vbLf, vbCrLf))
+        End Function
+
         Public Class GenerateConversionTests
             Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -43,6 +43,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
         End Function
 
         Protected Overrides Function IsCandidate(node As SyntaxNode, token As SyntaxToken, diagnostic As Diagnostic) As Boolean
+            ' If we have a diagnostic on "a.b.c" in something like a.b.c(...), then don't try to 
+            ' perform fixes on 'a' or 'a.b'.
+            Dim diagnosticSpan = diagnostic.Location.SourceSpan
+            If node.Span.Start = diagnosticSpan.Start AndAlso node.Span.End < diagnosticSpan.End Then
+                Return False
+            End If
+
             Return TypeOf node Is QualifiedNameSyntax OrElse
                 TypeOf node Is SimpleNameSyntax OrElse
                 TypeOf node Is MemberAccessExpressionSyntax OrElse


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11461

This was failing before because of the unending tail of problems around trying to map from a compiler error to the appropriate node in question.  We would previously look from the most narrowest node to the widest node possible.  This was a problem because a narrower node might look like something we could generate a method for.  

We now look for this and we don' try generating methods on prefix expressions of the node we have the error on.