### PR TITLE
Attempt type inference when there are no applicable methods

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -605,43 +605,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             return ThreeState.True;
         }
 
-        internal void ResolveOverloads<TMember>(
-            ImmutableArray<TMember> members,
-            ImmutableArray<TypeSymbol> typeArguments,
-            ImmutableArray<ArgumentSyntax> arguments,
-            OverloadResolutionResult<TMember> result,
-            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
-            bool allowRefOmittedArguments)
-            where TMember : Symbol
-        {
-            var methodsBuilder = ArrayBuilder<TMember>.GetInstance(members.Length);
-            methodsBuilder.AddRange(members);
-
-            var typeArgumentsBuilder = ArrayBuilder<TypeSymbol>.GetInstance(typeArguments.Length);
-            typeArgumentsBuilder.AddRange(typeArguments);
-
-            var analyzedArguments = AnalyzedArguments.GetInstance();
-            var unusedDiagnostics = DiagnosticBag.GetInstance();
-            foreach (var argumentSyntax in arguments)
-            {
-                BindArgumentAndName(analyzedArguments, unusedDiagnostics, false, argumentSyntax, allowArglist: false);
-            }
-
-            OverloadResolution.MethodOrPropertyOverloadResolution(
-                methodsBuilder,
-                typeArgumentsBuilder,
-                analyzedArguments,
-                result,
-                isMethodGroupConversion: false,
-                allowRefOmittedArguments: allowRefOmittedArguments,
-                useSiteDiagnostics: ref useSiteDiagnostics);
-
-            methodsBuilder.Free();
-            typeArgumentsBuilder.Free();
-            analyzedArguments.Free();
-            unusedDiagnostics.Free();
-        }
-
         internal bool IsSymbolAccessibleConditional(
             Symbol symbol,
             AssemblySymbol within,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -1768,8 +1768,7 @@ public class MyArgumentType
                 // (6,57): error CS1002: ; expected
                 //         var handler = new MyDelegateType((s, e) => { e. });
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(6, 57)
-                )
-                ;
+                );
             var tree = compilation.SyntaxTrees[0];
             var sm = compilation.GetSemanticModel(tree);
             var lambda = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
@@ -1780,6 +1779,189 @@ public class MyArgumentType
             Assert.Equal(TypeKind.Class, typeInfo.Type.TypeKind);
             Assert.NotEmpty(typeInfo.Type.GetMembers("SomePublicMember"));
         }
+
+        [Fact]
+        [WorkItem(11053, "https://github.com/dotnet/roslyn/issues/11053")]
+        [WorkItem(11358, "https://github.com/dotnet/roslyn/issues/11358")]
+        public void TestLambdaWithError07()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var parameter = new List<string>();
+        var result = parameter.FirstOrDefault(x => x. );
     }
 }
 
+public static class Enumerable
+{
+    public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
+    {
+        return default(TSource);
+    }
+
+    public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
+    {
+        return default(TSource);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (9,55): error CS1001: Identifier expected
+                //         var result = parameter.FirstOrDefault(x => x. );
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(9, 55)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var sm = compilation.GetSemanticModel(tree);
+            var lambda = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+            var eReference = lambda.Body.DescendantNodes().OfType<IdentifierNameSyntax>().First();
+            Assert.Equal("x", eReference.ToString());
+            var typeInfo = sm.GetTypeInfo(eReference);
+            Assert.Equal(TypeKind.Class, typeInfo.Type.TypeKind);
+            Assert.Equal("String", typeInfo.Type.Name);
+            Assert.NotEmpty(typeInfo.Type.GetMembers("Replace"));
+        }
+
+        [Fact]
+        [WorkItem(11053, "https://github.com/dotnet/roslyn/issues/11053")]
+        [WorkItem(11358, "https://github.com/dotnet/roslyn/issues/11358")]
+        public void TestLambdaWithError08()
+        {
+            var source =
+@"using System;
+using System.Collections.Generic;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var parameter = new List<string>();
+        var result = parameter.FirstOrDefault(x => x. );
+    }
+}
+
+public static class Enumerable
+{
+    public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, params TSource[] defaultValue)
+    {
+        return default(TSource);
+    }
+
+    public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, params TSource[] defaultValue)
+    {
+        return default(TSource);
+}
+}";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (9,55): error CS1001: Identifier expected
+                //         var result = parameter.FirstOrDefault(x => x. );
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(9, 55)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var sm = compilation.GetSemanticModel(tree);
+            var lambda = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+            var eReference = lambda.Body.DescendantNodes().OfType<IdentifierNameSyntax>().First();
+            Assert.Equal("x", eReference.ToString());
+            var typeInfo = sm.GetTypeInfo(eReference);
+            Assert.Equal(TypeKind.Class, typeInfo.Type.TypeKind);
+            Assert.Equal("String", typeInfo.Type.Name);
+            Assert.NotEmpty(typeInfo.Type.GetMembers("Replace"));
+        }
+
+        [Fact]
+        [WorkItem(11053, "https://github.com/dotnet/roslyn/issues/11053")]
+        [WorkItem(11358, "https://github.com/dotnet/roslyn/issues/11358")]
+        public void TestLambdaWithError09()
+        {
+            var source =
+@"using System;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var parameter = new MyList<string>();
+        var result = parameter.FirstOrDefault(x => x. );
+    }
+}
+
+public class MyList<TSource>
+{
+    public TSource FirstOrDefault(TSource defaultValue)
+    {
+        return default(TSource);
+    }
+
+    public TSource FirstOrDefault(Func<TSource, bool> predicate, TSource defaultValue)
+    {
+        return default(TSource);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (8,55): error CS1001: Identifier expected
+                //         var result = parameter.FirstOrDefault(x => x. );
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(8, 55)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var sm = compilation.GetSemanticModel(tree);
+            var lambda = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+            var eReference = lambda.Body.DescendantNodes().OfType<IdentifierNameSyntax>().First();
+            Assert.Equal("x", eReference.ToString());
+            var typeInfo = sm.GetTypeInfo(eReference);
+            Assert.Equal(TypeKind.Class, typeInfo.Type.TypeKind);
+            Assert.Equal("String", typeInfo.Type.Name);
+            Assert.NotEmpty(typeInfo.Type.GetMembers("Replace"));
+        }
+
+        [Fact]
+        [WorkItem(11053, "https://github.com/dotnet/roslyn/issues/11053")]
+        [WorkItem(11358, "https://github.com/dotnet/roslyn/issues/11358")]
+        public void TestLambdaWithError10()
+        {
+            var source =
+@"using System;
+
+public static class Program
+{
+    public static void Main()
+    {
+        var parameter = new MyList<string>();
+        var result = parameter.FirstOrDefault(x => x. );
+    }
+}
+
+public class MyList<TSource>
+{
+    public TSource FirstOrDefault(params TSource[] defaultValue)
+    {
+        return default(TSource);
+    }
+
+    public TSource FirstOrDefault(Func<TSource, bool> predicate, params TSource[] defaultValue)
+    {
+        return default(TSource);
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (8,55): error CS1001: Identifier expected
+                //         var result = parameter.FirstOrDefault(x => x. );
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(8, 55)
+                );
+            var tree = compilation.SyntaxTrees[0];
+            var sm = compilation.GetSemanticModel(tree);
+            var lambda = tree.GetCompilationUnitRoot().DescendantNodes().OfType<LambdaExpressionSyntax>().Single();
+            var eReference = lambda.Body.DescendantNodes().OfType<IdentifierNameSyntax>().First();
+            Assert.Equal("x", eReference.ToString());
+            var typeInfo = sm.GetTypeInfo(eReference);
+            Assert.Equal(TypeKind.Class, typeInfo.Type.TypeKind);
+            Assert.Equal("String", typeInfo.Type.Name);
+            Assert.NotEmpty(typeInfo.Type.GetMembers("Replace"));
+        }
+    }
+}


### PR DESCRIPTION
because there are arguments missing, to force lambda binding
for error recovery.
Fixes #11053, #11358 

@dotnet/roslyn-compiler Please review.