### PR TITLE
Remove 'missing dependencies ok' flag from crossgen script

### DIFF
--- a/build/scripts/crossgen.sh
+++ b/build/scripts/crossgen.sh
@@ -38,8 +38,7 @@ chmod +x crossgen
 
 ./crossgen -nologo -platform_assemblies_paths $BIN_DIR System.Reflection.Metadata.dll
 
-# The bootstrap build is currently not copying a dependency. See dotnet/roslyn #7907
-./crossgen -nologo -MissingDependenciesOK -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
+./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.dll
 
 ./crossgen -nologo -platform_assemblies_paths $BIN_DIR Microsoft.CodeAnalysis.CSharp.dll
 


### PR DESCRIPTION
Our project.json should now include all Roslyn dependencies, including
reflection dependencies, so this flag shouldn't be necessary. Fixes #7907