### PR TITLE
Iterator Property setter should not be treated as an iterator

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertyAccessorSymbol.vb
@@ -2,7 +2,6 @@
 
 Imports System.Collections.Immutable
 Imports System.Threading
-Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -28,7 +27,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        syntaxRef As SyntaxReference,
                        locations As ImmutableArray(Of Location))
 
-            MyBase.New(propertySymbol.ContainingSourceType, flags, syntaxRef, locations)
+            MyBase.New(
+                propertySymbol.ContainingSourceType,
+                If(flags.ToMethodKind() = MethodKind.PropertyGet, flags, flags And Not SourceMemberFlags.Iterator),
+                syntaxRef,
+                locations)
 
             m_property = propertySymbol
             _name = name


### PR DESCRIPTION
`vbc -debug` was throwing an NRE compiling a writable `Iterator Property`.

Fixes 220696 and #11531