### PR TITLE
Disallow invocation of extension methods off of types as query operators.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -440,7 +440,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             else if (memberSymbol.IsStatic)
             {
                 Debug.Assert(!invokedAsExtensionMethod || (receiverOpt != null));
-                if (!invokedAsExtensionMethod && !WasImplicitReceiver(receiverOpt) && IsMemberAccessedThroughVariableOrValue(receiverOpt))
+
+                if (invokedAsExtensionMethod)
+                {
+                    if (receiverOpt?.Kind == BoundKind.QueryClause && IsMemberAccessedThroughType(receiverOpt))
+                    {
+                        // Could not find an implementation of the query pattern for source type '{0}'.  '{1}' not found.
+                        diagnostics.Add(ErrorCode.ERR_QueryNoProvider, node.Location, receiverOpt.Type, memberSymbol.Name);
+                        return true;
+                    }
+                }
+                else if (!WasImplicitReceiver(receiverOpt) && IsMemberAccessedThroughVariableOrValue(receiverOpt))
                 {
                     if (this.Flags.Includes(BinderFlags.CollectionInitializerAddMethod))
                     {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/QueryTests.cs
@@ -2094,5 +2094,152 @@ class Program
                 Diagnostic(ErrorCode.ERR_UnsupportedTransparentIdentifierAccess, "x").WithArguments("x", "int")
                 );
         }
+
+        [Fact]
+        [WorkItem(204561, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=204561&_a=edit")]
+        public void Bug204561_01()
+        {
+            string sourceCode =
+@"
+class C
+{
+    public static void Main()
+    {
+        var x01 = from a in Test select a + 1;
+    }
+}
+
+public class Test
+{
+}
+
+public static class TestExtensions
+{
+    public static Test Select<T>(this Test x, System.Func<int, T> selector)
+    {
+        return null;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode);
+                
+            compilation.VerifyDiagnostics(
+                // (6,34): error CS1936: Could not find an implementation of the query pattern for source type 'Test'.  'Select' not found.
+                //         var x01 = from a in Test select a + 1;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "select a + 1").WithArguments("Test", "Select").WithLocation(6, 34)
+                );
+        }
+
+        [Fact]
+        [WorkItem(204561, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=204561&_a=edit")]
+        public void Bug204561_02()
+        {
+            string sourceCode =
+@"
+class C
+{
+    public static void Main()
+    {
+        var y02 = from a in Test select a + 1;
+        var x02 = from a in Test where a > 0 select a + 1;
+    }
+}
+
+class Test
+{
+    public static Test Select<T>(System.Func<int, T> selector)
+    {
+        return null;
+    }
+}
+
+static class TestExtensions
+{
+    public static Test Where(this Test x, System.Func<int, bool> filter)
+    {
+        return null;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode);
+
+            compilation.VerifyDiagnostics(
+                // (7,34): error CS1936: Could not find an implementation of the query pattern for source type 'Test'.  'Where' not found.
+                //         var x02 = from a in Test where a > 0 select a + 1;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "where a > 0").WithArguments("Test", "Where").WithLocation(7, 34),
+                // (7,46): error CS0176: Member 'Test.Select<int>(Func<int, int>)' cannot be accessed with an instance reference; qualify it with a type name instead
+                //         var x02 = from a in Test where a > 0 select a + 1;
+                Diagnostic(ErrorCode.ERR_ObjectProhibited, "select a + 1").WithArguments("Test.Select<int>(System.Func<int, int>)").WithLocation(7, 46)
+                );
+        }
+        
+        [Fact]
+        [WorkItem(204561, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=204561&_a=edit")]
+        public void Bug204561_03()
+        {
+            string sourceCode =
+@"
+class C
+{
+    public static void Main()
+    {
+        var y03 = from a in Test select a + 1;
+        var x03 = from a in Test where a > 0 select a + 1;
+    }
+}
+
+class Test
+{
+}
+
+static class TestExtensions
+{
+    public static Test Select<T>(this Test x, System.Func<int, T> selector)
+    {
+        return null;
+    }
+
+    public static Test Where(this Test x, System.Func<int, bool> filter)
+    {
+        return null;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode);
+
+            compilation.VerifyDiagnostics(
+                // (6,34): error CS1936: Could not find an implementation of the query pattern for source type 'Test'.  'Select' not found.
+                //         var y03 = from a in Test select a + 1;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "select a + 1").WithArguments("Test", "Select").WithLocation(6, 34),
+                // (7,34): error CS1936: Could not find an implementation of the query pattern for source type 'Test'.  'Where' not found.
+                //         var x03 = from a in Test where a > 0 select a + 1;
+                Diagnostic(ErrorCode.ERR_QueryNoProvider, "where a > 0").WithArguments("Test", "Where").WithLocation(7, 34)
+                );
+        }
+
+        [Fact]
+        [WorkItem(204561, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=204561&_a=edit")]
+        public void Bug204561_04()
+        {
+            string sourceCode =
+@"
+class C
+{
+    public static void Main()
+    {
+        var x04 = from a in Test select a + 1;
+    }
+}
+
+class Test
+{
+    public static Test Select<T>(System.Func<int, T> selector)
+    {
+        System.Console.WriteLine(""Select"");
+        return null;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(sourceCode, options: TestOptions.DebugExe);
+
+            CompileAndVerify(compilation, expectedOutput: "Select");
+        }
     }
 }


### PR DESCRIPTION
Fixes some of the scenarios for https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=204561&_a=edit.