### PR TITLE
Add 'AdditionalArguments' option to the build task

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/Csc.cs
@@ -266,6 +266,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendSwitchWithSplitting("/warnaserror+:", WarningsAsErrors, ",", ';', ',');
             commandLine.AppendSwitchWithSplitting("/warnaserror-:", WarningsNotAsErrors, ",", ';', ',');
 
+            // Add "AdditionalArguments" as the penultimate step for similar reasons as below
+            base.AddAdditionalArguments(commandLine);
+
             // It's a good idea for the response file to be the very last switch passed, just 
             // from a predictability perspective.  It also solves the problem that a dogfooder
             // ran into, which is described in an email thread attached to bug VSWhidbey 146883.

--- a/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/ManagedCompiler.cs
@@ -45,6 +45,12 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             get { return (string[])_store[nameof(AddModules)]; }
         }
 
+        public string AdditionalArguments
+        {
+            set { _store[nameof(AdditionalArguments)] = value; }
+            get { return (string)_store[nameof(AdditionalArguments)]; }
+        }
+
         public ITaskItem[] AdditionalFiles
         {
             set { _store[nameof(AdditionalFiles)] = value; }
@@ -707,6 +713,19 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             commandLine.AppendSwitchIfNotNull("/checksumalgorithm:", ChecksumAlgorithm);
 
             AddFeatures(commandLine, Features);
+        }
+
+        /// <summary>
+        /// Adds arguments passed as "AdditionalArguments" to the command line.
+        /// It should be done near the end of command line construction to allow
+        /// "AdditionalArguments" the flexibility to override earlier switches.
+        /// </summary>
+        protected void AddAdditionalArguments(CommandLineBuilderExtension commandLine)
+        {
+            if (!string.IsNullOrWhiteSpace(AdditionalArguments))
+            {
+                commandLine.AppendSwitch(AdditionalArguments);
+            }
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/Shared/Microsoft.CSharp.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Shared/Microsoft.CSharp.Core.targets
@@ -67,6 +67,7 @@
     <Csc  Condition=" '%(_CoreCompileResourceInputs.WithCulture)' != 'true' "
           AdditionalLibPaths="$(AdditionalLibPaths)"
           AddModules="@(AddModules)"
+          AdditionalArguments="$(CscAdditionalArguments)"
           AdditionalFiles="@(AdditionalFiles)"
           AllowUnsafeBlocks="$(AllowUnsafeBlocks)"
           Analyzers="@(Analyzer)"

--- a/src/Compilers/Core/MSBuildTask/Shared/Microsoft.VisualBasic.Core.targets
+++ b/src/Compilers/Core/MSBuildTask/Shared/Microsoft.VisualBasic.Core.targets
@@ -56,6 +56,7 @@
     <Vbc  Condition=" '%(_CoreCompileResourceInputs.WithCulture)' != 'true' "
           AdditionalLibPaths="$(AdditionalLibPaths)"
           AddModules="@(AddModules)"
+          AdditionalArguments="$(VbcAdditionalArguments)"
           AdditionalFiles="@(AdditionalFiles)"
           Analyzers="@(Analyzer)"
           BaseAddress="$(BaseAddress)"

--- a/src/Compilers/Core/MSBuildTask/Shared/Vbc.cs
+++ b/src/Compilers/Core/MSBuildTask/Shared/Vbc.cs
@@ -546,6 +546,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                 }
             }
 
+            // Add "AdditionalArguments" as the penultimate step for similar reasons as below
+            base.AddAdditionalArguments(commandLine);
+
             // It's a good idea for the response file to be the very last switch passed, just 
             // from a predictability perspective.  It also solves the problem that a dogfooder
             // ran into, which is described in an email thread attached to bug VSWhidbey 146883.

--- a/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/CscTests.cs
@@ -110,6 +110,31 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void AdditionalArgumentsOption()
+        {
+            var csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.AdditionalArguments = "/publicsign+";
+            Assert.Equal("/out:test.exe test.cs /publicsign+", csc.GenerateResponseFileContents());
+
+            csc.PublicSign = false;
+            // "AdditionalArguments" should go at the end (except if there's a response file)
+            Assert.Equal("/out:test.exe /publicsign- test.cs /publicsign+", csc.GenerateResponseFileContents());
+            csc.ResponseFiles = MSBuildUtil.CreateTaskItems("test.rsp");
+            Assert.Equal("/out:test.exe /publicsign- test.cs /publicsign+ @test.rsp", csc.GenerateResponseFileContents());
+
+            csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.AdditionalArguments = null;
+            Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
+
+            csc = new Csc();
+            csc.Sources = MSBuildUtil.CreateTaskItems("test.cs");
+            csc.AdditionalArguments = "";
+            Assert.Equal("/out:test.exe test.cs", csc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void TargetTypeDll()
         {
             var csc = new Csc();

--- a/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
+++ b/src/Compilers/Core/MSBuildTaskTests/VbcTests.cs
@@ -107,6 +107,31 @@ namespace Microsoft.CodeAnalysis.BuildTasks.UnitTests
         }
 
         [Fact]
+        public void AdditionalArgumentsOption()
+        {
+            var vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.AdditionalArguments = "/publicsign+";
+            Assert.Equal("/optionstrict:custom /out:test.exe test.vb /publicsign+", vbc.GenerateResponseFileContents());
+
+            vbc.PublicSign = false;
+            // "AdditionalArguments" should go at the end (except if there's a response file)
+            Assert.Equal("/optionstrict:custom /out:test.exe /publicsign- test.vb /publicsign+", vbc.GenerateResponseFileContents());
+            vbc.ResponseFiles = MSBuildUtil.CreateTaskItems("test.rsp");
+            Assert.Equal("/optionstrict:custom /out:test.exe /publicsign- test.vb /publicsign+ @test.rsp", vbc.GenerateResponseFileContents());
+
+            vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.AdditionalArguments = null;
+            Assert.Equal("/optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+
+            vbc = new Vbc();
+            vbc.Sources = MSBuildUtil.CreateTaskItems("test.vb");
+            vbc.AdditionalArguments = "";
+            Assert.Equal("/optionstrict:custom /out:test.exe test.vb", vbc.GenerateResponseFileContents());
+        }
+
+        [Fact]
         public void TargetTypeDll()
         {
             var vbc = new Vbc();


### PR DESCRIPTION
This option allows MSBuild users to append arbitrary raw arguments
to the csc or vbc compilations. This should allow users to override
provide arguments that MSBuild doesn't necessarily understand or
support. Fixes #11011.

This would have been very useful in the past when we wanted to let people try new csc bits, but didn't provide MSBuild hooks at the time. Now people would just be able to temporarily hack the argument through `AdditionalArguments`.