### PR TITLE
Bug 217740: don't crash when emitting or loading a DateTimeConstant(-1) attribute

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceComplexParameterSymbol.cs
@@ -642,8 +642,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (data != null)
             {
                 var attrValue = data.DefaultParameterValue;
-                if (!attrValue.IsBad &&
-                    (attrValue != ConstantValue.Unset) &&
+                if ((attrValue != ConstantValue.Unset) &&
                     (value != attrValue))
                 {
                     // CS8017: The parameter has multiple distinct default values.

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -515,6 +515,7 @@ public class D
 
             var ilReference = CompileIL(ilsource);
             CompileAndVerify(cssource, expectedOutput: "0", additionalRefs: new[] { ilReference });
+            // The native compiler would produce a working exe, but that exe would fail at runtime
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -596,7 +596,6 @@ public class Bar
                 );
         }
 
-
         [Fact]
         [WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
         public void DateTimeConstantAttributeWithBadDefaultValueOnField()

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -457,8 +457,6 @@ public class Bar
                     Assert.Equal(-1L, attributeValue); // check the attribute is constructed with a -1
 
                     // check .param has no value
-                    //var constantHandle = peModule.Module.MetadataReader.GetParameter(theParameter.Handle).GetDefaultValue();
-                    //Assert.True(constantHandle.IsNil);
                     var constantValue = peModule.Module.GetParamDefaultValue(theParameter.Handle);
                     Assert.Equal(ConstantValue.Null, constantValue);
                 };
@@ -503,6 +501,7 @@ public class Consumer
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "Method").WithArguments("p1", "Bar.Method(System.DateTime)").WithLocation(6, 19)
                 );
 
+            // The native compiler also gives an error: error CS1501: No overload for method 'Method' takes 0 arguments
             var libAssemblyRef = libComp.EmitToImageReference();
             var comp3 = CreateCompilationWithMscorlib(source2, new[] { libAssemblyRef });
             comp3.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -467,7 +467,7 @@ public class Bar
 
         [Fact]
         [WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
-        public void DateTimeConstantAttributeReferencedViaCompilationRef()
+        public void DateTimeConstantAttributeReferencedViaRef()
         {
             #region "Source"
             var source1 = @"
@@ -521,7 +521,11 @@ using System.Runtime.CompilerServices;
 
 public class Bar
 {
-    public void M1([DateTimeConstant(-1)] DateTime x = default(DateTime)) { }
+    public DateTime M1([DateTimeConstant(-1)] DateTime x = default(DateTime)) { return x; }
+    public static void Main()
+    {
+        Console.WriteLine(new Bar().M1().Ticks);
+    }
 }
 ";
             #endregion
@@ -554,7 +558,7 @@ public class Bar
                 Assert.Equal(ConstantValue.Null, constantValue);
             };
 
-            var comp = CompileAndVerify(source, symbolValidator: verifier);
+            var comp = CompileAndVerify(source, expectedOutput: "0", symbolValidator: verifier);
             comp.VerifyDiagnostics();
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -465,6 +465,58 @@ public class Bar
             comp.VerifyDiagnostics();
         }
 
+        [Fact, WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
+        public void LoadingDateTimeConstantWithBadValue()
+        {
+            var ilsource = @"
+.class public auto ansi beforefieldinit C
+       extends [mscorlib]System.Object
+{
+  .method public hidebysig instance valuetype [mscorlib]System.DateTime
+          Method([opt] valuetype [mscorlib]System.DateTime p) cil managed
+  {
+    .param [1]
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64) = ( 01 00 FF FF FF FF FF FF FF FF 00 00 )
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (valuetype [mscorlib]System.DateTime V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method C::Method
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method C::.ctor
+
+} // end of class C
+
+";
+
+            var cssource = @"
+public class D
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(new C().Method().Ticks);
+    }
+}
+";
+
+            var ilReference = CompileIL(ilsource);
+            CompileAndVerify(cssource, expectedOutput: "0", additionalRefs: new[] { ilReference });
+        }
+
         [Fact]
         public void TestDecimalConstantAttribute()
         {

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -596,6 +596,69 @@ public class Bar
                 );
         }
 
+
+        [Fact]
+        [WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
+        public void DateTimeConstantAttributeWithBadDefaultValueOnField()
+        {
+            #region "Source"
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+
+public class C
+{
+   [DateTimeConstant(-1)]
+   public DateTime F = default(DateTime);
+
+   public static void Main()
+   {
+     System.Console.WriteLine(new C().F.Ticks);
+   }
+}
+";
+            #endregion
+
+            // The native C# compiler emits this:
+            // .field public valuetype[mscorlib] System.DateTime F
+            // .custom instance void[mscorlib] System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64) = ( 01 00 FF FF FF FF FF FF FF FF 00 00 )
+
+            // using the native compiler, this code outputs 0
+            var comp = CompileAndVerify(source, expectedOutput: "0");
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        [WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
+        public void DateTimeConstantAttributeWithValidDefaultValueOnField()
+        {
+            #region "Source"
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+
+public class C
+{
+   [DateTimeConstant(42)]
+   public DateTime F = default(DateTime);
+
+   public static void Main()
+   {
+      System.Console.WriteLine(new C().F.Ticks);
+   }
+}
+";
+            #endregion
+
+            // The native C# compiler emits this:
+            // .field public valuetype[mscorlib] System.DateTime F
+            // .custom instance void[mscorlib] System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64) = ( 01 00 2A 00 00 00 00 00 00 00 00 00 )
+
+            // Using the native compiler, the code executes to output 0
+            var comp = CompileAndVerify(source, expectedOutput: "0");
+            comp.VerifyDiagnostics();
+        }
+
         [Fact, WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")]
         public void LoadingDateTimeConstantWithBadValue()
         {

--- a/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/OptionalArgumentsTests.cs
@@ -252,43 +252,53 @@ delegate void D([DecimalConstant(0, 0, 0, 0, 3)]decimal b = 4);
             CreateCompilationWithMscorlib(source, references: new[] { SystemRef }).VerifyDiagnostics(
                 // (5,14): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     void F1([DefaultParameterValue(1)]int o = 2);
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"),
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(5, 14),
                 // (6,14): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     void F2([DefaultParameterValue(1)]decimal o = 2);
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"),
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(6, 14),
+                // (6,51): error CS8017: The parameter has multiple distinct default values.
+                //     void F2([DefaultParameterValue(1)]decimal o = 2);
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(6, 51),
                 // (7,57): error CS8017: The parameter has multiple distinct default values.
                 //     void F4([DecimalConstant(0, 0, 0, 0, 1)]decimal o = 2);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(7, 57),
                 // (8,35): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     void F6([DateTimeConstant(1), DefaultParameterValue(1), DecimalConstant(0, 0, 0, 0, 1)]int o = 1);
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"),
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(8, 35),
                 // (8,61): error CS8017: The parameter has multiple distinct default values.
                 //     void F6([DateTimeConstant(1), DefaultParameterValue(1), DecimalConstant(0, 0, 0, 0, 1)]int o = 1);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 1)"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 1)").WithLocation(8, 61),
                 // (8,100): error CS8017: The parameter has multiple distinct default values.
                 //     void F6([DateTimeConstant(1), DefaultParameterValue(1), DecimalConstant(0, 0, 0, 0, 1)]int o = 1);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "1"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "1").WithLocation(8, 100),
                 // (9,35): error CS8017: The parameter has multiple distinct default values.
                 //     void F7([DateTimeConstant(2), DecimalConstant(0, 0, 0, 0, 2), DefaultParameterValue(2)]decimal o = 2);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 2)"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 2)").WithLocation(9, 35),
                 // (9,67): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     void F7([DateTimeConstant(2), DecimalConstant(0, 0, 0, 0, 2), DefaultParameterValue(2)]decimal o = 2);
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"),
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(9, 67),
                 // (9,104): error CS8017: The parameter has multiple distinct default values.
                 //     void F7([DateTimeConstant(2), DecimalConstant(0, 0, 0, 0, 2), DefaultParameterValue(2)]decimal o = 2);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(9, 104),
                 // (10,25): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
                 //     object this[int a, [DefaultParameterValue(1)]int o = 2] { get; set; }
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"),
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(10, 25),
+                // (10,58): error CS8017: The parameter has multiple distinct default values.
+                //     object this[int a, [DefaultParameterValue(1)]int o = 2] { get; set; }
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(10, 58),
                 // (11,44): error CS8017: The parameter has multiple distinct default values.
                 //     object this[[DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, 0), DateTimeConstant(0)]int o] { get; set; }
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 0)"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstant(0, 0, 0, 0, 0)").WithLocation(11, 44),
                 // (11,76): error CS8017: The parameter has multiple distinct default values.
                 //     object this[[DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, 0), DateTimeConstant(0)]int o] { get; set; }
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DateTimeConstant(0)"),
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DateTimeConstant(0)").WithLocation(11, 76),
+                // (5,47): error CS8017: The parameter has multiple distinct default values.
+                //     void F1([DefaultParameterValue(1)]int o = 2);
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(5, 47),
                 // (13,61): error CS8017: The parameter has multiple distinct default values.
                 // delegate void D([DecimalConstant(0, 0, 0, 0, 3)]decimal b = 4);
-                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "4"));
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "4").WithLocation(13, 61)
+                );
         }
 
         [WorkItem(529684, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529684")]
@@ -334,14 +344,22 @@ interface I
 {
     void M1([DefaultParameterValue(typeof(C)), DecimalConstantAttribute(0, 0, 0, 0, 0)] decimal o);
     void M2([DefaultParameterValue(0), DecimalConstantAttribute(0, 0, 0, 0, typeof(C))] decimal o);
+    void M3([DefaultParameterValue(0), DecimalConstantAttribute(0, 0, 0, 0, 0)] decimal o);
 }";
             CreateCompilationWithMscorlib(source, references: new[] { SystemRef }).VerifyDiagnostics(
+                // (7,40): error CS8017: The parameter has multiple distinct default values.
+                //     void M3([DefaultParameterValue(0), DecimalConstantAttribute(0, 0, 0, 0, 0)] decimal o);
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstantAttribute(0, 0, 0, 0, 0)").WithLocation(7, 40),
                 // (6,84): error CS0246: The type or namespace name 'C' could not be found (are you missing a using directive or an assembly reference?)
                 //     void M2([DefaultParameterValue(0), DecimalConstantAttribute(0, 0, 0, 0, typeof(C))] decimal o);
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C").WithArguments("C"),
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C").WithArguments("C").WithLocation(6, 84),
                 // (5,43): error CS0246: The type or namespace name 'C' could not be found (are you missing a using directive or an assembly reference?)
                 //     void M1([DefaultParameterValue(typeof(C)), DecimalConstantAttribute(0, 0, 0, 0, 0)] decimal o);
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C").WithArguments("C"));
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "C").WithArguments("C").WithLocation(5, 43),
+                // (5,48): error CS8017: The parameter has multiple distinct default values.
+                //     void M1([DefaultParameterValue(typeof(C)), DecimalConstantAttribute(0, 0, 0, 0, 0)] decimal o);
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "DecimalConstantAttribute(0, 0, 0, 0, 0)").WithLocation(5, 48)
+                );
         }
 
         [WorkItem(529684, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529684")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/NamedAndOptionalTests.cs
@@ -932,10 +932,16 @@ class Test{
 }
 ";
             CreateCompilationWithMscorlib(source, new[] { SystemRef }).VerifyDiagnostics(
-                // (5,21): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "Optional"),
                 // (9,21): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
-                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue"));
+                //     public int Bar([DefaultParameterValue(1)]int i = 2) {
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "DefaultParameterValue").WithLocation(9, 21),
+                // (9,54): error CS8017: The parameter has multiple distinct default values.
+                //     public int Bar([DefaultParameterValue(1)]int i = 2) {
+                Diagnostic(ErrorCode.ERR_ParamDefaultValueDiffersFromAttribute, "2").WithLocation(9, 54),
+                // (5,21): error CS1745: Cannot specify default parameter value in conjunction with DefaultParameterAttribute or OptionalAttribute
+                //     public int Foo([Optional]object i = null) {
+                Diagnostic(ErrorCode.ERR_DefaultValueUsedWithAttributes, "Optional").WithLocation(5, 21)
+                );
         }
 
         [WorkItem(10290, "DevDiv_Projects/Roslyn")]

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1242,7 +1242,7 @@ namespace Microsoft.CodeAnalysis
             return TryExtractValueFromAttribute(handle, out value, s_attributeStringValueExtractor);
         }
 
-        private bool TryExtractLongValueFromAttribute(CustomAttributeHandle handle, out long value)
+        internal bool TryExtractLongValueFromAttribute(CustomAttributeHandle handle, out long value)
         {
             return TryExtractValueFromAttribute(handle, out value, s_attributeLongValueExtractor);
         }

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1046,7 +1046,16 @@ namespace Microsoft.CodeAnalysis
             AttributeInfo info = FindLastTargetAttribute(token, AttributeDescription.DateTimeConstantAttribute);
             if (info.HasValue && TryExtractLongValueFromAttribute(info.Handle, out value))
             {
-                defaultValue = ConstantValue.Create(new DateTime(value));
+                // if value is outside this range, DateTime would throw when constructed
+                if (value < DateTime.MinValue.Ticks || value > DateTime.MaxValue.Ticks)
+                {
+                    defaultValue = ConstantValue.Bad;
+                }
+                else
+                {
+                    defaultValue = ConstantValue.Create(new DateTime(value));
+                }
+
                 return true;
             }
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.CodeAnalysis
         /// signatures array, -1 if
         /// this is not the target attribute.
         /// </returns>
-        private static int GetTargetAttributeSignatureIndex(MetadataReader metadataReader, CustomAttributeHandle customAttribute, AttributeDescription description)
+        internal static int GetTargetAttributeSignatureIndex(MetadataReader metadataReader, CustomAttributeHandle customAttribute, AttributeDescription description)
         {
             const int No = -1;
             EntityHandle ctor;

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1995,7 +1995,7 @@ namespace Microsoft.CodeAnalysis
         /// signatures array, -1 if
         /// this is not the target attribute.
         /// </returns>
-        internal static int GetTargetAttributeSignatureIndex(MetadataReader metadataReader, CustomAttributeHandle customAttribute, AttributeDescription description)
+        private static int GetTargetAttributeSignatureIndex(MetadataReader metadataReader, CustomAttributeHandle customAttribute, AttributeDescription description)
         {
             const int No = -1;
             EntityHandle ctor;

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -188,7 +188,6 @@ namespace Microsoft.CodeAnalysis
             // if value is outside this range, DateTime would throw when constructed
             if (value < DateTime.MinValue.Ticks || value > DateTime.MaxValue.Ticks)
             {
-                // Treat as-is parameter doesn't have default
                 return ConstantValue.Bad;
             }
 

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -183,7 +183,16 @@ namespace Microsoft.CodeAnalysis
 
         internal ConstantValue DecodeDateTimeConstantValue()
         {
-            return ConstantValue.Create(new DateTime(this.CommonConstructorArguments[0].DecodeValue<long>(SpecialType.System_Int64)));
+            long value = this.CommonConstructorArguments[0].DecodeValue<long>(SpecialType.System_Int64);
+
+            // if value is outside this range, DateTime would throw when constructed
+            if (value < DateTime.MinValue.Ticks || value > DateTime.MaxValue.Ticks)
+            {
+                // Treat as-is parameter doesn't have default
+                return ConstantValue.Unset;
+            }
+
+            return ConstantValue.Create(new DateTime(value));
         }
 
         #endregion

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -189,7 +189,7 @@ namespace Microsoft.CodeAnalysis
             if (value < DateTime.MinValue.Ticks || value > DateTime.MaxValue.Ticks)
             {
                 // Treat as-is parameter doesn't have default
-                return ConstantValue.Unset;
+                return ConstantValue.Bad;
             }
 
             return ConstantValue.Create(new DateTime(value));

--- a/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/EarlyWellKnownAttributeBinder.vb
@@ -91,7 +91,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case _
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxKind.GlobalName,
-                    SyntaxKind.IdentifierName
+                    SyntaxKind.IdentifierName,
+                    SyntaxKind.PredefinedType
                     ' References to constant type members or constant locals.
                     ' References to members of enumeration types.
                     Return True

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceFieldSymbol.vb
@@ -342,34 +342,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' If not, report ERR_FieldHasMultipleDistinctConstantValues.
         ''' </summary>
         Private Sub VerifyConstantValueMatches(attrValue As ConstantValue, ByRef arguments As DecodeWellKnownAttributeArguments(Of AttributeSyntax, VisualBasicAttributeData, AttributeLocation))
-            If Not attrValue.IsBad Then
-                Dim data = arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)()
-                Dim constValue As ConstantValue
+            Dim data = arguments.GetOrCreateData(Of CommonFieldWellKnownAttributeData)()
+            Dim constValue As ConstantValue
 
-                If Me.IsConst Then
-                    If Me.Type.IsDecimalType() OrElse Me.Type.IsDateTimeType() Then
-                        constValue = Me.GetConstantValue(SymbolsInProgress(Of FieldSymbol).Empty)
+            If Me.IsConst Then
+                If Me.Type.IsDecimalType() OrElse Me.Type.IsDateTimeType() Then
+                    constValue = Me.GetConstantValue(SymbolsInProgress(Of FieldSymbol).Empty)
 
-                        If constValue IsNot Nothing AndAlso Not constValue.IsBad AndAlso constValue <> attrValue Then
-                            arguments.Diagnostics.Add(ERRID.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.GetLocation())
-                        End If
-                    Else
+                    If constValue IsNot Nothing AndAlso Not constValue.IsBad AndAlso constValue <> attrValue Then
                         arguments.Diagnostics.Add(ERRID.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.GetLocation())
                     End If
+                Else
+                    arguments.Diagnostics.Add(ERRID.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.GetLocation())
+                End If
 
-                    If data.ConstValue = CodeAnalysis.ConstantValue.Unset Then
-                        data.ConstValue = attrValue
+                If data.ConstValue = CodeAnalysis.ConstantValue.Unset Then
+                    data.ConstValue = attrValue
+                End If
+            Else
+                constValue = data.ConstValue
+
+                If constValue <> CodeAnalysis.ConstantValue.Unset Then
+                    If constValue <> attrValue Then
+                        arguments.Diagnostics.Add(ERRID.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.GetLocation())
                     End If
                 Else
-                    constValue = data.ConstValue
-
-                    If constValue <> CodeAnalysis.ConstantValue.Unset Then
-                        If constValue <> attrValue Then
-                            arguments.Diagnostics.Add(ERRID.ERR_FieldHasMultipleDistinctConstantValues, arguments.AttributeSyntaxOpt.GetLocation())
-                        End If
-                    Else
-                        data.ConstValue = attrValue
-                    End If
+                    data.ConstValue = attrValue
                 End If
             End If
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -332,8 +332,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim data = GetEarlyDecodedWellKnownAttributeData()
             If data IsNot Nothing Then
                 Dim attrValue = data.DefaultParameterValue
-                If Not attrValue.IsBad AndAlso
-                    attrValue <> ConstantValue.Unset AndAlso
+                If attrValue <> ConstantValue.Unset AndAlso
                     value <> attrValue Then
                     Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_ParamDefaultValueDiffersFromAttribute)
                 End If

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -506,6 +506,8 @@ End Class
             ' .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute:: .ctor(Int64) = (1 00 80 73 3E 42 F6 37 A0 08 00 00 )
             ' .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute:: .ctor(Int64) = (1 00 FF FF FF FF FF FF FF FF 00 00 )
 
+            ' Using the native compiler, the code would output 621558279390000000
+
             Dim comp = CreateCompilationWithMscorlib(source)
             AssertTheseDiagnostics(comp,
                                    <expected><![CDATA[
@@ -544,6 +546,8 @@ End Class
             ' .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute:: .ctor(Int64) = (1 00 2A 00 00 00 00 00 00 00 00 00 )
             ' .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute:: .ctor(Int64) = (1 00 80 73 3E 42 F6 37 A0 08 00 00 )
 
+            ' Using the native compiler, the code would output 621558279390000000
+
             Dim comp = CreateCompilationWithMscorlib(source)
             AssertTheseDiagnostics(comp,
                                    <expected><![CDATA[
@@ -552,7 +556,6 @@ BC37226: The parameter has multiple distinct default values.
                                                                             ~~~~~~~~~~~~~~~~~~~~~~~
 ]]></expected>)
         End Sub
-
 
         <WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")>
         <Fact()>
@@ -574,7 +577,6 @@ End Class
 ]]>
     </file>
 </compilation>
-
 
             ' This is the same output as the native VB compiler
             Dim comp = CompileAndVerify(source, expectedOutput:="621558279390000000")

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -578,34 +578,12 @@ End Class
     </file>
 </compilation>
 
-            ' This is the same output as the native VB compiler
-            Dim comp = CompileAndVerify(source, expectedOutput:="621558279390000000")
-            comp.VerifyDiagnostics()
-
-            Dim libComp = CreateCompilationWithMscorlib(source)
-            Dim libCompRef = New VisualBasicCompilationReference(libComp)
-
-            Dim source2 =
-<compilation>
-    <file name="attr.vb"><![CDATA[
-Public Class Consumer
-    Public Shared Sub Main()
-        System.Console.WriteLine(Bar.F.Ticks)
-    End Sub
-End Class
-]]>
-    </file>
-</compilation>
-
-            Dim comp2 = CompileAndVerify(source2, expectedOutput:="621558279390000000", additionalRefs:={libCompRef})
-
-            ' Using the native compiler, this code crashes at runtime: Unhandled Exception: System.ArgumentOutOfRangeException: Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks.
-            Dim libAssemblyRef = libComp.EmitToImageReference()
-            Dim comp3 = CreateCompilationWithMscorlib(source2, references:={libAssemblyRef})
-            comp3.AssertTheseDiagnostics(<expected><![CDATA[
-BC30799: Field 'Bar.F' has an invalid constant value.
-        System.Console.WriteLine(Bar.F.Ticks)
-                                 ~~~~~
+            ' The native compiler would output 621558279390000000
+            Dim comp = CreateCompilationWithMscorlib(source)
+            comp.AssertTheseDiagnostics(<expected><![CDATA[
+BC37228: The field has multiple distinct constant values.
+    <DateTimeConstant(-1)>
+     ~~~~~~~~~~~~~~~~~~~~
 ]]></expected>)
 
         End Sub
@@ -725,7 +703,7 @@ End Class
     </file>
 </compilation>
 
-            ' Using the native compiler, this code outputs 621558279390000000
+            ' Using the native compiler, this code crashed
             Dim ilReference = CompileIL(ilSource.Value)
             Dim comp = CreateCompilationWithMscorlib(source, references:={ilReference})
             AssertTheseDiagnostics(comp,

--- a/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.vb
@@ -480,6 +480,72 @@ End Class
 
         <WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")>
         <Fact()>
+        Public Sub LoadingDateTimeConstantWithBadValueOnField()
+            Dim ilSource = <![CDATA[
+.class public auto ansi C
+       extends [mscorlib]System.Object
+{
+  .field private static initonly valuetype [mscorlib]System.DateTime f
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64) = ( 01 00 ff ff ff ff ff ff ff ff 00 00 )
+  .method public specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method C::.ctor
+
+  .method public instance void  Method() cil managed
+  {
+    // Code size       29 (0x1d)
+    .maxstack  2
+    .locals init (valuetype [mscorlib]System.DateTime V_0,
+             valuetype [mscorlib]System.DateTime V_1,
+             valuetype [mscorlib]System.DateTime V_2,
+             valuetype [mscorlib]System.DateTime V_3,
+             valuetype [mscorlib]System.DateTime V_4,
+             valuetype [mscorlib]System.DateTime V_5,
+             valuetype [mscorlib]System.DateTime V_6,
+             valuetype [mscorlib]System.DateTime V_7,
+             valuetype [mscorlib]System.DateTime V_8,
+             valuetype [mscorlib]System.DateTime V_9,
+             valuetype [mscorlib]System.DateTime V_10,
+             valuetype [mscorlib]System.DateTime V_11,
+             valuetype [mscorlib]System.DateTime V_12)
+    IL_0000:  ldc.i8     0x8a037f6423e7380
+    IL_0009:  newobj     instance void [mscorlib]System.DateTime::.ctor(int64)
+    IL_000e:  stloc.s    V_12
+    IL_0010:  ldloca.s   V_12
+    IL_0012:  call       instance int64 [mscorlib]System.DateTime::get_Ticks()
+    IL_0017:  call       void [mscorlib]System.Console::WriteLine(int64)
+    IL_001c:  ret
+  } // end of method C::Method
+
+} // end of class C
+                ]]>
+
+            Dim source =
+<compilation>
+    <file name="attr.vb"><![CDATA[
+Public Class D
+    Shared Sub Main()
+        Dim test = New C()
+        test.Method()
+    End Sub
+End Class
+]]>
+    </file>
+</compilation>
+
+            Dim ilReference = CompileIL(ilSource.Value)
+            CompileAndVerify(source, expectedOutput:="621558279390000000", additionalRefs:={ilReference})
+            ' This behavior hasn't changed from native VB compiler
+        End Sub
+
+        <WorkItem(217740, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217740")>
+        <Fact()>
         Public Sub LoadingDateTimeConstantWithBadValue()
             Dim ilSource = <![CDATA[
 .class public auto ansi beforefieldinit C
@@ -530,6 +596,7 @@ End Class
 
             Dim ilReference = CompileIL(ilSource.Value)
             CompileAndVerify(source, expectedOutput:="0", additionalRefs:={ilReference})
+            ' The native compiler would produce a working exe, but that exe would fail at runtime
         End Sub
 
         <WorkItem(531121, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531121")>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/OptionalArgumentsTests.vb
@@ -1152,6 +1152,7 @@ Imports System.Runtime.InteropServices
 Interface I
     Sub M1(<DefaultParameterValue(GetType(C)), DecimalConstant(0, 0, 0, 0, 0)> o As Decimal)
     Sub M2(<DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, GetType(C))> o As Decimal)
+    Sub M3(<DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, 0)> o As Decimal)
 End Interface
 ]]>
     </file>
@@ -1160,9 +1161,15 @@ End Interface
 BC30002: Type 'C' is not defined.
     Sub M1(<DefaultParameterValue(GetType(C)), DecimalConstant(0, 0, 0, 0, 0)> o As Decimal)
                                           ~
+BC37226: The parameter has multiple distinct default values.
+    Sub M1(<DefaultParameterValue(GetType(C)), DecimalConstant(0, 0, 0, 0, 0)> o As Decimal)
+                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30002: Type 'C' is not defined.
     Sub M2(<DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, GetType(C))> o As Decimal)
                                                                           ~
+BC37226: The parameter has multiple distinct default values.
+    Sub M3(<DefaultParameterValue(0), DecimalConstant(0, 0, 0, 0, 0)> o As Decimal)
+                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ]]></errors>)
         End Sub
 


### PR DESCRIPTION
There are two scenarios:

1. Compiling source that includes a DateTimeConstant(-1). 
This is the scenario reported by the Watson bug. 
The fix in `CommonAttributeData.cs` restores the behavior of the native compiler (nil .param, and DateTimeConstantAttribute(-1), as shown below).

2. Loading such attribute from metadata. Inspection of Rolsyn code found this issue, which was then confirmed to exists. 
Roslyn would crash when encountering such an attribute (and the optional flag is set on the parameter). 
In such a case, the native compilers would instead succeed, although the resulting binary would crash. 
The fix to Rolsyn in `PEModule.cs` makes the loading of such an attribute to load a default value instead. This change breaks back compat and will be submitted to the compat-council shortly.

```
                .param [1]
                .custom instance void [mscorlib]System.Runtime.CompilerServices.DateTimeConstantAttribute::.ctor(int64) = (
                                01 00 ff ff ff ff ff ff ff ff 00 00
                )
```

Fixes this [Watson crash](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=217681&triage=true&fullScreen=true&_a=edit).