### PR TITLE
Fix version of NETStandard.Library

### DIFF
--- a/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
+++ b/src/NuGet/Microsoft.Net.CSharp.Interactive.netcore.nuspec
@@ -19,7 +19,7 @@
             <group targetFramework="NETCoreApp1.0">
                 <dependency id="Microsoft.CodeAnalysis.Compilers" version="$version$" />
                 <dependency id="Microsoft.CodeAnalysis.Scripting" version="$version$" />
-                <dependency id="NETStandard.Library" version="1.5.0-rc3-24128-00" />
+                <dependency id="NETStandard.Library" version="1.6.0-rc3-24128-00" />
             </group>
         </dependencies>
     </metadata>

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-24128-00",
-    "NETStandard.Library": "1.5.0-rc3-24128-00",
+    "NETStandard.Library": "1.6.0-rc3-24128-00",
     "System.Xml.XmlDocument": "4.0.1-rc3-24128-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-24128-00"
   },

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-24128-00",
-    "NETStandard.Library": "1.5.0-rc3-24128-00",
+    "NETStandard.Library": "1.6.0-rc3-24128-00",
   },
   "frameworks": {
     "NETCoreApp1.0": { }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-24128-00",
-    "NETStandard.Library": "1.5.0-rc3-24128-00",
+    "NETStandard.Library": "1.6.0-rc3-24128-00",
     "System.Xml.XmlDocument": "4.0.1-rc3-24128-00",
     "System.Xml.XmlSerializer": "4.0.11-rc3-24128-00"
   },

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-24128-00",
-    "NETStandard.Library": "1.5.0-rc3-24128-00"
+    "NETStandard.Library": "1.6.0-rc3-24128-00"
   },
   "frameworks": {
     "NETCoreApp1.0": { }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Portable.Compatibility": "1.0.1-rc3-24128-00",
-    "NETStandard.Library": "1.5.0-rc3-24128-00",
+    "NETStandard.Library": "1.6.0-rc3-24128-00",
     "System.Console": "4.0.0-rc3-24128-00",
     "System.Security.Cryptography.Algorithms": "4.2.0-rc3-24128-00"
   },


### PR DESCRIPTION
Previous update to the latest CoreFX version (24128) didn't bump the version of NETStandard.Library references to 1.6.0. As a result building Roslyn.sln sometimes fails with an error from syntax generator. 

It's unclear why it hasn't been failing deterministically. The fix is to update the version.