### PR TITLE
Harden EnC against bugs in debugger/compiler to avoid VS crash

### DIFF
--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/DefinitionMap.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Symbols;
 using System.Reflection.Metadata.Ecma335;
 using Roslyn.Utilities;
+using System.IO;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -225,7 +226,22 @@ namespace Microsoft.CodeAnalysis.Emit
             {
                 // Method has not changed since initial generation. Generate a map
                 // using the local names provided with the initial metadata.
-                var debugInfo = baseline.DebugInformationProvider(previousHandle);
+                EditAndContinueMethodDebugInformation debugInfo;
+                try
+                {
+                    debugInfo = baseline.DebugInformationProvider(previousHandle);
+                }
+                catch (InvalidDataException)
+                {
+                    // TODO: localize message & use better error code (https://github.com/dotnet/roslyn/issues/11512): 
+                    diagnostics.Add(MessageProvider.CreateDiagnostic(
+                        MessageProvider.ERR_ModuleEmitFailure,
+                        method.Locations.First(),
+                        $"Unable to read debug information of method '{MessageProvider.GetErrorDisplayString(method)}' (token 0x{MetadataTokens.GetToken(previousHandle):X8}) " + 
+                        $"from assembly '{MessageProvider.GetErrorDisplayString(method.ContainingAssembly)}'"));
+
+                    return null;
+                }
 
                 methodId = new DebugId(debugInfo.MethodOrdinal, 0);
 

--- a/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
+++ b/src/Compilers/Core/Portable/Emit/EditAndContinue/EmitBaseline.cs
@@ -87,6 +87,8 @@ namespace Microsoft.CodeAnalysis.Emit
         /// <param name="module">The metadata of the module before editing.</param>
         /// <param name="debugInformationProvider">
         /// A function that for a method handle returns Edit and Continue debug information emitted by the compiler into the PDB.
+        /// The function shall throw <see cref="System.IO.InvalidDataException"/> if the debug information can't be read for the specified method.
+        /// This exception is caught and converted to an emit diagnostic. Other exceptions are passed through.
         /// </param>
         /// <returns>An <see cref="EmitBaseline"/> for the module.</returns>
         /// <remarks>
@@ -203,8 +205,9 @@ namespace Microsoft.CodeAnalysis.Emit
         internal readonly IReadOnlyDictionary<int, AddedOrChangedMethodInfo> AddedOrChangedMethods;
 
         /// <summary>
-        /// Local variable names for methods from metadata,
-        /// indexed by method row.
+        /// Reads EnC debug information of a method from the initial baseline PDB.
+        /// The function shall throw <see cref="System.IO.InvalidDataException"/> if the debug information can't be read for the specified method.
+        /// This exception is caught and converted to an emit diagnostic. Other exceptions are passed through.
         /// </summary>
         internal readonly Func<MethodDefinitionHandle, EditAndContinueMethodDebugInformation> DebugInformationProvider;
 

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
 using Roslyn.Utilities;
@@ -1028,12 +1029,7 @@ namespace Microsoft.CodeAnalysis
                     localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
                 }
             }
-            catch (UnsupportedSignatureContent)
-            {
-                localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
-                return false;
-            }
-            catch (BadImageFormatException)
+            catch (Exception e) when (e is UnsupportedSignatureContent || e is BadImageFormatException || e is IOException)
             {
                 localInfo = ImmutableArray<LocalInfo<TypeSymbol>>.Empty;
                 return false;

--- a/src/Features/Core/Portable/EditAndContinue/EditSession.cs
+++ b/src/Features/Core/Portable/EditAndContinue/EditSession.cs
@@ -388,9 +388,10 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
                     return new Deltas(ilStream.ToArray(), metadataStream.ToArray(), updateMethodTokens, pdbStream, changes.LineChanges, result);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
-                throw ExceptionUtilities.Unreachable;
+                // recover (cancel EnC)
+                return null;
             }
         }
 

--- a/src/Test/Utilities/Shared/Pdb/PdbTestUtilities.cs
+++ b/src/Test/Utilities/Shared/Pdb/PdbTestUtilities.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Immutable;
 using System.IO;
 using System.Reflection.Metadata;
 using Microsoft.CodeAnalysis;
@@ -16,7 +17,7 @@ namespace Roslyn.Test.Utilities
             var cdi = CustomDebugInfoUtilities.GetCustomDebugInfoBytes(symReader, handle, methodVersion: 1);
             if (cdi == null)
             {
-                return default(EditAndContinueMethodDebugInformation);
+                return EditAndContinueMethodDebugInformation.Create(default(ImmutableArray<byte>), default(ImmutableArray<byte>));
             }
 
             return GetEncMethodDebugInfo(cdi);

--- a/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/EditAndContinue/VsENCRebuildableProjectImpl.cs
@@ -976,6 +976,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
                 using (NonReentrantContext)
                 {
                     delta = emitTask.Result;
+
+                    if (delta == null)
+                    {
+                        // Non-fatal Watson has already been reported by the emit task
+                        return VSConstants.E_FAIL;
+                    }
                 }
 
                 var errorId = new EncErrorId(_encService.DebuggingSession, EditAndContinueDiagnosticUpdateSource.EmitErrorId);
@@ -1070,42 +1076,64 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.EditAndContinue
             return emitTask.Result;
         }
 
+        /// <summary>
+        /// Returns EnC debug information for initial version of the specified method.
+        /// </summary>
+        /// <exception cref="InvalidDataException">The debug information data is corrupt or can't be retrieved from the debugger.</exception>
         private EditAndContinueMethodDebugInformation GetBaselineEncDebugInfo(MethodDefinitionHandle methodHandle)
         {
             Debug.Assert(Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA);
-
             if (_pdbReader == null)
             {
                 // Unmarshal the symbol reader (being marshalled cross thread from STA -> MTA).
                 Debug.Assert(_pdbReaderObjAsStream != IntPtr.Zero);
                 object pdbReaderObjMta;
-                int hr = NativeMethods.GetObjectForStream(_pdbReaderObjAsStream, out pdbReaderObjMta);
-                _pdbReaderObjAsStream = IntPtr.Zero;
-                if (hr != VSConstants.S_OK)
+
+                var exception = Marshal.GetExceptionForHR(NativeMethods.GetObjectForStream(_pdbReaderObjAsStream, out pdbReaderObjMta));
+                if (exception != null)
                 {
-                    log.Write("Error unmarshaling object from stream.");
-                    return default(EditAndContinueMethodDebugInformation);
+                    // likely a bug in the compiler/debugger
+                    FatalError.ReportWithoutCrash(exception); 
+
+                    throw new InvalidDataException(exception.Message, exception);
                 }
+
+                _pdbReaderObjAsStream = IntPtr.Zero;
                 _pdbReader = (ISymUnmanagedReader)pdbReaderObjMta;
             }
 
             int methodToken = MetadataTokens.GetToken(methodHandle);
-            byte[] debugInfo = _pdbReader.GetCustomDebugInfoBytes(methodToken, methodVersion: 1);
-            if (debugInfo != null)
+
+            byte[] debugInfo;
+            try
             {
-                try
-                {
-                    var localSlots = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLocalSlotMap);
-                    var lambdaMap = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLambdaMap);
-                    return EditAndContinueMethodDebugInformation.Create(localSlots, lambdaMap);
-                }
-                catch (Exception e) when (e is InvalidOperationException || e is InvalidDataException)
-                {
-                    log.Write($"Error reading CDI of method 0x{methodToken:X8}: {e.Message}");
-                }
+                debugInfo = _pdbReader.GetCustomDebugInfoBytes(methodToken, methodVersion: 1);
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+            {
+                throw new InvalidDataException(e.Message, e);
             }
 
-            return default(EditAndContinueMethodDebugInformation);
+            try
+            {
+                ImmutableArray<byte> localSlots, lambdaMap;
+                if (debugInfo != null)
+                {
+                    localSlots = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLocalSlotMap);
+                    lambdaMap = CustomDebugInfoReader.TryGetCustomDebugInfoRecord(debugInfo, CustomDebugInfoKind.EditAndContinueLambdaMap);
+                }
+                else
+                {
+                    localSlots = lambdaMap = default(ImmutableArray<byte>);
+                }
+
+                return EditAndContinueMethodDebugInformation.Create(localSlots, lambdaMap);
+            }
+            catch (InvalidOperationException e) when (FatalError.ReportWithoutCrash(e)) // likely a bug in the compiler/debugger
+            {
+                // TODO: CustomDebugInfoReader should throw InvalidDataException
+                throw new InvalidDataException(e.Message, e);
+            }
         }
 
         public int EncApplySucceeded(int hrApplyResult)


### PR DESCRIPTION
This change implements error recovery in case we hit a bug in the debugger or a compiler that results in bad PDB data. Instead of crashing VS we report a not-fatal Watson and a diagnostic to the error list that informs the user that the debug information is bad.

This addresses crashes caused by bad marshalling of SymReader in the debugger (internal bug 187868) and IO exceptions while VS is running out of memory (internal bug 187908).

Additional work is needed in the debugger to address the root cause.