### PR TITLE
Throw BadImageFormatException decoding TypeRef with resolution scope with nil AssemblyRef

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataDecoder.cs
@@ -504,9 +504,13 @@ namespace Microsoft.CodeAnalysis
 
             if (tokenType == HandleKind.AssemblyReference)
             {
-                // TODO: Can refer to the containing assembly?
                 isNoPiaLocalType = false;
-                return LookupTopLevelTypeDefSymbol(Module.GetAssemblyReferenceIndexOrThrow((AssemblyReferenceHandle)tokenResolutionScope), ref fullName);
+                var assemblyRef = (AssemblyReferenceHandle)tokenResolutionScope;
+                if (assemblyRef.IsNil)
+                {
+                    throw new BadImageFormatException();
+                }
+                return LookupTopLevelTypeDefSymbol(Module.GetAssemblyReferenceIndexOrThrow(assemblyRef), ref fullName);
             }
 
             if (tokenType == HandleKind.ModuleReference)


### PR DESCRIPTION
Throw BadImageFormatException decoding TypeRef with resolution scope with nil AssemblyRef.

BadImageFormatException is handled by callers and the type is typically treated as an error type. Previously the nil AssemblyRef would result in an unhandled IndexOutOfRangeException.

Fixes #217689.