### PR TITLE
Update RoslynSemanticVersion to 1.2.3 in the microupdate branch.

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -1,6 +1,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">1.2.0</RoslynSemanticVersion>
+    <RoslynSemanticVersion Condition="'$(RoslynSemanticVersion)' == ''">1.2.3</RoslynSemanticVersion>
     <SystemReflectionMetadataAssemblyVersion Condition="'$(SystemReflectionMetadataAssemblyVersion)' == ''">1.2.0</SystemReflectionMetadataAssemblyVersion>
     <SystemCollectionsImmutableAssemblyVersion Condition="'$(SystemCollectionsImmutableAssemblyVersion)' == ''">1.1.37</SystemCollectionsImmutableAssemblyVersion>
     <NuGetCommandLineAssemblyVersion Condition="'$(NuGetCommandLineAssemblyVersion)' == ''">2.8.5</NuGetCommandLineAssemblyVersion>

--- a/build/scripts/VBCSCompiler.exe.config
+++ b/build/scripts/VBCSCompiler.exe.config
@@ -6,15 +6,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/build/scripts/csc.exe.config
+++ b/build/scripts/csc.exe.config
@@ -6,15 +6,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/build/scripts/vbc.exe.config
+++ b/build/scripts/vbc.exe.config
@@ -6,15 +6,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Compilers/CSharp/csc/csc.exe.config
+++ b/src/Compilers/CSharp/csc/csc.exe.config
@@ -8,15 +8,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Compilers/Server/VBCSCompiler/app.config
+++ b/src/Compilers/Server/VBCSCompiler/app.config
@@ -8,15 +8,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/Compilers/VisualBasic/vbc/vbc.exe.config
+++ b/src/Compilers/VisualBasic/vbc/vbc.exe.config
@@ -8,15 +8,15 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.65535.65535" newVersion="1.2.0.0" />
+        <bindingRedirect oldVersion="1.0.0.0-1.2.65535.65535" newVersion="1.2.3.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />

--- a/src/InteractiveWindow/Version.props
+++ b/src/InteractiveWindow/Version.props
@@ -1,5 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <RoslynSemanticVersion>1.2.0</RoslynSemanticVersion>
+    <RoslynSemanticVersion>1.2.3</RoslynSemanticVersion>
   </PropertyGroup>
 </Project>

--- a/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
+++ b/src/VisualStudio/Setup/ProvideRoslynBindingRedirection.cs
@@ -24,7 +24,7 @@ namespace Roslyn.VisualStudio.Setup
                 AssemblyName = Path.GetFileNameWithoutExtension(fileName),
                 PublicKeyToken = "31BF3856AD364E35",
                 OldVersionLowerBound = "0.7.0.0",
-                OldVersionUpperBound = "1.2.0.0",
+                OldVersionUpperBound = "1.2.3.0",
                 CodeBase = fileName,
             };
         }


### PR DESCRIPTION
The actual semantic version for the last micro update that we released from this branch for Update 2 was 1.2.2. However, we haven't been updating the version with each released micro update - RoslynSemanticVersion was still set to 1.2.0. And this meant we were still generating nuget packages with semantic version 1.2.0 in our builds - we would then manually fix up the version before releasing these nugets.

Update the version to 1.2.3 so that the version will be correct in case we end up having to spin any further micro updates from this branch for Update 2.

We should do the same for Update 3 (i.e. update semantic version to 1.3.1 as soon as Update 3 has shipped).