### PR TITLE
Add namespace-name suggestions for C#

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SuggestionModeCompletionProviderTests.cs
@@ -590,6 +590,22 @@ class a
             await VerifyBuilderAsync(markup);
         }
 
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceDeclaration_Unqualified()
+        {
+            var markup = @"namespace $$";
+            await VerifyBuilderAsync(markup);
+        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceDeclaration_Qualified()
+        {
+            var markup = @"namespace A.$$";
+            await VerifyBuilderAsync(markup);
+        }
+
         private async Task VerifyNotBuilderAsync(string markup)
         {
             await VerifyWorkerAsync(markup, isBuilder: false);

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -369,19 +369,165 @@ class CL {}";
             await VerifyItemExistsAsync(AddUsingDirectives("using System;", content), @"System");
         }
 
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task NamespaceName1()
+        public async Task NamespaceName_Unqualified_TopLevelNoPeers()
         {
-            await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"namespace $$"), @"String");
-            await VerifyItemIsAbsentAsync(AddUsingDirectives("using System;", @"namespace $$"), @"System");
+            var source = @"using System;
+
+namespace $$";
+
+            await VerifyItemExistsAsync(source, "System");
+            await VerifyItemIsAbsentAsync(source, "String");
         }
 
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-        public async Task NamespaceName2()
+        public async Task NamespaceName_Unqualified_TopLevelWithPeer()
         {
-            await VerifyItemIsAbsentAsync(@"namespace $$", @"String");
-            await VerifyItemIsAbsentAsync(@"namespace $$", @"System");
+            var source = @"
+namespace A { }
+
+namespace $$";
+
+            await VerifyItemExistsAsync(source, "A");
         }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Unqualified_NestedWithNoPeers()
+        {
+            var source = @"
+namespace A
+{
+    namespace $$
+}";
+
+            await VerifyNoItemsExistAsync(source);
+        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Unqualified_NestedWithPeer()
+        {
+            var source = @"
+namespace A
+{
+    namespace B { }
+
+    namespace $$
+}";
+
+            await VerifyItemIsAbsentAsync(source, "A");
+            await VerifyItemExistsAsync(source, "B");
+        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Unqualified_ExcludesCurrentDeclaration()
+        {
+            var source = @"namespace N$$S";
+
+            await VerifyItemIsAbsentAsync(source, "NS");
+        }
+
+//        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+//        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+//        public async Task NamespaceName_Unqualified_IncompleteDeclaration()
+//        {
+//            var source = @"
+//namespace A.B.C0 { }
+//
+//namespace A
+//{
+//    namespace B
+//    {
+//        namespace C$$
+//
+//        namespace C1.X { }
+//    }
+//
+//    namespace B.C2.Y { }
+//}
+//
+//namespace A.B.C3.Z { }";
+//
+//            await VerifyItemIsAbsentAsync(source, "C0");
+//            await VerifyItemExistsAsync(source, "C1");
+//            await VerifyItemExistsAsync(source, "C2");
+//            await VerifyItemExistsAsync(source, "C3");
+//            await VerifyItemIsAbsentAsync(source, "X");
+//            await VerifyItemIsAbsentAsync(source, "Y");
+//            await VerifyItemIsAbsentAsync(source, "Z");
+//        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Qualified_NoPeers()
+        {
+            var source = @"namespace A.$$";
+
+            await VerifyNoItemsExistAsync(source);
+        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Qualified_TopLevelWithPeer()
+        {
+            var source = @"
+namespace A.B { }
+
+namespace A.$$";
+
+            await VerifyItemExistsAsync(source, "B");
+        }
+
+        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task NamespaceName_Qualified_NestedWithPeer()
+        {
+            var source = @"
+namespace A
+{
+    namespace B.C { }
+
+    namespace B.$$
+}";
+
+            await VerifyItemIsAbsentAsync(source, "A");
+            await VerifyItemIsAbsentAsync(source, "B");
+            await VerifyItemExistsAsync(source, "C");
+        }
+
+//        [WorkItem(7213, "https://github.com/dotnet/roslyn/issues/7213")]
+//        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+//        public async Task NamespaceName_Qualified_IncompleteDeclaration()
+//        {
+//            var source = @"
+//namespace A.B.C.D0 { }
+//
+//namespace A
+//{
+//    namespace B
+//    {
+//        namespace C.D$$
+//
+//        namespace C.D1.X { }
+//    }
+//
+//    namespace B.C.D2.Y { }
+//}
+//
+//namespace A.B.C.D3.Z { }";
+//
+//            await VerifyItemIsAbsentAsync(source, "D0");
+//            await VerifyItemExistsAsync(source, "D1");
+//            await VerifyItemExistsAsync(source, "D2");
+//            await VerifyItemExistsAsync(source, "D3");
+//            await VerifyItemIsAbsentAsync(source, "X");
+//            await VerifyItemIsAbsentAsync(source, "Y");
+//            await VerifyItemIsAbsentAsync(source, "Z");
+//        }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
         public async Task UnderNamespace()

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SnippetCompletionProvider.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     return SpecializedCollections.EmptyEnumerable<CompletionItem>();
                 }
 
-                return await GetSnippetCompletionItemsAsync(workspace, semanticModel, position, itemSpan, isPreProcessorContext: true, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return await GetSnippetCompletionItemsAsync(workspace, semanticModel, itemSpan, isPreProcessorContext: true, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             if (semanticFacts.IsGlobalStatementContext(semanticModel, position, cancellationToken) ||
@@ -119,16 +119,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 semanticFacts.IsTypeContext(semanticModel, position, cancellationToken) ||
                 semanticFacts.IsTypeDeclarationContext(semanticModel, position, cancellationToken) ||
                 semanticFacts.IsNamespaceContext(semanticModel, position, cancellationToken) ||
+                semanticFacts.IsNamespaceDeclarationNameContext(semanticModel, position, cancellationToken) ||
                 semanticFacts.IsMemberDeclarationContext(semanticModel, position, cancellationToken) ||
                 semanticFacts.IsLabelContext(semanticModel, position, cancellationToken))
             {
-                return await GetSnippetCompletionItemsAsync(workspace, semanticModel, position, itemSpan, isPreProcessorContext: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+                return await GetSnippetCompletionItemsAsync(workspace, semanticModel, itemSpan, isPreProcessorContext: false, cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             return SpecializedCollections.EmptyEnumerable<CompletionItem>();
         }
 
-        private async Task<IEnumerable<CompletionItem>> GetSnippetCompletionItemsAsync(Workspace workspace, SemanticModel semanticModel, int position, TextSpan itemSpan, bool isPreProcessorContext, CancellationToken cancellationToken)
+        private async Task<IEnumerable<CompletionItem>> GetSnippetCompletionItemsAsync(Workspace workspace, SemanticModel semanticModel, TextSpan itemSpan, bool isPreProcessorContext, CancellationToken cancellationToken)
         {
             var service = _snippetInfoService ?? workspace.Services.GetLanguageServices(semanticModel.Language).GetService<ISnippetInfoService>();
             if (service == null)

--- a/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
@@ -59,6 +59,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.SuggestionMode
                 {
                     return CreateSuggestionModeItem(CSharpFeaturesResources.RangeVariable, itemSpan, CSharpFeaturesResources.AutoselectDisabledDueToPotentialRangeVariableDecl);
                 }
+                else if (tree.IsNamespaceDeclarationNameContext(position, cancellationToken))
+                {
+                    return CreateEmptySuggestionModeItem(itemSpan);
+                }
             }
 
             return null;

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTreeExtensions.cs
@@ -114,13 +114,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         public static bool IsNamespaceDeclarationNameContext(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)
         {
             var token = syntaxTree.FindTokenOnLeftOfPosition(position, cancellationToken);
-            var namespaceName = token.GetAncestor<NamespaceDeclarationSyntax>();
-            if (namespaceName == null)
+            var namespaceDeclaration = token.GetAncestor<NamespaceDeclarationSyntax>();
+            if (namespaceDeclaration == null)
             {
                 return false;
             }
 
-            return namespaceName.Name.Span.IntersectsWith(position);
+            return namespaceDeclaration.Name.Span.IntersectsWith(position) || token == namespaceDeclaration.NamespaceKeyword;
         }
 
         public static bool IsRightOfDotOrArrowOrColonColon(this SyntaxTree syntaxTree, int position, CancellationToken cancellationToken)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSemanticFactsService.cs
@@ -60,6 +60,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return semanticModel.SyntaxTree.IsNamespaceContext(position, cancellationToken, semanticModel);
         }
 
+        public bool IsNamespaceDeclarationNameContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
+        {
+            return semanticModel.SyntaxTree.IsNamespaceDeclarationNameContext(position, cancellationToken);
+        }
+
         public bool IsTypeDeclarationContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken)
         {
             return semanticModel.SyntaxTree.IsTypeDeclarationContext(

--- a/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SemanticsFactsService/ISemanticFactsService.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         bool IsStatementContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         bool IsTypeContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         bool IsNamespaceContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
+        bool IsNamespaceDeclarationNameContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         bool IsTypeDeclarationContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         bool IsMemberDeclarationContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);
         bool IsPreProcessorDirectiveContext(SemanticModel semanticModel, int position, CancellationToken cancellationToken);

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ContextQuery/AbstractSyntaxContext.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.CodeAnalysis.Host;
-using Microsoft.CodeAnalysis.LanguageServices;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
@@ -105,6 +105,16 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
         public TService GetWorkspaceService<TService>() where TService : class, IWorkspaceService
         {
             return this.Workspace.Services.GetService<TService>();
+        }
+
+        public bool IntersectsWith(Location location)
+        {
+            if (location == null)
+            {
+                throw new ArgumentNullException(nameof(location));
+            }
+
+            return location.SourceTree == SyntaxTree && location.SourceSpan.IntersectsWith(Position);
         }
     }
 }

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSemanticFactsService.vb
@@ -243,5 +243,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Public Function IsNameOfContext(semanticModel As SemanticModel, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISemanticFactsService.IsNameOfContext
             Return semanticModel.SyntaxTree.IsNameOfContext(position, cancellationToken)
         End Function
+
+        Public Function IsNamespaceDeclarationNameContext(semanticModel As SemanticModel, position As Integer, cancellationToken As CancellationToken) As Boolean Implements ISemanticFactsService.IsNamespaceDeclarationNameContext
+            '
+            ' TODO: part of https://github.com/dotnet/roslyn/issues/7213
+            '
+            Return False
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
This updates `CSharpRecommendationService` and `SuggestionModeCompletionProvider` to understand namespace declarations, and suggest existing namespaces as the user types.

A few notes:
- This inherits the `SymbolCompletionProvider` behaviour, so the completion list is only displayed when the user starts typing the name.
- This does not handle subsequent namespaces declarations in the same file which may be parsed incorrectly. [See the discussion here.](https://github.com/dotnet/roslyn/issues/7213#issuecomment-223830507) I've left two commented-out tests in the PR for now, but I'll remove them if nobody demands this case be handled.
- I updated the `SnippetCompletionProvider` to add its items when suggesting the first part of the namespace name. Please let me know if that's ok.
