### PR TITLE
Remove dependency on ITextSnapshotLine from indentation code.

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -13,8 +13,8 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
@@ -23,7 +23,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
     {
         internal class Indenter : AbstractIndenter
         {
-            public Indenter(SyntacticDocument document, IEnumerable<IFormattingRule> rules, OptionSet optionSet, ITextSnapshotLine line, CancellationToken cancellationToken) :
+            public Indenter(
+                SyntacticDocument document,
+                IEnumerable<IFormattingRule> rules,
+                OptionSet optionSet,
+                TextLine line,
+                CancellationToken cancellationToken) :
                 base(document, rules, optionSet, line, cancellationToken)
             {
             }
@@ -48,7 +53,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 // okay, now see whether previous line has anything meaningful
-                var lastNonWhitespacePosition = previousLine.GetLastNonWhitespacePosition();
+                var lastNonWhitespacePosition = previousLine.Value.GetLastNonWhitespacePosition();
                 if (!lastNonWhitespacePosition.HasValue)
                 {
                     return null;
@@ -59,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 var token = Tree.GetRoot(CancellationToken).FindToken(lastNonWhitespacePosition.Value);
                 if (token.IsKind(SyntaxKind.None) || indentStyle == FormattingOptions.IndentStyle.Block)
                 {
-                    return GetIndentationOfLine(previousLine);
+                    return GetIndentationOfLine(previousLine.Value);
                 }
 
                 // okay, now check whether the text we found is trivia or actual token.
@@ -74,14 +79,14 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                     Contract.Assert(token.FullSpan.Contains(lastNonWhitespacePosition.Value));
 
                     // okay, now check whether the trivia is at the beginning of the line
-                    var firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition();
+                    var firstNonWhitespacePosition = previousLine.Value.GetFirstNonWhitespacePosition();
                     if (!firstNonWhitespacePosition.HasValue)
                     {
                         return IndentFromStartOfLine(0);
                     }
 
                     var trivia = Tree.GetRoot(CancellationToken).FindTrivia(firstNonWhitespacePosition.Value, findInsideTrivia: true);
-                    if (trivia.Kind() == SyntaxKind.None || this.LineToBeIndented.LineNumber > previousLine.LineNumber + 1)
+                    if (trivia.Kind() == SyntaxKind.None || this.LineToBeIndented.LineNumber > previousLine.Value.LineNumber + 1)
                     {
                         // If the token belongs to the next statement and is also the first token of the statement, then it means the user wants
                         // to start type a new statement. So get indentation from the start of the line but not based on the token.
@@ -126,13 +131,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                     // this case we will keep the indentation of this trivia line
                     // this trivia can't be preprocessor by the way.
-                    return GetIndentationOfLine(previousLine);
+                    return GetIndentationOfLine(previousLine.Value);
                 }
             }
 
             private IndentationResult? GetIndentationBasedOnToken(SyntaxToken token)
             {
-                Contract.ThrowIfNull(LineToBeIndented);
                 Contract.ThrowIfNull(Tree);
                 Contract.ThrowIfTrue(token.Kind() == SyntaxKind.None);
 
@@ -172,7 +176,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 // if we couldn't determine indentation from the service, use heuristic to find indentation.
-                var snapshot = LineToBeIndented.Snapshot;
+                var sourceText = LineToBeIndented.Text;
 
                 // If this is the last token of an embedded statement, walk up to the top-most parenting embedded
                 // statement owner and use its indentation.
@@ -198,7 +202,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                         embeddedStatementOwner = embeddedStatementOwner.Parent;
                     }
 
-                    return GetIndentationOfLine(snapshot.GetLineFromPosition(embeddedStatementOwner.GetFirstToken(includeZeroWidth: true).SpanStart));
+                    return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(embeddedStatementOwner.GetFirstToken(includeZeroWidth: true).SpanStart));
                 }
 
                 switch (token.Kind())
@@ -240,7 +244,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                             if (nonTerminalNode is SwitchLabelSyntax)
                             {
-                                return GetIndentationOfLine(snapshot.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart), OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language));
+                                return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart), OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language));
                             }
 
                             // default case
@@ -255,7 +259,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                             // if this is closing an attribute, we shouldn't indent.
                             if (nonTerminalNode is AttributeListSyntax)
                             {
-                                return GetIndentationOfLine(snapshot.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart));
+                                return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(nonTerminalNode.GetFirstToken(includeZeroWidth: true).SpanStart));
                             }
 
                             // default case
@@ -264,7 +268,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                     case SyntaxKind.XmlTextLiteralToken:
                         {
-                            return GetIndentationOfLine(snapshot.GetLineFromPosition(token.SpanStart));
+                            return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(token.SpanStart));
                         }
 
                     case SyntaxKind.CommaToken:
@@ -331,15 +335,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 // find node that starts at the beginning of a line
-                var snapshot = LineToBeIndented.Snapshot;
+                var sourceText = LineToBeIndented.Text;
                 for (int i = (index - 1) / 2; i >= 0; i--)
                 {
                     var node = list[i];
                     var firstToken = node.GetFirstToken(includeZeroWidth: true);
 
-                    if (firstToken.IsFirstTokenOnLine(snapshot))
+                    if (firstToken.IsFirstTokenOnLine(sourceText))
                     {
-                        return GetIndentationOfLine(snapshot.GetLineFromPosition(firstToken.SpanStart));
+                        return GetIndentationOfLine(sourceText.Lines.GetLineFromPosition(firstToken.SpanStart));
                     }
                 }
 
@@ -368,12 +372,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 // find line where first token of the node is
-                var snapshot = LineToBeIndented.Snapshot;
+                var sourceText = LineToBeIndented.Text;
                 var firstToken = queryExpressionClause.GetFirstToken(includeZeroWidth: true);
-                var firstTokenLine = snapshot.GetLineFromPosition(firstToken.SpanStart);
+                var firstTokenLine = sourceText.Lines.GetLineFromPosition(firstToken.SpanStart);
 
                 // find line where given token is
-                var givenTokenLine = snapshot.GetLineFromPosition(token.SpanStart);
+                var givenTokenLine = sourceText.Lines.GetLineFromPosition(token.SpanStart);
 
                 if (firstTokenLine.LineNumber != givenTokenLine.LineNumber)
                 {
@@ -383,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 
                 // okay, we are right under the query expression.
                 // align caret to query expression
-                if (firstToken.IsFirstTokenOnLine(snapshot))
+                if (firstToken.IsFirstTokenOnLine(sourceText))
                 {
                     return GetIndentationOfToken(firstToken);
                 }
@@ -406,9 +410,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                     }
 
                     var clauseToken = clause.GetFirstToken(includeZeroWidth: true);
-                    if (clauseToken.IsFirstTokenOnLine(snapshot))
+                    if (clauseToken.IsFirstTokenOnLine(sourceText))
                     {
-                        var tokenSpan = clauseToken.Span.ToSnapshotSpan(snapshot);
                         return GetIndentationOfToken(clauseToken);
                     }
                 }
@@ -453,10 +456,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             {
                 var spaceToAdd = additionalSpace ?? this.OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language);
 
-                var snapshot = LineToBeIndented.Snapshot;
+                var sourceText = LineToBeIndented.Text;
 
                 // find line where given token is
-                var givenTokenLine = snapshot.GetLineFromPosition(token.SpanStart);
+                var givenTokenLine = sourceText.Lines.GetLineFromPosition(token.SpanStart);
 
                 // find right position
                 var position = GetCurrentPositionNotBelongToEndOfFileToken(LineToBeIndented.Start);
@@ -470,7 +473,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 }
 
                 // find line where first token of the node is
-                var firstTokenLine = snapshot.GetLineFromPosition(nonExpressionNode.GetFirstToken(includeZeroWidth: true).SpanStart);
+                var firstTokenLine = sourceText.Lines.GetLineFromPosition(nonExpressionNode.GetFirstToken(includeZeroWidth: true).SpanStart);
 
                 // single line expression
                 if (firstTokenLine.LineNumber == givenTokenLine.LineNumber)
@@ -482,14 +485,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 return GetIndentationOfLine(givenTokenLine);
             }
 
-            protected override bool HasPreprocessorCharacter(ITextSnapshotLine currentLine)
+            protected override bool HasPreprocessorCharacter(TextLine currentLine)
             {
-                if (currentLine == null)
-                {
-                    throw new ArgumentNullException(nameof(currentLine));
-                }
-
-                var text = currentLine.GetText();
+                var text = currentLine.ToString();
                 Contract.Requires(!string.IsNullOrWhiteSpace(text));
 
                 var trimmedText = text.Trim();

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -14,8 +14,8 @@ using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
@@ -30,7 +30,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             return s_instance;
         }
 
-        protected override async Task<AbstractIndenter> GetIndenterAsync(Document document, ITextSnapshotLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
+        protected override async Task<AbstractIndenter> GetIndenterAsync(
+            Document document, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
         {
             var syntacticDocument = await SyntacticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
             return new Indenter(syntacticDocument, formattingRules, optionSet, lineToBeIndented, cancellationToken);
@@ -39,23 +40,23 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
         protected override bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
             IEnumerable<IFormattingRule> formattingRules,
             SyntaxNode root,
-            ITextSnapshotLine line,
+            TextLine line,
             OptionSet optionSet,
             CancellationToken cancellationToken)
         {
-            return ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, (CompilationUnitSyntax)root, line, optionSet, cancellationToken);
+            return ShouldUseSmartTokenFormatterInsteadOfIndenter(
+                formattingRules, (CompilationUnitSyntax)root, line, optionSet, cancellationToken);
         }
 
         public static bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
             IEnumerable<IFormattingRule> formattingRules,
             CompilationUnitSyntax root,
-            ITextSnapshotLine line,
+            TextLine line,
             OptionSet optionSet,
             CancellationToken cancellationToken)
         {
             Contract.ThrowIfNull(formattingRules);
             Contract.ThrowIfNull(root);
-            Contract.ThrowIfNull(line);
 
             if (optionSet.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp) != FormattingOptions.IndentStyle.Smart)
             {

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatterCommandHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Text;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Operations;
 using Microsoft.VisualStudio.Utilities;
@@ -37,7 +38,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             return new SmartTokenFormatter(optionSet, formattingRules, (CompilationUnitSyntax)root);
         }
 
-        protected override bool UseSmartTokenFormatter(SyntaxNode root, ITextSnapshotLine line, IEnumerable<IFormattingRule> formattingRules, OptionSet options, CancellationToken cancellationToken)
+        protected override bool UseSmartTokenFormatter(SyntaxNode root, TextLine line, IEnumerable<IFormattingRule> formattingRules, OptionSet options, CancellationToken cancellationToken)
         {
             return CSharpIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, (CompilationUnitSyntax)root, line, options, cancellationToken);
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
 
@@ -1365,7 +1366,7 @@ class C
                 Assert.True(
                     CSharpIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(
                         Formatter.GetDefaultFormattingRules(workspace, root.Language),
-                        root, line, document.Options, CancellationToken.None));
+                        root, line.AsTextLine(), document.Options, CancellationToken.None));
 
                 var actualIndentation = await GetSmartTokenFormatterIndentationWorkerAsync(workspace, buffer, indentationLine, ch);
                 Assert.Equal(expectedIndentation.Value, actualIndentation);
@@ -1392,7 +1393,7 @@ class C
                 Assert.False(
                     CSharpIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(
                         Formatter.GetDefaultFormattingRules(workspace, root.Language),
-                        root, line, document.Options, CancellationToken.None));
+                        root, line.AsTextLine(), document.Options, CancellationToken.None));
 
                 await TestIndentationAsync(indentationLine, expectedIndentation, workspace);
             }

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -36,7 +36,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
 
         protected abstract ISmartTokenFormatter CreateSmartTokenFormatter(OptionSet optionSet, IEnumerable<IFormattingRule> formattingRules, SyntaxNode root);
 
-        protected abstract bool UseSmartTokenFormatter(SyntaxNode root, ITextSnapshotLine line, IEnumerable<IFormattingRule> formattingRules, OptionSet options, CancellationToken cancellationToken);
+        protected abstract bool UseSmartTokenFormatter(SyntaxNode root, TextLine line, IEnumerable<IFormattingRule> formattingRules, OptionSet options, CancellationToken cancellationToken);
         protected abstract bool IsInvalidToken(SyntaxToken token);
 
         protected abstract IEnumerable<IFormattingRule> GetFormattingRules(Document document, int position);
@@ -294,7 +294,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
         private bool TryFormatUsingTokenFormatter(ITextView view, ITextBuffer subjectBuffer, Document document, IEnumerable<IFormattingRule> formattingRules, CancellationToken cancellationToken)
         {
             var position = view.GetCaretPoint(subjectBuffer).Value;
-            var line = position.GetContainingLine();
+            var line = position.GetContainingLine().AsTextLine();
             var root = document.GetSyntaxRootAsync(cancellationToken).WaitAndGetResult(cancellationToken);
             var options = document.Options;
             if (!UseSmartTokenFormatter(root, line, formattingRules, options, cancellationToken))
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
             {
                 // if caret position is before the token, make sure we put caret at the beginning of the token so that caret
                 // is at the right position after formatting
-                var currentSnapshot = line.Snapshot;
+                var currentSnapshot = subjectBuffer.CurrentSnapshot;
                 if (position.Position < token.SpanStart)
                 {
                     view.TryMoveCaretToAndEnsureVisible(new SnapshotPoint(currentSnapshot, token.SpanStart));

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
         {
             protected readonly OptionSet OptionSet;
             protected readonly SyntacticDocument Document;
-            protected readonly ITextSnapshotLine LineToBeIndented;
+            protected readonly TextLine LineToBeIndented;
             protected readonly int TabSize;
             protected readonly CancellationToken CancellationToken;
 
@@ -33,7 +33,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             private static readonly Func<SyntaxToken, bool> s_tokenHasDirective = tk => tk.ContainsDirectives &&
                                                   (tk.LeadingTrivia.Any(tr => tr.IsDirective) || tk.TrailingTrivia.Any(tr => tr.IsDirective));
 
-            public AbstractIndenter(SyntacticDocument document, IEnumerable<IFormattingRule> rules, OptionSet optionSet, ITextSnapshotLine lineToBeIndented, CancellationToken cancellationToken)
+            public AbstractIndenter(
+                SyntacticDocument document,
+                IEnumerable<IFormattingRule> rules,
+                OptionSet optionSet,
+                TextLine lineToBeIndented,
+                CancellationToken cancellationToken)
             {
                 this.OptionSet = optionSet;
                 this.Document = document;
@@ -65,23 +70,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 
             protected IndentationResult GetIndentationOfToken(SyntaxToken token, int addedSpaces)
             {
-                return GetIndentationOfPosition(new SnapshotPoint(LineToBeIndented.Snapshot, token.SpanStart), addedSpaces);
+                return GetIndentationOfPosition(token.SpanStart, addedSpaces);
             }
 
-            protected IndentationResult GetIndentationOfLine(ITextSnapshotLine lineToMatch)
+            protected IndentationResult GetIndentationOfLine(TextLine lineToMatch)
             {
                 return GetIndentationOfLine(lineToMatch, addedSpaces: 0);
             }
 
-            protected IndentationResult GetIndentationOfLine(ITextSnapshotLine lineToMatch, int addedSpaces)
+            protected IndentationResult GetIndentationOfLine(TextLine lineToMatch, int addedSpaces)
             {
                 var firstNonWhitespace = lineToMatch.GetFirstNonWhitespacePosition();
-                firstNonWhitespace = firstNonWhitespace ?? lineToMatch.End.Position;
+                firstNonWhitespace = firstNonWhitespace ?? lineToMatch.End;
 
-                return GetIndentationOfPosition(new SnapshotPoint(lineToMatch.Snapshot, firstNonWhitespace.Value), addedSpaces);
+                return GetIndentationOfPosition(firstNonWhitespace.Value, addedSpaces);
             }
 
-            protected IndentationResult GetIndentationOfPosition(SnapshotPoint position, int addedSpaces)
+            protected IndentationResult GetIndentationOfPosition(int position, int addedSpaces)
             {
                 var tree = Document.SyntaxTree;
 
@@ -99,7 +104,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                 return new IndentationResult(position, addedSpaces);
             }
 
-            private TextSpan GetNormalizedSpan(SnapshotPoint position)
+            private TextSpan GetNormalizedSpan(int position)
             {
                 if (LineToBeIndented.Start < position)
                 {
@@ -109,7 +114,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                 return TextSpan.FromBounds(position, LineToBeIndented.Start);
             }
 
-            protected ITextSnapshotLine GetPreviousNonBlankOrPreprocessorLine()
+            protected TextLine? GetPreviousNonBlankOrPreprocessorLine()
             {
                 if (Tree == null)
                 {
@@ -122,15 +127,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                 }
 
                 var syntaxFacts = this.Document.Document.GetLanguageService<ISyntaxFactsService>();
-                var snapshot = this.LineToBeIndented.Snapshot;
+                var sourceText = this.LineToBeIndented.Text;
 
                 var lineNumber = this.LineToBeIndented.LineNumber - 1;
                 while (lineNumber >= 0)
                 {
-                    var actualLine = snapshot.GetLineFromLineNumber(lineNumber);
+                    var actualLine = sourceText.Lines[lineNumber];
 
                     // Empty line, no indentation to match.
-                    if (string.IsNullOrWhiteSpace(actualLine.GetText()))
+                    if (string.IsNullOrWhiteSpace(actualLine.ToString()))
                     {
                         lineNumber--;
                         continue;
@@ -141,34 +146,34 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                     var root = Tree.GetRoot(CancellationToken);
                     if (!root.ContainsDirectives)
                     {
-                        return snapshot.GetLineFromLineNumber(lineNumber);
+                        return sourceText.Lines[lineNumber];
                     }
 
                     // This line is inside an inactive region. Examine the 
                     // first preceding line not in an inactive region.
-                    var disabledSpan = syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Extent.Start, CancellationToken);
+                    var disabledSpan = syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Span.Start, CancellationToken);
                     if (disabledSpan != default(TextSpan))
                     {
-                        var targetLine = snapshot.GetLineNumberFromPosition(disabledSpan.Start);
+                        var targetLine = sourceText.Lines.GetLineFromPosition(disabledSpan.Start).LineNumber;
                         lineNumber = targetLine - 1;
                         continue;
                     }
 
                     // A preprocessor directive starts on this line.
                     if (HasPreprocessorCharacter(actualLine) &&
-                        root.DescendantTokens(actualLine.Extent.Span.ToTextSpan(), tk => tk.FullWidth() > 0).Any(s_tokenHasDirective))
+                        root.DescendantTokens(actualLine.Span, tk => tk.FullWidth() > 0).Any(s_tokenHasDirective))
                     {
                         lineNumber--;
                         continue;
                     }
 
-                    return snapshot.GetLineFromLineNumber(lineNumber);
+                    return sourceText.Lines[lineNumber];
                 }
 
                 return null;
             }
 
-            protected abstract bool HasPreprocessorCharacter(ITextSnapshotLine currentLine);
+            protected abstract bool HasPreprocessorCharacter(TextLine currentLine);
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
@@ -32,14 +32,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-            var textSnapshot = sourceText.FindCorrespondingEditorTextSnapshot();
-            if (textSnapshot == null)
-            {
-                // text snapshot doesn't exit. return null
-                return null;
-            }
-
-            var lineToBeIndented = textSnapshot.GetLineFromLineNumber(lineNumber);
+            var lineToBeIndented = sourceText.Lines[lineNumber];
 
             var formattingRules = GetFormattingRules(document, lineToBeIndented.Start);
 
@@ -53,9 +46,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             return indenter.GetDesiredIndentation();
         }
 
-        protected abstract Task<AbstractIndenter> GetIndenterAsync(Document document, ITextSnapshotLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
+        protected abstract Task<AbstractIndenter> GetIndenterAsync(
+            Document document, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
 
         protected abstract bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
-            IEnumerable<IFormattingRule> formattingRules, SyntaxNode root, ITextSnapshotLine line, OptionSet optionSet, CancellationToken cancellationToken);
+            IEnumerable<IFormattingRule> formattingRules, SyntaxNode root, TextLine line, OptionSet optionSet, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/Text/Extensions.cs
+++ b/src/EditorFeatures/Text/Extensions.cs
@@ -46,6 +46,11 @@ namespace Microsoft.CodeAnalysis.Text
             return t == null ? null : t.EditorSnapshot;
         }
 
+        internal static TextLine AsTextLine(this ITextSnapshotLine line)
+        {
+            return line.Snapshot.AsText().Lines[line.LineNumber];
+        }
+
         public static SourceText AsText(this ITextSnapshot textSnapshot)
         {
             return SnapshotSourceText.From(textSnapshot);

--- a/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
+++ b/src/EditorFeatures/Text/Shared/Extensions/ITextSnapshotLineExtensions.cs
@@ -61,20 +61,7 @@ namespace Microsoft.CodeAnalysis.Text.Shared.Extensions
         /// </summary>
         public static int? GetLastNonWhitespacePosition(this ITextSnapshotLine line)
         {
-            Contract.ThrowIfNull(line);
-
-            int startPosition = line.Start;
-            var text = line.GetText();
-
-            for (int i = text.Length - 1; i >= 0; i--)
-            {
-                if (!char.IsWhiteSpace(text[i]))
-                {
-                    return startPosition + i;
-                }
-            }
-
-            return null;
+            return line.AsTextLine().GetLastNonWhitespacePosition();
         }
 
         /// <summary>

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/SmartTokenFormatterCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/SmartTokenFormatterCommandHandler.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
@@ -40,7 +41,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
         End Function
 
         Protected Overrides Function UseSmartTokenFormatter(root As SyntaxNode,
-                                                            line As ITextSnapshotLine,
+                                                            line As TextLine,
                                                             formattingRules As IEnumerable(Of IFormattingRule),
                                                             options As OptionSet,
                                                             cancellationToken As CancellationToken) As Boolean

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -4,17 +4,21 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic.Formatting
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
     Partial Friend Class VisualBasicIndentationService
         Private Class Indenter
             Inherits AbstractIndenter
 
-            Public Sub New(document As SyntacticDocument, rules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, line As ITextSnapshotLine, cancellationToken As CancellationToken)
+            Public Sub New(document As SyntacticDocument,
+                           rules As IEnumerable(Of IFormattingRule),
+                           optionSet As OptionSet,
+                           line As TextLine,
+                           cancellationToken As CancellationToken)
                 MyBase.New(document, rules, optionSet, line, cancellationToken)
             End Sub
 
@@ -31,7 +35,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                     Return IndentFromStartOfLine(0)
                 End If
 
-                Dim lastNonWhitespacePosition = previousLine.GetLastNonWhitespacePosition()
+                Dim lastNonWhitespacePosition = previousLine.Value.GetLastNonWhitespacePosition()
                 If Not lastNonWhitespacePosition.HasValue Then
                     Return Nothing
                 End If
@@ -40,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 If token.Kind = SyntaxKind.None OrElse
                     indentStyle = FormattingOptions.IndentStyle.Block Then
 
-                    Return GetIndentationOfLine(previousLine)
+                    Return GetIndentationOfLine(previousLine.Value)
                 End If
 
                 If token.Span.End = lastNonWhitespacePosition.Value + 1 Then
@@ -52,7 +56,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 
                     ' preserve the indentation of the comment trivia before a case statement
                     If trivia.Kind = SyntaxKind.CommentTrivia AndAlso trivia.Token.IsKind(SyntaxKind.CaseKeyword) AndAlso trivia.Token.Parent.IsKind(SyntaxKind.CaseStatement) Then
-                        Return GetIndentationOfLine(previousLine)
+                        Return GetIndentationOfLine(previousLine.Value)
                     End If
 
                     If trivia.Kind = SyntaxKind.LineContinuationTrivia OrElse trivia.Kind = SyntaxKind.CommentTrivia Then
@@ -65,7 +69,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                     End If
 
                     ' okay, now check whether the trivia is at the beginning of the line
-                    Dim firstNonWhitespacePosition = previousLine.GetFirstNonWhitespacePosition()
+                    Dim firstNonWhitespacePosition = previousLine.Value.GetFirstNonWhitespacePosition()
                     If Not firstNonWhitespacePosition.HasValue Then
                         Return IndentFromStartOfLine(0)
                     End If
@@ -76,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                         Return GetIndentationBasedOnToken(firstTokenOnLine)
                     End If
 
-                    Return GetIndentationOfLine(previousLine)
+                    Return GetIndentationOfLine(previousLine.Value)
                 End If
             End Function
 
@@ -89,10 +93,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 Return token.GetPreviousToken()
             End Function
 
-            Protected Overrides Function HasPreprocessorCharacter(currentLine As ITextSnapshotLine) As Boolean
-                ThrowIfNull(currentLine)
-
-                Dim text = currentLine.GetText()
+            Protected Overrides Function HasPreprocessorCharacter(currentLine As TextLine) As Boolean
+                Dim text = currentLine.ToString()
                 Contract.Assert(String.IsNullOrWhiteSpace(text) = False)
 
                 Dim trimmedText = text.Trim()
@@ -102,7 +104,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             End Function
 
             Private Function GetIndentationBasedOnToken(token As SyntaxToken, Optional trivia As SyntaxTrivia = Nothing) As IndentationResult?
-                Dim snapshot = LineToBeIndented.Snapshot
+                Dim sourceText = LineToBeIndented.Text
 
                 Dim position = GetCurrentPositionNotBelongToEndOfFileToken(LineToBeIndented.Start)
 
@@ -239,7 +241,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 ' based on current indentation level.
                 If token.Kind = SyntaxKind.XmlTextLiteralToken OrElse
                    token.Kind = SyntaxKind.XmlEntityLiteralToken Then
-                    Return GetIndentationOfLine(LineToBeIndented.Snapshot.GetLineFromPosition(token.SpanStart))
+                    Return GetIndentationOfLine(LineToBeIndented.Text.Lines.GetLineFromPosition(token.SpanStart))
                 End If
 
                 ' check alignment token indentation
@@ -252,28 +254,28 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             End Function
 
             Private Function GetIndentationFromTokenLineAfterLineContinuation(token As SyntaxToken, trivia As SyntaxTrivia) As IndentationResult
-                Dim snapshot = LineToBeIndented.Snapshot
-                Dim position = LineToBeIndented.Start.Position
+                Dim sourceText = LineToBeIndented.Text
+                Dim position = LineToBeIndented.Start
 
                 position = GetCurrentPositionNotBelongToEndOfFileToken(position)
 
-                Dim currentTokenLine = snapshot.GetLineFromPosition(token.SpanStart)
+                Dim currentTokenLine = sourceText.Lines.GetLineFromPosition(token.SpanStart)
 
                 ' error case where the line continuation belongs to a meaningless token such as empty token for skipped text
                 If token.Kind = SyntaxKind.EmptyToken Then
-                    Dim baseLine = snapshot.GetLineFromPosition(trivia.SpanStart)
+                    Dim baseLine = sourceText.Lines.GetLineFromPosition(trivia.SpanStart)
                     Return GetIndentationOfLine(baseLine)
                 End If
 
                 Dim xmlEmbeddedExpression = token.GetAncestor(Of XmlEmbeddedExpressionSyntax)()
                 If xmlEmbeddedExpression IsNot Nothing Then
-                    Dim firstExpressionLine = snapshot.GetLineFromPosition(xmlEmbeddedExpression.GetFirstToken(includeZeroWidth:=True).SpanStart)
+                    Dim firstExpressionLine = sourceText.Lines.GetLineFromPosition(xmlEmbeddedExpression.GetFirstToken(includeZeroWidth:=True).SpanStart)
                     Return GetIndentationFromTwoLines(firstExpressionLine, currentTokenLine, token, position)
                 End If
 
                 If FormattingHelpers.IsGreaterThanInAttribute(token) Then
                     Dim attribute = token.GetAncestor(Of AttributeListSyntax)()
-                    Dim baseLine = snapshot.GetLineFromPosition(attribute.GetFirstToken(includeZeroWidth:=True).SpanStart)
+                    Dim baseLine = sourceText.Lines.GetLineFromPosition(attribute.GetFirstToken(includeZeroWidth:=True).SpanStart)
                     Return GetIndentationOfLine(baseLine)
                 End If
 
@@ -288,7 +290,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 ' this can happen if only token in the file is End Of File Token
                 If statement Is Nothing Then
                     If trivia.Kind <> SyntaxKind.None Then
-                        Dim triviaLine = snapshot.GetLineFromPosition(trivia.SpanStart)
+                        Dim triviaLine = sourceText.Lines.GetLineFromPosition(trivia.SpanStart)
                         Return GetIndentationOfLine(triviaLine, Me.OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language))
                     End If
 
@@ -297,7 +299,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                 End If
 
                 ' find line where first token of statement is starting on
-                Dim firstTokenLine = snapshot.GetLineFromPosition(statement.GetFirstToken(includeZeroWidth:=True).SpanStart)
+                Dim firstTokenLine = sourceText.Lines.GetLineFromPosition(statement.GetFirstToken(includeZeroWidth:=True).SpanStart)
                 Return GetIndentationFromTwoLines(firstTokenLine, currentTokenLine, token, position)
             End Function
 
@@ -308,7 +310,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
                      TypeOf token.Parent Is TypeParameterListSyntax)
             End Function
 
-            Private Function GetIndentationFromTwoLines(firstLine As ITextSnapshotLine, secondLine As ITextSnapshotLine, token As SyntaxToken, position As Integer) As IndentationResult
+            Private Function GetIndentationFromTwoLines(firstLine As TextLine, secondLine As TextLine, token As SyntaxToken, position As Integer) As IndentationResult
                 If firstLine.LineNumber = secondLine.LineNumber Then
                     ' things are on same line, put the indentation size
                     Return GetIndentationOfCurrentPosition(token, position, Me.OptionSet.GetOption(FormattingOptions.IndentationSize, token.Language))

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.Options
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text
@@ -22,13 +23,14 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             Return s_instance
         End Function
 
-        Protected Overrides Async Function GetIndenterAsync(document As Document, lineToBeIndented As ITextSnapshotLine, formattingRules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, cancellationToken As CancellationToken) As Tasks.Task(Of AbstractIndenter)
+        Protected Overrides Async Function GetIndenterAsync(document As Document, lineToBeIndented As TextLine, formattingRules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, cancellationToken As CancellationToken) As Tasks.Task(Of AbstractIndenter)
             Dim synDocument = Await SyntacticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(False)
             Return New Indenter(synDocument, formattingRules, optionSet, lineToBeIndented, cancellationToken)
         End Function
 
         Protected Overrides Function ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules As IEnumerable(Of IFormattingRule),
-                                                                                   root As SyntaxNode, line As ITextSnapshotLine,
+                                                                                   root As SyntaxNode,
+                                                                                   line As TextLine,
                                                                                    optionSet As OptionSet,
                                                                                    cancellationToken As CancellationToken) As Boolean
             Return ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, DirectCast(root, CompilationUnitSyntax), line, optionSet, cancellationToken)
@@ -37,7 +39,7 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
         Public Overloads Shared Function ShouldUseSmartTokenFormatterInsteadOfIndenter(
                 formattingRules As IEnumerable(Of IFormattingRule),
                 root As CompilationUnitSyntax,
-                line As ITextSnapshotLine,
+                line As TextLine,
                 optionSet As OptionSet,
                 CancellationToken As CancellationToken,
                 Optional neverUseWhenHavingMissingToken As Boolean = True) As Boolean

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartTokenFormatter_FormatTokenTests.vb
@@ -5,6 +5,7 @@ Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
 Imports Microsoft.CodeAnalysis.Formatting
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text.Editor
@@ -193,7 +194,8 @@ End Class
                 Dim previousToken = token.GetPreviousToken(includeZeroWidth:=True)
                 Dim ignoreMissingToken = previousToken.IsMissing AndAlso line.Start.Position = position
 
-                Assert.True(VisualBasicIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules, root, line, workspace.Options, Nothing, ignoreMissingToken))
+                Assert.True(VisualBasicIndentationService.ShouldUseSmartTokenFormatterInsteadOfIndenter(
+                            formattingRules, root, line.AsTextLine, workspace.Options, Nothing, ignoreMissingToken))
 
                 Dim smartFormatter = New SmartTokenFormatter(document.Options, formattingRules, root)
                 Dim changes = Await smartFormatter.FormatTokenAsync(workspace, token, Nothing)

--- a/src/Workspaces/Core/Portable/Shared/Extensions/TextLineExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/TextLineExtensions.cs
@@ -9,6 +9,22 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
 {
     internal static class TextLineExtensions
     {
+        public static int? GetLastNonWhitespacePosition(this TextLine line)
+        {
+            int startPosition = line.Start;
+            var text = line.ToString();
+
+            for (int i = text.Length - 1; i >= 0; i--)
+            {
+                if (!char.IsWhiteSpace(text[i]))
+                {
+                    return startPosition + i;
+                }
+            }
+
+            return null;
+        }
+
         /// <summary>
         /// Returns the first non-whitespace position on the given line, or null if 
         /// the line is empty or contains only whitespace.


### PR DESCRIPTION
This can allow us to move hte indentation service lower.  It also enabled using the indentation service from features that only have a document and aren't connected to an editor.