### PR TITLE
Adding back the PopulateSwitch tests.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -338,6 +338,8 @@
     <Compile Include="Outlining\RegionDirectiveOutlinerTests.cs" />
     <Compile Include="Outlining\SimpleLambdaExpressionOutlinerTests.cs" />
     <Compile Include="Outlining\TypeDeclarationOutlinerTests.cs" />
+    <Compile Include="PopulateSwitch\PopulateSwitchTests.cs" />
+    <Compile Include="PopulateSwitch\PopulateSwitchTests_FixAllTests.cs" />
     <Compile Include="QuickInfo\SemanticQuickInfoSourceTests.cs" />
     <Compile Include="QuickInfo\SyntacticQuickInfoSourceTests.cs" />
     <Compile Include="Semantics\SpeculationAnalyzerTests.cs" />

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
@@ -1,0 +1,934 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.PopulateSwitch;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwitch
+{
+    public partial class PopulateSwitchTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        internal override Tuple<DiagnosticAnalyzer, CodeFixProvider> CreateDiagnosticProviderAndFixer(Workspace workspace)
+        {
+            return new Tuple<DiagnosticAnalyzer, CodeFixProvider>(
+                new PopulateSwitchDiagnosticAnalyzer(), new PopulateSwitchCodeFixProvider());
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task AllMembersAndDefaultExist()
+        {
+            await TestMissingAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task AllMembersExist_NotDefault()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_NotDefault()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_WithDefault()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_NotDefault_EnumHasExplicitType()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum : long
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum : long
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_WithMembersAndDefaultInSection_NewValuesAboveDefaultSection()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                default:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.FizzBuzz:
+                    break;
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_WithMembersAndDefaultInSection_AssumesDefaultIsInLastSection()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                default:
+                    break;
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                default:
+                    break;
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NoMembersExist0()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                    break;
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+", index: 0);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NoMembersExist1()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NoMembersExist2()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                    break;
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task UsingStaticEnum_AllMembersExist()
+        {
+            await TestMissingAsync(
+            @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch ([|e|])
+            {
+                case CreateNew:
+                    break;
+                case Create:
+                    break;
+                case Open:
+                    break;
+                case OpenOrCreate:
+                    break;
+                case Truncate:
+                    break;
+                case Append:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task UsingStaticEnum_AllMembersExist_OutOfDefaultOrder()
+        {
+            await TestMissingAsync(
+            @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch ([|e|])
+            {
+                case CreateNew:
+                    break;
+                case OpenOrCreate:
+                    break;
+                case Truncate:
+                    break;
+                case Open:
+                    break;
+                case Append:
+                    break;
+                case Create:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task UsingStaticEnum_MembersExist()
+        {
+            await TestAsync(
+            @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch ([|e|])
+            {
+                case CreateNew:
+                    break;
+                case Create:
+                    break;
+                case Open:
+                    break;
+                case OpenOrCreate:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch (e)
+            {
+                case CreateNew:
+                    break;
+                case Create:
+                    break;
+                case Open:
+                    break;
+                case OpenOrCreate:
+                    break;
+                case Truncate:
+                    break;
+                case Append:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task UsingStaticEnum_NoMembersExist()
+        {
+            await TestAsync(
+            @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch ([|e|])
+            {
+            }
+        }
+    }
+}
+",
+                        @"
+using static System.IO.FileMode;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = Append;
+            switch (e)
+            {
+                case CreateNew:
+                    break;
+                case Create:
+                    break;
+                case Open:
+                    break;
+                case OpenOrCreate:
+                    break;
+                case Truncate:
+                    break;
+                case Append:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_NotDefault_EnumHasNonFlagsAttribute()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    [System.Obsolete]
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    [System.Obsolete]
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_NotDefault_EnumIsNested()
+        {
+            await TestAsync(
+            @"
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        enum MyEnum
+        {
+            Fizz, Buzz, FizzBuzz
+        }
+
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+            }
+        }
+    }
+}
+",
+                        @"
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        enum MyEnum
+        {
+            Fizz, Buzz, FizzBuzz
+        }
+
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_SwitchIsNotEnum()
+        {
+            await TestMissingAsync(
+            @"
+using System;
+namespace ConsoleApplication1
+{
+    class MyClass
+    {
+        void Method()
+        {
+            var e = ""test"";
+            switch ([|e|])
+            {
+                case ""test1"":
+                case ""test1"":
+                default:
+                    break;
+            }
+        }
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task NotAllMembersExist_NotDefault_UsingConstants()
+        {
+            await TestAsync(
+            @"
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ([|e|])
+            {
+                case (MyEnum)0:
+                case (MyEnum)1:
+                    break;
+            }
+        }
+    }
+",
+                        @"
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case (MyEnum)0:
+                case (MyEnum)1:
+                    break;
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+", index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        public async Task AllMissingTokens()
+        {
+            await TestAsync(
+            @"
+enum MyEnum
+{
+    Fizz
+}
+class MyClass
+{
+    void Method()
+    {
+        var e = MyEnum.Fizz;
+        switch ([|e|])
+    }
+}
+",
+            @"
+enum MyEnum
+{
+    Fizz
+}
+class MyClass
+{
+    void Method()
+    {
+        var e = MyEnum.Fizz;
+        switch (e)
+        {
+            case MyEnum.Fizz:
+                break;
+        }
+    }
+");
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
@@ -1,0 +1,491 @@
+﻿using Roslyn.Test.Utilities;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.PopulateSwitch
+{
+    public partial class PopulateSwitchTests : AbstractCSharpDiagnosticProviderBasedUserDiagnosticTest
+    {
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInDocument()
+        {
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ({|FixAllInDocument:e|})
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, compareTokens: false);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInProject()
+        {
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch ({|FixAllInProject:e|})
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum.Fizz;
+            switch (e)
+            {
+                case MyEnum.Fizz:
+                case MyEnum.Buzz:
+                case MyEnum.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, compareTokens: false);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        [Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)]
+        public async Task TestFixAllInSolution()
+        {
+            var input = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum1
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum1.Fizz;
+            switch ({|FixAllInSolution:e|})
+            {
+                case MyEnum1.Fizz:
+                case MyEnum1.Buzz:
+                case MyEnum1.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum2
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum2.Fizz;
+            switch (e)
+            {
+                case MyEnum2.Fizz:
+                case MyEnum2.Buzz:
+                case MyEnum2.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication2
+{
+    enum MyEnum3
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum3.Fizz;
+            switch (e)
+            {
+                case MyEnum3.Fizz:
+                case MyEnum3.Buzz:
+                case MyEnum3.FizzBuzz:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            var expected = @"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum1
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass1
+    {
+        void Method()
+        {
+            var e = MyEnum1.Fizz;
+            switch (e)
+            {
+                case MyEnum1.Fizz:
+                case MyEnum1.Buzz:
+                case MyEnum1.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+        <Document>
+namespace ConsoleApplication1
+{
+    enum MyEnum2
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass2
+    {
+        void Method()
+        {
+            var e = MyEnum2.Fizz;
+            switch (e)
+            {
+                case MyEnum2.Fizz:
+                case MyEnum2.Buzz:
+                case MyEnum2.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+    <Project Language=""C#"" AssemblyName=""Assembly2"" CommonReferences=""true"">
+        <Document>
+namespace ConsoleApplication2
+{
+    enum MyEnum3
+    {
+        Fizz, Buzz, FizzBuzz
+    }
+    class MyClass3
+    {
+        void Method()
+        {
+            var e = MyEnum3.Fizz;
+            switch (e)
+            {
+                case MyEnum3.Fizz:
+                case MyEnum3.Buzz:
+                case MyEnum3.FizzBuzz:
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+
+            await TestAsync(input, expected, compareTokens: false);
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -329,6 +329,8 @@
     <Compile Include="Outlining\RegionDirectiveOutlinerTests.vb" />
     <Compile Include="Outlining\TypeDeclarationOutlinerTests.vb" />
     <Compile Include="Outlining\XmlExpressionOutlinerTests.vb" />
+    <Compile Include="PopulateSwitch\PopulateSwitchTests.vb" />
+    <Compile Include="PopulateSwitch\PopulateSwitchTests_FixAllTests.vb" />
     <Compile Include="QuickInfo\SemanticQuickInfoSourceTests.vb" />
     <Compile Include="Recommendations\ArrayStatements\EraseKeywordRecommenderTests.vb" />
     <Compile Include="Recommendations\ArrayStatements\PreserveKeywordRecommenderTests.vb" />

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests.vb
@@ -1,0 +1,660 @@
+﻿Imports Microsoft.CodeAnalysis.CodeFixes
+Imports Microsoft.CodeAnalysis.Diagnostics
+Imports Microsoft.CodeAnalysis.PopulateSwitch
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.PopulateSwitch
+    Partial Public Class PopulateSwitchTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        Friend Overrides Function CreateDiagnosticProviderAndFixer(workspace As Workspace) As Tuple(Of DiagnosticAnalyzer, CodeFixProvider)
+            Return New Tuple(Of DiagnosticAnalyzer, CodeFixProvider)(
+                New PopulateSwitchDiagnosticAnalyzer(), New PopulateSwitchCodeFixProvider())
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function AllMembersAndElseExist() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function AllMembersExist_NotElse() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_NotElse() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_WithElse() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_NotElse_EnumHasExplicitType() As Task
+            Dim markup =
+<File>
+Enum MyEnum As Long
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum As Long
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_WithMembersAndElseInBlock_NewValuesAboveElseBlock() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz ' not legal.  VB does not allow fallthrough.
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz ' not legal.  VB does not allow fallthrough.
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NoMembersExist() As Task
+            Dim markup =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function ImportsEnum_AllMembersExist() As Task
+            Dim markup =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case [|e|]
+            Case CreateNew
+                Exit Select
+            Case Create
+                Exit Select
+            Case Open
+                Exit Select
+            Case OpenOrCreate
+                Exit Select
+            Case Truncate
+                Exit Select
+            Case Append
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function ImportsEnum_AllMembersExist_OutOfDefaultOrder() As Task
+            Dim markup =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case [|e|]
+            Case Truncate
+                Exit Select
+            Case Append
+                Exit Select
+            Case CreateNew
+                Exit Select
+            Case Open
+                Exit Select
+            Case OpenOrCreate
+                Exit Select
+            Case Create
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestMissingAsync(markup)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function ImportsEnum_NotAllMembersExist() As Task
+            Dim markup =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case [|e|]
+            Case CreateNew
+                Exit Select
+            Case Create
+                Exit Select
+            Case Open
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case e
+            Case CreateNew
+                Exit Select
+            Case Create
+                Exit Select
+            Case Open
+                Exit Select
+            Case OpenOrCreate
+                Exit Select
+            Case Truncate
+                Exit Select
+            Case Append
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, compareTokens:=False)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function ImportsEnum_NoMembersExist() As Task
+            Dim markup =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case [|e|]
+            
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Imports System.IO.FileMode
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = CreateNew
+        Select Case e
+            Case CreateNew
+                Exit Select
+            Case Create
+                Exit Select
+            Case Open
+                Exit Select
+            Case OpenOrCreate
+                Exit Select
+            Case Truncate
+                Exit Select
+            Case Append
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_EnumHasNonFlagsAttribute() As Task
+            Dim markup =
+<File>
+&lt;System.Obsolete&gt;
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+&lt;System.Obsolete&gt;
+Enum MyEnum
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_EnumIsNested() As Task
+            Dim markup =
+<File>
+Class Foo
+    Enum MyEnum
+        Fizz
+        Buzz
+        FizzBuzz
+    End Enum
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case [|e|]
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Dim expected =
+<File>
+Class Foo
+    Enum MyEnum
+        Fizz
+        Buzz
+        FizzBuzz
+    End Enum
+    Sub Bar()
+        Dim e = MyEnum.Fizz
+        Select Case e
+            Case MyEnum.Fizz
+                Exit Select
+            Case MyEnum.Buzz
+                Exit Select
+            Case MyEnum.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected, index:=2)
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        Public Async Function NotAllMembersExist_SwitchIsNotEnum() As Task
+            Dim markup =
+<File>
+Class Foo
+    Sub Bar()
+        Dim e = "Test"
+        Select Case [|e|]
+            Case "Fizz"
+                Exit Select
+            Case "Test"
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+            Dim expected =
+<File>
+Class Foo
+    Sub Bar()
+        Dim e = "Test"
+        Select Case e
+            Case "Fizz"
+                Exit Select
+            Case "Test"
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class
+</File>
+
+            Await TestAsync(markup, expected)
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.vb
@@ -1,0 +1,460 @@
+﻿Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Diagnostics.PopulateSwitch
+    Partial Public Class PopulateSwitchTests
+        Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
+        Public Async Function TestFixAllInDocument() As Task
+            Dim input = <Workspace>
+                            <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case {|FixAllInDocument:e|}
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+
+        Select Case e
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                                <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                            <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                <ProjectReference>Assembly1</ProjectReference>
+                                <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                        </Workspace>.ToString()
+
+            Dim expected = <Workspace>
+                               <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                   <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case e
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+
+        Select Case e
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                                   <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                               <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                   <ProjectReference>Assembly1</ProjectReference>
+                                   <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                           </Workspace>.ToString()
+
+            Await TestAsync(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
+        End Function
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
+        Public Async Function TestFixAllInProject() As Task
+            Dim input = <Workspace>
+                            <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case {|FixAllInProject:e|}
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                                <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.Buzz
+                Exit Select
+            Case MyEnum2.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                            <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                <ProjectReference>Assembly1</ProjectReference>
+                                <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+            Case MyEnum3.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                        </Workspace>.ToString()
+
+            Dim expected = <Workspace>
+                               <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                   <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case e
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                                   <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.Buzz
+                Exit Select
+            Case MyEnum2.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                               <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                   <ProjectReference>Assembly1</ProjectReference>
+                                   <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+            Case MyEnum3.FizzBuzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                           </Workspace>.ToString()
+
+            Await TestAsync(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
+        End Function
+
+        <Fact>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)>
+        <Trait(Traits.Feature, Traits.Features.CodeActionsFixAllOccurrences)>
+        Public Async Function TestFixAllInSolution() As Task
+            Dim input = <Workspace>
+                            <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case {|FixAllInSolution:e|}
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                                <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                            <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                <ProjectReference>Assembly1</ProjectReference>
+                                <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                </Document>
+                            </Project>
+                        </Workspace>.ToString()
+
+            Dim expected = <Workspace>
+                               <Project Language="Visual Basic" AssemblyName="Assembly1" CommonReferences="true">
+                                   <Document><![CDATA[
+Enum MyEnum1
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum1.Fizz
+        Select Case e
+            Case MyEnum1.Fizz
+                Exit Select
+            Case MyEnum1.Buzz
+                Exit Select
+            Case MyEnum1.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                                   <Document><![CDATA[
+Enum MyEnum2
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum2.Fizz
+        Select Case e
+            Case MyEnum2.Fizz
+                Exit Select
+            Case MyEnum2.Buzz
+                Exit Select
+            Case MyEnum2.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                               <Project Language="Visual Basic" AssemblyName="Assembly2" CommonReferences="true">
+                                   <ProjectReference>Assembly1</ProjectReference>
+                                   <Document><![CDATA[
+Enum MyEnum3
+    Fizz
+    Buzz
+    FizzBuzz
+End Enum
+Class Foo
+    Sub Bar()
+        Dim e = MyEnum3.Fizz
+        Select Case e
+            Case MyEnum3.Fizz
+                Exit Select
+            Case MyEnum3.Buzz
+                Exit Select
+            Case MyEnum3.FizzBuzz
+                Exit Select
+            Case Else
+                Exit Select
+        End Select
+    End Sub
+End Class]]>
+                                   </Document>
+                               </Project>
+                           </Workspace>.ToString()
+
+            Await TestAsync(input, expected, compareTokens:=False, fixAllActionEquivalenceKey:=Nothing)
+        End Function
+    End Class
+End Namespace


### PR DESCRIPTION
These got removed through a series of unfortunate merges.  Back when we disabled PopulateSwitch in master we deleted these.  When we merged future back into master they stayed deleted. :(