### PR TITLE
add <ShortcutPath> element to VSIX packages and enable NGEN

### DIFF
--- a/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
+++ b/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="21BAC26D-2935-4D0D-A282-AD647E2592B5" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Expression Evaluators</DisplayName>
     <Description xml:space="preserve">Roslyn Expression Evaluators</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\Expression Evaluators</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />

--- a/src/InteractiveWindow/VisualStudio/source.extension.vsixmanifest
+++ b/src/InteractiveWindow/VisualStudio/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="1F42C6D0-F876-4AF0-8185-1BEB0A325BB2" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>VisualStudio Interactive Components</DisplayName>
     <Description>Interactive components for Visual Studio.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\VisualStudio Interactive Components</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Language Services</DisplayName>
     <Description>C# and VB.NET language services for Visual Studio.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\Language Services</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.Pro" />
@@ -11,6 +12,30 @@
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Installer>
+    <Actions>
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.Workspaces.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.Workspaces.Desktop.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.EditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.Workspaces.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.EditorFeatures.Text.dll" />
+      <Action Type="Ngen" Path="Microsoft.VisualStudio.LanguageServices.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.EditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.EditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />
+    </Actions>
+  </Installer>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>

--- a/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
+++ b/src/VisualStudio/SetupInteractive/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="A5E5EE8D-39AE-42FF-8BBF-53C5B09C07D7" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Interactive Language Services</DisplayName>
     <Description>Roslyn interactive language services.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\Interactive Language Services</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />

--- a/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="500fff63-afcf-4195-8db4-3fa8a5180e79" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Interactive Components</DisplayName>
     <Description>Interactive Roslyn components for Visual Studio.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\Interactive Components</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
@@ -11,6 +12,13 @@
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Installer>
+    <Actions>
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.CSharp.InteractiveEditorFeatures.dll" />
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.InteractiveEditorFeatures.dll" />
+    </Actions>
+  </Installer>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />


### PR DESCRIPTION
To allow our VSIX packages to play nice with other components in a future version of VS, they need to be installed to a stable directory.  Currently, installing a VSIX will place it under `Common7\IDE\Extensions\asdfasdf.asd` where `asdfasdf.asd` isn't a stable path.

When reviewing these changes, look specifically at the value for the `<ShortcutPath>` element and offer any feedback on the location.

This also marks specific assemblies to be NGENed on install.