### PR TITLE
Make compiler familiar with TH2 format of DeprecatedAttribute.

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_WellKnownAttributes.cs
@@ -7426,7 +7426,7 @@ class Class6
         }
 
         [Fact]
-        public void TestDeprecatedAttribute1()
+        public void TestDeprecatedAttributeTH1()
         {
             var source1 = @"
 using System;
@@ -7441,6 +7441,8 @@ namespace Windows.Foundation.Metadata
         {
         }
 
+        // this signature is only used in TH1 metadata
+        // see: https://github.com/dotnet/roslyn/issues/10630
         public DeprecatedAttribute(System.String message, DeprecationType type, System.UInt32 version, Type contract)
         {
         }
@@ -7456,6 +7458,93 @@ namespace Windows.Foundation.Metadata
 public class Test
 {
         [Deprecated(""hello"", DeprecationType.Deprecate, 1, typeof(int))]
+        public static void Foo()
+        {
+
+        }
+
+        [Deprecated(""hi"", DeprecationType.Deprecate, 1)]
+        public static void Bar()
+        {
+
+        }
+}
+";
+            var compilation1 = CreateCompilationWithMscorlibAndSystemCore(source1);
+
+            var source2 = @"
+namespace ConsoleApplication74
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Test.Foo();
+            Test.Bar();
+        }
+    }
+}
+
+
+";
+            var compilation2 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { compilation1.EmitToImageReference() });
+
+
+            compilation2.VerifyDiagnostics(
+    // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
+    //             Test.Foo();
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "Test.Foo()").WithArguments("Test.Foo()", "hello").WithLocation(8, 13),
+    // (9,13): warning CS0618: 'Test.Bar()' is obsolete: 'hi'
+    //             Test.Bar();
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "Test.Bar()").WithArguments("Test.Bar()", "hi").WithLocation(9, 13)
+);
+
+            var compilation3 = CreateCompilationWithMscorlibAndSystemCore(source2, new[] { new CSharpCompilationReference(compilation1) });
+
+
+            compilation3.VerifyDiagnostics(
+    // (8,13): warning CS0618: 'Test.Foo()' is obsolete: 'hello'
+    //             Test.Foo();
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "Test.Foo()").WithArguments("Test.Foo()", "hello").WithLocation(8, 13),
+    // (9,13): warning CS0618: 'Test.Bar()' is obsolete: 'hi'
+    //             Test.Bar();
+    Diagnostic(ErrorCode.WRN_DeprecatedSymbolStr, "Test.Bar()").WithArguments("Test.Bar()", "hi").WithLocation(9, 13)
+);
+        }
+
+        [Fact]
+        public void TestDeprecatedAttributeTH2()
+        {
+            var source1 = @"
+using System;
+using Windows.Foundation.Metadata;
+
+namespace Windows.Foundation.Metadata
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Interface | AttributeTargets.Delegate, AllowMultiple = true)]
+    public sealed class DeprecatedAttribute : Attribute
+    {
+        public DeprecatedAttribute(System.String message, DeprecationType type, System.UInt32 version)
+        {
+        }
+
+        // this signature is only used in TH2 metadata and onwards
+        // see: https://github.com/dotnet/roslyn/issues/10630
+        public DeprecatedAttribute(System.String message, DeprecationType type, System.UInt32 version, String contract)
+        {
+        }
+    }
+
+    public enum DeprecationType
+    {
+        Deprecate = 0,
+        Remove = 1
+    }
+}
+
+public class Test
+{
+        [Deprecated(""hello"", DeprecationType.Deprecate, 1, ""hello"")]
         public static void Foo()
         {
 

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -1145,6 +1145,7 @@ namespace Microsoft.CodeAnalysis
                 case 0: // DeprecatedAttribute(String, DeprecationType, UInt32) 
                 case 1: // DeprecatedAttribute(String, DeprecationType, UInt32, Platform) 
                 case 2: // DeprecatedAttribute(String, DeprecationType, UInt32, Type) 
+                case 3: // DeprecatedAttribute(String, DeprecationType, UInt32, String) 
                     return TryExtractValueFromAttribute(attributeInfo.Handle, out obsoleteData, s_attributeDeprecatedDataExtractor);
 
                 default:

--- a/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/AttributeDescription.cs
@@ -189,6 +189,7 @@ namespace Microsoft.CodeAnalysis
         private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32 = new byte[] { (byte)SignatureAttributes.Instance, 3, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32 };
         private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32_Platform = new byte[] { (byte)SignatureAttributes.Instance, 4, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32, TypeHandle, (byte)TypeHandleTarget.Platform };
         private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32_Type = new byte[] { (byte)SignatureAttributes.Instance, 4, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32, TypeHandle, (byte)TypeHandleTarget.SystemType };
+        private static readonly byte[] s_signature_HasThis_Void_String_DeprecationType_UInt32_String = new byte[] { (byte)SignatureAttributes.Instance, 4, Void, String, TypeHandle, (byte)TypeHandleTarget.DeprecationType, UInt32, String };
 
         // TODO: We should reuse the byte arrays for well-known attributes with same signatures.
 
@@ -386,7 +387,8 @@ namespace Microsoft.CodeAnalysis
         {
             s_signature_HasThis_Void_String_DeprecationType_UInt32,
             s_signature_HasThis_Void_String_DeprecationType_UInt32_Platform,
-            s_signature_HasThis_Void_String_DeprecationType_UInt32_Type
+            s_signature_HasThis_Void_String_DeprecationType_UInt32_Type,
+            s_signature_HasThis_Void_String_DeprecationType_UInt32_String,
         };
 
         // early decoded attributes:

--- a/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
+++ b/src/Compilers/Core/Portable/Symbols/Attributes/CommonAttributeData.cs
@@ -231,6 +231,7 @@ namespace Microsoft.CodeAnalysis
             {
                 // DeprecatedAttribute(String, DeprecationType, UInt32) 
                 // DeprecatedAttribute(String, DeprecationType, UInt32, Platform) 
+                // DeprecatedAttribute(String, DeprecationType, UInt32, String) 
 
                 message = (string)args[0].Value;
                 isError = ((int)args[1].Value == 1);


### PR DESCRIPTION
So far compiler knows about the following signatures of DeprecatedAttribute constructor.
   DeprecatedAttribute(String, DeprecationType, UInt32)
   DeprecatedAttribute(String, DeprecationType, UInt32, Platform)
   DeprecatedAttribute(String, DeprecationType, UInt32, Type)

As of TH2 and onwards  Windows SDK  uses the following signature for the DeprecatedAttribute:

     DeprecatedAttribute(String, DeprecationType, UInt32, String)

Notice the "String" at the end of the signature.
This change adds the TH2 attribute signature to the known set.

Fixes: #10630