### PR TITLE
Initialize the error list toggle state when error list is initialized

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.cs
@@ -64,6 +64,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             var errorList2 = _errorList as IErrorList2;
             if (errorList2 != null)
             {
+                InitializeFullSolutionAnalysisState(workspace, errorList2);
                 workspace.WorkspaceChanged += OnWorkspaceChanged;
                 errorList2.AnalysisToggleStateChanged += OnErrorListFullSolutionAnalysisToggled;
                 workspace.Services.GetService<IOptionService>().OptionChanged += OnOptionChanged;
@@ -193,6 +194,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                 .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, e.NewState)
                 .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, e.NewState)
                 .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, TypeScriptLanguageName, e.NewState);
+        }
+
+        private static void InitializeFullSolutionAnalysisState(Workspace workspace, IErrorList2 errorList2)
+        {
+            // Initialize the error list toggle state based on full solution analysis state for all supported languages.
+            var fullAnalysisState = workspace.Options.GetOption(RuntimeOptions.FullSolutionAnalysis) && 
+                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, LanguageNames.CSharp) &&
+                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, LanguageNames.VisualBasic) &&
+                ServiceFeatureOnOffOptions.IsClosedFileDiagnosticsEnabled(workspace, TypeScriptLanguageName);
+            errorList2.AnalysisToggleState = fullAnalysisState;
         }
 
         private static void SetFullSolutionAnalysisState(Workspace workspace, IErrorList2 errorList2)


### PR DESCRIPTION
Currently, we initialize the error list toggle state only when workspace changes (solution add/remove/reload or project add/remove/reload) OR when FSD options change. However, if you start VS and bring up error list without opening any solution or changing FSD options, we might show stale error list state if your settings file or settings store changed after last VS session. Fix is to initialize the error list toggle state as soon as error list is initialized.

Fixes #11539