### PR TITLE
Fixes for VB partial type completion provider

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -864,7 +864,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' </summary>
         Private Function CheckSymbolLocationsAgainstSyntax(symbol As NamedTypeSymbol, nodeToCheck As VisualBasicSyntaxNode) As NamedTypeSymbol
             For Each location In symbol.Locations
-                If location.SourceTree Is Me.SyntaxTree AndAlso nodeToCheck.Span.Contains(location.SourceSpan.Start) Then
+                If location.SourceTree Is Me.SyntaxTree AndAlso nodeToCheck.Span.IntersectsWith(location.SourceSpan.Start) Then
                     Return symbol
                 End If
             Next

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/PartialTypeCompletionProviderTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Threading.Tasks
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
@@ -53,9 +52,6 @@ Partial Class $$</text>
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestPartialGenericClassCommitOnParen() As Task
-            ' TODO(DustinCa): This is testing the wrong behavior and will need to be updated to the commented expected
-            ' result when https://github.com/dotnet/roslyn/issues/4137 is fixed.
-
             Dim text = <text>Class Bar
 End Class
                            
@@ -70,17 +66,22 @@ End Class
 Partial Class C(Of Bar)
 End Class
 
-Partial Class C(Of Bar)(</text>
-
-            '            Dim expected = <text>Class Bar
-            'End Class
-
-            'Partial Class C(Of Bar)
-            'End Class
-
-            'Partial Class C(</text>
+Partial Class C(</text>
 
             Await VerifyProviderCommitAsync(text.Value, "C(Of Bar)", expected.Value, "("c, "", SourceCodeKind.Regular)
+        End Function
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/11569"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPartialClassWithSameMemberName() As Task
+            Dim text = <text>Partial Class C(Of T)
+    Sub C()
+    End Sub
+End Class
+
+Partial Class $$C(Of T)
+End Class</text>
+
+            Await VerifyItemExistsAsync(text.Value, "C(Of T)")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
@@ -102,6 +103,21 @@ End Class
 Partial Class C(Of Bar)</text>
 
             Await VerifyProviderCommitAsync(text.Value, "C(Of Bar)", expected.Value, Nothing, "", SourceCodeKind.Regular)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPartialGenericClassCommitOnSpace() As Task
+            Dim text = <text>Partial Class C(Of T)
+End Class
+
+Partial Class $$</text>
+
+            Dim expected = <text>Partial Class C(Of T)
+End Class
+
+Partial Class C(Of T) </text>
+
+            Await VerifyProviderCommitAsync(text.Value, "C(Of T)", expected.Value, " "c, "", SourceCodeKind.Regular)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
@@ -194,6 +210,30 @@ Partial Class $$</text>
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNotPartialClassesInOuterNamespaces() As Task
+            Dim text = <text>Partial Class C
+
+End Class
+
+Namespace N
+    Partial Class $$
+End Namespace
+</text>
+
+            Await VerifyNoItemsExistAsync(text.Value)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNotPartialClassesInOuterClass() As Task
+            Dim text = <text>Partial Class C
+    Partial Class $$
+End Class
+</text>
+
+            Await VerifyNoItemsExistAsync(text.Value)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestIncludeConstraints() As Task
             Dim text = <text>
 Partial Class C1(Of T As Exception)
@@ -225,6 +265,62 @@ End Class
 Partial Class '$$</text>
 
             Await VerifyNoItemsExistAsync(text.Value)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestImportaAlias() As Task
+            Dim text = <text>Imports A = C
+Partial Class C
+End Class
+
+Partial Class $$</text>
+
+            Await VerifyItemExistsAsync(text.Value, "C")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPartialClassWithReservedName() As Task
+            Dim text = <text>Partial Class [Class]
+End Class
+
+Partial Class $$</text>
+
+            Dim expected = <text>Partial Class [Class]
+End Class
+
+Partial Class [Class]</text>
+
+            Await VerifyProviderCommitAsync(text.Value, "Class", expected.Value, Nothing, "", SourceCodeKind.Regular)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPartialGenericClassWithReservedName() As Task
+            Dim text = <text>Partial Class [Class](Of T)
+End Class
+
+Partial Class $$</text>
+
+            Dim expected = <text>Partial Class [Class](Of T)
+End Class
+
+Partial Class [Class](Of T)</text>
+
+            Await VerifyProviderCommitAsync(text.Value, "Class(Of T)", expected.Value, Nothing, "", SourceCodeKind.Regular)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestPartialGenericClassWithReservedNameCommittedWithParen() As Task
+            Dim text = <text>Partial Class [Class](Of T)
+End Class
+
+Partial Class $$</text>
+
+            Dim expected = <text>Partial Class [Class](Of T)
+End Class
+
+Partial Class [Class](</text>
+
+            Await VerifyProviderCommitAsync(text.Value, "Class(Of T)", expected.Value, "("c, "", SourceCodeKind.Regular)
         End Function
 
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -566,8 +566,8 @@ End Class")
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
-        Public Async Function TestGenerateInDerivedType_Crash() As Task
-            Await TestMissingAsync(
+        Public Async Function TestGenerateInDerivedType_InvalidClassStatement() As Task
+            Await TestAsync(
 "
 Public Class Base
     Public Sub New(a As Integer, Optional b As String = Nothing)
@@ -578,6 +578,20 @@ End Class
 Public Class [|;;|]Derived
     Inherits Base
 
+End Class",
+"
+Public Class Base
+    Public Sub New(a As Integer, Optional b As String = Nothing)
+
+    End Sub
+End Class
+
+Public Class ;;Derived
+    Inherits Base
+
+    Public Sub New(a As Integer, Optional b As String = Nothing)
+        MyBase.New(a, b)
+    End Sub
 End Class")
         End Function
 


### PR DESCRIPTION
A few fixes for the VB `PartialTypeCompletionProvider`.

- [x] When a user presses '(' only the type name will be inserted. This fixes #4137. I initially tried deriving from `AbstractSymbolCompletionProvider` but it seemed to over-complicate the implementation, and produced incorrect results when import aliases were in scope.

- [x] For consistency with the other providers and VS2013, the display text is no longer escaped, so a type named `Class` will no longer show as `[Class]`. The actual insertion text is unchanged, apart from the fix above.

- [x] Only types from within the directly enclosing symbol are suggested. ~~This had some ... complications. Please see the comments for questions and concerns.~~ I've updated the PR with a much simpler, and hopefully safer, change for this.

- [x] Fix `NotNewDeclaredMember`
