### PR TITLE
Implement "target type preselection" redux

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProviderTests.cs
@@ -465,5 +465,31 @@ enum Colors
 ";
             await VerifyItemExistsAsync(markup, "Colors");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NotAfterDot()
+        {
+            var markup =
+@"namespace ConsoleApplication253
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            M(E.$$)
+        }
+
+        static void M(E e) { }
+    }
+
+    enum E
+    {
+        A,
+        B,
+    }
+}
+";
+            await VerifyNoItemsExistAsync(markup);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8767,5 +8767,92 @@ class Class2
             await VerifyNoItemsExistAsync("#!$$", sourceCodeKind: SourceCodeKind.Script);
             await VerifyNoItemsExistAsync("#! S$$", sourceCodeKind: SourceCodeKind.Script, usePreviousCharAsTrigger: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task CompoundNameTargetTypePreselection()
+        {
+            var markup = @"
+class Class1
+{
+    void foo()
+    {
+        int x = 3;
+        string y = x.$$
+    }
+}";
+            await VerifyItemExistsAsync(markup, "ToString", matchPriority: SymbolMatchPriority.PreferEventOrMethod);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TargetTypeInCollectionInitializer1()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int z;
+        string q;
+        List<int> x = new List<int>() { $$  }
+    }
+}";
+            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocal);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TargetTypeInCollectionInitializer2()
+        {
+            var markup = @"
+using System.Collections.Generic;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        int z;
+        string q;
+        List<int> x = new List<int>() { 1, $$  }
+    }
+}";
+            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocal);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TargeTypeInObjectInitializer1()
+        {
+            var markup = @"
+class C
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+
+    void foo()
+    {
+        int i;
+        var c = new C() { X = $$ }
+    }
+}";
+            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocal);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TargeTypeInObjectInitializer2()
+        {
+            var markup = @"
+class C
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+
+    void foo()
+    {
+        int i;
+        var c = new C() { X = 1, Y = $$ }
+    }
+}";
+            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocal);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8798,7 +8798,7 @@ class Program
         List<int> x = new List<int>() { $$  }
     }
 }";
-            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocal);
+            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -8816,7 +8816,7 @@ class Program
         List<int> x = new List<int>() { 1, $$  }
     }
 }";
-            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocal);
+            await VerifyItemExistsAsync(markup, "z", matchPriority: SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -8834,7 +8834,7 @@ class C
         var c = new C() { X = $$ }
     }
 }";
-            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocal);
+            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
@@ -8852,7 +8852,7 @@ class C
         var c = new C() { X = 1, Y = $$ }
     }
 }";
-            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocal);
+            await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/BoolKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(bool x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ByteKeywordRecommenderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +608,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(byte x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/CharKeywordRecommenderTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
-
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -658,6 +660,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(char x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DecimalKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -607,6 +608,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(decimal x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/DoubleKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(double x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/FloatKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -579,6 +580,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(float x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/IntKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -675,6 +676,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(int x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/LongKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(int x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ObjectKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -613,6 +614,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(object x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RecommenderTests.cs
@@ -87,6 +87,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
                     var result = (await RecommendKeywordsAsync(position, context)).Single();
                     Assert.NotNull(result);
                     Assert.Equal(keywordText, result.Keyword);
+                    if (matchPriority != null)
+                    {
+                        Assert.Equal(matchPriority.Value, result.MatchPriority);
+                    }
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/SByteKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(sbyte x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ShortKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -600,6 +601,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(short x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ThisKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -615,6 +616,21 @@ class C
     int M => this.x;$$
     int p;
 }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    void Main(string[] args)
+    {
+        Helper($$)
+    }
+    void Helper(Program x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UIntKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(uint x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/ULongKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(ulong x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/UShortKeywordRecommenderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Completion.Providers;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -606,6 +607,21 @@ using System;
 /// <see cref=""List{$$}"" />
 class C { }
 ");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        public async Task Preselection()
+        {
+            await VerifyKeywordAsync(@"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Helper($$)
+    }
+    static void Helper(ushort x) { }
+}
+", matchPriority: SymbolMatchPriority.Keyword);
         }
     }
 }

--- a/src/EditorFeatures/Core/Extensibility/Completion/CompletionHelper.cs
+++ b/src/EditorFeatures/Core/Extensibility/Completion/CompletionHelper.cs
@@ -165,6 +165,11 @@ namespace Microsoft.CodeAnalysis.Editor
         /// </summary>
         public virtual bool IsBetterFilterMatch(CompletionItem item1, CompletionItem item2, string filterText, CompletionTrigger trigger, ImmutableArray<string> recentItems)
         {
+            return IsBetterFilterMatchWorker(item1, item2, filterText, recentItems);
+        }
+
+        protected bool IsBetterFilterMatchWorker(CompletionItem item1, CompletionItem item2, string filterText, ImmutableArray<string> recentItems)
+        {
             var match1 = GetMatch(item1, filterText);
             var match2 = GetMatch(item2, filterText);
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1682,5 +1682,208 @@ class C
             End Using
 
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Threading;
+class Program
+{
+    void Cancel(int x, CancellationToken cancellationToken)
+    {
+        Cancel(x + 1, cancellationToken: $$)
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cancellationToken", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    static void Main(string[] args)
+    {
+        int aaz = 0;
+        args = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("a")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("args", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection_DoesNotOverrideEnumPreselection() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+enum E
+{
+
+}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        E e;
+        e = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("E", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class D {}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+       int cw = 7;
+       D cx = new D();
+       D cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalsOverType() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class A {}
+
+class Program
+{
+    static void Main(string[] args)
+    {
+       A cx = new A();
+       A cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionParameterOverMethod() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    bool f;
+
+    void foo(bool x) { }
+
+    void Main(string[] args) 
+    {
+        foo($$) // Not "Equals"
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("f", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6942"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionConvertibility1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+abstract class C {}
+class D : C {}
+class Program
+{
+    static void Main(string[] args)
+    {
+       D cx = new D();
+       C cx2 = $$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionParamsArray() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    static void Main(string[] args)
+    {
+       int yx;
+       M2($$
+    }
+    static void M2(params int[] yx) { }
+ }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("yx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalOverProperty() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    public int aaa { get; }
+
+     void Main(string[] args)
+    {
+        int aaq;
+
+        int y = a$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("aaq", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionSetterValuey() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+class Program
+{
+    int _x;
+    int X
+    {
+        set
+        {
+            _x = $$
+        }
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1825,26 +1825,6 @@ class Program
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
-        Public Async Function TargetTypePreselectionParamsArray() As Task
-            Using state = TestState.CreateCSharpTestState(
-                           <Document><![CDATA[
-class Program
-{
-    static void Main(string[] args)
-    {
-       int yx;
-       M2($$
-    }
-    static void M2(params int[] yx) { }
- }
-}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
-                state.SendInvokeCompletionList()
-                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                Await state.AssertSelectedCompletionItem("yx", isHardSelected:=True).ConfigureAwait(True)
-            End Using
-        End Function
-
-        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TargetTypePreselectionLocalOverProperty() As Task
             Using state = TestState.CreateCSharpTestState(
                            <Document><![CDATA[

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2430,7 +2430,7 @@ Class Program
 End Class]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                Await state.AssertSelectedCompletionItem("value", isHardSelected:=True).ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=False, isSoftSelected:=True).ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2430,7 +2430,7 @@ Class Program
 End Class]]></Document>)
                 state.SendInvokeCompletionList()
                 Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
-                Await state.AssertSelectedCompletionItem("value", isHardSelected:=False).ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=True).ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -980,13 +980,11 @@ Class Foo
         Bar(0$$
     End Sub
 End Class
-class Foo
                               </Document>)
 
                 state.SendTypeChars(", ")
                 Await state.WaitForAsynchronousOperationsAsync()
-                Await state.AssertSelectedCompletionItem(displayText:="Numeros", isSoftSelected:=True)
-                Assert.Equal(1, state.CurrentCompletionPresenterSession.PresentationItems.Where(Function(c) c.Item.DisplayText = "Numeros").Count())
+                Await state.AssertSelectedCompletionItem(displayText:="Numeros.Dos", isSoftSelected:=True)
             End Using
         End Function
 
@@ -2290,6 +2288,149 @@ End Module]]></Document>)
                 state.SendTypeChars("t")
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem("T")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Imports System.Threading
+Module Program
+    Sub Cancel(x As Integer, cancellationToken As CancellationToken)
+        Cancel(x + 1, $$)
+    End Sub
+End Module]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cancellationToken").ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection2() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Module Program
+    Sub Main(args As String())
+        Dim aaz As Integer
+        args = $$
+    End Sub
+End Module]]></Document>)
+                state.SendTypeChars("a")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("args").ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselection3() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class D
+End Class
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim cw = 7
+       Dim cx as D = new D()
+       Dim  cx2 as D = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionLocalsOverType() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class A 
+End Class
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim  cx = new A()
+       Dim cx2 as A = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/6942"), Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionConvertibility1() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Mustinherit Class C 
+End Class
+Class D 
+inherits C
+End Class
+Class Program
+    Sub Main(string() args)
+    
+       Dim cx = new D()
+       Dim cx2 as C = $$
+    End Sub
+End Class
+]]></Document>)
+                state.SendTypeChars("c")
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("cx", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionParamsArray() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+
+Class Program
+
+    Sub Main(string() args)
+    
+       Dim azc as integer
+       M2(a$$
+    End Sub
+    Sub M2(params int() yx)  
+    End Sub
+End Class
+ 
+]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("azc", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionSetterValue() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                           <Document><![CDATA[
+Class Program
+    Private Async As Integer
+    Public Property NewProperty() As Integer
+        Get
+            Return Async
+        End Get
+        Set(ByVal value As Integer)
+            Async = $$
+        End Set
+    End Property
+End Class]]></Document>)
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("value", isHardSelected:=False).ConfigureAwait(True)
             End Using
         End Function
     End Class

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/MeKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Expressions/MeKeywordRecommenderTests.vb
@@ -1,5 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Completion.Providers
+
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Expressions
     Public Class MeKeywordRecommenderTests
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
@@ -196,6 +198,24 @@ End Class|</File>
         <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
         Public Async Function MeInNameOf2Test() As Task
             Await VerifyRecommendationsMissingAsync(<MethodBody>Dim s = NameOf(System.|</MethodBody>, "Me")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function Preselection() As Task
+            Dim code =
+<File>
+Class Program
+    Sub Main(args As String())
+        Foo(|)
+    End Sub
+
+    Sub Foo(x As Program)
+
+    End Sub
+End Class
+</File>
+
+            Await VerifyRecommendationsWithPriority(code, SymbolMatchPriority.Keyword, "Me")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/RecommendationTestHelpers.vb
@@ -2,6 +2,7 @@
 
 Imports System.Threading
 Imports System.Xml.Linq
+Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders
@@ -50,16 +51,25 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Assert.Equal(expectedText, recommendedKeyword.DescriptionFactory(CancellationToken.None).GetFullText())
         End Function
 
+        Friend Async Function VerifyRecommendationsWithPriority(testSource As XElement, priority As Integer, ParamArray recommendations As String()) As Task
+            Assert.NotEmpty(recommendations)
+
+            Dim source = ConvertTestSourceTag(testSource)
+
+            Await VerifyRecommendationsContainNothingTypedAsync(source, priority, recommendations).ConfigureAwait(False)
+            Await VerifyRecommendationsContainPartiallyTypedAsync(source, priority, recommendations).ConfigureAwait(False)
+        End Function
+
         Friend Async Function VerifyRecommendationsContainAsync(testSource As XElement, ParamArray recommendations As String()) As Task
             Assert.NotEmpty(recommendations)
 
             Dim source = ConvertTestSourceTag(testSource)
 
-            Await VerifyRecommendationsContainNothingTypedAsync(source, recommendations)
-            Await VerifyRecommendationsContainPartiallyTypedAsync(source, recommendations)
+            Await VerifyRecommendationsContainNothingTypedAsync(source, Nothing, recommendations)
+            Await VerifyRecommendationsContainPartiallyTypedAsync(source, Nothing, recommendations)
         End Function
 
-        Private Async Function VerifyRecommendationsContainNothingTypedAsync(source As String, ParamArray recommendations As String()) As Task
+        Private Async Function VerifyRecommendationsContainNothingTypedAsync(source As String, priority As Integer?, ParamArray recommendations As String()) As Task
             ' Test with the | removed
             Dim recommendedKeywords = Await GetRecommendedKeywordsAsync(source.Replace("|", ""), source.IndexOf("|"c))
 
@@ -67,6 +77,10 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             For Each recommendation In recommendations
                 Assert.Contains(recommendation, recommendedKeywordStrings)
             Next
+
+            If priority.HasValue Then
+                Assert.All(recommendedKeywords.Where(Function(k) recommendations.Contains(k.Keyword)), Sub(k) Assert.Equal(k.MatchPriority, priority.Value))
+            End If
 
             VerifyRecommendationsHaveDescriptionText(recommendedKeywords.Where(Function(k) recommendations.Contains(k.Keyword)))
         End Function
@@ -77,14 +91,21 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations
             Next
         End Sub
 
-        Private Async Function VerifyRecommendationsContainPartiallyTypedAsync(source As String, ParamArray recommendations As String()) As Task
+        Private Async Function VerifyRecommendationsContainPartiallyTypedAsync(source As String, priority As Integer?, ParamArray recommendations As String()) As Task
             ' Test with the | replaced with the first character of the keywords we expect
             For Each partiallyTypedRecommendation In recommendations.Select(Function(recommendation) recommendation(0)).Distinct()
-                Dim recommendedKeywords = (Await GetRecommendedKeywordStringsAsync(source.Replace("|"c, partiallyTypedRecommendation), source.IndexOf("|"c) + 1)).ToArray()
+                Dim recommendedKeywords = (Await GetRecommendedKeywordsAsync(source.Replace("|"c, partiallyTypedRecommendation), source.IndexOf("|"c) + 1)).ToArray()
+                Dim recommendedKeywordStrings = recommendedKeywords.Select(Function(k) k.Keyword)
 
                 For Each recommendation In recommendations
-                    Assert.Contains(recommendation, recommendedKeywords)
+                    Assert.Contains(recommendation, recommendedKeywordStrings)
                 Next
+
+                If priority.HasValue Then
+                    Assert.All(recommendedKeywords.Where(Function(k) recommendations.Contains(k.Keyword)), Sub(k) Assert.Equal(k.MatchPriority, priority.Value))
+                End If
+
+                VerifyRecommendationsHaveDescriptionText(recommendedKeywords.Where(Function(k) recommendations.Contains(k.Keyword)))
             Next
         End Function
 

--- a/src/EditorFeatures/VisualBasicTest/Recommendations/Types/BuiltInTypesKeywordRecommenderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Recommendations/Types/BuiltInTypesKeywordRecommenderTests.vb
@@ -1,5 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports Microsoft.CodeAnalysis.Completion.Providers
+
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Recommendations.Types
     Public Class BuiltInTypesKeywordRecommenderTests
         Private ReadOnly _keywordList As String() = {
@@ -93,5 +95,22 @@ End Class
             Await VerifyRecommendationsMissingAsync(code, _keywordList)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)>
+        Public Async Function Preselection() As Task
+            Dim code =
+<File>
+Class Program
+    Sub Main(args As String())
+        Foo(|)
+    End Sub
+
+    Sub Foo(x As Integer)
+
+    End Sub
+End Class
+</File>
+
+            Await VerifyRecommendationsWithPriority(code, SymbolMatchPriority.Keyword, "Integer")
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Completion\CompletionProviders\SnippetCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\SpeculativeTCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\XmlDocCommentCompletionProvider.cs" />
+    <Compile Include="Completion\KeywordRecommenders\AbstractSpecialTypePreselectingKeywordRecommender.cs" />
     <Compile Include="Completion\KeywordRecommenders\LoadKeywordRecommender.cs" />
     <Compile Include="Completion\SuggestionMode\CSharpSuggestionModeCompletionProvider.cs" />
     <Compile Include="Completion\CompletionProviders\SymbolCompletionProvider.cs" />

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/EnumAndCompletionListTagCompletionProvider.cs
@@ -58,6 +58,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     return;
                 }
 
+                // Don't show up within member access
+                // This previously worked because the type inferrer didn't work
+                // in member access expressions.
+                if (token.IsKind(SyntaxKind.DotToken))
+                {
+                    return;
+                }
+
                 var typeInferenceService = document.GetLanguageService<ITypeInferenceService>();
                 Contract.ThrowIfNull(typeInferenceService, nameof(typeInferenceService));
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/KeywordCompletionProvider.cs
@@ -175,7 +175,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 span: span,
                 description: keyword.DescriptionFactory(CancellationToken.None),
                 glyph: Glyph.Keyword,
-                shouldFormatOnCommit: keyword.ShouldFormatOnCommit);
+                shouldFormatOnCommit: keyword.ShouldFormatOnCommit,
+                matchPriority: keyword.MatchPriority);
         }
 
         internal override TextSpan GetCurrentSpan(TextSpan span, SourceText text)

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/NamedParameterCompletionProvider.cs
@@ -97,7 +97,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     symbol: parameter,
                     descriptionPosition: token.SpanStart,
                     filterText: escapedName,
-                    rules: CompletionItemRules.Default));
+                    rules: CompletionItemRules.Default,
+                    matchPriority: SymbolMatchPriority.PreferNamedArgument));
             }
         }
 

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -109,16 +109,32 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
         private static CompletionItemRules s_importDirectiveRules =
             CompletionItemRules.Create(commitCharacterRules: ImmutableArray.Create(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, '.', ';')));
+        private static CompletionItemRules s_importDirectiveRules_Preselect = s_importDirectiveRules.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection);
+        private static CompletionItemRules s_PreselectionRules = CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection);
 
-        protected override CompletionItemRules GetCompletionItemRules(IReadOnlyList<ISymbol> symbols, AbstractSyntaxContext context)
+        protected override CompletionItemRules GetCompletionItemRules(List<ISymbol> symbols, AbstractSyntaxContext context, bool preselect)
         {
             if (context.IsInImportsDirective)
             {
-                return s_importDirectiveRules;
+                return preselect ? s_importDirectiveRules_Preselect : s_importDirectiveRules;
             }
             else
             {
-                return CompletionItemRules.Default;
+                return preselect ? s_PreselectionRules : CompletionItemRules.Default;
+            }
+        }
+
+        protected override CompletionItemRules GetCompletionItemRules(IReadOnlyList<ISymbol> symbols, AbstractSyntaxContext context)
+        {
+            // Unused
+            throw new NotImplementedException();
+        }
+
+        protected override CompletionItemSelectionBehavior PreselectedItemSelectionBehavior
+        {
+            get
+            {
+                return CompletionItemSelectionBehavior.HardSelection;
             }
         }
     }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -16,14 +16,22 @@ using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.LanguageServices;
+using System.Linq;
+using Microsoft.CodeAnalysis.Shared.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
-    internal partial class SymbolCompletionProvider : AbstractSymbolCompletionProvider
+    internal partial class SymbolCompletionProvider : AbstractRecommendationServiceBasedCompletionProvider
     {
         protected override Task<IEnumerable<ISymbol>> GetSymbolsWorker(AbstractSyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)
         {
             return Recommender.GetRecommendedSymbolsAtPositionAsync(context.SemanticModel, position, context.Workspace, options, cancellationToken);
+        }
+
+        protected override bool IsInstrinsic(ISymbol s)
+        {
+            var ts = s as ITypeSymbol;
+            return ts != null && ts.IsIntrinsicType();
         }
 
         protected override string GetInsertionText(ISymbol symbol, AbstractSyntaxContext context, char ch)

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/AbstractSpecialTypePreselectingKeywordRecommender.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
+
+namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
+{
+    internal abstract class AbstractSpecialTypePreselectingKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    {
+        public AbstractSpecialTypePreselectingKeywordRecommender(
+            SyntaxKind keywordKind, 
+            bool isValidInPreprocessorContext = false, 
+            bool shouldFormatOnCommit = false) 
+            : base(keywordKind, isValidInPreprocessorContext, shouldFormatOnCommit)
+        {
+        }
+
+        protected abstract SpecialType SpecialType { get; }
+
+        protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            return context.InferredTypes.Any(t => t.SpecialType == this.SpecialType);
+        }
+    }
+}

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/BoolKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/BoolKeywordRecommender.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
@@ -9,7 +11,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class BoolKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class BoolKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public BoolKeywordRecommender()
             : base(SyntaxKind.BoolKeyword)
@@ -44,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Boolean;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ByteKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ByteKeywordRecommender.cs
@@ -6,10 +6,12 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class ByteKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class ByteKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public ByteKeywordRecommender()
             : base(SyntaxKind.ByteKeyword)
@@ -46,5 +48,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Byte;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/CharKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/CharKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class CharKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class CharKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public CharKeywordRecommender()
             : base(SyntaxKind.CharKeyword)
@@ -44,5 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Char;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DecimalKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DecimalKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class DecimalKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class DecimalKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public DecimalKeywordRecommender()
             : base(SyntaxKind.DecimalKeyword)
@@ -44,5 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Decimal;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DoubleKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/DoubleKeywordRecommender.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading;
+using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -9,7 +11,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class DoubleKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class DoubleKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public DoubleKeywordRecommender()
             : base(SyntaxKind.DoubleKeyword)
@@ -44,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Double;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FloatKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/FloatKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class FloatKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class FloatKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public FloatKeywordRecommender()
             : base(SyntaxKind.FloatKeyword)
@@ -44,5 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Single;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IntKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/IntKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class IntKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class IntKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public IntKeywordRecommender()
             : base(SyntaxKind.IntKeyword)
@@ -45,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Int32;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LongKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/LongKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class LongKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class LongKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public LongKeywordRecommender()
             : base(SyntaxKind.LongKeyword)
@@ -45,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Int64;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ObjectKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ObjectKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class ObjectKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class ObjectKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public ObjectKeywordRecommender()
             : base(SyntaxKind.ObjectKeyword)
@@ -43,5 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Object;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SByteKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/SByteKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class SByteKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class SByteKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public SByteKeywordRecommender()
             : base(SyntaxKind.SByteKeyword)
@@ -45,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_SByte;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ShortKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ShortKeywordRecommender.cs
@@ -6,10 +6,12 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class ShortKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class ShortKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public ShortKeywordRecommender()
             : base(SyntaxKind.ShortKeyword)
@@ -45,5 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_Int16;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StringKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/StringKeywordRecommender.cs
@@ -6,10 +6,12 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class StringKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class StringKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public StringKeywordRecommender()
             : base(SyntaxKind.StringKeyword)
@@ -43,5 +45,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_String;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ThisKeywordRecommender.cs
@@ -92,5 +92,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 
             return true;
         }
+
+        protected override bool ShouldPreselect(CSharpSyntaxContext context, CancellationToken cancellationToken)
+        {
+            var outerType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken);
+            return context.InferredTypes.Any(t => t == outerType);
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UIntKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UIntKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class UIntKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class UIntKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public UIntKeywordRecommender()
             : base(SyntaxKind.UIntKeyword)
@@ -45,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_UInt32;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ULongKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/ULongKeywordRecommender.cs
@@ -6,10 +6,12 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class ULongKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class ULongKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public ULongKeywordRecommender()
             : base(SyntaxKind.ULongKeyword)
@@ -45,5 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_UInt64;
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UShortKeywordRecommender.cs
@@ -6,10 +6,11 @@ using Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Microsoft.CodeAnalysis.Shared.Extensions;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
 {
-    internal class UShortKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
+    internal class UShortKeywordRecommender : AbstractSpecialTypePreselectingKeywordRecommender
     {
         public UShortKeywordRecommender()
             : base(SyntaxKind.UShortKeyword)
@@ -45,5 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                     canBePartial: false,
                     cancellationToken: cancellationToken);
         }
+
+        protected override SpecialType SpecialType => SpecialType.System_UInt16;
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractKeywordCompletionProvider.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 description: keyword.DescriptionFactory(CancellationToken.None),
                 glyph: Glyph.Keyword,
                 tags: s_Tags,
-                matchPriority: keyword.ShouldPreselect ? MatchPriority.Preselect : MatchPriority.Default);
+                matchPriority: keyword.MatchPriority);
         }
 
         protected virtual async Task<IEnumerable<RecommendedKeyword>> RecommendKeywordsAsync(

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -60,10 +60,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected override CompletionItem CreateItem(string displayText, string insertionText, int position, List<ISymbol> symbols, AbstractSyntaxContext context, TextSpan span, bool preselect, SupportedPlatformData supportedPlatformData)
         {
             var matchPriority = preselect ? ComputeSymbolMatchPriority(symbols[0]) : MatchPriority.Default;
-            var rules = GetCompletionItemRules(symbols, context);
+            var rules = GetCompletionItemRules(symbols, context, preselect);
             if (preselect)
             {
-                rules = rules.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection);
+                rules = rules.WithSelectionBehavior(PreselectedItemSelectionBehavior);
             }
 
             return SymbolCompletionItem.Create(
@@ -78,6 +78,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 matchPriority: matchPriority,
                 rules: rules);
         }
+
+        protected abstract CompletionItemRules GetCompletionItemRules(List<ISymbol> symbols, AbstractSyntaxContext context, bool preselect);
+
+        protected abstract CompletionItemSelectionBehavior PreselectedItemSelectionBehavior { get; }
 
         protected abstract bool IsInstrinsic(ISymbol symbol);
 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Recommendations;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.Completion.Providers
+{
+    internal abstract class AbstractRecommendationServiceBasedCompletionProvider : AbstractSymbolCompletionProvider
+    {
+        protected override Task<IEnumerable<ISymbol>> GetSymbolsWorker(AbstractSyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)
+        {
+            var recommender = context.GetLanguageService<IRecommendationService>();
+            return recommender.GetRecommendedSymbolsAtPositionAsync(context.Workspace, context.SemanticModel, position, options, cancellationToken);
+        }
+
+        protected override async Task<IEnumerable<ISymbol>> GetPreselectedSymbolsWorker(AbstractSyntaxContext context, int position, OptionSet options, CancellationToken cancellationToken)
+        {
+            var recommender = context.GetLanguageService<IRecommendationService>();
+            var typeInferrer = context.GetLanguageService<ITypeInferenceService>();
+
+            var inferredTypes = typeInferrer.InferTypes(context.SemanticModel, position, cancellationToken)
+                .Where(t => t.SpecialType != SpecialType.System_Void)
+                .ToSet();
+            if (inferredTypes.Count == 0)
+            {
+                return SpecializedCollections.EmptyEnumerable<ISymbol>();
+            }
+
+            var symbols = await recommender.GetRecommendedSymbolsAtPositionAsync(
+                context.Workspace, 
+                context.SemanticModel, 
+                position, 
+                options, 
+                cancellationToken).ConfigureAwait(false);
+            return symbols.Where(s => inferredTypes.Contains(GetSymbolType(s)) && !IsInstrinsic(s));
+        }
+
+        private ITypeSymbol GetSymbolType(ISymbol symbol)
+        {
+            if (symbol is IMethodSymbol)
+            {
+                return ((IMethodSymbol)symbol).ReturnType;
+            }
+
+            return symbol.GetSymbolType();
+        }
+
+        protected override CompletionItem CreateItem(string displayText, string insertionText, int position, List<ISymbol> symbols, AbstractSyntaxContext context, TextSpan span, bool preselect, SupportedPlatformData supportedPlatformData)
+        {
+            var matchPriority = preselect ? ComputeSymbolMatchPriority(symbols[0]) : MatchPriority.Default;
+
+            return SymbolCompletionItem.Create(
+                displayText: displayText,
+                insertionText: insertionText,
+                filterText: GetFilterText(symbols[0], displayText, context),
+                span: span,
+                contextPosition: context.Position,
+                descriptionPosition: position,
+                symbols: symbols,
+                supportedPlatforms: supportedPlatformData,
+                matchPriority: matchPriority,
+                rules: GetCompletionItemRules(symbols, context));
+        }
+
+        protected abstract bool IsInstrinsic(ISymbol s);
+
+        private static int ComputeSymbolMatchPriority(ISymbol symbol)
+        {
+            if (symbol.MatchesKind(SymbolKind.Local, SymbolKind.Parameter, SymbolKind.RangeVariable))
+            {
+                return SymbolMatchPriority.PreferLocal;
+            }
+
+            if (symbol.MatchesKind(SymbolKind.Field, SymbolKind.Property))
+            {
+                return SymbolMatchPriority.PreferFieldOrProperty;
+            }
+
+            if (symbol.MatchesKind(SymbolKind.Event, SymbolKind.Method))
+            {
+                return SymbolMatchPriority.PreferEventOrMethod;
+            }
+
+            return SymbolMatchPriority.PreferType;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -42,6 +42,8 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 position, 
                 options, 
                 cancellationToken).ConfigureAwait(false);
+
+            // Don't preselect intrinsic type symbols so we can preselect their keywords instead.
             return symbols.Where(s => inferredTypes.Contains(GetSymbolType(s)) && !IsInstrinsic(s));
         }
 
@@ -72,13 +74,13 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 rules: GetCompletionItemRules(symbols, context));
         }
 
-        protected abstract bool IsInstrinsic(ISymbol s);
+        protected abstract bool IsInstrinsic(ISymbol symbol);
 
         private static int ComputeSymbolMatchPriority(ISymbol symbol)
         {
             if (symbol.MatchesKind(SymbolKind.Local, SymbolKind.Parameter, SymbolKind.RangeVariable))
             {
-                return SymbolMatchPriority.PreferLocal;
+                return SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable;
             }
 
             if (symbol.MatchesKind(SymbolKind.Field, SymbolKind.Property))

--- a/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractRecommendationServiceBasedCompletionProvider.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         protected override CompletionItem CreateItem(string displayText, string insertionText, int position, List<ISymbol> symbols, AbstractSyntaxContext context, TextSpan span, bool preselect, SupportedPlatformData supportedPlatformData)
         {
             var matchPriority = preselect ? ComputeSymbolMatchPriority(symbols[0]) : MatchPriority.Default;
+            var rules = GetCompletionItemRules(symbols, context);
+            if (preselect)
+            {
+                rules = rules.WithSelectionBehavior(CompletionItemSelectionBehavior.HardSelection);
+            }
 
             return SymbolCompletionItem.Create(
                 displayText: displayText,
@@ -71,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 symbols: symbols,
                 supportedPlatforms: supportedPlatformData,
                 matchPriority: matchPriority,
-                rules: GetCompletionItemRules(symbols, context));
+                rules: rules);
         }
 
         protected abstract bool IsInstrinsic(ISymbol symbol);

--- a/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
+++ b/src/Features/Core/Portable/Completion/Providers/RecommendedKeyword.cs
@@ -14,10 +14,10 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         public Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> DescriptionFactory { get; }
         public bool IsIntrinsic { get; }
         public bool ShouldFormatOnCommit { get; }
-        public bool ShouldPreselect { get; }
+        public int MatchPriority { get; }
 
-        public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false, bool shouldPreselect = false)
-            : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit, shouldPreselect)
+        public RecommendedKeyword(string keyword, string toolTip = "", Glyph glyph = Glyph.Keyword, bool isIntrinsic = false, bool shouldFormatOnCommit = false, int? matchPriority = null)
+            : this(keyword, glyph, _ => CreateDisplayParts(keyword, toolTip), isIntrinsic, shouldFormatOnCommit, matchPriority)
         {
         }
 
@@ -41,14 +41,14 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
               Func<CancellationToken, ImmutableArray<SymbolDisplayPart>> descriptionFactory,
               bool isIntrinsic = false,
               bool shouldFormatOnCommit = false,
-              bool shouldPreselect = false)
+              int? matchPriority = null)
         {
             this.Keyword = keyword;
             this.Glyph = glyph;
             this.DescriptionFactory = descriptionFactory;
             this.IsIntrinsic = isIntrinsic;
             this.ShouldFormatOnCommit = shouldFormatOnCommit;
-            this.ShouldPreselect = shouldPreselect;
+            this.MatchPriority = matchPriority ?? Completion.MatchPriority.Default;
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.CodeAnalysis.Completion.Providers
+{
+    internal class SymbolMatchPriority
+    {
+        internal static int Keyword = 100;
+        internal static int PreferType = 200;
+        internal static int PreferNamedArgument = 300;
+        internal static int PreferEventOrMethod = 400;
+        internal static int PreferFieldOrProperty = 500;
+        internal static int PreferLocal = 600;
+    }
+}

--- a/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
+++ b/src/Features/Core/Portable/Completion/Providers/SymbolMatchPriority.cs
@@ -13,6 +13,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         internal static int PreferNamedArgument = 300;
         internal static int PreferEventOrMethod = 400;
         internal static int PreferFieldOrProperty = 500;
-        internal static int PreferLocal = 600;
+        internal static int PreferLocalOrParameterOrRangeVariable = 600;
     }
 }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -191,6 +191,8 @@
     <Compile Include="Completion\CompletionService.cs" />
     <Compile Include="Completion\Providers\MemberInsertingCompletionItem.cs" />
     <Compile Include="Completion\MatchPriority.cs" />
+    <Compile Include="Completion\Providers\AbstractRecommendationServiceBasedCompletionProvider.cs" />
+    <Compile Include="Completion\Providers\SymbolMatchPriority.cs" />
     <Compile Include="Completion\Providers\UnionCompletionItemComparer.cs" />
     <Compile Include="Completion\Providers\AbstractKeywordCompletionProvider.cs" />
     <Compile Include="Completion\Providers\AbstractObjectCreationCompletionProvider.cs" />

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -34,8 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                     Return m.Kind = SymbolKind.Field AndAlso
                         DirectCast(m, IFieldSymbol).IsConst AndAlso
                         m.IsEditorBrowsable(hideAdvancedMembers, context.SemanticModel.Compilation)
-                End Function).ToList()
-            result.Add(enumType)
+                End Function)
 
             Return Task.FromResult(Of IEnumerable(Of ISymbol))(result)
         End Function

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
@@ -83,18 +83,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
         Private Shared s_importDirectiveRules As CompletionItemRules =
             CompletionItemRules.Create(commitCharacterRules:=ImmutableArray.Create(CharacterSetModificationRule.Create(CharacterSetModificationKind.Replace, "."c)))
+        Private Shared s_importDirectiveRules_preselect As CompletionItemRules =
+            s_importDirectiveRules.WithSelectionBehavior(CompletionItemSelectionBehavior.SoftSelection)
+        Private Shared s_preselectedCompletionItemRules As CompletionItemRules =
+            CompletionItemRules.Default.WithSelectionBehavior(CompletionItemSelectionBehavior.SoftSelection)
+
+        Protected Overrides Function GetCompletionItemRules(symbols As List(Of ISymbol), context As AbstractSyntaxContext, preselect As Boolean) As CompletionItemRules
+            If context.IsInImportsDirective Then
+                Return If(preselect, s_importDirectiveRules_preselect, s_importDirectiveRules)
+            Else
+                Return If(preselect, s_preselectedCompletionItemRules, CompletionItemRules.Default)
+            End If
+        End Function
 
         Protected Overrides Function GetCompletionItemRules(symbols As IReadOnlyList(Of ISymbol), context As AbstractSyntaxContext) As CompletionItemRules
-            If context.IsInImportsDirective Then
-                Return s_importDirectiveRules
-            Else
-                Return CompletionItemRules.Default
-            End If
+            ' Unused
+            Throw New NotImplementedException
         End Function
 
         Protected Overrides Function IsInstrinsic(s As ISymbol) As Boolean
             Return If(TryCast(s, ITypeSymbol)?.IsIntrinsicType(), False)
         End Function
+
+        Protected Overrides ReadOnly Property PreselectedItemSelectionBehavior As CompletionItemSelectionBehavior
+            Get
+                Return CompletionItemSelectionBehavior.SoftSelection
+            End Get
+        End Property
 
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
@@ -15,11 +15,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
 
     Partial Friend Class SymbolCompletionProvider
-        Inherits AbstractSymbolCompletionProvider
-
-        Protected Overrides Function GetSymbolsWorker(context As AbstractSyntaxContext, position As Integer, options As OptionSet, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of ISymbol))
-            Return Recommender.GetRecommendedSymbolsAtPositionAsync(context.SemanticModel, position, context.Workspace, options, cancellationToken)
-        End Function
+        Inherits AbstractRecommendationServiceBasedCompletionProvider
 
         Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
             Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
@@ -94,6 +90,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Else
                 Return CompletionItemRules.Default
             End If
+        End Function
+
+        Protected Overrides Function IsInstrinsic(s As ISymbol) As Boolean
+            Return If(TryCast(s, ITypeSymbol)?.IsIntrinsicType(), False)
         End Function
 
     End Class

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
@@ -18,11 +19,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
             If (context.IsAnyExpressionContext OrElse context.IsSingleLineStatementContext OrElse context.IsNameOfContext) AndAlso
                 targetToken.GetInnermostDeclarationContext().IsKind(SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) Then
 
+                Dim priority = MatchPriority.Default
+                Dim enclosingType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken)
+                If enclosingType IsNot Nothing AndAlso context.InferredTypes.Any(Function(t) t Is enclosingType) Then
+                    priority = SymbolMatchPriority.Keyword
+                End If
+
                 If targetToken.GetContainingMemberBlockBegin().TypeSwitch(
                     Function(methodBase As MethodBaseSyntax) Not methodBase.Modifiers.Any(SyntaxKind.SharedKeyword),
                     Function(propertyStatement As PropertyStatementSyntax) Not propertyStatement.Modifiers.Any(SyntaxKind.SharedKeyword),
                     Function(eventStatement As EventStatementSyntax) Not eventStatement.Modifiers.Any(SyntaxKind.SharedKeyword)) Then
-                    Return SpecializedCollections.SingletonEnumerable(New RecommendedKeyword(SyntaxFacts.GetText(SyntaxKind.MeKeyword), VBFeaturesResources.MeKeywordToolTip))
+
+                    Return SpecializedCollections.SingletonEnumerable(New RecommendedKeyword(SyntaxFacts.GetText(SyntaxKind.MeKeyword), VBFeaturesResources.MeKeywordToolTip, matchPriority:=priority))
                 End If
 
                 If targetToken.GetContainingMember().TypeSwitch(Function(fieldInitializer As FieldDeclarationSyntax) Not fieldInitializer.Modifiers.Any(SyntaxKind.SharedKeyword)) Then

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/MeKeywordRecommender.vb
@@ -19,6 +19,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
             If (context.IsAnyExpressionContext OrElse context.IsSingleLineStatementContext OrElse context.IsNameOfContext) AndAlso
                 targetToken.GetInnermostDeclarationContext().IsKind(SyntaxKind.ClassBlock, SyntaxKind.StructureBlock) Then
 
+                ' Preselect the Me kewyord when the target type is the same 
+                ' as the enclosing type symbol of the body we're typing in
+
                 Dim priority = MatchPriority.Default
                 Dim enclosingType = context.SemanticModel.GetEnclosingNamedType(context.Position, cancellationToken)
                 If enclosingType IsNot Nothing AndAlso context.InferredTypes.Any(Function(t) t Is enclosingType) Then

--- a/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
+++ b/src/Features/VisualBasic/Portable/Completion/KeywordRecommenders/Expressions/TrueFalseKeywordRecommender.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
 Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
@@ -13,11 +14,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.KeywordRecommenders.Expr
         Inherits AbstractKeywordRecommender
 
         Protected Overrides Function RecommendKeywords(context As VisualBasicSyntaxContext, cancellationToken As CancellationToken) As IEnumerable(Of RecommendedKeyword)
-            Dim preselect As Boolean = ShouldPreselect(context, cancellationToken)
+            Dim matchPriority = If(ShouldPreselect(context, cancellationToken), CodeAnalysis.Completion.MatchPriority.Preselect, CodeAnalysis.Completion.MatchPriority.Default)
 
             If context.IsAnyExpressionContext Then
-                Return {New RecommendedKeyword("True", VBFeaturesResources.TrueKeywordToolTip, shouldPreselect:=preselect),
-                        New RecommendedKeyword("False", VBFeaturesResources.FalseKeywordToolTip, shouldPreselect:=preselect)}
+                Return {New RecommendedKeyword("True", VBFeaturesResources.TrueKeywordToolTip, matchPriority:=matchPriority),
+                        New RecommendedKeyword("False", VBFeaturesResources.FalseKeywordToolTip, matchPriority:=matchPriority)}
             End If
 
             Return SpecializedCollections.EmptyEnumerable(Of RecommendedKeyword)()

--- a/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
+++ b/src/Features/VisualBasic/Portable/Completion/VisualBasicCompletionService.vb
@@ -92,8 +92,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion
 
         Protected Overrides Function GetBetterItem(item As CompletionItem, existingItem As CompletionItem) As CompletionItem
             ' If one Is a keyword, And the other Is some other item that inserts the same text as the keyword,
-            ' keep the keyword (VB only)
-            If IsKeywordItem(existingItem) Then
+            ' keep the keyword (VB only), unless the other item is preselected
+            If IsKeywordItem(existingItem) AndAlso existingItem.Rules.MatchPriority >= item.Rules.MatchPriority Then
                 Return existingItem
             End If
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/CSharpSyntaxContext.cs
@@ -4,10 +4,9 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using System;
-using Microsoft.CodeAnalysis.LanguageServices;
 
 namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 {
@@ -49,7 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public readonly bool IsCrefContext;
         public readonly bool IsCatchFilterContext;
         public readonly bool IsDestructorTypeContext;
-
 
         private CSharpSyntaxContext(
             Workspace workspace,

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.cs
@@ -98,5 +98,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 : namespaceUsings;
             return allUsings.Where(u => u.Alias != null);
         }
+
+        public static bool IsIntrinsicType(this ITypeSymbol typeSymbol)
+        {
+            switch (typeSymbol.SpecialType)
+            {
+                case SpecialType.System_Boolean:
+                case SpecialType.System_Char:
+                case SpecialType.System_SByte:
+                case SpecialType.System_Int16:
+                case SpecialType.System_Int32:
+                case SpecialType.System_Int64:
+                case SpecialType.System_Byte:
+                case SpecialType.System_UInt16:
+                case SpecialType.System_UInt32:
+                case SpecialType.System_UInt64:
+                case SpecialType.System_Single:
+                case SpecialType.System_Double:
+                // NOTE: VB treats System.DateTime as an intrinsic, while C# does not, see "predeftype.h"
+                //case SpecialType.System_DateTime:
+                case SpecialType.System_Decimal:
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/TypeInferenceService/AbstractTypeInferenceService.cs
@@ -74,6 +74,23 @@ namespace Microsoft.CodeAnalysis.LanguageServices.TypeInferenceService
                             .Distinct()
                             .ToImmutableReadOnlyListOrEmpty();
             }
+
+            protected IEnumerable<ITypeSymbol> ExpandParamsParameter(IParameterSymbol parameterSymbol)
+            {
+                var result = new List<ITypeSymbol>();
+                result.Add(parameterSymbol.Type);
+
+                if (parameterSymbol.IsParams)
+                {
+                    var arrayTypeSymbol = parameterSymbol.Type as IArrayTypeSymbol;
+                    if (arrayTypeSymbol != null)
+                    {
+                        result.Add(arrayTypeSymbol.ElementType);
+                    }
+                }
+
+                return result;
+            }
         }
 
         protected abstract AbstractTypeInferrer CreateTypeInferrer(SemanticModel semanticModel, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 
         public bool IsInQuery { get; }
         public bool IsInImportsDirective { get; }
-        public IEnumerable<ITypeSymbol> InferredTypes { get; private set; }
+        public IEnumerable<ITypeSymbol> InferredTypes { get; }
 
         private ISet<INamedTypeSymbol> ComputeOuterTypes(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
@@ -28,7 +29,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             bool isEnumTypeMemberAccessContext,
             bool isNameOfContext,
             bool isInQuery,
-            bool isInImportsDirective)
+            bool isInImportsDirective,
+            CancellationToken cancellationToken)
         {
             this.Workspace = workspace;
             this.SemanticModel = semanticModel;
@@ -48,6 +50,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
             this.IsNameOfContext = isNameOfContext;
             this.IsInQuery = isInQuery;
             this.IsInImportsDirective = isInImportsDirective;
+            this.InferredTypes = ComputeInferredTypes(workspace, semanticModel, position, cancellationToken);
         }
 
         public Workspace Workspace { get; }
@@ -74,6 +77,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 
         public bool IsInQuery { get; }
         public bool IsInImportsDirective { get; }
+        public IEnumerable<ITypeSymbol> InferredTypes { get; private set; }
 
         private ISet<INamedTypeSymbol> ComputeOuterTypes(CancellationToken cancellationToken)
         {
@@ -89,6 +93,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 
             return SpecializedCollections.EmptySet<INamedTypeSymbol>();
         }
+
+        protected IEnumerable<ITypeSymbol> ComputeInferredTypes(Workspace workspace,
+            SemanticModel semanticModel,
+            int position,
+            CancellationToken cancellationToken)
+        {
+            var typeInferenceService = workspace?.Services.GetLanguageServices(semanticModel.Language).GetService<ITypeInferenceService>()
+                ?? GetTypeInferenceServiceWithoutWorkspace();
+            return typeInferenceService.InferTypes(semanticModel, position, cancellationToken);
+        }
+
+        internal abstract ITypeInferenceService GetTypeInferenceServiceWithoutWorkspace();
 
         public ISet<INamedTypeSymbol> GetOuterTypes(CancellationToken cancellationToken)
         {

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ContextQuery/VisualBasicSyntaxContext.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Threading
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Utilities
@@ -93,7 +94,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 isEnumTypeMemberAccessContext:=isEnumTypeMemberAccessContext,
                 isNameOfContext:=isNameOfContext,
                 isInQuery:=isInQuery,
-                isInImportsDirective:=isInImportsDirective)
+                isInImportsDirective:=isInImportsDirective,
+                cancellationToken:=cancellationToken)
 
             Dim syntaxTree = semanticModel.SyntaxTree
 
@@ -270,6 +272,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
                 Position, TargetToken, Function(joinOperator) joinOperator.JoinedVariables.LastCollectionExpression(), cancellationToken)
         End Function
 
+        Friend Overrides Function GetTypeInferenceServiceWithoutWorkspace() As ITypeInferenceService
+            Return New VisualBasicTypeInferenceService()
+        End Function
     End Class
 End Namespace
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ITypeSymbolExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ITypeSymbolExtensions.vb
@@ -97,5 +97,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
             Return compilation.GetSpecialType(specialType)
         End Function
+
+        <Extension>
+        Public Function IsIntrinsicType(this As ITypeSymbol) As Boolean
+            Select Case this.SpecialType
+                Case SpecialType.System_Boolean,
+                     SpecialType.System_Byte,
+                     SpecialType.System_SByte,
+                     SpecialType.System_Int16,
+                     SpecialType.System_UInt16,
+                     SpecialType.System_Int32,
+                     SpecialType.System_UInt32,
+                     SpecialType.System_Int64,
+                     SpecialType.System_UInt64,
+                     SpecialType.System_Single,
+                     SpecialType.System_Double,
+                     SpecialType.System_Decimal,
+                     SpecialType.System_DateTime,
+                     SpecialType.System_Char,
+                     SpecialType.System_String
+                    Return True
+                Case Else
+                    Return False
+            End Select
+        End Function
     End Module
 End Namespace


### PR DESCRIPTION
This is https://github.com/dotnet/roslyn/pull/6878 merged against Matt's big completion refactoring--almost all of code is the same as before. Now, instead of a function called on a provider to determine which of its two items were better, the MatchPriority enum (should this be an int) now includes many levels of priority.

