### PR TITLE
Enc: Unify time-based versions of assemblies from all previous generations

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -387,34 +387,42 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 return null;
             }
 
-            public override Symbol VisitAssembly(AssemblySymbol symbol)
+            public override Symbol VisitAssembly(AssemblySymbol assembly)
             {
-                if (symbol.IsLinked)
+                if (assembly.IsLinked)
                 {
-                    return symbol;
+                    return assembly;
                 }
 
-                // the current source assembly:
-                if (symbol.Identity.Equals(_sourceAssembly.Identity))
+                // When we map synthesized symbols from previous generations to the latest compilation 
+                // we might encounter a symbol that is defined in arbitrary preceding generation, 
+                // not just the immediately preceding generation. If the source assembly uses time-based 
+                // versioning assemblies of preceding generations might differ in their version number.
+                if (IdentityEqualIgnoringVersionWildcard(assembly, _sourceAssembly))
                 {
                     return _otherAssembly;
                 }
 
-                // find a referenced assembly with the exactly same source identity:
+                // find a referenced assembly with the same source identity (modulo assembly version patterns):
                 foreach (var otherReferencedAssembly in _otherAssembly.Modules[0].ReferencedAssemblySymbols)
                 {
-                    var identity = symbol.Identity;
-                    var otherIdentity = otherReferencedAssembly.Identity;
-
-                    if (AssemblyIdentityComparer.SimpleNameComparer.Equals(identity.Name, otherIdentity.Name) &&
-                        (symbol.AssemblyVersionPattern ?? symbol.Identity.Version).Equals(otherReferencedAssembly.AssemblyVersionPattern ?? otherReferencedAssembly.Identity.Version) &&
-                        AssemblyIdentity.EqualIgnoringNameAndVersion(identity, otherIdentity))
+                    if (IdentityEqualIgnoringVersionWildcard(assembly, otherReferencedAssembly))
                     {
                         return otherReferencedAssembly;
                     }
                 }
 
                 return null;
+            }
+
+            private static bool IdentityEqualIgnoringVersionWildcard(AssemblySymbol left, AssemblySymbol right)
+            {
+                var leftIdentity = left.Identity;
+                var rightIdentity = right.Identity;
+
+                return AssemblyIdentityComparer.SimpleNameComparer.Equals(leftIdentity.Name, rightIdentity.Name) &&
+                       (left.AssemblyVersionPattern ?? leftIdentity.Version).Equals(right.AssemblyVersionPattern ?? rightIdentity.Version) &&
+                       AssemblyIdentity.EqualIgnoringNameAndVersion(leftIdentity, rightIdentity);
             }
 
             public override Symbol VisitNamespace(NamespaceSymbol @namespace)

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
@@ -495,5 +495,129 @@ class C
         {
             AssertEx.Equal(expected, reader.GetAssemblyReferences().Select(aref => $"{reader.GetString(aref.Name)}, {aref.Version}"));
         }
+
+        [Fact]
+        [WorkItem(202017, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/202017")]
+        public void CurrentComplationVersionWildcards()
+        {
+            var source0 = MarkedSource(@"
+using System;
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")]
+
+class C
+{
+    static void M()
+    {
+        new Action(<N:0>() => { Console.WriteLine(1); }</N:0>).Invoke();
+    }
+
+    static void F()
+    {
+    }
+}");
+            var source1 = MarkedSource(@"
+using System;
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")]
+
+class C
+{
+    static void M()
+    {
+        new Action(<N:0>() => { Console.WriteLine(1); }</N:0>).Invoke();
+        new Action(<N:1>() => { Console.WriteLine(2); }</N:1>).Invoke();
+    }
+
+    static void F()
+    {
+    }
+}");
+            var source2 = MarkedSource(@"
+using System;
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")]
+
+class C
+{
+    static void M()
+    {
+        new Action(<N:0>() => { Console.WriteLine(1); }</N:0>).Invoke();
+        new Action(<N:1>() => { Console.WriteLine(2); }</N:1>).Invoke();
+    }
+
+    static void F()
+    {
+        Console.WriteLine(1);
+    }
+}");
+            var source3 = MarkedSource(@"
+using System;
+[assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")]
+
+class C
+{
+    static void M()
+    {
+        new Action(<N:0>() => { Console.WriteLine(1); }</N:0>).Invoke();
+        new Action(<N:1>() => { Console.WriteLine(2); }</N:1>).Invoke();
+        new Action(<N:2>() => { Console.WriteLine(3); }</N:2>).Invoke();
+        new Action(<N:3>() => { Console.WriteLine(4); }</N:3>).Invoke();
+    }
+
+    static void F()
+    {
+        Console.WriteLine(1);
+    }
+}");
+
+            var options = ComSafeDebugDll.WithCryptoPublicKey(TestResources.TestKeys.PublicKey_ce65828c82a341f2);
+
+            var compilation0 = CreateCompilationWithMscorlib(source0.Tree, options: options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 0)));
+            var compilation1 = compilation0.WithSource(source1.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 10)));
+            var compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 20)));
+            var compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(new DateTime(2016, 1, 1, 1, 0, 30)));
+
+            var v0 = CompileAndVerify(compilation0, verify: false);
+            var md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData);
+            var reader0 = md0.MetadataReader;
+
+            var m0 = compilation0.GetMember<MethodSymbol>("C.M");
+            var m1 = compilation1.GetMember<MethodSymbol>("C.M");
+            var m2 = compilation2.GetMember<MethodSymbol>("C.M");
+            var m3 = compilation3.GetMember<MethodSymbol>("C.M");
+
+            var f1 = compilation1.GetMember<MethodSymbol>("C.F");
+            var f2 = compilation2.GetMember<MethodSymbol>("C.F");
+
+            var generation0 = EmitBaseline.CreateInitialBaseline(md0, v0.CreateSymReader().GetEncMethodDebugInfo);
+
+            // First update adds some new synthesized members (lambda related)
+            var diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables: true)));
+
+            diff1.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__0_0, <>9__0_1#1, <M>b__0_0, <M>b__0_1#1}");
+
+            // Second update is if a method that doesn't produce any synthesized members 
+            var diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));
+
+            diff2.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__0_0, <>9__0_1#1, <M>b__0_0, <M>b__0_1#1}");
+
+            // Last update again adds some new synthesized members (lambdas).
+            // Synthesized members added in the first update need to be mapped to the current compilation.
+            // Their containing assembly version is different than the version of the previous assembly and 
+            // hence we need to account for wildcards when comparing the versions.
+            var diff3 = compilation3.EmitDifference(
+                diff2.NextGeneration,
+                ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, m2, m3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables: true)));
+
+            diff3.VerifySynthesizedMembers(
+                "C: {<>c}",
+                "C.<>c: {<>9__0_0, <>9__0_1#1, <>9__0_2#3, <>9__0_3#3, <M>b__0_0, <M>b__0_1#1, <M>b__0_2#3, <M>b__0_3#3}");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.cs
@@ -598,7 +598,7 @@ class C
                 "C: {<>c}",
                 "C.<>c: {<>9__0_0, <>9__0_1#1, <M>b__0_0, <M>b__0_1#1}");
 
-            // Second update is if a method that doesn't produce any synthesized members 
+            // Second update is to a method that doesn't produce any synthesized members 
             var diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
                 ImmutableArray.Create(new SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables: true)));

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -465,7 +465,7 @@ End Class")
                 "C: {_Closure$__}",
                 "C._Closure$__: {$I1-0, $I1-1#1, _Lambda$__1-0, _Lambda$__1-1#1}")
 
-            ' Second update is if a method that doesn't produce any synthesized members 
+            ' Second update is to a method that doesn't produce any synthesized members 
             Dim diff2 = compilation2.EmitDifference(
                 diff1.NextGeneration,
                 ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables:=True)))

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EditAndContinue/AssemblyReferencesTests.vb
@@ -344,5 +344,147 @@ End Class
         Public Sub VerifyAssemblyReferences(reader As AggregatedMetadataReader, expected As String())
             AssertEx.Equal(expected, reader.GetAssemblyReferences().Select(Function(aref) $"{reader.GetString(aref.Name)}, {aref.Version}"))
         End Sub
+
+        <Fact>
+        <WorkItem(202017, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/202017")>
+        Public Sub CurrentComplationVersionWildcards()
+            Dim source0 = MarkedSource("
+Imports System
+<Assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")>
+
+Class C
+    Shared Sub M()
+        Console.WriteLine(New Action(
+            <N:0>Sub() 
+                   Console.WriteLine(1) 
+                 End Sub</N:0>))
+    End Sub
+
+    Shared Sub F()
+    End Sub
+End Class")
+            Dim source1 = MarkedSource("
+Imports System
+<Assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")>
+
+Class C
+    Shared Sub M()
+        Console.WriteLine(New Action(
+            <N:0>Sub() 
+                   Console.WriteLine(1) 
+                 End Sub</N:0>))
+
+        Console.WriteLine(New Action(
+            <N:1>Sub() 
+                   Console.WriteLine(2) 
+                 End Sub</N:1>))
+    End Sub
+
+    Shared Sub F()
+    End Sub
+End Class")
+            Dim source2 = MarkedSource("
+Imports System
+<Assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")>
+
+Class C
+    Shared Sub M()
+       Console.WriteLine(New Action(
+            <N:0>Sub() 
+                   Console.WriteLine(1) 
+                 End Sub</N:0>))
+
+        Console.WriteLine(New Action(
+            <N:1>Sub() 
+                   Console.WriteLine(2) 
+                 End Sub</N:1>))
+    End Sub
+
+    Shared Sub F()
+        Console.WriteLine(1)
+    End Sub
+End Class")
+            Dim source3 = MarkedSource("
+Imports System
+<Assembly: System.Reflection.AssemblyVersion(""1.0.0.*"")>
+
+Class C
+    Shared Sub M()
+       Console.WriteLine(New Action(
+            <N:0>Sub() 
+                   Console.WriteLine(1) 
+                 End Sub</N:0>))
+
+        Console.WriteLine(New Action(
+            <N:1>Sub() 
+                   Console.WriteLine(2) 
+                 End Sub</N:1>))
+
+        Console.WriteLine(New Action(
+            <N:2>Sub() 
+                   Console.WriteLine(3) 
+                 End Sub</N:2>))
+
+        Console.WriteLine(New Action(
+            <N:3>Sub() 
+                   Console.WriteLine(4) 
+                 End Sub</N:3>))
+    End Sub
+
+    Shared Sub F()
+        Console.WriteLine(1)
+    End Sub
+End Class")
+            Dim options = ComSafeDebugDll.WithCryptoPublicKey(TestResources.TestKeys.PublicKey_ce65828c82a341f2)
+
+            Dim compilation0 = CreateCompilationWithMscorlib(source0.Tree, options:=options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 0)))
+            Dim compilation1 = compilation0.WithSource(source1.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 10)))
+            Dim compilation2 = compilation1.WithSource(source2.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 20)))
+            Dim compilation3 = compilation2.WithSource(source3.Tree).WithOptions(options.WithCurrentLocalTime(New DateTime(2016, 1, 1, 1, 0, 30)))
+
+            Dim v0 = CompileAndVerify(compilation0, verify:=False)
+            Dim md0 = ModuleMetadata.CreateFromImage(v0.EmittedAssemblyData)
+            Dim reader0 = md0.MetadataReader
+
+            Dim m0 = compilation0.GetMember(Of MethodSymbol)("C.M")
+            Dim m1 = compilation1.GetMember(Of MethodSymbol)("C.M")
+            Dim m2 = compilation2.GetMember(Of MethodSymbol)("C.M")
+            Dim m3 = compilation3.GetMember(Of MethodSymbol)("C.M")
+
+            Dim f1 = compilation1.GetMember(Of MethodSymbol)("C.F")
+            Dim f2 = compilation2.GetMember(Of MethodSymbol)("C.F")
+
+            Dim generation0 = EmitBaseline.CreateInitialBaseline(md0, AddressOf v0.CreateSymReader().GetEncMethodDebugInfo)
+
+            ' First update adds some new synthesized members (lambda related)
+            Dim diff1 = compilation1.EmitDifference(
+                generation0,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, m0, m1, GetSyntaxMapFromMarkers(source0, source1), preserveLocalVariables:=True)))
+
+            diff1.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I1-0, $I1-1#1, _Lambda$__1-0, _Lambda$__1-1#1}")
+
+            ' Second update is if a method that doesn't produce any synthesized members 
+            Dim diff2 = compilation2.EmitDifference(
+                diff1.NextGeneration,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, f1, f2, GetSyntaxMapFromMarkers(source1, source2), preserveLocalVariables:=True)))
+
+            diff2.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I1-0, $I1-1#1, _Lambda$__1-0, _Lambda$__1-1#1}")
+
+            ' Last update again adds some new synthesized members (lambdas).
+            ' Synthesized members added in the first update need to be mapped to the current compilation.
+            ' Their containing assembly version is different than the version of the previous assembly and 
+            ' hence we need to account for wildcards when comparing the versions.
+            Dim diff3 = compilation3.EmitDifference(
+                diff2.NextGeneration,
+                ImmutableArray.Create(New SemanticEdit(SemanticEditKind.Update, m2, m3, GetSyntaxMapFromMarkers(source2, source3), preserveLocalVariables:=True)))
+
+            diff3.VerifySynthesizedMembers(
+                "C: {_Closure$__}",
+                "C._Closure$__: {$I1-0, $I1-1#1, $I1-2#3, $I1-3#3, _Lambda$__1-0, _Lambda$__1-1#1, _Lambda$__1-2#3, _Lambda$__1-3#3}")
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes internal bugs 202017 and 208698: VS crash during EnC.

When we map synthesized symbols from previous generations to the latest compilation 
we might encounter a symbol that is defined in arbitrary preceding generation, not just the immediately preceding generation. If the source assembly uses time-based versioning (i.e. attribute ```AssemblyVersion(x.y.*)```) assemblies of preceding generations might differ in their version number. We previously assumed that mapping only needs to deal with the version patterns of referenced assemblies, but it actually needs to handle them for the source assembly as well.