### PR TITLE
Port https://github.com/dotnet/roslyn/pull/11398 over to SymbolKeys. …

### DIFF
--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.BodyLevelSymbolKey.cs
@@ -69,6 +69,26 @@ namespace Microsoft.CodeAnalysis
 
                 foreach (var declaringLocation in containingSymbol.DeclaringSyntaxReferences)
                 {
+                    // This operation can potentially fail. If containingSymbol came from 
+                    // a SpeculativeSemanticModel, containingSymbol.ContainingAssembly.Compilation
+                    // may not have been rebuilt to reflect the trees used by the 
+                    // SpeculativeSemanticModel to produce containingSymbol. In that case,
+                    // asking the ContainingAssembly's complation for a SemanticModel based
+                    // on trees for containingSymbol with throw an ArgumentException.
+                    // Unfortunately, the best way to avoid this (currently) is to see if
+                    // we're asking for a model for a tree that's part of the compilation.
+                    // (There's no way to get back to a SemanticModel from a symbol).
+
+                    // TODO (rchande): It might be better to call compilation.GetSemanticModel
+                    // and catch the ArgumentException. The compilation internally has a 
+                    // Dictionary<SyntaxTree, ...> that it uses to check if the SyntaxTree
+                    // is applicable wheras the public interface requires us to enumerate
+                    // the entire IEnumerable of trees in the Compilation.
+                    if (!compilation.SyntaxTrees.Contains(declaringLocation.SyntaxTree))
+                    {
+                        continue;
+                    }
+
                     var node = declaringLocation.GetSyntax(cancellationToken);
                     if (node.Language == LanguageNames.VisualBasic)
                     {


### PR DESCRIPTION
The previous fix only addressed symbol ids.