### PR TITLE
Fix bug in expression evaluator's logic to deal with multi-module ass…

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/MetadataUtilities.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
                 }
                 if (modulesByName == null)
                 {
-                    modulesByName = new Dictionary<string, ModuleMetadata>(); // Requires case-insensitive comparison?
+                    modulesByName = new Dictionary<string, ModuleMetadata>(StringComparer.OrdinalIgnoreCase); // Requires case-insensitive comparison
                 }
                 var name = metadata.Name;
                 modulesByName[name] = modulesByName.ContainsKey(name) ? null : metadata;


### PR DESCRIPTION
…emblies.

The 'modulesByName' dictionary needs to use case-insensitive comparison since the of the netmodule in the metadata of the netmodule
and the primary assembly might differ in case.

For example, consider a managed C++ application compiled as follows:

> cl /clr /Zi /LN Stringer.cpp
> cl /clr Client.cpp /Zi /link /ASSEMBLYMODULE:stringer.netmodule

The difference in casing between the two command-lines will cause subsequent lookups
of the netmodule's metadata by mvid to fail.  The eventual symptoms include missing text
in the breakpoints window and callstack window and expressions failing to evaluate.

The fix is to use case-insensitive comparison for the dictionary.
