### PR TITLE
Strip underscores from parameter names when generating members.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -328,7 +328,7 @@ class D
 }",
 @"class C {
     private readonly int prop;
-    public int GetProp() { return this.prop; }
+    public int GetProp() { return prop; }
 }");
         }
 
@@ -344,7 +344,7 @@ class D
 }",
 @"class C {
     private readonly int prop;
-    public int GetProp() { return this.prop; }
+    public int GetProp() { return prop; }
     public C() {
         this.prop = this.GetProp() + 1;
     }
@@ -363,7 +363,7 @@ class D
 }",
 @"class C {
     private readonly int prop;
-    public int GetProp() { return this.prop; }
+    public int GetProp() { return prop; }
     public C() {
         this.prop = this.GetProp() * (x + y);
     }
@@ -379,7 +379,7 @@ class D
 }",
 @"class C {
     private readonly int prop = 1;
-    public int GetProp() { return this.prop; }
+    public int GetProp() { return prop; }
 }");
         }
 
@@ -394,7 +394,7 @@ class D
 @"class C {
     private int prop;
     private readonly int prop1 = 1;
-    public int GetProp() { return this.prop1; }
+    public int GetProp() { return prop1; }
 }");
         }
 
@@ -407,7 +407,7 @@ class D
 }",
 @"class C {
     private readonly int pascalCase;
-    public int GetPascalCase() { return this.pascalCase; }
+    public int GetPascalCase() { return pascalCase; }
 }");
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/OverrideCompletionProviderTests.cs
@@ -840,7 +840,7 @@ class Derived<X> : CFoo
 {
     public override X Something<X>(X arg)
     {
-        return base.Something<X>(arg);$$
+        return base.Something(arg);$$
     }
 }";
             await VerifyCustomCommitProviderAsync(markupBeforeCommit, "Something<X>(X arg)", expectedCodeAfterCommit);

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -907,5 +907,36 @@ class D {
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(11563, "https://github.com/dotnet/roslyn/issues/11563")]
+        public async Task DoNotStripSingleUnderscore()
+        {
+            await TestAsync(
+@"class C { 
+    int _;
+    void M() {
+        new [|D|](_);
+    }
+}
+
+class D {
+}",
+@"class C { 
+    int _;
+
+    void M() {
+        new D(_);
+    }
+}
+
+class D {
+    private int _;
+
+    public D(int _) {
+        this._ = _;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -872,5 +872,40 @@ withScriptOption: true);
 parseOptions: TestOptions.Regular.WithTuplesFeature(),
 withScriptOption: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(11563, "https://github.com/dotnet/roslyn/issues/11563")]
+        public async Task StripUnderscoresFromParameterNames()
+        {
+            await TestAsync(
+@"class C { 
+    int _i;
+    string _s;
+    void M() {
+        new [|D|](_i, _s);
+    }
+}
+
+class D {
+}",
+@"class C { 
+    int _i;
+    string _s;
+
+    void M() {
+        new D(_i, _s);
+    }
+}
+
+class D {
+    private int _i;
+    private string _s;
+
+    public D(int i, string s) {
+        _i = i;
+        _s = s;
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.vb
@@ -350,7 +350,7 @@ end class",
 "class C
     Private _Prop As Integer
     Public Function GetProp() As Integer
-        Return Me._Prop
+        Return _Prop
     End Function
 end class")
         End Function
@@ -367,7 +367,7 @@ end class",
 "class C
     Private _Prop As Integer
     Public Function GetProp() As Integer
-        Return Me._Prop
+        Return _Prop
     End Function
     public sub new()
         me._Prop = 1
@@ -384,7 +384,7 @@ end class",
 "class C
     Private _Prop As Integer = 1
     Public Function GetProp() As Integer
-        Return Me._Prop
+        Return _Prop
     End Function
 end class")
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -238,7 +238,7 @@ NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End C
         Public Async Function TestExistingMethod() As Task
             Await TestAsync(
 NewLines("Class A \n Sub Test() \n Dim t As New C([|u|]:=5) \n End Sub \n End Class \n Class C \n Public Sub u() \n End Sub \n End Class"),
-NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class \n Class C \n Private u1 As Integer \n Public Sub New(u As Integer) \n Me.u1 = u \n End Sub \n Public Sub u() \n End Sub \n End Class"))
+NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class \n Class C \n Private u1 As Integer \n Public Sub New(u As Integer) \n u1 = u \n End Sub \n Public Sub u() \n End Sub \n End Class"))
         End Function
 
         <WorkItem(542055, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542055")>
@@ -246,7 +246,7 @@ NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class 
         Public Async Function TestDetectAssignmentToSharedFieldFromInstanceConstructor() As Task
             Await TestAsync(
 NewLines("Class Program \n Sub Test() \n Dim x = New A([|P|]:=5) \n End Sub \n End Class \n Class A \n Shared Property P As Integer \n End Class"),
-NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End Class \n Class A \n Private P1 As Integer \n Public Sub New(P As Integer) \n Me.P1 = P \n End Sub \n Shared Property P As Integer \n End Class"))
+NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End Class \n Class A \n Private P1 As Integer \n Public Sub New(P As Integer) \n P1 = P \n End Sub \n Shared Property P As Integer \n End Class"))
         End Function
 
         <WorkItem(542055, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542055")>
@@ -254,7 +254,7 @@ NewLines("Class Program \n Sub Test() \n Dim x = New A(P:=5) \n End Sub \n End C
         Public Async Function TestExistingFieldWithSameNameButIncompatibleType() As Task
             Await TestAsync(
 NewLines("Class A \n Sub Test() \n Dim t As New B([|x|]:=5) \n End Sub \n End Class \n Class B \n Private x As String \n End Class"),
-NewLines("Class A \n Sub Test() \n Dim t As New B(x:=5) \n End Sub \n End Class \n Class B \n Private x As String \n Private x1 As Integer \n Public Sub New(x As Integer) \n Me.x1 = x \n End Sub \n End Class"))
+NewLines("Class A \n Sub Test() \n Dim t As New B(x:=5) \n End Sub \n End Class \n Class B \n Private x As String \n Private x1 As Integer \n Public Sub New(x As Integer) \n x1 = x \n End Sub \n End Class"))
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
@@ -314,7 +314,7 @@ NewLines("Class C \n Inherits B \n Sub New \n MyBase.New([|1|]) \n End Sub \n En
         Public Async Function TestConflictingFieldNameInSubclass() As Task
             Await TestAsync(
 NewLines("Class A \n Sub Test() \n Dim t As New C([|u|]:=5) \n End Sub \n End Class \n Class C \n Inherits B \n Private x As String \n End Class \n Class B \n Protected u As String \n End Class"),
-NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class \n Class C \n Inherits B \n Private u1 As Integer \n Private x As String \n Public Sub New(u As Integer) \n Me.u1 = u \n End Sub \n End Class \n Class B \n Protected u As String \n End Class"))
+NewLines("Class A \n Sub Test() \n Dim t As New C(u:=5) \n End Sub \n End Class \n Class C \n Inherits B \n Private u1 As Integer \n Private x As String \n Public Sub New(u As Integer) \n u1 = u \n End Sub \n End Class \n Class B \n Protected u As String \n End Class"))
         End Function
 
         <WorkItem(542442, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542442")>

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.Linq;
@@ -10,8 +9,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor;
 using Microsoft.CodeAnalysis.Host.Mef;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateConstructor
 {
@@ -162,13 +161,13 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateConstructor
             return false;
         }
 
-        protected override IList<string> GenerateParameterNames(
+        protected override IList<ParameterName> GenerateParameterNames(
             SemanticModel semanticModel, IEnumerable<ArgumentSyntax> arguments, IList<string> reservedNames)
         {
             return semanticModel.GenerateParameterNames(arguments, reservedNames);
         }
 
-        protected override IList<string> GenerateParameterNames(
+        protected override IList<ParameterName> GenerateParameterNames(
             SemanticModel semanticModel, IEnumerable<AttributeArgumentSyntax> arguments, IList<string> reservedNames)
         {
             return semanticModel.GenerateParameterNames(arguments, reservedNames);

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeGeneration;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -14,7 +13,7 @@ using Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
-using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
 {
@@ -25,15 +24,13 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
         {
             private readonly InvocationExpressionSyntax _invocationExpression;
 
-            public InvocationExpressionInfo(
-                SemanticDocument document,
-                AbstractGenerateParameterizedMemberService<TService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax>.State state)
+            public InvocationExpressionInfo(SemanticDocument document, State state)
                 : base(document, state)
             {
                 _invocationExpression = state.InvocationExpressionOpt;
             }
 
-            protected override IList<string> DetermineParameterNames(CancellationToken cancellationToken)
+            protected override IList<ParameterName> DetermineParameterNames(CancellationToken cancellationToken)
             {
                 return this.Document.SemanticModel.GenerateParameterNames(
                     _invocationExpression.ArgumentList);

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -22,6 +22,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.GenerateType
 {
@@ -522,7 +523,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
             return false;
         }
 
-        protected override IList<string> GenerateParameterNames(
+        protected override IList<ParameterName> GenerateParameterNames(
             SemanticModel semanticModel, IList<ArgumentSyntax> arguments)
         {
             return semanticModel.GenerateParameterNames(arguments);

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Internal.Log;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
@@ -29,8 +29,8 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
         protected abstract bool TryInitializeClassDeclarationGenerationState(SemanticDocument document, SyntaxNode classDeclaration, CancellationToken cancellationToken, out SyntaxToken token, out IMethodSymbol constructor, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeConstructorInitializerGeneration(SemanticDocument document, SyntaxNode constructorInitializer, CancellationToken cancellationToken, out SyntaxToken token, out IList<TArgumentSyntax> arguments, out INamedTypeSymbol typeToGenerateIn);
         protected abstract bool TryInitializeSimpleAttributeNameGenerationState(SemanticDocument document, SyntaxNode simpleName, CancellationToken cancellationToken, out SyntaxToken token, out IList<TArgumentSyntax> arguments, out IList<TAttributeArgumentSyntax> attributeArguments, out INamedTypeSymbol typeToGenerateIn);
-        protected abstract IList<string> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TArgumentSyntax> arguments, IList<string> reservedNames = null);
-        protected virtual IList<string> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TAttributeArgumentSyntax> arguments, IList<string> reservedNames = null) { return null; }
+        protected abstract IList<ParameterName> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TArgumentSyntax> arguments, IList<string> reservedNames = null);
+        protected virtual IList<ParameterName> GenerateParameterNames(SemanticModel semanticModel, IEnumerable<TAttributeArgumentSyntax> arguments, IList<string> reservedNames = null) { return null; }
         protected abstract string GenerateNameForArgument(SemanticModel semanticModel, TArgumentSyntax argument);
         protected virtual string GenerateNameForArgument(SemanticModel semanticModel, TAttributeArgumentSyntax argument) { return null; }
         protected abstract RefKind GetRefKind(TArgumentSyntax argument);
@@ -92,45 +92,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 
                 default:
                     return false;
-            }
-        }
-
-        private struct ParameterName : IEquatable<ParameterName>
-        {
-            /// <summary>
-            /// The name the underlying naming system came up with based on the argument itself.
-            /// This might be a name like "_value".  We pass this along because it can help
-            /// later parts of the GenerateConstructor process when doing things like field hookup.
-            /// </summary>
-            public readonly string NameBasedOnArgument;
-
-            /// <summary>
-            /// The name we think should actually be used for this parameter.  This will include
-            /// stripping the name of things like underscores.
-            /// </summary>
-            public readonly string BestNameForParameter;
-
-            public ParameterName(string nameBasedOnArgument)
-            {
-                NameBasedOnArgument = nameBasedOnArgument;
-
-                var trimmed = nameBasedOnArgument.TrimStart('_');
-                BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
-            }
-
-            public override bool Equals(object obj)
-            {
-                return Equals((ParameterName)obj);
-            }
-
-            public bool Equals(ParameterName other)
-            {
-                return NameBasedOnArgument.Equals(other.NameBasedOnArgument);
-            }
-
-            public override int GetHashCode()
-            {
-                return NameBasedOnArgument.GetHashCode();
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -91,6 +92,45 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 
                 default:
                     return false;
+            }
+        }
+
+        private struct ParameterName : IEquatable<ParameterName>
+        {
+            /// <summary>
+            /// The name the underlying naming system came up with based on the argument itself.
+            /// This might be a name like "_value".  We pass this along because it can help
+            /// later parts of the GenerateConstructor process when doing things like field hookup.
+            /// </summary>
+            public readonly string NameBasedOnArgument;
+
+            /// <summary>
+            /// The name we think should actually be used for this parameter.  This will include
+            /// stripping the name of things like underscores.
+            /// </summary>
+            public readonly string BestNameForParameter;
+
+            public ParameterName(string nameBasedOnArgument)
+            {
+                NameBasedOnArgument = nameBasedOnArgument;
+
+                var trimmed = nameBasedOnArgument.TrimStart('_');
+                BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return Equals((ParameterName)obj);
+            }
+
+            public bool Equals(ParameterName other)
+            {
+                return NameBasedOnArgument.Equals(other.NameBasedOnArgument);
+            }
+
+            public override int GetHashCode()
+            {
+                return NameBasedOnArgument.GetHashCode();
             }
         }
     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateParameterizedMember/AbstractGenerateParameterizedMemberService.MethodSignatureInfo.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
@@ -54,9 +55,10 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
                 return _methodSymbol.Parameters.Select(p => p.Type).ToList();
             }
 
-            protected override IList<string> DetermineParameterNames(CancellationToken cancellationToken)
+            protected override IList<ParameterName> DetermineParameterNames(CancellationToken cancellationToken)
             {
-                return _methodSymbol.Parameters.Select(p => p.Name).ToList();
+                return _methodSymbol.Parameters.Select(p => new ParameterName(p.Name, isFixed: true))
+                                               .ToList();
             }
 
             protected override IList<ITypeSymbol> DetermineTypeArguments(CancellationToken cancellationToken)

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.Editor.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CodeGeneration;
 using Microsoft.CodeAnalysis.ProjectManagement;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateType
@@ -565,7 +566,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
             }
 
             private bool TryFindMatchingField(
-                string parameterName,
+                ParameterName parameterName,
                 ITypeSymbol parameterType,
                 Dictionary<string, ISymbol> parameterToFieldMap,
                 bool caseSensitive)
@@ -579,12 +580,12 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         _state.BaseTypeOrInterfaceOpt
                             .GetBaseTypesAndThis()
                             .SelectMany(t => t.GetMembers())
-                            .Where(s => s.Name.Equals(parameterName, comparison));
+                            .Where(s => s.Name.Equals(parameterName.NameBasedOnArgument, comparison));
                     var symbol = query.FirstOrDefault(IsSymbolAccessible);
 
                     if (IsViableFieldOrProperty(parameterType, symbol))
                     {
-                        parameterToFieldMap[parameterName] = symbol;
+                        parameterToFieldMap[parameterName.BestNameForParameter] = symbol;
                         return true;
                     }
                 }

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.GenerateNamedType.cs
@@ -227,7 +227,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                     {
                         if (!TryFindMatchingField(parameterName, parameterType, parameterToExistingFieldMap, caseSensitive: false))
                         {
-                            parameterToNewFieldMap[parameterName] = parameterName;
+                            parameterToNewFieldMap[parameterName.BestNameForParameter] = parameterName.NameBasedOnArgument;
                         }
                     }
 
@@ -236,7 +236,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
                         refKind: refKind,
                         isParams: false,
                         type: parameterType,
-                        name: parameterName));
+                        name: parameterName.BestNameForParameter));
                 }
 
                 // Empty Constructor for Struct is not allowed

--- a/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
+++ b/src/Features/Core/Portable/GenerateType/AbstractGenerateTypeService.cs
@@ -15,6 +15,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.LanguageServices.ProjectInfoService;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.GenerateType
@@ -39,7 +40,7 @@ namespace Microsoft.CodeAnalysis.GenerateType
         protected abstract string DefaultFileExtension { get; }
         protected abstract IList<ITypeParameterSymbol> GetTypeParameters(State state, SemanticModel semanticModel, CancellationToken cancellationToken);
         protected abstract Accessibility GetAccessibility(State state, SemanticModel semanticModel, bool intoNamespace, CancellationToken cancellationToken);
-        protected abstract IList<string> GenerateParameterNames(SemanticModel semanticModel, IList<TArgumentSyntax> arguments);
+        protected abstract IList<ParameterName> GenerateParameterNames(SemanticModel semanticModel, IList<TArgumentSyntax> arguments);
 
         protected abstract INamedTypeSymbol DetermineTypeToGenerateIn(SemanticModel semanticModel, TSimpleNameSyntax simpleName, CancellationToken cancellationToken);
         protected abstract ITypeSymbol DetermineArgumentType(SemanticModel semanticModel, TArgumentSyntax argument, CancellationToken cancellationToken);

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateConstructor/VisualBasicGenerateConstructorService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateConstructor/VisualBasicGenerateConstructorService.vb
@@ -5,6 +5,7 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
 Imports Microsoft.CodeAnalysis.Host.Mef
 Imports Microsoft.CodeAnalysis.LanguageServices
+Imports Microsoft.CodeAnalysis.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
 
@@ -17,11 +18,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateConstructor
             Return semanticModel.GenerateNameForArgument(argument)
         End Function
 
-        Protected Overrides Function GenerateParameterNames(semanticModel As SemanticModel, arguments As IEnumerable(Of ArgumentSyntax), Optional reservedNames As IList(Of String) = Nothing) As IList(Of String)
+        Protected Overrides Function GenerateParameterNames(
+                semanticModel As SemanticModel,
+                arguments As IEnumerable(Of ArgumentSyntax),
+                Optional reservedNames As IList(Of String) = Nothing) As IList(Of ParameterName)
             Return semanticModel.GenerateParameterNames(arguments?.ToList(), reservedNames)
         End Function
 
-        Protected Overrides Function GetArgumentType(semanticModel As SemanticModel, argument As ArgumentSyntax, cancellationToken As CancellationToken) As Microsoft.CodeAnalysis.ITypeSymbol
+        Protected Overrides Function GetArgumentType(
+                semanticModel As SemanticModel,
+                argument As ArgumentSyntax,
+                cancellationToken As CancellationToken) As ITypeSymbol
             Return argument.DetermineType(semanticModel, cancellationToken)
         End Function
 

--- a/src/Features/VisualBasic/Portable/GenerateMember/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateMember/GenerateParameterizedMember/VisualBasicGenerateParameterizedMemberService.vb
@@ -7,6 +7,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.GenerateMember.GenerateParameterizedMember
+Imports Microsoft.CodeAnalysis.Utilities
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateMethod
     Partial Friend MustInherit Class VisualBasicGenerateParameterizedMemberService(Of TService As AbstractGenerateParameterizedMemberService(Of TService, SimpleNameSyntax, ExpressionSyntax, InvocationExpressionSyntax))
@@ -23,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateMember.GenerateMethod
                 Me.InvocationExpression = state.InvocationExpressionOpt
             End Sub
 
-            Protected Overrides Function DetermineParameterNames(cancellationToken As CancellationToken) As IList(Of String)
+            Protected Overrides Function DetermineParameterNames(cancellationToken As CancellationToken) As IList(Of ParameterName)
                 Dim typeParametersNames = Me.DetermineTypeParameters(cancellationToken).Select(Function(t) t.Name).ToList()
                 Return Me.Document.SemanticModel.GenerateParameterNames(
                     Me.InvocationExpression.ArgumentList, reservedNames:=typeParametersNames)

--- a/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
+++ b/src/Features/VisualBasic/Portable/GenerateType/VisualBasicGenerateTypeService.vb
@@ -12,6 +12,7 @@ Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Shared.Options
 Imports Microsoft.CodeAnalysis.Simplification
 Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -29,7 +30,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.GenerateType
             End Get
         End Property
 
-        Protected Overrides Function GenerateParameterNames(semanticModel As SemanticModel, arguments As IList(Of ArgumentSyntax)) As IList(Of String)
+        Protected Overrides Function GenerateParameterNames(semanticModel As SemanticModel, arguments As IList(Of ArgumentSyntax)) As IList(Of ParameterName)
             Return semanticModel.GenerateParameterNames(arguments)
         End Function
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3531,7 +3531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             return SyntaxFactory.ExpressionStatement((ExpressionSyntax)expression);
         }
 
-        public override SyntaxNode MemberAccessExpression(SyntaxNode expression, SyntaxNode simpleName)
+        internal override SyntaxNode MemberAccessExpressionWorker(SyntaxNode expression, SyntaxNode simpleName)
         {
             return SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,

--- a/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions
@@ -246,21 +247,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return type.CreateParameterName(capitalize);
         }
 
-        public static IList<string> GenerateParameterNames(
+        public static IList<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             ArgumentListSyntax argumentList)
         {
             return semanticModel.GenerateParameterNames(argumentList.Arguments);
         }
 
-        public static IList<string> GenerateParameterNames(
+        public static IList<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             AttributeArgumentListSyntax argumentList)
         {
             return semanticModel.GenerateParameterNames(argumentList.Arguments);
         }
 
-        public static IList<string> GenerateParameterNames(
+        public static IList<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             IEnumerable<ArgumentSyntax> arguments,
             IList<string> reservedNames = null)
@@ -274,10 +275,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var parameterNames = reservedNames.Concat(
                 arguments.Select(a => semanticModel.GenerateNameForArgument(a))).ToList();
 
-            return NameGenerator.EnsureUniqueness(parameterNames, isFixed).Skip(reservedNames.Count).ToList();
+            return GenerateNames(reservedNames, isFixed, parameterNames);
         }
 
-        public static IList<string> GenerateParameterNames(
+        private static IList<ParameterName> GenerateNames(IList<string> reservedNames, List<bool> isFixed, List<string> parameterNames)
+        {
+            return NameGenerator.EnsureUniqueness(parameterNames, isFixed)
+                                .Select((name, index) => new ParameterName(name, isFixed[index]))
+                                .Skip(reservedNames.Count).ToList();
+        }
+
+        public static IList<ParameterName> GenerateParameterNames(
             this SemanticModel semanticModel,
             IEnumerable<AttributeArgumentSyntax> arguments,
             IList<string> reservedNames = null)
@@ -291,7 +299,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             var parameterNames = reservedNames.Concat(
                 arguments.Select(a => semanticModel.GenerateNameForArgument(a))).ToList();
 
-            return NameGenerator.EnsureUniqueness(parameterNames, isFixed).Skip(reservedNames.Count).ToList();
+            return GenerateNames(reservedNames, isFixed, parameterNames);
         }
 
         public static ISet<INamespaceSymbol> GetUsingNamespacesInScope(this SemanticModel semanticModel, SyntaxNode location)

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -1722,7 +1722,13 @@ namespace Microsoft.CodeAnalysis.Editing
         /// <summary>
         /// Creates a member access expression.
         /// </summary>
-        public abstract SyntaxNode MemberAccessExpression(SyntaxNode expression, SyntaxNode memberName);
+        public virtual SyntaxNode MemberAccessExpression(SyntaxNode expression, SyntaxNode memberName)
+        {
+            return MemberAccessExpressionWorker(expression, memberName)
+                .WithAdditionalAnnotations(Simplification.Simplifier.Annotation);
+        }
+
+        internal abstract SyntaxNode MemberAccessExpressionWorker(SyntaxNode expression, SyntaxNode memberName);
 
         /// <summary>
         /// Creates a member access expression.

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.LanguageServices
 {

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+*REMOVED*abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.MemberAccessExpression(Microsoft.CodeAnalysis.SyntaxNode expression, Microsoft.CodeAnalysis.SyntaxNode memberName) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>
 Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>.CodeStyleOption(T value, Microsoft.CodeAnalysis.CodeStyle.NotificationOption notification) -> void
 Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>.Notification.get -> Microsoft.CodeAnalysis.CodeStyle.NotificationOption
@@ -29,9 +30,9 @@ override Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft
 override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption(Microsoft.CodeAnalysis.Options.OptionKey optionAndLanguage, object value) -> Microsoft.CodeAnalysis.Options.OptionSet
 override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.Option<T> option, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
 override Microsoft.CodeAnalysis.Options.DocumentOptionSet.WithChangedOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option, string language, T value) -> Microsoft.CodeAnalysis.Options.OptionSet
-static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool
 static Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>.Default.get -> Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>
 static Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>.FromXElement(System.Xml.Linq.XElement element) -> Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<T>
+static Microsoft.CodeAnalysis.Editing.DeclarationModifiers.TryParse(string value, out Microsoft.CodeAnalysis.Editing.DeclarationModifiers modifiers) -> bool
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.NamingPreferences.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<string>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyEventAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyFieldAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
@@ -45,4 +46,5 @@ static readonly Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Error -> Mic
 static readonly Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Info -> Microsoft.CodeAnalysis.CodeStyle.NotificationOption
 static readonly Microsoft.CodeAnalysis.CodeStyle.NotificationOption.None -> Microsoft.CodeAnalysis.CodeStyle.NotificationOption
 static readonly Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Warning -> Microsoft.CodeAnalysis.CodeStyle.NotificationOption
+virtual Microsoft.CodeAnalysis.Editing.SyntaxGenerator.MemberAccessExpression(Microsoft.CodeAnalysis.SyntaxNode expression, Microsoft.CodeAnalysis.SyntaxNode memberName) -> Microsoft.CodeAnalysis.SyntaxNode
 virtual Microsoft.CodeAnalysis.Workspace.UpdateGeneratedDocuments(Microsoft.CodeAnalysis.ProjectId projectId, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentsRemoved, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.DocumentInfo> documentsAdded) -> void

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
@@ -198,14 +198,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     if (TryGetValue(parameterToExistingFieldMap, parameterName, out fieldName) ||
                         TryGetValue(parameterToNewFieldMap, parameterName, out fieldName))
                     {
-                        var fieldReference = factory.IdentifierName(fieldName);
-
-                        var qualifiedFieldReference = StringComparer.OrdinalIgnoreCase.Equals(parameterName, fieldName)
-                            ? factory.MemberAccessExpression(factory.ThisExpression(), fieldReference)
-                            : fieldReference;
-
                         var assignExpression = factory.AssignmentStatement(
-                            qualifiedFieldReference,
+                            factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(fieldName)),
                             factory.IdentifierName(parameterName));
                         var statement = factory.ExpressionStatement(assignExpression);
                         yield return statement;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -197,10 +198,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     if (TryGetValue(parameterToExistingFieldMap, parameterName, out fieldName) ||
                         TryGetValue(parameterToNewFieldMap, parameterName, out fieldName))
                     {
+                        var fieldReference = factory.IdentifierName(fieldName);
+
+                        var qualifiedFieldReference = StringComparer.OrdinalIgnoreCase.Equals(parameterName, fieldName)
+                            ? factory.MemberAccessExpression(factory.ThisExpression(), fieldReference)
+                            : fieldReference;
+
                         var assignExpression = factory.AssignmentStatement(
-                            factory.MemberAccessExpression(
-                                factory.ThisExpression(),
-                                factory.IdentifierName(fieldName)),
+                            qualifiedFieldReference,
                             factory.IdentifierName(parameterName));
                         var statement = factory.ExpressionStatement(assignExpression);
                         yield return statement;

--- a/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
+++ b/src/Workspaces/Core/Portable/Utilities/ParameterName.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Utilities
+{
+    internal struct ParameterName : IEquatable<ParameterName>
+    {
+        //public static readonly IEqualityComparer<ParameterName> OrdinalComparer = new ParameterNameEqualityComparer(StringComparer.Ordinal);
+        //public static readonly IEqualityComparer<ParameterName> OrdinalIgnoreCaseComparer = new ParameterNameEqualityComparer(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// The name the underlying naming system came up with based on the argument itself.
+        /// This might be a name like "_value".  We pass this along because it can help
+        /// later parts of the GenerateConstructor process when doing things like field hookup.
+        /// </summary>
+        public readonly string NameBasedOnArgument;
+
+        /// <summary>
+        /// The name we think should actually be used for this parameter.  This will include
+        /// stripping the name of things like underscores.
+        /// </summary>
+        public readonly string BestNameForParameter;
+
+        public ParameterName(string nameBasedOnArgument, bool isFixed)
+        {
+            NameBasedOnArgument = nameBasedOnArgument;
+
+            if (isFixed)
+            {
+                // If the parameter name is fixed, we have to accept it as is.
+                BestNameForParameter = NameBasedOnArgument;
+            }
+            else
+            {
+                // Otherwise, massage it a bit to be a more suitable match for
+                // how people actually writing parameters.
+                var trimmed = nameBasedOnArgument.TrimStart('_');
+                BestNameForParameter = trimmed.Length > 0 ? trimmed.ToCamelCase() : nameBasedOnArgument;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals((ParameterName)obj);
+        }
+
+        public bool Equals(ParameterName other)
+        {
+            return NameBasedOnArgument.Equals(other.NameBasedOnArgument);
+        }
+
+        public override int GetHashCode()
+        {
+            return NameBasedOnArgument.GetHashCode();
+        }
+
+        //private class ParameterNameEqualityComparer: IEqualityComparer<ParameterName>
+        //{
+        //    private readonly StringComparer _comparer;
+
+        //    public ParameterNameEqualityComparer(StringComparer comparer)
+        //    {
+        //        this._comparer = comparer;
+        //    }
+
+        //    public bool Equals(ParameterName x, ParameterName y)
+        //    {
+        //        return _comparer.Equals(x.BestNameForParameter, y.BestNameForParameter);
+        //    }
+
+        //    public int GetHashCode(ParameterName obj)
+        //    {
+        //        return _comparer.GetHashCode(obj.BestNameForParameter);
+        //    }
+        //}
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -473,6 +473,7 @@
     <Compile Include="Utilities\ForegroundThreadDataKind.cs" />
     <Compile Include="Utilities\IReadOnlyDictionaryExtensions.cs" />
     <Compile Include="Utilities\IReadOnlyListExtensions.cs" />
+    <Compile Include="Utilities\ParameterName.cs" />
     <Compile Include="Utilities\SpellChecker.cs" />
     <Compile Include="Utilities\StringEscapeEncoder.cs" />
     <Compile Include="Utilities\ValuesSources\CachedWeakValueSource.cs" />

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -199,7 +199,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
             Return SyntaxFactory.OrElseExpression(Parenthesize(left), Parenthesize(right))
         End Function
 
-        Public Overrides Function MemberAccessExpression(expression As SyntaxNode, simpleName As SyntaxNode) As SyntaxNode
+        Friend Overrides Function MemberAccessExpressionWorker(expression As SyntaxNode, simpleName As SyntaxNode) As SyntaxNode
             Return SyntaxFactory.SimpleMemberAccessExpression(
                 ParenthesizeLeft(expression),
                 SyntaxFactory.Token(SyntaxKind.DotToken),


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11563