### PR TITLE
fix crash due to race in build synchronization

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.ProjectState.cs
@@ -200,7 +200,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                 foreach (var documentId in result.DocumentIds)
                 {
                     var document = project.GetDocument(documentId);
-                    Contract.ThrowIfNull(document);
+                    if (document == null)
+                    {
+                        // it can happen with build synchronization since, in build case, 
+                        // we don't have actual snapshot (we have no idea what sources out of proc build has picked up)
+                        // so we might be out of sync.
+                        // example of such cases will be changing anything about solution while building is going on.
+                        // it can be user explict actions such as unloading project, deleting a file, but also it can be 
+                        // something project system or roslyn workspace does such as populating workspace right after
+                        // solution is loaded.
+                        continue;
+                    }
 
                     await SerializeAsync(serializer, document, document.Id, _owner.SyntaxStateName, GetResult(result, AnalysisKind.Syntax, document.Id)).ConfigureAwait(false);
                     await SerializeAsync(serializer, document, document.Id, _owner.SemanticStateName, GetResult(result, AnalysisKind.Semantic, document.Id)).ConfigureAwait(false);


### PR DESCRIPTION
when we synchronize build errors with live errors there is this known race. since we can't exactly know what sources (snapshot) out of proc build (csc) has picked up, we do our best by picking up current solution in workspace and hope 2 actually picked same things up. most of time this works since solution doesn't get changed that frequently relatively speaking. but certainly there are cases where they differ.

in those case, we make sure VS doesn't crash. and it looks like there is one place we missed the guarding.