### PR TITLE
Make call to compilation.CompleteTrees really unconditional.

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -508,10 +508,10 @@ namespace Microsoft.CodeAnalysis
                                     {
                                         compilation.ReportUnusedImports(null, diagnosticBag, cancellationToken);
                                     }
-
-                                    compilation.CompleteTrees(null);
                                 }
                             }
+
+                            compilation.CompleteTrees(null);
 
                             if (analyzerDriver != null)
                             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -841,8 +841,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (CompilationEventQueue.Count == 0 &&
-                        (prePopulatedEventQueue || CompilationEventQueue.IsCompleted))
+                    // NOTE: IsCompleted guarantees that Count will not increase
+                    //       the other is not true, so we need to check IsCompleted first and then check the Count
+                    if ((prePopulatedEventQueue || CompilationEventQueue.IsCompleted) &&
+                        CompilationEventQueue.Count == 0)
                     {
                         break;
                     }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -842,7 +842,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     cancellationToken.ThrowIfCancellationRequested();
 
                     // NOTE: IsCompleted guarantees that Count will not increase
-                    //       the other is not true, so we need to check IsCompleted first and then check the Count
+                    //       the reverse is not true, so we need to check IsCompleted first and then check the Count
                     if ((prePopulatedEventQueue || CompilationEventQueue.IsCompleted) &&
                         CompilationEventQueue.Count == 0)
                     {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     //       the queue can either have waiters or items, not both
                     //       adding an item would "unwait" the waiters
                     //       the fact that we _had_ waiters at the time we completed the queue
-                    //       guarantees that there is no items in the que now or in the future, 
+                    //       guarantees that there is no items in the queue now or in the future, 
                     //       so it is safe to cancel waiters with no loss of diagnostics
                     Debug.Assert(this.Count == 0, "we should not be cancelling the waiters when we have items in the queue");
                     foreach (var tcs in existingWaiters)

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AsyncQueue.cs
@@ -168,14 +168,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                     return false;
                 }
 
-                existingWaiters = _waiters;
                 _completed = true;
+
+                existingWaiters = _waiters;
                 _waiters = null;
             }
 
             Task.Run(() =>
             {
-                if (existingWaiters != null)
+                if (existingWaiters?.Count > 0)
                 {
                     // cancel waiters.
                     // NOTE: AsyncQueue has an invariant that 


### PR DESCRIPTION
Make call to compilation.CompleteTrees really unconditional.

Fixes https://github.com/dotnet/roslyn/issues/11368