### PR TITLE
fix issue with telemetry.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -16,7 +16,7 @@ using Roslyn.Utilities;
 namespace Microsoft.CodeAnalysis.Diagnostics
 {
     [ExportIncrementalAnalyzerProvider(
-        highPriorityForActiveFile: true, name: WellKnownSolutionCrawlerAnalyzers.Diagnostic, 
+        highPriorityForActiveFile: true, name: WellKnownSolutionCrawlerAnalyzers.Diagnostic,
         workspaceKinds: new string[] { WorkspaceKind.Host, WorkspaceKind.Interactive })]
     internal partial class DiagnosticAnalyzerService : IIncrementalAnalyzerProvider
     {
@@ -187,6 +187,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics
                 return Analyzer.SynchronizeWithBuildAsync(workspace, diagnostics);
             }
             #endregion
+
+            public override void LogAnalyzerCountSummary()
+            {
+                Analyzer.LogAnalyzerCountSummary();
+            }
 
             public void TurnOff(bool useV2)
             {

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/CompilerAnalysisResult.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/CompilerAnalysisResult.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
+
+namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
+{
+    /// <summary>
+    /// Basically typed tuple.
+    /// </summary>
+    internal struct CompilerAnalysisResult
+    {
+        public readonly ImmutableDictionary<DiagnosticAnalyzer, AnalysisResult> AnalysisResult;
+        public readonly ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo> TelemetryInfo;
+
+        public CompilerAnalysisResult(
+            ImmutableDictionary<DiagnosticAnalyzer, AnalysisResult> analysisResult,
+            ImmutableDictionary<DiagnosticAnalyzer, AnalyzerTelemetryInfo> telemetryInfo)
+        {
+            AnalysisResult = analysisResult;
+            TelemetryInfo = telemetryInfo;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/CompilerDiagnosticExecutor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/CompilerDiagnosticExecutor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
     /// </summary>
     internal static class CompilerDiagnosticExecutor
     {
-        public static async Task<ImmutableDictionary<DiagnosticAnalyzer, AnalysisResult>> AnalyzeAsync(this CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken)
+        public static async Task<CompilerAnalysisResult> AnalyzeAsync(this CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken)
         {
             var version = await DiagnosticIncrementalAnalyzer.GetDiagnosticVersionAsync(project, cancellationToken).ConfigureAwait(false);
 
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 builder.Add(analyzer, result.ToResult());
             }
 
-            return builder.ToImmutable();
+            return new CompilerAnalysisResult(builder.ToImmutable(), analysisResult.AnalyzerTelemetryInfo);
         }
 
         /// <summary>

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Diagnostics.Log;
+using Microsoft.CodeAnalysis.Diagnostics.Telemetry;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Options;
@@ -152,10 +153,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 if (analyzerDriverOpt != null)
                 {
                     // calculate regular diagnostic analyzers diagnostics
-                    result = await analyzerDriverOpt.AnalyzeAsync(project, cancellationToken).ConfigureAwait(false);
+                    var compilerResult = await analyzerDriverOpt.AnalyzeAsync(project, cancellationToken).ConfigureAwait(false);
+                    result = compilerResult.AnalysisResult;
 
                     // record telemetry data
-                    await UpdateAnalyzerTelemetryDataAsync(analyzerDriverOpt, project, cancellationToken).ConfigureAwait(false);
+                    UpdateAnalyzerTelemetryData(compilerResult, project, cancellationToken);
                 }
 
                 // check whether there is IDE specific project diagnostic analyzer
@@ -389,24 +391,11 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 }
             }
 
-            private async Task UpdateAnalyzerTelemetryDataAsync(CompilationWithAnalyzers analyzerDriver, Project project, CancellationToken cancellationToken)
+            private void UpdateAnalyzerTelemetryData(CompilerAnalysisResult analysisResult, Project project, CancellationToken cancellationToken)
             {
-                foreach (var analyzer in analyzerDriver.Analyzers)
+                foreach (var kv in analysisResult.TelemetryInfo)
                 {
-                    await UpdateAnalyzerTelemetryDataAsync(analyzerDriver, analyzer, project, cancellationToken).ConfigureAwait(false);
-                }
-            }
-
-            private async Task UpdateAnalyzerTelemetryDataAsync(CompilationWithAnalyzers analyzerDriver, DiagnosticAnalyzer analyzer, Project project, CancellationToken cancellationToken)
-            {
-                try
-                {
-                    var analyzerTelemetryInfo = await analyzerDriver.GetAnalyzerTelemetryInfoAsync(analyzer, cancellationToken).ConfigureAwait(false);
-                    DiagnosticAnalyzerLogger.UpdateAnalyzerTypeCount(analyzer, analyzerTelemetryInfo, project, _owner.DiagnosticLogAggregator);
-                }
-                catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
-                {
-                    throw ExceptionUtilities.Unreachable;
+                    DiagnosticAnalyzerLogger.UpdateAnalyzerTypeCount(kv.Key, kv.Value, project, _owner.DiagnosticLogAggregator);
                 }
             }
 

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer_GetDiagnostics.cs" />
     <Compile Include="Diagnostics\EngineV1\DiagnosticIncrementalAnalyzer_GetLatestDiagnosticsForSpan.cs" />
     <Compile Include="Diagnostics\EngineV1\MemberRangeMap.cs" />
+    <Compile Include="Diagnostics\EngineV2\CompilerAnalysisResult.cs" />
     <Compile Include="Diagnostics\EngineV2\DiagnosticDataSerializer.cs" />
     <Compile Include="Diagnostics\EngineV2\DiagnosticIncrementalAnalyzer.AnalysisData.cs" />
     <Compile Include="Diagnostics\EngineV2\DiagnosticIncrementalAnalyzer.AnalysisKind.cs" />

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerLogger.cs
@@ -249,7 +249,7 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
             foreach (var analyzer in analyzers)
             {
-                var diagIncrementalAnalyzer = analyzer as BaseDiagnosticIncrementalAnalyzer;
+                var diagIncrementalAnalyzer = analyzer as DiagnosticAnalyzerService.IncrementalAnalyzerDelegatee;
                 if (diagIncrementalAnalyzer != null)
                 {
                     diagIncrementalAnalyzer.LogAnalyzerCountSummary();


### PR DESCRIPTION
it looks like diagnostic telemetry got broken when we introduced a new flag for diagnostic engines in update 1.

also some refactoring to use telemetry info returned rather than calling separate API.