### PR TITLE
Adjust implementation of MemberSemanticModel.GetEnclosingBinderInternal to avoid NullReferenceException.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/MemberSemanticModel.vb
@@ -1271,7 +1271,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Debug.Assert(current.Parent.Kind = SyntaxKind.WithStatement)
                     Debug.Assert(current.Parent.Parent.Kind = SyntaxKind.WithBlock)
 
-                    current = current.Parent.Parent.Parent
+                    current = current.Parent.Parent
+
+                    ' If we are speculating on the With block, we might have reached our root,
+                    ' return memberBinder in this case.
+                    If current Is binderRoot Then
+                        Return memberBinder
+                    End If
+
+                    current = current.Parent
                     ' Proceed to the end of If statement
 
                 End If


### PR DESCRIPTION
The change addresses the situation when SemanticModel is created to speculate on a With block and the function is trying to locate a binder for the With expression within the block.

Fixes https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=187910&_a=edit.

@dotnet/roslyn-compiler Please review Update3 fix.

@MattGertz, @jaredpar For approval. 