### PR TITLE
Allow debugging output when debugging unit tests

### DIFF
--- a/src/Test/Utilities/Desktop/ThrowingTraceListener.cs
+++ b/src/Test/Utilities/Desktop/ThrowingTraceListener.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Xunit;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -25,12 +24,68 @@ namespace Microsoft.CodeAnalysis
             throw new DebugAssertFailureException(message + Environment.NewLine + detailMessage);
         }
 
+        public override void Write(object o)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, o != null ? o.ToString() : null);
+            }
+        }
+
+        public override void Write(object o, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, o != null ? o.ToString() : null);
+            }
+        }
+
         public override void Write(string message)
         {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, message);
+            }
+        }
+
+        public override void Write(string message, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, message);
+            }
+        }
+
+        public override void WriteLine(object o)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, (o != null ? o.ToString() : null) + Environment.NewLine);
+            }
+        }
+
+        public override void WriteLine(object o, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, (o != null ? o.ToString() : null) + Environment.NewLine);
+            }
         }
 
         public override void WriteLine(string message)
         {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, null, message + Environment.NewLine);
+            }
+        }
+
+        public override void WriteLine(string message, string category)
+        {
+            if (Debugger.IsLogging())
+            {
+                Debugger.Log(0, category, message + Environment.NewLine);
+            }
         }
 
         [Serializable]

--- a/src/Test/Utilities/Desktop/ThrowingTraceListener.cs
+++ b/src/Test/Utilities/Desktop/ThrowingTraceListener.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (Debugger.IsLogging())
             {
-                Debugger.Log(0, null, o != null ? o.ToString() : null);
+                Debugger.Log(0, null, o?.ToString());
             }
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (Debugger.IsLogging())
             {
-                Debugger.Log(0, category, o != null ? o.ToString() : null);
+                Debugger.Log(0, category, o?.ToString());
             }
         }
 
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (Debugger.IsLogging())
             {
-                Debugger.Log(0, null, (o != null ? o.ToString() : null) + Environment.NewLine);
+                Debugger.Log(0, null, o?.ToString() + Environment.NewLine);
             }
         }
 
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis
         {
             if (Debugger.IsLogging())
             {
-                Debugger.Log(0, category, (o != null ? o.ToString() : null) + Environment.NewLine);
+                Debugger.Log(0, category, o?.ToString() + Environment.NewLine);
             }
         }
 


### PR DESCRIPTION
Previously, our custom TraceListener had been [updated](https://github.com/dotnet/roslyn/blob/5b83429a56125c0d4c12ac2c614506aa16c96a2e/src/Test/Utilities/Desktop/ThrowingTraceListener.cs) to disallow logging since Console, Trace and Debug are [no longer supported xUnit for logging output](https://xunit.github.io/docs/capturing-output.html). However, this unintentionally shut off sending the output to the debugger as well, which is perfectly reasonable when a debugger is attached. This change passes the output through to the debugger if `Debugger.IsLogging()` is true, which returns true when a debugger is attached that has logging enabled.

cc @jasonmalinowski 