### PR TITLE
Fixes #633 - Constructor names were classifying as types within xml docs

### DIFF
--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -1477,5 +1477,52 @@ class C
                 TestOptions.Regular.WithTuplesFeature(),
                 Options.Script.WithTuplesFeature());
         }
+
+        [WorkItem(633, "https://github.com/dotnet/roslyn/issues/633")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task InXmlDocCref_WhenTypeOnlyIsSpecified_ItIsClassified()
+        {
+            await TestAsync(@"
+/// <summary>
+/// <see cref=""MyClass""/>
+/// </summary>
+class MyClass
+{
+    public MyClass(int x) { }
+}
+",
+    Class("MyClass"));
+        }
+
+        [WorkItem(633, "https://github.com/dotnet/roslyn/issues/633")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task InXmlDocCref_WhenConstructorOnlyIsSpecified_NothingIsClassified()
+        {
+            await TestAsync(@"
+/// <summary>
+/// <see cref=""MyClass(int)""/>
+/// </summary>
+class MyClass
+{
+    public MyClass(int x) { }
+}
+");
+        }
+
+        [WorkItem(633, "https://github.com/dotnet/roslyn/issues/633")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task InXmlDocCref_WhenTypeAndConstructorSpecified_OnlyTypeIsClassified()
+        {
+            await TestAsync(@"
+/// <summary>
+/// <see cref=""MyClass.MyClass(int)""/>
+/// </summary>
+class MyClass
+{
+    public MyClass(int x) { }
+}
+",
+    Class("MyClass"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/TotalClassifierTests.cs
@@ -681,5 +681,60 @@ namespace N
                 Punctuation.Semicolon,
                 Punctuation.CloseCurly);
         }
+
+        [WorkItem(633, "https://github.com/dotnet/roslyn/issues/633")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Classification)]
+        public async Task XmlDocCref()
+        {
+            await TestAsync(@"
+/// <summary>
+/// <see cref=""MyClass.MyClass(int)""/>
+/// </summary>
+class MyClass
+{
+    public MyClass(int x) { }
+}
+",
+                XmlDoc.Delimiter("///"),
+                XmlDoc.Text(" "),
+                XmlDoc.Delimiter("<"),
+                XmlDoc.Name("summary"),
+                XmlDoc.Delimiter(">"),
+                XmlDoc.Delimiter("///"),
+                XmlDoc.Text(" "),
+                XmlDoc.Delimiter("<"),
+                XmlDoc.Name("see"),
+                XmlDoc.AttributeName(" "),
+                XmlDoc.AttributeName("cref"),
+                XmlDoc.Delimiter("="),
+                XmlDoc.AttributeQuotes("\""),
+                Class("MyClass"),
+                Operators.Dot,
+                Identifier("MyClass"),
+                Punctuation.OpenParen,
+                Keyword("int"),
+                Punctuation.CloseParen,
+                XmlDoc.AttributeQuotes("\""),
+                XmlDoc.Delimiter("/>"),
+                XmlDoc.Delimiter("///"),
+                XmlDoc.Text(" "),
+                XmlDoc.Delimiter("</"),
+                XmlDoc.Name("summary"),
+                XmlDoc.Delimiter(">"),
+                Keyword("class"),
+                Class("MyClass"),
+                Punctuation.OpenCurly,
+                Keyword("public"),
+                Identifier("MyClass"),
+                Punctuation.OpenParen,
+                Keyword("int"),
+                Identifier("x"),
+                Punctuation.CloseParen,
+                Punctuation.OpenCurly,
+                Punctuation.CloseCurly,
+                Punctuation.CloseCurly
+
+                );
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
+++ b/src/Workspaces/CSharp/Portable/Classification/Classifiers/NameSyntaxClassifier.cs
@@ -138,7 +138,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Classification.Classifiers
                 {
                     symbol = (symbol as IAliasSymbol).Target;
                 }
-                else if (symbol.IsConstructor())
+                else if (symbol.IsConstructor() && name.IsParentKind(SyntaxKind.Attribute))
                 {
                     symbol = symbol.ContainingType;
                 }


### PR DESCRIPTION
Fixes #633
This is because NameSyntaxClassifier was choosing the parent symbol of a constructor to classify by. We're now
restricting this to only in the case of attributes (which always refer to constructors but we want to classify like
types).

I'm not 100% sure if the behaviour of using the parent symbol in the case of constructors was just intended to cover attributes but restricting it to this satisfies the existing tests.
I first did the tests in SemanticClassifierTests but it's not clear which instance of "MyClass" is being referred to so I also did a test in TotalClassifierTests.

I've tested this in Visual Studio also and now the classification in the bug looks like this:
![image](https://cloud.githubusercontent.com/assets/396538/15663561/533671c0-26f4-11e6-9c12-af483fd66694.png)
