### PR TITLE
Handle IOException when reading method body during EnC

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -278,7 +278,12 @@ namespace Microsoft.CodeAnalysis.Emit
                     previousLocals = TryGetLocalSlotMapFromMetadata(previousHandle, debugInfo);
                     if (previousLocals.IsDefault)
                     {
-                        // TODO: Report error that metadata is not supported.
+                        // TODO: localize message & use better error code (https://github.com/dotnet/roslyn/issues/11512): 
+                        diagnostics.Add(MessageProvider.CreateDiagnostic(
+                            MessageProvider.ERR_ModuleEmitFailure,
+                            method.Locations.First(),
+                            $"Unable to read metadata of method '{MessageProvider.GetErrorDisplayString(method)}' from assembly '{MessageProvider.GetErrorDisplayString(method.ContainingAssembly)}'"));
+
                         return null;
                     }
                 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using Roslyn.Utilities;
@@ -1028,12 +1029,7 @@ namespace Microsoft.CodeAnalysis
                     localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
                 }
             }
-            catch (UnsupportedSignatureContent)
-            {
-                localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
-                return false;
-            }
-            catch (BadImageFormatException)
+            catch (Exception e) when (e is UnsupportedSignatureContent || e is BadImageFormatException || e is IOException)
             {
                 localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
                 return false;

--- a/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/PEModule.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -147,6 +148,17 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <exception cref="IOException">
+        /// Error reading from the stream (only when prefetching data).
+        /// Only thrown first time the reader is accessed.
+        /// </exception>
+        /// <exception cref="BadImageFormatException">
+        /// The data read from stream have invalid format.
+        /// Only thrown first time the reader is accessed.
+        /// </exception>
+        /// <exception cref="ObjectDisposedException">
+        /// The underlying memory has been disposed.
+        /// </exception>
         internal MetadataReader MetadataReader
         {
             get
@@ -168,6 +180,8 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <exception cref="IOException">Error reading from the stream (only when prefetching data).</exception>
+        /// <exception cref="BadImageFormatException">The data read from stream have invalid format.</exception>
         private unsafe void InitializeMetadataReader()
         {
             MetadataReader newReader;
@@ -2949,6 +2963,7 @@ namespace Microsoft.CodeAnalysis
             get { return _peReaderOpt != null && _peReaderOpt.IsEntireImageAvailable; }
         }
 
+        /// <exception cref="IOException">Error reading from the stream (only when prefetching data).</exception>
         /// <exception cref="BadImageFormatException">Invalid metadata.</exception>
         internal MethodBodyBlock GetMethodBodyOrThrow(MethodDefinitionHandle methodHandle)
         {


### PR DESCRIPTION
Fixes a VS crash on one of the code paths reported by Watson in internal bug 187908.

Since method bodies are located in a PE block that's not initially loaded when the compiler opens a metadata file, reading them might result in IOException. For example, if there is not enough memory to map the file content to memory. We should handle IOException and report a diagnostic.