### PR TITLE
Missed Nameof usage in Update SyntaxList`1.cs

### DIFF
--- a/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxList`1.cs
@@ -265,7 +265,7 @@ namespace Microsoft.CodeAnalysis
             }
             else
             {
-                throw new ArgumentException("nodeInList");
+                throw new ArgumentException(nameof(nodeInList));
             }
         }
 


### PR DESCRIPTION
Utilise `nameof`