### PR TITLE
Harden active statement mapping

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -7957,6 +7957,52 @@ class C
             edits.VerifyRudeDiagnostics(active);
         }
 
+        [Fact]
+        public void MisplacedActiveStatement2()
+        {
+            string src1 = @"
+class C
+{
+    static <AS:0>void</AS:0> Main(string[] args)
+    {
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main(string[] args)
+    <AS:0>{</AS:0>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void MisplacedTrackingSpan1()
+        {
+            string src1 = @"
+class C
+{
+    static <AS:0>void</AS:0> Main(string[] args)
+    {
+    }
+}";
+            string src2 = @"
+class C
+{
+    static <TS:0>void</TS:0> Main(string[] args)
+    <AS:0>{</AS:0>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
         #endregion
 
         #region Unmodified Documents

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -4749,6 +4749,94 @@ End Class
             edits.VerifyRudeDiagnostics(active)
         End Sub
 
+        <Fact>
+        Public Sub MisplacedActiveStatement2()
+            Dim src1 = "
+Class C
+    <AS:0><Attr></AS:0>
+    Shared Sub Main()
+    End Sub
+End Class"
+            Dim src2 = "
+Class C
+    <Attr>
+    <AS:0>Shared Sub Main()</AS:0>
+    End Sub
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan1()
+            Dim src1 = "
+Class C
+    <AS:0><Attr></AS:0>
+    Shared Sub Main()
+    End Sub
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0><Attr></TS:0>
+    <AS:0>Shared Sub Main()</AS:0>
+    End Sub
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan2()
+            Dim src1 = "
+Class C
+    Dim f = <AS:0>1</AS:0>
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Dim</TS:0> <AS:0>f = 1</AS:0>
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan3()
+            Dim src1 = "
+Class C
+    Dim <AS:0>f</AS:0>, g As New C()
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Dim</TS:0> <AS:0>f</AS:0>, g As New C()
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan4()
+            Dim src1 = "
+Class C
+    <AS:0>Property</AS:0> f As New C()
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Property</TS:0> <AS:0>f As New C()</AS:0>
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
         <Fact, WorkItem(1359, "https://github.com/dotnet/roslyn/issues/1359")>
         Public Sub Lambdas_LeafEdits_GeneralStatement()
             Dim src1 = "

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -270,13 +270,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     declarationBody = constructor.Initializer;
                     partnerDeclarationBodyOpt = partnerConstructor?.Initializer;
                 }
-                else
-                {
-                    Debug.Assert(!(declarationBody is BlockSyntax));
+            }
 
-                    // let's find a labeled node that encompasses the body:
-                    position = declarationBody.SpanStart;
-                }
+            if (!declarationBody.FullSpan.Contains(position))
+            {
+                // invalid position, let's find a labeled node that encompasses the body:
+                position = declarationBody.SpanStart;
             }
 
             SyntaxNode node;
@@ -284,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 SyntaxUtilities.FindLeafNodeAndPartner(declarationBody, position, partnerDeclarationBodyOpt, out node, out partnerOpt);
             }
-            else
+            else 
             {
                 node = declarationBody.FindToken(position).Parent;
                 partnerOpt = null;
@@ -453,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             SyntaxNode root = GetEncompassingAncestor(containerOpt);
 
-            while (node != root)
+            while (node != root && node != null)
             {
                 SyntaxNode body;
                 if (LambdaUtilities.IsLambdaBodyStatementOrExpression(node, out body))

--- a/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
+++ b/src/Features/Core/Portable/EditAndContinue/AbstractEditAndContinueAnalyzer.cs
@@ -123,6 +123,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
         /// <remarks>
         /// The declaration body node may not contain the <paramref name="position"/>. 
         /// This happens when an active statement associated with the member is outside of its body (e.g. C# constructor).
+        /// If the position doesn't correspond to any statement uses the start of the <paramref name="declarationBody"/>.
         /// </remarks>
         protected abstract SyntaxNode FindStatementAndPartner(SyntaxNode declarationBody, int position, SyntaxNode partnerDeclarationBodyOpt, out SyntaxNode partnerOpt, out int statementPart);
 
@@ -506,10 +507,24 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     lineEdits.AsImmutable(),
                     hasSemanticErrors: false);
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (ReportFatalErrorAnalyzeDocumentAsync(baseActiveStatements, e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
+        }
+
+        // Active statements spans are usually unavailable in crash dumps due to a bug in the debugger (DevDiv #150901), 
+        // so we stash them here in plain array (can't use immutable, see the bug) just before we report NFW.
+        private static ActiveStatementSpan[] s_fatalErrorBaseActiveStatements;
+
+        private static bool ReportFatalErrorAnalyzeDocumentAsync(ImmutableArray<ActiveStatementSpan> baseActiveStatements, Exception e)
+        {
+            if (!(e is OperationCanceledException))
+            {
+                s_fatalErrorBaseActiveStatements = baseActiveStatements.ToArray();
+            }
+
+            return FatalError.ReportUnlessCanceled(e);
         }
 
         internal Dictionary<SyntaxNode, EditKind> BuildEditMap(EditScript<SyntaxNode> editScript)
@@ -598,7 +613,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
             {
                 if (!editedActiveStatements[i])
                 {
-                    Debug.Assert(newExceptionRegions[i].IsDefault);
+                    Contract.ThrowIfFalse(newExceptionRegions[i].IsDefault);
 
                     TextSpan trackedSpan = default(TextSpan);
                     bool isTracked = trackingService != null &&
@@ -622,9 +637,11 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                         continue;
                     }
 
+                    Contract.ThrowIfFalse(oldMember.FullSpan.Contains(oldStatementSpan.Start));
+
                     SyntaxNode newMember;
                     bool hasPartner = topMatch.TryGetNewNode(oldMember, out newMember);
-                    Debug.Assert(hasPartner);
+                    Contract.ThrowIfFalse(hasPartner);
 
                     SyntaxNode oldBody = TryGetDeclarationBody(oldMember, isMember: true);
                     SyntaxNode newBody = TryGetDeclarationBody(newMember, isMember: true);
@@ -645,7 +662,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     if (isTracked && trackedSpan.Length != 0 && newMember.Span.Contains(trackedSpan))
                     {
                         int trackedStatementPart;
+
                         var trackedStatement = FindStatement(newBody, trackedSpan.Start, out trackedStatementPart);
+                        Contract.ThrowIfNull(trackedStatement);
 
                         // In rare cases the tracking span might have been moved outside of lambda.
                         // It is not an error to move the statement - we just ignore it.
@@ -660,8 +679,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
 
                     if (newStatement == null)
                     {
-                        Debug.Assert(statementPart == -1);
+                        Contract.ThrowIfFalse(statementPart == -1);
                         FindStatementAndPartner(oldBody, oldStatementSpan.Start, newBody, out newStatement, out statementPart);
+                        Contract.ThrowIfNull(newStatement);
                     }
 
                     if (diagnostics.Count == 0)
@@ -940,7 +960,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                 int statementPart;
 
                 var oldStatementStart = oldText.Lines.GetTextSpan(oldActiveStatements[ordinal].Span).Start;
+
                 var oldStatementSyntax = FindStatement(oldBody, oldStatementStart, out statementPart);
+                Contract.ThrowIfNull(oldStatementSyntax);
+
                 var oldEnclosingLambdaBody = FindEnclosingLambdaBody(oldBody, oldStatementSyntax);
 
                 if (oldEnclosingLambdaBody != null)
@@ -975,6 +998,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     {
                         int part;
                         var newStatementSyntax = FindStatement(newBody, trackedSpan.Start, out part);
+                        Contract.ThrowIfNull(newStatementSyntax);
+
                         var newEnclosingLambdaBody = FindEnclosingLambdaBody(newBody, newStatementSyntax);
 
                         // The tracking span might have been moved outside of the lambda span.


### PR DESCRIPTION
Don't assume anything about position of tracking spans and active statements, they might be off.

Fixes VS crash during EnC (internal bug 179950)