### PR TITLE
Update VirtualTreePoint.cs

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 
         public override string ToString()
         {
-            return string.Format("VirtualTreePoint { Tree: '{0}', Text: '{1}', Position: '{2}', VirtualSpaces '{3}' }", Tree, Text, Position, VirtualSpaces);
+            return string.Format("VirtualTreePoint {{ Tree: '{0}', Text: '{1}', Position: '{2}', VirtualSpaces '{3}' }}", Tree, Text, Position, VirtualSpaces);
         }
 
         public TextLine GetContainingLine()

--- a/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 
         public override string ToString()
         {
-            return $"VirtualTreePoint {{ Tree: '{Tree}', Text: '{Text}', Position: '{Position}', VirtualSpaces '{VirtualPosition}' }}";
+            return $"VirtualTreePoint {{ Tree: '{Tree}', Text: '{Text}', Position: '{Position}', VirtualSpaces '{VirtualSpaces}' }}";
         }
 
         public TextLine GetContainingLine()

--- a/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/VirtualTreePoint.cs
@@ -125,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
 
         public override string ToString()
         {
-            return string.Format("VirtualTreePoint {{ Tree: '{0}', Text: '{1}', Position: '{2}', VirtualSpaces '{3}' }}", Tree, Text, Position, VirtualSpaces);
+            return $"VirtualTreePoint {{ Tree: '{Tree}', Text: '{Text}', Position: '{Position}', VirtualSpaces '{VirtualPosition}' }}";
         }
 
         public TextLine GetContainingLine()


### PR DESCRIPTION
Fix for ##11574
Escape the braces withing the built `String Format` text.