### PR TITLE
Ignore VS Code-generated dirs in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+# Visual Studio Code
+.vscode/


### PR DESCRIPTION
This commit adds `.vscode/` to the gitignore, so contributors using VS Code won't face issues with `git add -A :/` (which adds all the unstaged changes).