### PR TITLE
Order 'PopulateSwitch' after 'GenerateMethod'

### DIFF
--- a/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/GenerateMethod/GenerateMethodCodeFixProvider.cs
@@ -35,6 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.GenerateMethod
     }
 
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = PredefinedCodeFixProviderNames.GenerateMethod), Shared]
+    [ExtensionOrder(Before = PredefinedCodeFixProviderNames.PopulateSwitch)]
     [ExtensionOrder(After = PredefinedCodeFixProviderNames.GenerateEnumMember)]
     internal class GenerateMethodCodeFixProvider : AbstractGenerateMemberCodeFixProvider
     {

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -19,6 +19,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeFixProviderNames.PopulateSwitch), Shared]
     [ExtensionOrder(After = PredefinedCodeFixProviderNames.ImplementInterface)]
+    [ExtensionOrder(After = PredefinedCodeFixProviderNames.GenerateMethod)]
     internal class PopulateSwitchCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(IDEDiagnosticIds.PopulateSwitchDiagnosticId);

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -19,7 +19,6 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
 {
     [ExportCodeFixProvider(LanguageNames.CSharp, LanguageNames.VisualBasic, Name = PredefinedCodeFixProviderNames.PopulateSwitch), Shared]
     [ExtensionOrder(After = PredefinedCodeFixProviderNames.ImplementInterface)]
-    [ExtensionOrder(After = PredefinedCodeFixProviderNames.GenerateMethod)]
     internal class PopulateSwitchCodeFixProvider : CodeFixProvider
     {
         public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(IDEDiagnosticIds.PopulateSwitchDiagnosticId);

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -11,6 +11,7 @@ Imports System.Composition
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.GenerateMethod), [Shared]>
+    <ExtensionOrder(Before:=PredefinedCodeFixProviderNames.PopulateSwitch)>
     <ExtensionOrder(After:=PredefinedCodeFixProviderNames.GenerateEvent)>
     Friend Class GenerateParameterizedMemberCodeFixProvider
         Inherits AbstractGenerateMemberCodeFixProvider


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11301