### PR TITLE
removed culture dependency from ConversionsTests

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/Conversions.vb
@@ -4776,7 +4776,7 @@ Module Module1
         TestSng(value2)
         TestDbl(value)
 
-        Dim value3 As System.IComparable = "5/23/2016"
+        Dim value3 As System.IComparable = "2016-5-23"
         TestDate(value3)
         TestChar(value3)
     End Sub
@@ -4866,7 +4866,7 @@ End Module
 1
 1
 23
-5")
+2")
 
             verifier.VerifyIL("Module1.TestArray",
             <![CDATA[


### PR DESCRIPTION
This test currently fails on my de-CH machine because it is using an en-US date format ("M/d/yyyy").

I've changed it to use a date format which should be OK for all cultures ("yyyy-M-d").