### PR TITLE
Add the RuntimeMetadataVersion property to *.targets

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Shared/Microsoft.CSharp.Core.targets
@@ -113,6 +113,7 @@
           ReportAnalyzer="$(ReportAnalyzer)"
           Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
           ResponseFiles="$(CompilerResponseFile)"
+          RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
           SkipCompilerExecution="$(SkipCompilerExecution)"
           Sources="@(Compile)"
           SubsystemVersion="$(SubsystemVersion)"

--- a/src/Compilers/Core/MSBuildTask/Shared/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Shared/Microsoft.VisualBasic.Core.targets
@@ -107,6 +107,7 @@
           Resources="@(_CoreCompileResourceInputs);@(CompiledLicenseFile)"
           ResponseFiles="$(CompilerResponseFile)"
           RootNamespace="$(RootNamespace)"
+          RuntimeMetadataVersion="$(RuntimeMetadataVersion)"
           SdkPath="$(FrameworkPathOverride)"
           SkipCompilerExecution="$(SkipCompilerExecution)"
           Sources="@(Compile)"


### PR DESCRIPTION
The RuntimeMetadataVersion flag was in the options and the task,
but the targets never passed the property through to the task.

I noticed this when writing PR #11657