### PR TITLE
Bring back "UseHostObjectToExecute" to Csc task...

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
@@ -690,23 +690,41 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                                 HostObjectInitializationStatus.NoActionReturnFailure;
                         }
 
-                        // Roslyn does not support compiling through the host object
+                        if (!this.HostCompilerSupportsAllParameters)
+                        {
+                            // Since the host compiler has refused to take on the responsibility for this compilation,
+                            // we're about to shell out to the command-line compiler to handle it.  If some of the
+                            // references don't exist on disk, we know the command-line compiler will fail, so save
+                            // the trouble, and just throw a consistent error ourselves.  This allows us to give
+                            // more information than the compiler would, and also make things consistent across
+                            // Vbc / Csc / etc.  Actually, the real reason is bug 275726 (ddsuites\src\vs\env\vsproject\refs\ptp3).
+                            // This suite behaves differently in localized builds than on English builds because 
+                            // VBC.EXE doesn't localize the word "error" when they emit errors and so we can't scan for it.
+                            if (!CheckAllReferencesExistOnDisk())
+                            {
+                                return HostObjectInitializationStatus.NoActionReturnFailure;
+                            }
 
-                        // Since the host compiler has refused to take on the responsibility for this compilation,
-                        // we're about to shell out to the command-line compiler to handle it.  If some of the
-                        // references don't exist on disk, we know the command-line compiler will fail, so save
-                        // the trouble, and just throw a consistent error ourselves.  This allows us to give
-                        // more information than the compiler would, and also make things consistent across
-                        // Vbc / Csc / etc.  Actually, the real reason is bug 275726 (ddsuites\src\vs\env\vsproject\refs\ptp3).
-                        // This suite behaves differently in localized builds than on English builds because 
-                        // VBC.EXE doesn't localize the word "error" when they emit errors and so we can't scan for it.
-                        if (!CheckAllReferencesExistOnDisk())
+                            // The host compiler doesn't support some of the switches/parameters
+                            // being passed to it.  Therefore, we resort to using the command-line compiler
+                            // in this case.
+                            UsedCommandLineTool = true;
+                            return HostObjectInitializationStatus.UseAlternateToolToExecute;
+                        }
+
+                        // Ok, by now we validated that the host object supports the necessary switches
+                        // and parameters.  Last thing to check is whether the host object is up to date,
+                        // and in that case, we will inform the caller that no further action is necessary.
+                        if (hostObjectSuccessfullyInitialized)
+                        {
+                            return cscHostObject.IsUpToDate() ?
+                                HostObjectInitializationStatus.NoActionReturnSuccess :
+                                HostObjectInitializationStatus.UseHostObjectToExecute;
+                        }
+                        else
                         {
                             return HostObjectInitializationStatus.NoActionReturnFailure;
                         }
-
-                        UsedCommandLineTool = true;
-                        return HostObjectInitializationStatus.UseAlternateToolToExecute;
                     }
                     else
                     {


### PR DESCRIPTION
This code path was never ported forward to the new version of the Csc
task, because it wasn't needed for Roslyn scenarios (IDE HostObject
returns 'true' from IsDesignTime, so it short-circuits above, and real
builds always "UseAlternateToolToExecute").

For test impact builds, it would be useful to bring back the capability to
call Emit in the same process as MSBuild.