### PR TITLE
Block any commits that derive from a bad merge we removed via force push

### DIFF
--- a/build/scripts/check-branch.ps1
+++ b/build/scripts/check-branch.ps1
@@ -1,12 +1,7 @@
-# This script is meant to guard against accidental merges of our core
-# branches.  For instance it should guard against future -> master merges
-# that weren't intended.  
+# Check if the branch contains any bad commits we want to prevent reappearing
 
-if (${env:ghprbTargetBranch} -eq "master") {
-    [string]$output = git branch --contains 00677493dc69ceac4e9e4c01a73be90c75e7d340 
-    if ($output.Length -ne 0) {
-        write-host "Error!!! Accidental merge of future into master"
-        exit 1
-    }
+[string]$output = git branch --contains 29a0db828359046e61542c4b62fa72743a905a40
+if ($output.Length -ne 0) {
+    write-host "Error!!! Branch still contains something we got rid of in a force push."
+    exit 1
 }
-


### PR DESCRIPTION
- It should no longer block future -> master merges, since we've done
  that now.
- It should block any new pull requests that contain the previous
  bad merge.

*Review*: @dotnet/roslyn-infrastructure 