### PR TITLE
Added support for implicitly-typed out variables.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -168,6 +168,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return this.Next.GetDeclaredLocalFunctionsForScope(scopeDesignator);
         }
 
+        /// <summary>
+        /// If this binder owns a scope for locals, return syntax node that is used
+        /// as the scope designator. Otherwise, null.
+        /// </summary>
+        internal virtual SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return null;
+            }
+        }
+
         internal virtual bool IsLocalFunctionsScopeBinder
         {
             get

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1859,6 +1859,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BoundKind.PropertyGroup:
                     expr = BindIndexedPropertyAccess((BoundPropertyGroup)expr, mustHaveAllOptionalParameters: false, diagnostics: diagnostics);
                     break;
+
+                case BoundKind.Local:
+                    Debug.Assert(expr.Syntax.Kind() != SyntaxKind.Argument || valueKind == BindValueKind.RefOrOut);
+                    break;
+
+                case BoundKind.OutVarLocalPendingInference:
+                    Debug.Assert(valueKind == BindValueKind.RefOrOut);
+                    return expr;
             }
 
             bool hasResolutionErrors = false;

--- a/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
@@ -85,6 +85,19 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                if (_statements.Count == 1)
+                {
+                    return _statements.First();
+                }
+
+                return _statements.Node;
+            }
+        }
+
         internal override ImmutableArray<LocalFunctionSymbol> GetDeclaredLocalFunctionsForScope(CSharpSyntaxNode scopeDesignator)
         {
             if (IsMatchingScopeDesignator(scopeDesignator))

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -51,5 +51,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -56,5 +56,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForEachLoopBinder.cs
@@ -890,5 +890,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -107,5 +107,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableBinder.cs
@@ -11,8 +11,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal sealed class PatternVariableBinder : LocalScopeBinder
     {
-        public readonly CSharpSyntaxNode ScopeDesignator;
-
         internal PatternVariableBinder(CSharpSyntaxNode scopeDesignator, Binder next) : base(next)
         {
             this.ScopeDesignator = scopeDesignator;
@@ -21,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            PatternVariableFinder.FindPatternVariables(this, builder, ScopeDesignator);
+            PatternVariableFinder.FindPatternVariables(this, builder, (CSharpSyntaxNode)ScopeDesignator);
             return builder.ToImmutableAndFree();
         }
 
@@ -39,5 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator { get; }
     }
 }

--- a/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/PatternVariableFinder.cs
@@ -165,6 +165,27 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
+            var contextKind = node.Identifier.
+                                   Parent. // ArgumentSyntax
+                                   Parent. // ArgumentListSyntax
+                                   Parent. // invocation/constructor initializer
+                                   Kind();
+
+            switch (contextKind)
+            {
+                case SyntaxKind.InvocationExpression:
+                case SyntaxKind.ObjectCreationExpression:
+                case SyntaxKind.ThisConstructorInitializer:
+                case SyntaxKind.BaseConstructorInitializer:
+                    break;
+                default:
+
+                    // It looks like we are deling with a syntax tree that has a shape that could never be
+                    // produced by the LanguageParser, including all error conditions. 
+                    // Out Variable declarations can only appear in an argument list of the syntax nodes mentioned above.
+                    throw ExceptionUtilities.UnexpectedValue(contextKind);
+            }
+
             _localsBuilder.Add(SourceLocalSymbol.MakeLocal(_binder.ContainingMemberOrLambda, _binder, RefKind.None, node.Type, node.Identifier, LocalDeclarationKind.RegularVariable));
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -924,7 +924,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If the expression is untyped because it is a lambda, anonymous method, method group or null
             // then we never want to report the error "you need a ref on that thing". Rather, we want to
             // say that you can't convert "null" to "ref int".
-            if (!argument.HasExpressionType())
+            if (!argument.HasExpressionType() && argument.Kind != BoundKind.OutVarLocalPendingInference)
             {
                 // If the problem is that a lambda isn't convertible to the given type, also report why.
                 // The argument and parameter type might match, but may not have same in/out modifiers
@@ -971,6 +971,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
+                Debug.Assert(argument.Kind != BoundKind.OutVarLocalPendingInference);
+
                 TypeSymbol argType = argument.Display as TypeSymbol;
                 Debug.Assert((object)argType != null);
 

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -332,6 +332,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             throw ExceptionUtilities.Unreachable;
         }
+        
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _switchSyntax;
+            }
+        }
 
         # region "Switch statement binding methods"
 

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -150,5 +150,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
+        internal override SyntaxNode ScopeDesignator
+        {
+            get
+            {
+                return _syntax;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1459,4 +1459,11 @@
   <Node Name="BoundWildcardPattern" Base="BoundPattern">
   </Node>
 
+  <!-- The node is transformed into BoundLocal after inference -->
+  <Node Name="OutVarLocalPendingInference" Base="BoundExpression">
+    <!-- Type is not significant for this node type; always null -->
+    <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
+    <Field Name="LocalSymbol" Type="LocalSymbol"/>
+  </Node>
+
 </Tree>

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return new Argument(ArgumentKind.Named, parameter, argument);
                 });
         }
-        
+
         private static IOperation CreateParamArray(IParameterSymbol parameter, ImmutableArray<BoundExpression> boundArguments, int firstArgumentElementIndex, SyntaxNode invocationSyntax)
         {
             if (parameter.Type.TypeKind == TypeKind.Array)
@@ -500,7 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class BoundTupleExpression 
+    internal partial class BoundTupleExpression
     {
         protected override OperationKind ExpressionKind => OperationKind.None;
 
@@ -1277,7 +1277,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal partial class BoundImplicitReceiver : IInstanceReferenceExpression
     {
         InstanceReferenceKind IInstanceReferenceExpression.InstanceReferenceKind => InstanceReferenceKind.Implicit;
-        
+
         protected override OperationKind ExpressionKind => OperationKind.InstanceReferenceExpression;
 
         public override void Accept(OperationVisitor visitor)
@@ -1906,7 +1906,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return visitor.VisitNoneOperation(this, argument);
         }
     }
-    
+
     internal partial class BoundDynamicCollectionElementInitializer
     {
         protected override OperationKind ExpressionKind => OperationKind.None;
@@ -2799,4 +2799,21 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override OperationKind ExpressionKind => OperationKind.None;
     }
 
+    /// <summary>
+    /// Providing iplementation as OperationKind.None. This implementation is sufficient because the node doesn't survive initial binding.
+    /// </summary>
+    internal partial class OutVarLocalPendingInference
+    {
+        public override void Accept(OperationVisitor visitor)
+        {
+            visitor.VisitNoneOperation(this);
+        }
+
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        {
+            return visitor.VisitNoneOperation(this, argument);
+        }
+
+        protected override OperationKind ExpressionKind => OperationKind.None;
+    }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -75,4 +75,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             get { throw ExceptionUtilities.Unreachable; }
         }
     }
+
+    internal partial class OutVarLocalPendingInference
+    {
+        public override object Display
+        {
+            get
+            {
+                return MessageID.IDS_FeatureOutVar.Localize();
+            }
+        }
+    }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/OutVarLocalPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/OutVarLocalPendingInference.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal partial class OutVarLocalPendingInference
+    {
+        public BoundLocal SetInferredType(TypeSymbol type, bool success)
+        {
+            var syntaxNode = (ArgumentSyntax)this.Syntax;
+
+            Binder.DeclareLocalVariable(
+                (SourceLocalSymbol)this.LocalSymbol,
+                syntaxNode.Identifier,
+                type);
+
+            return new BoundLocal(syntaxNode, this.LocalSymbol, constantValueOpt: null, type: type, hasErrors: this.HasErrors || !success);
+        }
+
+        public BoundLocal FailInference(Binder binder, DiagnosticBag diagnosticsOpt)
+        {
+            if (diagnosticsOpt != null)
+            {
+                Binder.Error(diagnosticsOpt, ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedOutVariable, ((ArgumentSyntax)this.Syntax).Identifier);
+            }
+
+            return this.SetInferredType(binder.CreateErrorType("var"), success: false);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -200,6 +200,7 @@
     <Compile Include="BoundTree\BoundTreeWalker.cs" />
     <Compile Include="BoundTree\Constructors.cs" />
     <Compile Include="BoundTree\Expression.cs" />
+    <Compile Include="BoundTree\OutVarLocalPendingInference.cs" />
     <Compile Include="BoundTree\PseudoVariableExpressions.cs" />
     <Compile Include="BoundTree\Formatting.cs" />
     <Compile Include="BoundTree\NoOpStatementFlavor.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4787,6 +4787,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Reference to an implicitly-typed out variable &apos;{0}&apos; is not permitted in the same argument list..
+        /// </summary>
+        internal static string ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList {
+            get {
+                return ResourceManager.GetString("ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot initialize an implicitly-typed variable with an array initializer.
         /// </summary>
         internal static string ERR_ImplicitlyTypedVariableAssignedArrayInitializer {
@@ -6875,6 +6884,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Out variable declarations are not allowed within constructor initializers..
+        /// </summary>
+        internal static string ERR_OutVarInConstructorInitializer {
+            get {
+                return ResourceManager.GetString("ERR_OutVarInConstructorInitializer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; cannot define overloaded methods that differ only on ref and out.
         /// </summary>
         internal static string ERR_OverloadRefOut {
@@ -8675,6 +8693,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot infer the type of implicitly-typed out variable..
+        /// </summary>
+        internal static string ERR_TypeInferenceFailedForImplicitlyTypedOutVariable {
+            get {
+                return ResourceManager.GetString("ERR_TypeInferenceFailedForImplicitlyTypedOutVariable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Type parameter declaration must be an identifier not a type.
         /// </summary>
         internal static string ERR_TypeParamMustBeIdentifier {
@@ -9702,7 +9729,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to out var.
+        ///   Looks up a localized string similar to out variable declaration.
         /// </summary>
         internal static string IDS_FeatureOutVar {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4873,6 +4873,15 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>tuples</value>
   </data>
   <data name="IDS_FeatureOutVar" xml:space="preserve">
-    <value>out var</value>
+    <value>out variable declaration</value>
+  </data>
+  <data name="ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList" xml:space="preserve">
+    <value>Reference to an implicitly-typed out variable '{0}' is not permitted in the same argument list.</value>
+  </data>
+  <data name="ERR_TypeInferenceFailedForImplicitlyTypedOutVariable" xml:space="preserve">
+    <value>Cannot infer the type of implicitly-typed out variable.</value>
+  </data>
+  <data name="ERR_OutVarInConstructorInitializer" xml:space="preserve">
+    <value>Out variable declarations are not allowed within constructor initializers.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -519,10 +519,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Named arguments handled in special way.
                 return this.GetNamedArgumentSymbolInfo((IdentifierNameSyntax)expression, cancellationToken);
             }
-            else
+            else if (expression.Parent?.Kind() == SyntaxKind.Argument && 
+                     ((ArgumentSyntax)expression.Parent).Type == expression)
             {
-                return this.GetSymbolInfoWorker(expression, SymbolInfoOptions.DefaultOptions, cancellationToken);
+                TypeSymbol outVarType = (GetDeclaredSymbol((ArgumentSyntax)expression.Parent, cancellationToken) as LocalSymbol)?.Type;
+
+                if (outVarType?.IsErrorType() == false)
+                {
+                    return new SymbolInfo(outVarType);
+                }
+
+                return SymbolInfo.None;
             }
+
+            return this.GetSymbolInfoWorker(expression, SymbolInfoOptions.DefaultOptions, cancellationToken);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1367,6 +1367,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_RefReturnLocal = 8924,
         ERR_RefReturnLocal2 = 8925,
         ERR_RefReturnStructThis = 8926,
+        ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8927,
+        ERR_TypeInferenceFailedForImplicitlyTypedOutVariable = 8928,
+        ERR_OutVarInConstructorInitializer = 8929,
 
         // more diagnostics for ref locals and ref returns
         ERR_MustBeRefAssignable = 8930,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/VariablesDeclaredWalker.cs
@@ -140,13 +140,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override void VisitLvalue(BoundLocal node)
         {
-            if (!node.WasCompilerGenerated && node.Syntax.Kind() == SyntaxKind.Argument &&
+            CheckOutVarDeclaration(node);
+            base.VisitLvalue(node);
+        }
+
+        private void CheckOutVarDeclaration(BoundLocal node)
+        {
+            if (IsInside &&
+                !node.WasCompilerGenerated && node.Syntax.Kind() == SyntaxKind.Argument &&
                 ((ArgumentSyntax)node.Syntax).Identifier == node.LocalSymbol.IdentifierToken)
             {
                 _variablesDeclared.Add(node.LocalSymbol);
             }
+        }
 
-            base.VisitLvalue(node);
+        public override BoundNode VisitLocal(BoundLocal node)
+        {
+            CheckOutVarDeclaration(node);
+            return base.VisitLocal(node);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -9483,7 +9483,14 @@ tryAgain:
             }
             else
             {
-                if (refOrOutKeyword != null && refOrOutKeyword.Kind == SyntaxKind.OutKeyword &&
+                // According to Language Specification, section 7.6.7 Element access
+                //      The argument-list of an element-access is not allowed to contain ref or out arguments.
+                // However, due to backward compatibility, compiler overlooks this restriction during parsing
+                // and even ignores out/ref modifiers in element access during binding.
+                //
+                // We will enforce that language rule for out variables declarations at the parser level. 
+                if (!isIndexer &&
+                    refOrOutKeyword != null && refOrOutKeyword.Kind == SyntaxKind.OutKeyword &&
                     IsPossibleOutVarDeclaration())
                 {
                     expression = null;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -186,6 +186,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case DeclarationPattern:
                         return ((DeclarationPatternSyntax)parent).Type == node;
+
+                    case Argument:
+                        return ((ArgumentSyntax)parent).Type == node;
                 }
             }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -850,6 +850,12 @@ public class X
             Assert.Same(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier.ValueText).Single());
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier.ValueText));
 
+            var type = ((LocalSymbol)symbol).Type;
+            if (!decl.Type.IsVar || !type.IsErrorType())
+            {
+                Assert.Equal(type, model.GetSymbolInfo(decl.Type).Symbol);
+            }
+
             foreach (var reference in references)
             {
                 Assert.Same(symbol, model.GetSymbolInfo(reference).Symbol);
@@ -866,6 +872,12 @@ public class X
             Assert.Same(symbol, model.GetDeclaredSymbol((SyntaxNode)decl));
             Assert.NotEqual(symbol, model.LookupSymbols(decl.SpanStart, name: decl.Identifier.ValueText).Single());
             Assert.True(model.LookupNames(decl.SpanStart).Contains(decl.Identifier.ValueText));
+
+            var type = ((LocalSymbol)symbol).Type;
+            if (!decl.Type.IsVar || !type.IsErrorType())
+            {
+                Assert.Equal(type, model.GetSymbolInfo(decl.Type).Symbol);
+            }
         }
 
         private static void VerifyNotAPatternLocal(SemanticModel model, IdentifierNameSyntax reference)


### PR DESCRIPTION
Also addressed feedback provided for the previous change.

@dotnet/roslyn-compiler Please review.