### PR TITLE
Fix reporting of ERR_EncUpdateFailedMissingAttribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -593,16 +593,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var importChain = methodWithBody.ImportChainOpt;
                     compilationState.CurrentImportChain = importChain;
 
-                    var method = methodWithBody.Method;
-                    var lambda = method as SynthesizedLambdaMethod;
-                    var variableSlotAllocatorOpt = ((object)lambda != null) ?
-                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(lambda, lambda.TopLevelMethod) :
-                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method, method);
-
                     // We make sure that an asynchronous mutation to the diagnostic bag does not 
                     // confuse the method body generator by making a fresh bag and then loading
                     // any diagnostics emitted into it back into the main diagnostic bag.
                     var diagnosticsThisMethod = DiagnosticBag.GetInstance();
+
+                    var method = methodWithBody.Method;
+                    var lambda = method as SynthesizedLambdaMethod;
+                    var variableSlotAllocatorOpt = ((object)lambda != null) ?
+                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(lambda, lambda.TopLevelMethod, diagnosticsThisMethod) :
+                        _moduleBeingBuiltOpt.TryCreateVariableSlotAllocator(method, method, diagnosticsThisMethod);
 
                     AsyncStateMachine stateMachineType;
 
@@ -1209,7 +1209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (lazyVariableSlotAllocator == null)
                 {
-                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method);
+                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method, diagnostics);
                 }
 
                 BoundStatement bodyWithoutLambdas = loweredBody;

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/PEDeltaAssemblyBuilder.cs
@@ -193,9 +193,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             return anonymousTypes;
         }
 
-        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod)
+        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod, DiagnosticBag diagnostics)
         {
-            return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method, topLevelMethod);
+            return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, Compilation, method, topLevelMethod, diagnostics);
         }
 
         internal override ImmutableArray<AnonymousTypeKey> GetPreviousAnonymousTypes()

--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
         /// </summary>
         internal virtual NamedTypeSymbol DynamicOperationContextType => null;
 
-        internal virtual VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod)
+        internal virtual VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol method, MethodSymbol topLevelMethod, DiagnosticBag diagnostics)
         {
             return null;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbol.cs
@@ -1182,10 +1182,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         #region IMethodSymbolInternal
 
-        int IMethodSymbolInternal.CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree)
-        {
-            return CalculateLocalSyntaxOffset(localPosition, localTree);
-        }
+        bool IMethodSymbolInternal.IsIterator => IsIterator;
+
+        int IMethodSymbolInternal.CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree) => CalculateLocalSyntaxOffset(localPosition, localTree);
 
         #endregion
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.cs
@@ -4756,8 +4756,206 @@ class C
                     new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.EmitResult.Diagnostics.Verify(
-                // error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' is missing.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute).WithArguments("C.F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute"));
+                // (7,29): error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' is missing.
+                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("C.F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(7, 29));
+        }
+
+        [Fact, WorkItem(9119, "https://github.com/dotnet/roslyn/issues/9119")]
+        public void BadIteratorStateMachineAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>yield return 0;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>yield return 1;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+
+            var compilation0 = CreateCompilationWithMscorlib(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            // the ctor is missing a parameter
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify(
+                // (12,29): error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' is missing.
+                //     public IEnumerable<int> F()
+                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("C.F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(12, 29));
+        }
+
+        [Fact]
+        public void AddedIteratorStateMachineAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>yield return 0;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { public IteratorStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>yield return 1;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+
+            var compilation0 = CreateCompilationWithMscorlib(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            // older versions of mscorlib don't contain IteratorStateMachineAttribute
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var ism1 = compilation1.GetMember<TypeSymbol>("System.Runtime.CompilerServices.IteratorStateMachineAttribute");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Insert, null, ism1),
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            // We conclude the original method wasn't a state machine.
+            // The IDE however reports a Rude Edit in that case.
+            diff1.EmitResult.Diagnostics.Verify();
+        }
+
+        [Fact]
+        public void SourceIteratorStateMachineAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { public IteratorStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>yield return 0;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System;
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { public IteratorStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>yield return 1;</N:1>
+        Console.WriteLine(a);
+    }
+}
+");
+
+            var compilation0 = CreateCompilationWithMscorlib(new[] { source0.Tree }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            // older versions of mscorlib don't contain IteratorStateMachineAttribute
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
         }
 
         [Fact, WorkItem(9119, "https://github.com/dotnet/roslyn/issues/9119")]
@@ -4811,10 +5009,402 @@ class C
                     new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
 
             diff1.EmitResult.Diagnostics.Verify(
-                // error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' is missing.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute).WithArguments("C.F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute"),
-                // error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' is missing.
-                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute).WithArguments("C.F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute"));
+                // (6,28): error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' is missing.
+                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("C.F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute").WithLocation(6, 28));
+        }
+
+        [Fact]
+        public void AddedAsyncStateMachineAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>await new Task<int>();</N:1>
+        return a;
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    public class AsyncStateMachineAttribute : Attribute { public AsyncStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>await new Task<int>();</N:1>
+        return a;
+    }
+}
+");
+                        
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.Minimal.mincorlib, TestReferences.NetFx.Minimal.minasync }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            // older versions of mscorlib don't contain IteratorStateMachineAttribute
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var asm1 = compilation1.GetMember<TypeSymbol>("System.Runtime.CompilerServices.AsyncStateMachineAttribute");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Insert, null, asm1),
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
+        }
+
+        [Fact]
+        public void SourceAsyncStateMachineAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    public class AsyncStateMachineAttribute : Attribute { public AsyncStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>await new Task<int>();</N:1>
+        return a;
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Threading.Tasks;
+
+namespace System.Runtime.CompilerServices
+{
+    public class AsyncStateMachineAttribute : Attribute { public AsyncStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>await new Task<int>();</N:1>
+        return a;
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.Minimal.mincorlib, TestReferences.NetFx.Minimal.minasync }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            v0.VerifyDiagnostics();
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
+        }
+
+        [Fact, WorkItem(10190, "https://github.com/dotnet/roslyn/issues/10190")]
+        public void NonAsyncToAsync()
+        {
+            var source0 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public Task<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>return Task.FromResult(a);</N:1>
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>return await Task.FromResult(a);</N:1>
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30316_17626.mscorlib }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
+        }
+
+        [Fact]
+        public void NonAsyncToAsync_MissingAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public Task<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        a++;
+        <N:1>return new Task<int>();</N:1>
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public async Task<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        a++;
+        <N:1>return await new Task<int>();</N:1>
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.Minimal.mincorlib, TestReferences.NetFx.Minimal.minasync }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify(
+                // (6,28): error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.AsyncStateMachineAttribute' is missing.
+                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("C.F()", "System.Runtime.CompilerServices.AsyncStateMachineAttribute").WithLocation(6, 28));
+        }
+
+        [Fact]
+        public void NonIteratorToIterator_MissingAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>return new int[] { a };</N:1>
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Collections.Generic;
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>yield return a;</N:1>
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v2_0_50727.mscorlib }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify(
+                // (6,29): error CS7043: Cannot update 'C.F()'; attribute 'System.Runtime.CompilerServices.IteratorStateMachineAttribute' is missing.
+                Diagnostic(ErrorCode.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("C.F()", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(6, 29));
+        }
+
+        [Fact]
+        public void NonIteratorToIterator_SourceAttribute()
+        {
+            var source0 = MarkedSource(@"
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { public IteratorStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 0</N:0>;
+        <N:1>return new int[] { a };</N:1>
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Collections.Generic;
+
+namespace System.Runtime.CompilerServices
+{
+    public class IteratorStateMachineAttribute : Attribute { public IteratorStateMachineAttribute(Type type) { } }
+}
+
+class C
+{
+    public IEnumerable<int> F()
+    {
+        int <N:0>a = 1</N:0>;
+        <N:1>yield return a;</N:1>
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v2_0_50727.mscorlib }, options: ComSafeDebugDll);
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
+        }
+
+        [Fact]
+        public void NonAsyncToAsyncLambda()
+        {
+            var source0 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public object F()
+    {
+        return new System.Func<Task<int>>(<N:2>() =>
+        <N:3>{
+           int <N:0>a = 0</N:0>;
+           <N:1>return Task.FromResult(a);</N:1>
+        }</N:3></N:2>);
+    }
+}
+");
+            var source1 = MarkedSource(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public object F()
+    {
+        return new System.Func<Task<int>>(<N:2>async () =>
+        <N:3>{
+           int <N:0>a = 0</N:0>;
+           <N:1>return await Task.FromResult(a);</N:1>
+        }</N:3></N:2>);
+    }
+}
+");
+
+            var compilation0 = CreateCompilation(new[] { source0.Tree }, new[] { TestReferences.NetFx.v4_0_30316_17626.mscorlib }, options: ComSafeDebugDll.WithMetadataImportOptions(MetadataImportOptions.All));
+            var compilation1 = compilation0.WithSource(source1.Tree);
+
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+
+            var f0 = compilation0.GetMember<MethodSymbol>("C.F");
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    new SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.EmitResult.Diagnostics.Verify();
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__0_0, <F>b__0_0, <<F>b__0_0>d}",
+                "C.<>c.<<F>b__0_0>d: {<>1__state, <>t__builder, <>4__this, <a>5__1, <>s__2, <>u__1, MoveNext, SetStateMachine}");
         }
     }
 }

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EncVariableSlotAllocator.cs
@@ -190,11 +190,9 @@ namespace Microsoft.CodeAnalysis.Emit
             DiagnosticBag diagnostics, 
             out int slotIndex)
         {
-            // Well-formed state machine attribute wasn't found in the baseline (the type is missing or bad).
-            // Should rarely happen since the IDE reports a rude edit if the attribute type doesn't exist.
+            // The previous method was not a state machine (it is allowed to change non-state machine to a state machine):
             if (_hoistedLocalSlotsOpt == null)
             {
-                ReportMissingStateMachineAttribute(diagnostics);
                 slotIndex = -1;
                 return false;
             }
@@ -225,27 +223,15 @@ namespace Microsoft.CodeAnalysis.Emit
 
         public override bool TryGetPreviousAwaiterSlotIndex(Cci.ITypeReference currentType, DiagnosticBag diagnostics, out int slotIndex)
         {
-            // Well-formed state machine attribute wasn't found in the baseline (the type is missing or bad).
-            // Should rarely happen since the IDE reports a rude edit if the attribute type doesn't exist.
+            // The previous method was not a state machine (it is allowed to change non-state machine to a state machine):
             if (_awaiterMapOpt == null)
             {
-                ReportMissingStateMachineAttribute(diagnostics);
                 slotIndex = -1;
                 return false;
             }
 
             return _awaiterMapOpt.TryGetValue(_symbolMap.MapReference(currentType), out slotIndex);
         }
-
-        private void ReportMissingStateMachineAttribute(DiagnosticBag diagnostics)
-        {
-            diagnostics.Add(_messageProvider.CreateDiagnostic(
-                _messageProvider.ERR_EncUpdateFailedMissingAttribute,
-                NoLocation.Singleton, 
-                _messageProvider.GetErrorDisplayString(_previousTopLevelMethod),
-                (_previousTopLevelMethod.IsAsync ? AttributeDescription.AsyncStateMachineAttribute : AttributeDescription.IteratorStateMachineAttribute).FullName));
-        }
-
 
         private bool TryGetPreviousSyntaxOffset(SyntaxNode currentSyntax, out int previousSyntaxOffset)
         {

--- a/src/Compilers/Core/Portable/Symbols/IMethodSymbolInternal.cs
+++ b/src/Compilers/Core/Portable/Symbols/IMethodSymbolInternal.cs
@@ -4,6 +4,11 @@ namespace Microsoft.CodeAnalysis.Symbols
 {
     internal interface IMethodSymbolInternal : IMethodSymbol
     {
+        /// <summary>
+        /// True if the method is a source method implemented as an iterator.
+        /// </summary>
+        bool IsIterator { get; }
+
         int CalculateLocalSyntaxOffset(int declaratorPosition, SyntaxTree declaratorTree);
     }
 }

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/PEDeltaAssemblyBuilder.vb
@@ -213,8 +213,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             Return anonymousTypes
         End Function
 
-        Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
-            Return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, method, topLevelMethod)
+        Friend Overrides Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
+            Return _previousDefinitions.TryCreateVariableSlotAllocator(_previousGeneration, Compilation, method, topLevelMethod, diagnostics)
         End Function
 
         Friend Overrides Function GetPreviousAnonymousTypes() As ImmutableArray(Of AnonymousTypeKey)

--- a/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/PEModuleBuilder.vb
@@ -316,7 +316,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
             End Get
         End Property
 
-        Friend Overridable Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
+        Friend Overridable Function TryCreateVariableSlotAllocator(method As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
             Return Nothing
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -898,7 +898,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' produce a unique method ordinal for the corresponding state machine type, whose name includes the (unique) method name.
             Const methodOrdinal As Integer = -1
 
-            Dim slotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method.TopLevelMethod)
+            Dim slotAllocatorOpt = CompilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method.TopLevelMethod, Diagnostics)
             Return Rewriter.RewriteIteratorAndAsync(loweredBody, method, methodOrdinal, CompilationState, Diagnostics, slotAllocatorOpt, stateMachineTypeOpt)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Rewriter.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 If lazyVariableSlotAllocator Is Nothing Then
                     ' synthesized lambda methods are handled in LambdaRewriter.RewriteLambdaAsMethod
                     Debug.Assert(TypeOf method IsNot SynthesizedLambdaMethod)
-                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method)
+                    lazyVariableSlotAllocator = compilationState.ModuleBuilderOpt.TryCreateVariableSlotAllocator(method, method, diagnostics)
                 End If
 
                 ' Lowers lambda expressions into expressions that construct delegates.    

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSymbol.vb
@@ -961,6 +961,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 #End Region
 
 #Region "IMethodSymbolInternal"
+        Private ReadOnly Property IMethodSymbolInternal_IsIterator As Boolean Implements IMethodSymbolInternal.IsIterator
+            Get
+                Return Me.IsIterator
+            End Get
+        End Property
+
         Private Function IMethodSymbolInternal_CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer Implements IMethodSymbolInternal.CalculateLocalSyntaxOffset
             Return CalculateLocalSyntaxOffset(localPosition, localTree)
         End Function

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/EditAndContinueStateMachineTests.vb
@@ -4447,12 +4447,185 @@ End Class
                 ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
             diff1.EmitResult.Diagnostics.Verify(
-                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute).WithArguments("Public Function F() As IEnumerable(Of Integer)", "System.Runtime.CompilerServices.IteratorStateMachineAttribute"))
+                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("Public Function F() As IEnumerable(Of Integer)", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(6, 30))
         End Sub
 
-        <Fact, WorkItem(9119, "https://github.com/dotnet/roslyn/issues/9119")>
-        Public Sub MissingAsyncStateMachineAttribute()
-            Dim common = "
+        <Fact>
+        Public Sub BadIteratorStateMachineAttribute()
+            Dim source0 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Namespace System.Runtime.CompilerServices
+    Public Class IteratorStateMachineAttribute 
+        Inherits Attribute
+    End Class
+End Namespace
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        <N:1>Yield 0</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Namespace System.Runtime.CompilerServices
+    Public Class IteratorStateMachineAttribute 
+        Inherits Attribute
+    End Class
+End Namespace
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        <N:1>Yield 1</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            ' the ctor is missing a parameter
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify(
+                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("Public Function F() As IEnumerable(Of Integer)", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(12, 30))
+        End Sub
+
+        <Fact>
+        Public Sub AddedIteratorStateMachineAttribute()
+            Dim source0 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        <N:1>Yield 0</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Namespace System.Runtime.CompilerServices
+    Public Class IteratorStateMachineAttribute 
+        Inherits Attribute
+
+        Sub New(type As Type)
+        End Sub
+    End Class
+End Namespace
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        <N:1>Yield 1</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            ' older versions of mscorlib don't contain IteratorStateMachineAttribute
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_IteratorStateMachineAttribute__ctor))
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+            Dim ism1 = compilation1.GetMember(Of TypeSymbol)("System.Runtime.CompilerServices.IteratorStateMachineAttribute")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(
+                    New SemanticEdit(SemanticEditKind.Insert, Nothing, ism1),
+                    New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify()
+        End Sub
+
+        <Fact>
+        Public Sub SourceIteratorStateMachineAttribute()
+            Dim source0 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Namespace System.Runtime.CompilerServices
+    Public Class IteratorStateMachineAttribute 
+        Inherits Attribute
+
+        Sub New(type As Type)
+        End Sub
+    End Class
+End Namespace
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        <N:1>Yield 0</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System
+Imports System.Collections.Generic
+
+Namespace System.Runtime.CompilerServices
+    Public Class IteratorStateMachineAttribute 
+        Inherits Attribute
+
+        Sub New(type As Type)
+        End Sub
+    End Class
+End Namespace
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        <N:1>Yield 1</N:1>
+        Console.WriteLine(a)
+    End Function
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify()
+        End Sub
+
+        Const AsyncHelpers = "
 Imports System
 Imports System.Threading.Tasks
 
@@ -4466,7 +4639,9 @@ Namespace Microsoft.VisualBasic.CompilerServices
     End Class
 End Namespace"
 
-            Dim source0 = MarkedSource(common & "
+        <Fact, WorkItem(9119, "https://github.com/dotnet/roslyn/issues/9119")>
+        Public Sub MissingAsyncStateMachineAttribute()
+            Dim source0 = MarkedSource(AsyncHelpers & "
 Class C
     Public Async Function F() As Task(Of Integer)
         Dim <N:0>a</N:0> As Integer = 0
@@ -4475,7 +4650,7 @@ Class C
     End Function
 End Class
 ")
-            Dim source1 = MarkedSource(common & "
+            Dim source1 = MarkedSource(AsyncHelpers & "
 Class C
     Public Async Function F() As Task(Of Integer)
         Dim <N:0>a</N:0> As Integer = 1
@@ -4501,8 +4676,123 @@ End Class
                 ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
 
             diff1.EmitResult.Diagnostics.Verify(
-                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute).WithArguments("Public Function F() As Task(Of Integer)", "System.Runtime.CompilerServices.AsyncStateMachineAttribute"),
-                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute).WithArguments("Public Function F() As Task(Of Integer)", "System.Runtime.CompilerServices.AsyncStateMachineAttribute"))
+                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("Public Function F() As Task(Of Integer)", "System.Runtime.CompilerServices.AsyncStateMachineAttribute").WithLocation(15, 27))
+        End Sub
+
+        <Fact, WorkItem(10190, "https://github.com/dotnet/roslyn/issues/10190")>
+        Public Sub NonAsyncToAsync()
+            Dim source0 = MarkedSource(AsyncHelpers & "
+Class C
+    Public Function F() As Task(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        <N:1>Return Task.FromResult(a)</N:1>
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource(AsyncHelpers & "
+Class C
+    Public Async Function F() As Task(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        <N:1>Return Await Task.FromResult(a)</N:1>
+    End Function
+End Class
+")
+            Dim compilation0 = CompilationUtils.CreateCompilation({source0.Tree}, {TestReferences.NetFx.v4_0_30316_17626.mscorlib}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Assert.NotNull(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify()
+        End Sub
+
+        <Fact>
+        Public Sub NonAsyncToAsync_MissingAttribute()
+            Dim source0 = MarkedSource(AsyncHelpers & "
+Class C
+    Public Function F() As Task(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        a = a + 1
+        <N:1>Return New Task(Of Integer)()</N:1>
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource(AsyncHelpers & "
+Class C
+    Public Async Function F() As Task(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        a = a + 1
+        <N:1>Return Await New Task(Of Integer)()</N:1>
+    End Function
+End Class
+")
+            Dim compilation0 = CompilationUtils.CreateCompilation({source0.Tree}, {TestReferences.NetFx.Minimal.mincorlib, TestReferences.NetFx.Minimal.minasync}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Assert.Null(compilation0.GetWellKnownTypeMember(WellKnownMember.System_Runtime_CompilerServices_AsyncStateMachineAttribute__ctor))
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify(
+                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("Public Function F() As Task(Of Integer)", "System.Runtime.CompilerServices.AsyncStateMachineAttribute").WithLocation(15, 27))
+        End Sub
+
+        <Fact>
+        Public Sub NonIteratorToIterator_MissingAttribute()
+            Dim source0 = MarkedSource("
+Imports System.Collections.Generic
+
+Class C
+    Public Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 0
+        <N:1>Return { 0 }</N:1>
+    End Function
+End Class
+")
+            Dim source1 = MarkedSource("
+Imports System.Collections.Generic
+
+Class C
+    Public Iterator Function F() As IEnumerable(Of Integer)
+        Dim <N:0>a</N:0> As Integer = 1
+        <N:1>Yield a</N:1>
+    End Function
+End Class
+")
+            Dim compilation0 = CreateCompilationWithMscorlib({source0.Tree}, options:=ComSafeDebugDll)
+            Dim compilation1 = compilation0.WithSource(source1.Tree)
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim f0 = compilation0.GetMember(Of MethodSymbol)("C.F")
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f0, f1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.EmitResult.Diagnostics.Verify(
+                Diagnostic(ERRID.ERR_EncUpdateFailedMissingAttribute, "F").WithArguments("Public Function F() As IEnumerable(Of Integer)", "System.Runtime.CompilerServices.IteratorStateMachineAttribute").WithLocation(5, 30))
         End Sub
     End Class
 End Namespace

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EEAssemblyBuilder.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         public override int CurrentGenerationOrdinal => 0;
 
-        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol symbol, MethodSymbol topLevelMethod)
+        internal override VariableSlotAllocator TryCreateVariableSlotAllocator(MethodSymbol symbol, MethodSymbol topLevelMethod, DiagnosticBag diagnostics)
         {
             var method = symbol as EEMethodSymbol;
             if (((object)method != null) && Methods.Contains(method))

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -71,7 +71,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Get
         End Property
 
-        Friend Overrides Function TryCreateVariableSlotAllocator(symbol As MethodSymbol, topLevelMethod As MethodSymbol) As VariableSlotAllocator
+        Friend Overrides Function TryCreateVariableSlotAllocator(symbol As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
             Dim method = TryCast(symbol, EEMethodSymbol)
             If method IsNot Nothing AndAlso _methods.Contains(method) Then
                 Dim defs = GetLocalDefinitions(method.Locals)


### PR DESCRIPTION
Move detection of the error to another code path, where we actually know that we are missing a state machine attribute.

We previously reported the error even in cases we shouldn't have: e.g. when an ordinary method was changed to an async/iterator method.

Fixes https://github.com/dotnet/roslyn/issues/10190

