### PR TITLE
Add support for IntPtr conversion in the call arguments optimizer.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -331,8 +331,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     return false;
 
                                 default:
-                                    // Unhandled conversion kind in reordering logic
-                                    throw ExceptionUtilities.UnexpectedValue(conv.ConversionKind);
+                                    // when this assert is hit, examine whether such conversion kind is 
+                                    // 1) actually expected to get this far
+                                    // 2) figure if it is possibly not producing or consuming any sideeffects (rare case)
+                                    // 3) add a case for it
+                                    Debug.Assert(false, "Unexpected conversion kind" + conv.ConversionKind);
+
+                                    // it is safe to assume that conversion is not reorderable
+                                    return false;
                             }
                             break;
                         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Call.cs
@@ -301,6 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConversionKind.MethodGroup:
                                 case ConversionKind.NullLiteral:
                                     return true;
+
                                 case ConversionKind.Boxing:
                                 case ConversionKind.ImplicitDynamic:
                                 case ConversionKind.ExplicitDynamic:
@@ -321,9 +322,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 case ConversionKind.IntegerToPointer:
                                     current = conv.Operand;
                                     break;
+
                                 case ConversionKind.ExplicitUserDefined:
                                 case ConversionKind.ImplicitUserDefined:
+                                // expression trees rewrite this later.
+                                // it is a kind of user defined conversions on IntPtr and in some cases can fail
+                                case ConversionKind.IntPtr:
                                     return false;
+
                                 default:
                                     // Unhandled conversion kind in reordering logic
                                     throw ExceptionUtilities.UnexpectedValue(conv.ConversionKind);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConversionTests.cs
@@ -995,5 +995,41 @@ class C
   IL_0030:  ret
 }");
         }
+
+        [Fact]
+        [WorkItem(11751, "https://github.com/dotnet/roslyn/issues/11751")]
+        public void ExprTreeCOM_IntPtr()
+        {
+            var source =
+@"
+using System;
+using System.Linq.Expressions;
+using System.Runtime.InteropServices;
+
+unsafe class Program
+{
+
+    static void Main(string[] args)
+    {
+        IntPtr y = new IntPtr();
+                
+        IAaa i = null;
+
+        Expression<Action> e = () =>  i.Test((ulong)y, null);
+    }
+}
+
+[ComImport]
+[Guid(""A88A175D-2448-447A-B786-64682CBEF156"")]
+public interface IAaa
+{
+    void Test(ulong y, object z);
+}
+
+";
+
+            var compilation = CreateCompilationWithMscorlib45AndCSruntime(source, options: TestOptions.ReleaseExe.WithAllowUnsafe(true));
+            CompileAndVerify(compilation);
+        }
     }
 }


### PR DESCRIPTION
IntPtr conversion can stay in the bound tree past lowering in a case where a COM method is invoked in an Expression Tree lambda.

Fixes: #11751