### PR TITLE
Harden active statement mapping

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -1719,18 +1719,18 @@ class C
             string src2 = @"
 class C
 {
-    <AS:1>public static readonly int a = F(1);</AS:1>
+    <AS:1>public static readonly int <TS:1>a = F(1)</TS:1>;</AS:1>
 
     public C() {}
 
     public static int F(int a)
     {
-        <AS:0>return a + 1;</AS:0> 
+        <TS:0><AS:0>return a + 1;</AS:0></TS:0>
     }
 
     static void Main(string[] args)
     {
-        <AS:2>C c = new C();</AS:2>
+        <TS:2><AS:2>C c = new C();</AS:2></TS:2>
     }
 }";
             var edits = GetTopEdits(src1, src2);
@@ -7949,6 +7949,52 @@ class C
     {
         <AS:0>return a;</AS:0> 
         <AS:2>return a;</AS:2> 
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void MisplacedActiveStatement2()
+        {
+            string src1 = @"
+class C
+{
+    static <AS:0>void</AS:0> Main(string[] args)
+    {
+    }
+}";
+            string src2 = @"
+class C
+{
+    static void Main(string[] args)
+    <AS:0>{</AS:0>
+    }
+}";
+            var edits = GetTopEdits(src1, src2);
+            var active = GetActiveStatements(src1, src2);
+
+            edits.VerifyRudeDiagnostics(active);
+        }
+
+        [Fact]
+        public void MisplacedTrackingSpan1()
+        {
+            string src1 = @"
+class C
+{
+    static <AS:0>void</AS:0> Main(string[] args)
+    {
+    }
+}";
+            string src2 = @"
+class C
+{
+    static <TS:0>void</TS:0> Main(string[] args)
+    <AS:0>{</AS:0>
     }
 }";
             var edits = GetTopEdits(src1, src2);

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/Extensions.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/Helpers/Extensions.cs
@@ -19,7 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue.UnitTests
             CSharpEditAndContinueTestHelpers.Instance.VerifyUnchangedDocument(
                 ActiveStatementsDescription.ClearTags(source),
                 description.OldSpans,
-                description.TrackingSpans,
+                description.OldTrackingSpans,
                 description.NewSpans,
                 description.OldRegions,
                 description.NewRegions);

--- a/src/EditorFeatures/Test/EditAndContinue/ActiveStatementDescription.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/ActiveStatementDescription.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         public readonly TextSpan[] NewSpans;
         public readonly ImmutableArray<TextSpan>[] OldRegions;
         public readonly ImmutableArray<TextSpan>[] NewRegions;
-        public readonly TextSpan?[] TrackingSpans;
+        public readonly TextSpan?[] OldTrackingSpans;
 
         private ActiveStatementsDescription()
         {
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             NewSpans = Array.Empty<TextSpan>();
             OldRegions = Array.Empty<ImmutableArray<TextSpan>>();
             NewRegions = Array.Empty<ImmutableArray<TextSpan>>();
-            TrackingSpans = null;
+            OldTrackingSpans = null;
         }
 
         public ActiveStatementsDescription(string oldSource, string newSource)
@@ -37,7 +37,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
 
             // Tracking spans are marked in the new source since the editor moves them around as the user 
             // edits the source and we get their positions when analyzing the new source.
-            TrackingSpans = GetTrackingSpans(newSource, OldSpans.Length);
+            // The EnC analyzer uses old trackign spans as hints to find matching nodes.
+            // After an edit the tracking spans are updated to match new active statements.
+            OldTrackingSpans = GetTrackingSpans(newSource, OldSpans.Length);
         }
 
         internal static readonly ActiveStatementsDescription Empty = new ActiveStatementsDescription();

--- a/src/EditorFeatures/Test/EditAndContinue/EditAndContinueTestHelpers.cs
+++ b/src/EditorFeatures/Test/EditAndContinue/EditAndContinueTestHelpers.cs
@@ -80,9 +80,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
         {
             var oldActiveStatements = description.OldSpans;
 
-            if (description.TrackingSpans != null)
+            if (description.OldTrackingSpans != null)
             {
-                Assert.Equal(oldActiveStatements.Length, description.TrackingSpans.Length);
+                Assert.Equal(oldActiveStatements.Length, description.OldTrackingSpans.Length);
             }
 
             string newSource = editScript.Match.NewRoot.SyntaxTree.ToString();
@@ -100,9 +100,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
             DocumentId documentId = DocumentId.CreateNewId(ProjectId.CreateNewId("TestEnCProject"), "TestEnCDocument");
 
             TestActiveStatementTrackingService trackingService;
-            if (description.TrackingSpans != null)
+            if (description.OldTrackingSpans != null)
             {
-                trackingService = new TestActiveStatementTrackingService(documentId, description.TrackingSpans);
+                trackingService = new TestActiveStatementTrackingService(documentId, description.OldTrackingSpans);
             }
             else
             {
@@ -156,8 +156,9 @@ namespace Microsoft.CodeAnalysis.EditAndContinue.UnitTests
                 }
             }
 
-            if (description.TrackingSpans != null)
+            if (description.OldTrackingSpans != null)
             {
+                // Verify that the new tracking spans are equal to the new active statements.
                 AssertEx.Equal(trackingService.TrackingSpans, description.NewSpans.Select(s => (TextSpan?)s));
             }
         }

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/ActiveStatementTests.vb
@@ -4749,6 +4749,94 @@ End Class
             edits.VerifyRudeDiagnostics(active)
         End Sub
 
+        <Fact>
+        Public Sub MisplacedActiveStatement2()
+            Dim src1 = "
+Class C
+    <AS:0><Attr></AS:0>
+    Shared Sub Main()
+    End Sub
+End Class"
+            Dim src2 = "
+Class C
+    <Attr>
+    <AS:0>Shared Sub Main()</AS:0>
+    End Sub
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan1()
+            Dim src1 = "
+Class C
+    <AS:0><Attr></AS:0>
+    Shared Sub Main()
+    End Sub
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0><Attr></TS:0>
+    <AS:0>Shared Sub Main()</AS:0>
+    End Sub
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan2()
+            Dim src1 = "
+Class C
+    Dim f = <AS:0>1</AS:0>
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Dim</TS:0> <AS:0>f = 1</AS:0>
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan3()
+            Dim src1 = "
+Class C
+    Dim <AS:0>f</AS:0>, g As New C()
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Dim</TS:0> <AS:0>f</AS:0>, g As New C()
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
+        <Fact>
+        Public Sub MisplacedTrackingSpan4()
+            Dim src1 = "
+Class C
+    <AS:0>Property</AS:0> f As New C()
+End Class"
+            Dim src2 = "
+Class C
+    <TS:0>Property</TS:0> <AS:0>f As New C()</AS:0>
+End Class"
+            Dim edits = GetTopEdits(src1, src2)
+            Dim active = GetActiveStatements(src1, src2)
+
+            edits.VerifyRudeDiagnostics(active)
+        End Sub
+
         <Fact, WorkItem(1359, "https://github.com/dotnet/roslyn/issues/1359")>
         Public Sub Lambdas_LeafEdits_GeneralStatement()
             Dim src1 = "

--- a/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/Extensions.vb
+++ b/src/EditorFeatures/VisualBasicTest/EditAndContinue/Helpers/Extensions.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.EditAndContinue.UnitTests
             VisualBasicEditAndContinueTestHelpers.Instance.VerifyUnchangedDocument(
                 ActiveStatementsDescription.ClearTags(source),
                 description.OldSpans,
-                description.TrackingSpans,
+                description.OldTrackingSpans,
                 description.NewSpans,
                 description.OldRegions,
                 description.NewRegions)

--- a/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/CSharpEditAndContinueAnalyzer.cs
@@ -270,13 +270,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     declarationBody = constructor.Initializer;
                     partnerDeclarationBodyOpt = partnerConstructor?.Initializer;
                 }
-                else
-                {
-                    Debug.Assert(!(declarationBody is BlockSyntax));
+            }
 
-                    // let's find a labeled node that encompasses the body:
-                    position = declarationBody.SpanStart;
-                }
+            if (!declarationBody.FullSpan.Contains(position))
+            {
+                // invalid position, let's find a labeled node that encompasses the body:
+                position = declarationBody.SpanStart;
             }
 
             SyntaxNode node;
@@ -284,7 +283,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             {
                 SyntaxUtilities.FindLeafNodeAndPartner(declarationBody, position, partnerDeclarationBodyOpt, out node, out partnerOpt);
             }
-            else
+            else 
             {
                 node = declarationBody.FindToken(position).Parent;
                 partnerOpt = null;
@@ -453,7 +452,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
         {
             SyntaxNode root = GetEncompassingAncestor(containerOpt);
 
-            while (node != root)
+            while (node != root && node != null)
             {
                 SyntaxNode body;
                 if (LambdaUtilities.IsLambdaBodyStatementOrExpression(node, out body))


### PR DESCRIPTION
Don't assume anything about position of tracking spans and active statements, they might be off.

Fixes VS crash during EnC (internal bug 179950)