### PR TITLE
Make 'SplitStringLiteral' fully synchronous.

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -24,12 +25,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
         internal class Indenter : AbstractIndenter
         {
             public Indenter(
+                ISyntaxFactsService syntaxFacts,
                 SyntaxTree syntaxTree,
                 IEnumerable<IFormattingRule> rules,
                 OptionSet optionSet,
                 TextLine line,
                 CancellationToken cancellationToken) :
-                base(syntaxTree, rules, optionSet, line, cancellationToken)
+                base(syntaxFacts, syntaxTree, rules, optionSet, line, cancellationToken)
             {
             }
 

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.Indenter.cs
@@ -24,12 +24,12 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
         internal class Indenter : AbstractIndenter
         {
             public Indenter(
-                SyntacticDocument document,
+                SyntaxTree syntaxTree,
                 IEnumerable<IFormattingRule> rules,
                 OptionSet optionSet,
                 TextLine line,
                 CancellationToken cancellationToken) :
-                base(document, rules, optionSet, line, cancellationToken)
+                base(syntaxTree, rules, optionSet, line, cancellationToken)
             {
             }
 

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -31,9 +32,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
         }
 
         protected override AbstractIndenter GetIndenter(
-            SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
+            ISyntaxFactsService syntaxFacts, SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
         {
-            return new Indenter(syntaxTree, formattingRules, optionSet, lineToBeIndented, cancellationToken);
+            return new Indenter(
+                syntaxFacts, syntaxTree, formattingRules,
+                optionSet, lineToBeIndented, cancellationToken);
         }
 
         protected override bool ShouldUseSmartTokenFormatterInsteadOfIndenter(

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -30,11 +30,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             return s_instance;
         }
 
-        protected override async Task<AbstractIndenter> GetIndenterAsync(
-            Document document, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
+        protected override AbstractIndenter GetIndenter(
+            SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken)
         {
-            var syntacticDocument = await SyntacticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(false);
-            return new Indenter(syntacticDocument, formattingRules, optionSet, lineToBeIndented, cancellationToken);
+            return new Indenter(syntaxTree, formattingRules, optionSet, lineToBeIndented, cancellationToken);
         }
 
         protected override bool ShouldUseSmartTokenFormatterInsteadOfIndenter(

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.InterpolatedStringSplitter.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
             public InterpolatedStringSplitter(
                 Document document, int position,
-                SyntaxTree syntaxTree, SyntaxNode root, SourceText sourceText,
+                SyntaxNode root, SourceText sourceText,
                 InterpolatedStringExpressionSyntax interpolatedStringExpression,
                 bool useTabs, int tabSize, CancellationToken cancellationToken)
-                : base(document, position, syntaxTree, root, sourceText, useTabs, tabSize, cancellationToken)
+                : base(document, position, root, sourceText, useTabs, tabSize, cancellationToken)
             {
                 _interpolatedStringExpression = interpolatedStringExpression;
             }

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.SimpleStringSplitter.cs
@@ -12,8 +12,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             private const char QuoteCharacter = '"';
             private readonly SyntaxToken _token;
 
-            public SimpleStringSplitter(Document document, int position, SyntaxTree syntaxTree, SyntaxNode root, SourceText sourceText, SyntaxToken token, bool useTabs, int tabSize, CancellationToken cancellationToken)
-                : base(document, position, syntaxTree, root, sourceText, useTabs, tabSize, cancellationToken)
+            public SimpleStringSplitter(Document document, int position, SyntaxNode root, SourceText sourceText, SyntaxToken token, bool useTabs, int tabSize, CancellationToken cancellationToken)
+                : base(document, position, root, sourceText, useTabs, tabSize, cancellationToken)
             {
                 _token = token;
             }

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
@@ -19,17 +19,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             protected readonly Document Document;
             protected readonly int CursorPosition;
             protected readonly SourceText SourceText;
-            protected readonly SyntaxTree SyntaxTree;
             protected readonly SyntaxNode Root;
             protected readonly int TabSize;
             protected readonly bool UseTabs;
             protected readonly CancellationToken CancellationToken;
 
-            public StringSplitter(Document document, int position, SyntaxTree syntaxTree, SyntaxNode root, SourceText sourceText, bool useTabs, int tabSize, CancellationToken cancellationToken)
+            public StringSplitter(Document document, int position, SyntaxNode root, SourceText sourceText, bool useTabs, int tabSize, CancellationToken cancellationToken)
             {
                 Document = document;
                 CursorPosition = position;
-                SyntaxTree = syntaxTree;
                 Root = root;
                 SourceText = sourceText;
                 UseTabs = useTabs;
@@ -39,7 +37,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
             public static StringSplitter Create(
                 Document document, int position,
-                SyntaxTree syntaxTree, SyntaxNode root, SourceText sourceText,
+                SyntaxNode root, SourceText sourceText,
                 bool useTabs, int tabSize, CancellationToken cancellationToken)
             {
                 var token = root.FindToken(position);
@@ -47,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 if (token.IsKind(SyntaxKind.StringLiteralToken))
                 {
                     return new SimpleStringSplitter(
-                        document, position, syntaxTree, root,
+                        document, position, root,
                         sourceText, token, useTabs, tabSize,
                         cancellationToken);
                 }
@@ -56,7 +54,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 if (interpolatedStringExpression != null)
                 {
                     return new InterpolatedStringSplitter(
-                        document, position, syntaxTree, root,
+                        document, position, root,
                         sourceText, interpolatedStringExpression,
                         useTabs, tabSize, cancellationToken);
                 }
@@ -92,19 +90,19 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
             protected abstract BinaryExpressionSyntax CreateSplitString();
 
-            public async Task<int?> TrySplitAsync()
+            public int? TrySplit()
             {
                 if (!CheckToken())
                 {
                     return null;
                 }
 
-                return await TrySplitWorkerAsync().ConfigureAwait(false);
+                return TrySplitWorker();
             }
 
-            private async Task<int?> TrySplitWorkerAsync()
+            private int? TrySplitWorker()
             {
-                var newDocumentAndCaretPosition = await SplitStringAsync().ConfigureAwait(false);
+                var newDocumentAndCaretPosition = SplitString();
                 if (newDocumentAndCaretPosition == null)
                 {
                     return null;
@@ -127,7 +125,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                     SyntaxFactory.TriviaList(SyntaxFactory.ElasticCarriageReturnLineFeed));
             }
 
-            private async Task<Tuple<Document, int>> SplitStringAsync()
+            private Tuple<Document, int> SplitString()
             {
                 var splitString = CreateSplitString();
 
@@ -135,7 +133,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 var newRoot = Root.ReplaceNode(nodeToReplace, splitString);
                 var rightExpression = newRoot.GetAnnotatedNodes(RightNodeAnnotation).Single();
 
-                var indentString = await GetIndentStringAsync(newRoot).ConfigureAwait(false);
+                var indentString = GetIndentString(newRoot);
                 if (indentString == null)
                 {
                     return null;
@@ -148,21 +146,21 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 return Tuple.Create(newDocument2, rightExpression.Span.Start + indentString.Length + StringOpenQuoteLength());
             }
 
-            private async Task<string> GetIndentStringAsync(SyntaxNode newRoot)
+            private string GetIndentString(SyntaxNode newRoot)
             {
                 var newDocument = Document.WithSyntaxRoot(newRoot);
 
                 var indentationService = newDocument.GetLanguageService<IIndentationService>();
                 var originalLineNumber = SourceText.Lines.GetLineFromPosition(CursorPosition).LineNumber;
-                var desiredIndentation = await indentationService.GetDesiredIndentationAsync(
-                    newDocument, originalLineNumber + 1, CancellationToken).ConfigureAwait(false);
+                var desiredIndentation = indentationService.GetDesiredIndentation(
+                    newDocument, originalLineNumber + 1, CancellationToken);
 
                 if (desiredIndentation == null)
                 {
                     return null;
                 }
 
-                var newSourceText = await newDocument.GetTextAsync(CancellationToken).ConfigureAwait(false);
+                var newSourceText = newDocument.GetSyntaxRootSynchronously(CancellationToken).SyntaxTree.GetText(CancellationToken);
                 var baseLine = newSourceText.Lines.GetLineFromPosition(desiredIndentation.Value.BasePosition);
                 var baseOffsetInLine = desiredIndentation.Value.BasePosition - baseLine.Start;
 

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
@@ -30,23 +30,28 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
         {
             var textView = args.TextView;
             var subjectBuffer = args.SubjectBuffer;
-            var caret = textView.GetCaretPoint(subjectBuffer);
+            var spans = textView.Selection.GetSnapshotSpansOnBuffer(subjectBuffer);
 
-            if (caret != null)
+            // Don't split strings if there is any actual selection.
+            if (spans.Count == 1 && spans[0].IsEmpty)
             {
-                // Quick check.  If the line doesn't contain a quote in it before the caret,
-                // then no point in doing any more expensive synchronous work.
-                var line = subjectBuffer.CurrentSnapshot.GetLineFromPosition(caret.Value);
-                if (LineContainsQuote(line, caret.Value))
+                var caret = textView.GetCaretPoint(subjectBuffer);
+                if (caret != null)
                 {
-                    return SplitString(textView, subjectBuffer, caret);
+                    // Quick check.  If the line doesn't contain a quote in it before the caret,
+                    // then no point in doing any more expensive synchronous work.
+                    var line = subjectBuffer.CurrentSnapshot.GetLineFromPosition(caret.Value);
+                    if (LineContainsQuote(line, caret.Value))
+                    {
+                        return SplitString(textView, subjectBuffer, caret.Value);
+                    }
                 }
             }
 
             return false;
         }
 
-        private bool SplitString(ITextView textView, ITextBuffer subjectBuffer, SnapshotPoint? caret)
+        private bool SplitString(ITextView textView, ITextBuffer subjectBuffer, SnapshotPoint caret)
         {
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
 
@@ -58,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
                 if (enabled)
                 {
                     var cursorPosition = SplitStringLiteral(
-                        subjectBuffer, document, caret.Value.Position, CancellationToken.None);
+                        subjectBuffer, document, caret, CancellationToken.None);
 
                     if (cursorPosition != null)
                     {

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.cs
@@ -57,8 +57,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
 
                 if (enabled)
                 {
-                    var cursorPosition = SplitStringLiteralAsync(
-                        subjectBuffer, document, caret.Value.Position, CancellationToken.None).GetAwaiter().GetResult();
+                    var cursorPosition = SplitStringLiteral(
+                        subjectBuffer, document, caret.Value.Position, CancellationToken.None);
 
                     if (cursorPosition != null)
                     {
@@ -95,23 +95,22 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             return false;
         }
 
-        private async Task<int?> SplitStringLiteralAsync(
+        private int? SplitStringLiteral(
             ITextBuffer subjectBuffer, Document document, int position, CancellationToken cancellationToken)
         {
             var useTabs = subjectBuffer.GetOption(FormattingOptions.UseTabs);
             var tabSize = subjectBuffer.GetOption(FormattingOptions.TabSize);
 
-            var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-            var root = await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
-            var sourceText = await syntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var root = document.GetSyntaxRootSynchronously(cancellationToken);
+            var sourceText = root.SyntaxTree.GetText(cancellationToken);
 
-            var splitter = StringSplitter.Create(document, position, syntaxTree, root, sourceText, useTabs, tabSize, cancellationToken);
+            var splitter = StringSplitter.Create(document, position, root, sourceText, useTabs, tabSize, cancellationToken);
             if (splitter == null)
             {
                 return null;
             }
 
-            return await splitter.TrySplitAsync().ConfigureAwait(false);
+            return splitter.TrySplit();
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/FormatterTestsBase.cs
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             }
         }
 
-        internal static async Task TestIndentationAsync(int point, int? expectedIndentation, ITextView textView, TestHostDocument subjectDocument)
+        internal static void TestIndentation(int point, int? expectedIndentation, ITextView textView, TestHostDocument subjectDocument)
         {
             var textUndoHistory = new Mock<ITextUndoHistoryRegistry>();
             var editorOperationsFactory = new Mock<IEditorOperationsFactoryService>();
@@ -140,13 +140,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             else
             {
                 var provider = new SmartIndent(textView);
-                actualIndentation = await provider.GetDesiredIndentationAsync(indentationLineFromBuffer);
+                actualIndentation = provider.GetDesiredIndentation(indentationLineFromBuffer);
             }
 
             Assert.Equal(expectedIndentation, actualIndentation.Value);
         }
 
-        public static async Task TestIndentationAsync(int indentationLine, int? expectedIndentation, TestWorkspace workspace)
+        public static void TestIndentation(int indentationLine, int? expectedIndentation, TestWorkspace workspace)
         {
             var snapshot = workspace.Documents.First().TextBuffer.CurrentSnapshot;
             var bufferGraph = new Mock<IBufferGraph>(MockBehavior.Strict);
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
             var provider = new SmartIndent(textView.Object);
 
             var indentationLineFromBuffer = snapshot.GetLineFromLineNumber(indentationLine);
-            var actualIndentation = await provider.GetDesiredIndentationAsync(indentationLineFromBuffer);
+            var actualIndentation = provider.GetDesiredIndentation(indentationLineFromBuffer);
 
             Assert.Equal(expectedIndentation, actualIndentation);
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -1395,7 +1395,7 @@ class C
                         Formatter.GetDefaultFormattingRules(workspace, root.Language),
                         root, line.AsTextLine(), document.Options, CancellationToken.None));
 
-                await TestIndentationAsync(indentationLine, expectedIndentation, workspace);
+                TestIndentation(indentationLine, expectedIndentation, workspace);
             }
         }
     }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterEnterOnTokenTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
     public class SmartIndenterEnterOnTokenTests : FormatterTestsBase
     {
         [WorkItem(537808, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537808")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodBody1()
         {
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Preprocessor1()
         {
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Preprocessor2()
         {
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Preprocessor3()
         {
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Comments()
         {
@@ -96,7 +96,7 @@ class Class
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task UsingDirective()
         {
@@ -110,7 +110,7 @@ using System.Linq;
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterTopOfFileComment()
         {
@@ -124,7 +124,7 @@ class
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task DottedName()
         {
@@ -137,7 +137,7 @@ Collection;
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Namespace()
         {
@@ -153,7 +153,7 @@ namespace NS
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NamespaceDottedName()
         {
@@ -168,7 +168,7 @@ NS2
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NamespaceBody()
         {
@@ -185,7 +185,7 @@ class
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NamespaceCloseBrace()
         {
@@ -202,7 +202,7 @@ namespace NS
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Class()
         {
@@ -220,7 +220,7 @@ namespace NS
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ClassBody()
         {
@@ -239,7 +239,7 @@ int
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ClassCloseBrace()
         {
@@ -258,7 +258,7 @@ namespace NS
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Method()
         {
@@ -279,7 +279,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodBody()
         {
@@ -301,7 +301,7 @@ int
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodCloseBrace()
         {
@@ -323,7 +323,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Statement()
         {
@@ -346,7 +346,7 @@ int
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodCall()
         {
@@ -366,7 +366,7 @@ a: 1,
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Switch()
         {
@@ -389,7 +389,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchBody()
         {
@@ -413,7 +413,7 @@ case
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchCase()
         {
@@ -438,7 +438,7 @@ int
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchCaseBlock()
         {
@@ -463,7 +463,7 @@ namespace NS
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Block()
         {
@@ -489,7 +489,7 @@ int
                 expectedIndentation: 24);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MultilineStatement1()
         {
@@ -511,7 +511,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MultilineStatement2()
         {
@@ -535,7 +535,7 @@ namespace NS
         }
 
         // Bug number 902477
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Comments2()
         {
@@ -555,7 +555,7 @@ int
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterCompletedBlock()
         {
@@ -576,7 +576,7 @@ int
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterTopLevelAttribute()
         {
@@ -595,7 +595,7 @@ int
         }
 
         [WorkItem(537802, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537802")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EmbededStatement()
         {
@@ -618,7 +618,7 @@ int
         }
 
         [WorkItem(537808, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537808")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodBraces1()
         {
@@ -636,7 +636,7 @@ int
         }
 
         [WorkItem(537808, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537808")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodBraces2()
         {
@@ -655,7 +655,7 @@ int
         }
 
         [WorkItem(537795, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537795")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Property1()
         {
@@ -676,7 +676,7 @@ int
         }
 
         [WorkItem(537563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537563")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Class1()
         {
@@ -691,7 +691,7 @@ int
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070773, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070773")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ArrayInitializer1()
@@ -708,7 +708,7 @@ int
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ArrayInitializer2()
         {
@@ -727,7 +727,7 @@ int
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070773, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070773")]
         [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
         public async Task ArrayInitializer3()
@@ -748,7 +748,7 @@ int
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression2()
         {
@@ -768,7 +768,7 @@ int
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression3()
         {
@@ -788,7 +788,7 @@ int
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression4()
         {
@@ -808,7 +808,7 @@ int
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(853748, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/853748")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ArrayInitializer()
@@ -829,7 +829,7 @@ int
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(939305, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/939305")]
         [WorkItem(1070773, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070773")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
@@ -851,7 +851,7 @@ int
                 expectedIndentation: 14);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070773, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070773")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CollectionExpression()
@@ -873,7 +873,7 @@ int
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070773, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070773")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ObjectInitializer()
@@ -900,7 +900,7 @@ class What
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Preprocessor()
         {
@@ -913,7 +913,7 @@ class What
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070774")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInitializerWithTypeBody_Implicit()
@@ -930,7 +930,7 @@ class What
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070774")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInitializerWithTypeBody_ImplicitNew()
@@ -947,7 +947,7 @@ class What
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070774")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInitializerWithTypeBody_Explicit()
@@ -964,7 +964,7 @@ class What
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070774")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInitializerWithTypeBody_Collection()
@@ -982,7 +982,7 @@ class X {
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1070774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1070774")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInitializerWithTypeBody_ObjectInitializers()
@@ -1007,7 +1007,7 @@ class What
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationString_1()
@@ -1028,7 +1028,7 @@ class What
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationString_2()
@@ -1049,7 +1049,7 @@ class What
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationString_3()
@@ -1070,7 +1070,7 @@ class What
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationString_4()
@@ -1091,7 +1091,7 @@ class What
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task OutsideInterpolationString()
@@ -1112,7 +1112,7 @@ class What
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_1()
@@ -1133,7 +1133,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_2()
@@ -1155,7 +1155,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_3()
@@ -1176,7 +1176,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_4()
@@ -1197,7 +1197,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_5()
@@ -1218,7 +1218,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_6()
@@ -1239,7 +1239,7 @@ Program.number}"";
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task InsideInterpolationSyntax_7()
@@ -1260,7 +1260,7 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(872, "https://github.com/dotnet/roslyn/issues/872")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task IndentLambdaBodyOneIndentationToFirstTokenOfTheStatement()
@@ -1281,7 +1281,7 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(1339, "https://github.com/dotnet/roslyn/issues/1339")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task IndentAutoPropertyInitializerAsPartOfTheDeclaration()
@@ -1300,7 +1300,7 @@ Program.number}"";
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task IndentPatternPropertyFirst()
         {
@@ -1321,7 +1321,7 @@ class C
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task IndentPatternPropertySecond()
         {

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2709,7 +2709,7 @@ class C
                     var indentationLine = projectedDocument.TextBuffer.CurrentSnapshot.GetLineFromPosition(projectedDocument.CursorPosition.Value);
                     var point = projectedDocument.GetTextView().BufferGraph.MapDownToBuffer(indentationLine.Start, PointTrackingMode.Negative, subjectDocument.TextBuffer, PositionAffinity.Predecessor);
 
-                    await TestIndentationAsync(point.Value, expectedIndentation, projectedDocument.GetTextView(), subjectDocument);
+                    TestIndentation(point.Value, expectedIndentation, projectedDocument.GetTextView(), subjectDocument);
                 }
             }
         }
@@ -2728,7 +2728,7 @@ class C
             {
                 using (var workspace = await TestWorkspace.CreateCSharpAsync(code, parseOptions: option))
                 {
-                    await TestIndentationAsync(indentationLine, expectedIndentation, workspace);
+                    TestIndentation(indentationLine, expectedIndentation, workspace);
                 }
             }
         }
@@ -2748,7 +2748,7 @@ class C
                 {
                     var wpfTextView = workspace.Documents.First().GetTextView();
                     var line = wpfTextView.TextBuffer.CurrentSnapshot.GetLineFromPosition(wpfTextView.Caret.Position.BufferPosition).LineNumber;
-                    await TestIndentationAsync(line, expectedIndentation, workspace);
+                    TestIndentation(line, expectedIndentation, workspace);
                 }
             }
         }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
 {
     public partial class SmartIndenterTests : FormatterTestsBase
     {
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EmptyFile()
         {
@@ -23,7 +23,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NoPreviousLine()
         {
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EndOfFileInactive()
         {
@@ -64,7 +64,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EndOfFileInactive2()
         {
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting.Indentation
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Comments()
         {
@@ -99,7 +99,7 @@ class Class
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task UsingDirective()
         {
@@ -112,7 +112,7 @@ class Class
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task DottedName()
         {
@@ -125,7 +125,7 @@ class Class
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Namespace()
         {
@@ -140,7 +140,7 @@ namespace NS
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NamespaceDottedName()
         {
@@ -155,7 +155,7 @@ namespace NS.
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NamespaceBody()
         {
@@ -171,7 +171,7 @@ namespace NS
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Class()
         {
@@ -188,7 +188,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ClassBody()
         {
@@ -206,7 +206,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Method()
         {
@@ -226,7 +226,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodBody()
         {
@@ -247,7 +247,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Property()
         {
@@ -267,7 +267,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PropertyGetBody()
         {
@@ -289,7 +289,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PropertySetBody()
         {
@@ -312,7 +312,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Statement()
         {
@@ -334,7 +334,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task FieldInitializer()
         {
@@ -349,7 +349,7 @@ namespace NS
                 expectedIndentation: 4);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task FieldInitializerWithNamespace()
         {
@@ -367,7 +367,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MethodCall()
         {
@@ -395,7 +395,7 @@ namespace NS
                 expectedIndentation: null);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Switch()
         {
@@ -417,7 +417,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchBody()
         {
@@ -440,7 +440,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchCase()
         {
@@ -464,7 +464,7 @@ namespace NS
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Block()
         {
@@ -489,7 +489,7 @@ namespace NS
                 expectedIndentation: 24);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MultilineStatement1()
         {
@@ -511,7 +511,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MultilineStatement2()
         {
@@ -535,7 +535,7 @@ namespace NS
         }
 
         // Bug number 902477
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Comments2()
         {
@@ -554,7 +554,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterCompletedBlock()
         {
@@ -574,7 +574,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterCompletedBlockNestedInOtherBlock()
         {
@@ -595,7 +595,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterTopLevelAttribute()
         {
@@ -613,7 +613,7 @@ namespace NS
         }
 
         [WorkItem(537802, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537802")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EmbeddedStatement()
         {
@@ -635,7 +635,7 @@ namespace NS
         }
 
         [WorkItem(537883, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537883")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EnterAfterComment()
         {
@@ -656,7 +656,7 @@ namespace NS
         }
 
         [WorkItem(538121, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538121")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedBlock1()
         {
@@ -676,7 +676,7 @@ namespace NS
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement1()
         {
@@ -698,7 +698,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement2()
         {
@@ -721,7 +721,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement3()
         {
@@ -744,7 +744,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement4()
         {
@@ -765,7 +765,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement5()
         {
@@ -786,7 +786,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement6()
         {
@@ -807,7 +807,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement7()
         {
@@ -830,7 +830,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task NestedEmbeddedStatement8()
         {
@@ -854,7 +854,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label1()
         {
@@ -876,7 +876,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label2()
         {
@@ -896,7 +896,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label3()
         {
@@ -919,7 +919,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label4()
         {
@@ -941,7 +941,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label5()
         {
@@ -963,7 +963,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Label6()
         {
@@ -983,7 +983,7 @@ namespace NS
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression1()
         {
@@ -1003,7 +1003,7 @@ namespace NS
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression2()
         {
@@ -1023,7 +1023,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression3()
         {
@@ -1043,7 +1043,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression4()
         {
@@ -1063,7 +1063,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression5()
         {
@@ -1084,7 +1084,7 @@ namespace NS
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression6()
         {
@@ -1106,7 +1106,7 @@ namespace NS
                 expectedIndentation: 20);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(538779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538779")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression7()
@@ -1129,7 +1129,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(538779, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538779")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression8()
@@ -1153,7 +1153,7 @@ namespace NS
                 expectedIndentation: 30);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(538780, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538780")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression9()
@@ -1176,7 +1176,7 @@ namespace NS
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(538780, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538780")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task QueryExpression10()
@@ -1201,7 +1201,7 @@ namespace NS
         }
 
         [WorkItem(538333, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538333")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Statement1()
         {
@@ -1217,7 +1217,7 @@ namespace NS
         }
 
         [WorkItem(538933, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538933")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EndOfFile1()
         {
@@ -1236,7 +1236,7 @@ namespace NS
         }
 
         [WorkItem(539059, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539059")]
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task VerbatimString()
         {
@@ -1253,7 +1253,7 @@ namespace NS
                 expectedIndentation: 0);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(539892, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539892")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Bug5994()
@@ -1281,7 +1281,7 @@ class Program
                 expectedIndentation: 15);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(539990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539990")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Bug6124()
@@ -1308,7 +1308,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(539990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539990")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task Bug6124_1()
@@ -1336,7 +1336,7 @@ class Program
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterIfWithSingleStatementInTopLevelMethod_Bug7291_1()
         {
@@ -1353,7 +1353,7 @@ class Program
                 options: Options.Script);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterIfWithSingleStatementInTopLevelMethod_Bug7291_2()
         {
@@ -1373,7 +1373,7 @@ class Program
 
         [WorkItem(540634, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540634")]
         [WorkItem(544268, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544268")]
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task FirstArgumentInArgumentList()
         {
             var code = @"class Program
@@ -1400,7 +1400,7 @@ class Program
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ForLoop()
         {
@@ -1418,7 +1418,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CallBaseCtor()
         {
@@ -1434,7 +1434,7 @@ class Program
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task MultipleDeclarations()
         {
@@ -1453,7 +1453,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CloseBracket()
         {
@@ -1472,7 +1472,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchLabel()
         {
@@ -1495,7 +1495,7 @@ class Program
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task TypeParameters()
         {
@@ -1510,7 +1510,7 @@ T2>() { }
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(542428, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542428")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task TypeArguments()
@@ -1531,7 +1531,7 @@ T2>() { }
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(542983, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542983")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ConstructorInitializer1()
@@ -1547,7 +1547,7 @@ T2>() { }
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(542983, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542983")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ConstructorInitializer2()
@@ -1564,7 +1564,7 @@ T2>() { }
                 expectedIndentation: 14);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(542983, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542983")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ConstructorInitializer3()
@@ -1581,7 +1581,7 @@ T2>() { }
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543131, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543131")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LockStatement1()
@@ -1606,7 +1606,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543533, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543533")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ConstructorInitializer()
@@ -1622,7 +1622,7 @@ class Program
                 expectedIndentation: 8);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(952803, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/952803")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ArrayInitializer()
@@ -1646,7 +1646,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543563")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LambdaEmbededInExpression()
@@ -1686,7 +1686,7 @@ class FooClass : IDisposable
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543563")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LambdaEmbededInExpression_1()
@@ -1705,7 +1705,7 @@ class FooClass : IDisposable
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543563")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LambdaEmbededInExpression_3()
@@ -1743,7 +1743,7 @@ class FooClass : IDisposable
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543563")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LambdaEmbededInExpression_2()
@@ -1763,7 +1763,7 @@ class FooClass : IDisposable
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(543563, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543563")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task LambdaEmbededInExpression_4()
@@ -1790,7 +1790,7 @@ class Class
                 expectedIndentation: 16);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(530074, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530074")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EnterInArgumentList1()
@@ -1809,7 +1809,7 @@ class Class
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(530074, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530074")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EnterInArgumentList2()
@@ -1828,7 +1828,7 @@ class Class
                 expectedIndentation: 12);
         }
 
-        [Fact]
+        [WpfFact]
         [WorkItem(806266, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/806266")]
         [Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task EnterInArgumentList3()
@@ -1848,7 +1848,7 @@ class Class
         }
 
         [WorkItem(9216, "DevDiv_Projects/Roslyn")]
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task FollowPreviousLineInMultilineStatements()
         {
             var code = @"class Program
@@ -2254,7 +2254,7 @@ if(languages == null || languages.Length == 0)
                 expectedIndentation: 16);
         }
 
-        [Fact, WorkItem(530948, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530948"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(530948, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530948"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CommaSeparatedListEnumMembers()
         {
             var code = @"enum MyEnum
@@ -2269,7 +2269,7 @@ if(languages == null || languages.Length == 0)
                 expectedIndentation: 4);
         }
 
-        [Fact, WorkItem(530796, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530796"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(530796, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530796"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task RelativeIndentationForBracesInExpression()
         {
             var code = @"class C
@@ -2290,7 +2290,7 @@ if(languages == null || languages.Length == 0)
                 expectedIndentation: 12);
         }
 
-        [Fact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchSection()
         {
             var code = @"class C
@@ -2338,7 +2338,7 @@ if(languages == null || languages.Length == 0)
                 expectedIndentation: 16);
         }
 
-        [Fact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task SwitchSection2()
         {
             var code = @"class C
@@ -2391,7 +2391,7 @@ if(languages == null || languages.Length == 0)
                 expectedIndentation: 12);
         }
 
-        [Fact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(584599, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/584599"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CommentAtTheEndOfLine()
         {
             var code = @"using System;
@@ -2419,7 +2419,7 @@ class Program
                 expectedIndentation: 8);
         }
 
-        [Fact, WorkItem(912735, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/912735"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(912735, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/912735"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CommentAtTheEndOfLineWithExecutableAfterCaret()
         {
             var code = @"using System;
@@ -2447,7 +2447,7 @@ class Program
                 expectedIndentation: 8);
         }
 
-        [Fact, WorkItem(912735, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/912735"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, WorkItem(912735, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/912735"), Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task CommentAtTheEndOfLineInsideInitializer()
         {
             var code = @"using System;
@@ -2480,7 +2480,7 @@ class Program
         }
 
         [WorkItem(5495, "https://github.com/dotnet/roslyn/issues/5495")]
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterBadQueryContinuationWithSelectOrGroupClause()
         {
             var code = @"using System.Collections.Generic;
@@ -2530,7 +2530,7 @@ namespace ConsoleApplication1
         }
 
         [WorkItem(5495, "https://github.com/dotnet/roslyn/issues/5495")]
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task AfterPartialFromClause()
         {
             var code = @"
@@ -2552,7 +2552,7 @@ class C
         }
 
         [WorkItem(5635, "https://github.com/dotnet/roslyn/issues/5635")]
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task ConstructorInitializerMissingBaseOrThisKeyword()
         {
             var code = @"
@@ -2570,7 +2570,7 @@ class C
                 expectedIndentation: 8);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task DontCreateIndentOperationForBrokenBracketedArgumentList()
         {
             var code = @"
@@ -2590,7 +2590,7 @@ class Program
                 expectedIndentation: 12);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PatternPropertyIndentFirst()
         {
             var code = @"
@@ -2611,7 +2611,7 @@ class C
                 expectedIndentation: 12);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PatternPropertyIndentSecond()
         {
             var code = @"
@@ -2633,7 +2633,7 @@ class C
                 expectedIndentation: 12);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PatternPropertyIndentNestedFirst()
         {
             var code = @"
@@ -2658,7 +2658,7 @@ class C
                 expectedIndentation: 16);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]
         public async Task PatternPropertyIndentNestedSecond()
         {
             var code = @"

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -129,8 +129,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
             }
 
             var indentationService = document.GetLanguageService<IIndentationService>();
-            var indentation = indentationService.GetDesiredIndentationAsync(document,
-                currentPosition.GetContainingLine().LineNumber, cancellationToken).WaitAndGetResult(cancellationToken);
+            var indentation = indentationService.GetDesiredIndentation(document,
+                currentPosition.GetContainingLine().LineNumber, cancellationToken);
 
             // looks like we can't.
             if (!indentation.HasValue)

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.LanguageServices;
@@ -12,7 +11,6 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
-using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 {
@@ -21,7 +19,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
         internal abstract class AbstractIndenter
         {
             protected readonly OptionSet OptionSet;
-            protected readonly SyntacticDocument Document;
             protected readonly TextLine LineToBeIndented;
             protected readonly int TabSize;
             protected readonly CancellationToken CancellationToken;
@@ -32,25 +29,30 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 
             private static readonly Func<SyntaxToken, bool> s_tokenHasDirective = tk => tk.ContainsDirectives &&
                                                   (tk.LeadingTrivia.Any(tr => tr.IsDirective) || tk.TrailingTrivia.Any(tr => tr.IsDirective));
+            private readonly ISyntaxFactsService _syntaxFacts;
 
             public AbstractIndenter(
+                ISyntaxFactsService syntaxFacts,
                 SyntaxTree syntaxTree,
                 IEnumerable<IFormattingRule> rules,
                 OptionSet optionSet,
                 TextLine lineToBeIndented,
                 CancellationToken cancellationToken)
             {
+                var syntaxRoot = syntaxTree.GetRoot(cancellationToken);
+
+                this._syntaxFacts = syntaxFacts;
                 this.OptionSet = optionSet;
                 this.Tree = syntaxTree;
                 this.LineToBeIndented = lineToBeIndented;
-                this.TabSize = this.OptionSet.GetOption(FormattingOptions.TabSize, this.Document.Root.Language);
+                this.TabSize = this.OptionSet.GetOption(FormattingOptions.TabSize, syntaxRoot.Language);
                 this.CancellationToken = cancellationToken;
 
                 this.Rules = rules;
                 this.Finder = new BottomUpBaseIndentationFinder(
                          new ChainedFormattingRules(this.Rules, OptionSet),
                          this.TabSize,
-                         this.OptionSet.GetOption(FormattingOptions.IndentationSize, this.Document.Root.Language),
+                         this.OptionSet.GetOption(FormattingOptions.IndentationSize, syntaxRoot.Language),
                          tokenStream: null,
                          lastToken: default(SyntaxToken));
             }
@@ -87,15 +89,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 
             protected IndentationResult GetIndentationOfPosition(int position, int addedSpaces)
             {
-                var tree = Document.SyntaxTree;
-
-                if (tree.OverlapsHiddenPosition(GetNormalizedSpan(position), CancellationToken))
+                if (this.Tree.OverlapsHiddenPosition(GetNormalizedSpan(position), CancellationToken))
                 {
                     // Oops, the line we want to line up to is either hidden, or is in a different
                     // visible region.
-                    var root = tree.GetRoot(CancellationToken.None);
+                    var root = this.Tree.GetRoot(CancellationToken.None);
                     var token = root.FindTokenFromEnd(LineToBeIndented.Start);
-                    var indentation = Finder.GetIndentationOfCurrentPosition(tree, token, LineToBeIndented.Start, CancellationToken.None);
+                    var indentation = Finder.GetIndentationOfCurrentPosition(this.Tree, token, LineToBeIndented.Start, CancellationToken.None);
 
                     return new IndentationResult(LineToBeIndented.Start, indentation);
                 }
@@ -125,7 +125,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                     return null;
                 }
 
-                var syntaxFacts = this.Document.Document.GetLanguageService<ISyntaxFactsService>();
                 var sourceText = this.LineToBeIndented.Text;
 
                 var lineNumber = this.LineToBeIndented.LineNumber - 1;
@@ -150,7 +149,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 
                     // This line is inside an inactive region. Examine the 
                     // first preceding line not in an inactive region.
-                    var disabledSpan = syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Span.Start, CancellationToken);
+                    var disabledSpan = _syntaxFacts.GetInactiveRegionSpanAroundPosition(this.Tree, actualLine.Span.Start, CancellationToken);
                     if (disabledSpan != default(TextSpan))
                     {
                         var targetLine = sourceText.Lines.GetLineFromPosition(disabledSpan.Start).LineNumber;

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.AbstractIndenter.cs
@@ -34,20 +34,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                                                   (tk.LeadingTrivia.Any(tr => tr.IsDirective) || tk.TrailingTrivia.Any(tr => tr.IsDirective));
 
             public AbstractIndenter(
-                SyntacticDocument document,
+                SyntaxTree syntaxTree,
                 IEnumerable<IFormattingRule> rules,
                 OptionSet optionSet,
                 TextLine lineToBeIndented,
                 CancellationToken cancellationToken)
             {
                 this.OptionSet = optionSet;
-                this.Document = document;
+                this.Tree = syntaxTree;
                 this.LineToBeIndented = lineToBeIndented;
                 this.TabSize = this.OptionSet.GetOption(FormattingOptions.TabSize, this.Document.Root.Language);
                 this.CancellationToken = cancellationToken;
 
                 this.Rules = rules;
-                this.Tree = this.Document.SyntaxTree;
                 this.Finder = new BottomUpBaseIndentationFinder(
                          new ChainedFormattingRules(this.Rules, OptionSet),
                          this.TabSize,

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
@@ -3,12 +3,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
-using Microsoft.VisualStudio.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
@@ -42,12 +42,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                 return null;
             }
 
-            var indenter = GetIndenter(root.SyntaxTree, lineToBeIndented, formattingRules, document.Options, cancellationToken);
+            var indenter = GetIndenter(
+                document.GetLanguageService<ISyntaxFactsService>(),
+                root.SyntaxTree, lineToBeIndented, formattingRules,
+                document.Options, cancellationToken);
+
             return indenter.GetDesiredIndentation();
         }
 
         protected abstract AbstractIndenter GetIndenter(
-            SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
+            ISyntaxFactsService syntaxFacts, SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
 
         protected abstract bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
             IEnumerable<IFormattingRule> formattingRules, SyntaxNode root, TextLine line, OptionSet optionSet, CancellationToken cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
@@ -27,10 +27,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
             return formattingRules;
         }
 
-        public async Task<IndentationResult?> GetDesiredIndentationAsync(Document document, int lineNumber, CancellationToken cancellationToken)
+        public IndentationResult? GetDesiredIndentation(Document document, int lineNumber, CancellationToken cancellationToken)
         {
-            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var root = document.GetSyntaxRootSynchronously(cancellationToken);
+            var sourceText = root.SyntaxTree.GetText(cancellationToken);
 
             var lineToBeIndented = sourceText.Lines[lineNumber];
 
@@ -42,12 +42,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
                 return null;
             }
 
-            var indenter = await GetIndenterAsync(document, lineToBeIndented, formattingRules, document.Options, cancellationToken).ConfigureAwait(false);
+            var indenter = GetIndenter(root.SyntaxTree, lineToBeIndented, formattingRules, document.Options, cancellationToken);
             return indenter.GetDesiredIndentation();
         }
 
-        protected abstract Task<AbstractIndenter> GetIndenterAsync(
-            Document document, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
+        protected abstract AbstractIndenter GetIndenter(
+            SyntaxTree syntaxTree, TextLine lineToBeIndented, IEnumerable<IFormattingRule> formattingRules, OptionSet optionSet, CancellationToken cancellationToken);
 
         protected abstract bool ShouldUseSmartTokenFormatterInsteadOfIndenter(
             IEnumerable<IFormattingRule> formattingRules, SyntaxNode root, TextLine line, OptionSet optionSet, CancellationToken cancellationToken);

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
@@ -40,6 +40,6 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal interface IIndentationService : ILanguageService
     {
-        Task<IndentationResult?> GetDesiredIndentationAsync(Document document, int lineNumber, CancellationToken cancellationToken);
+        IndentationResult? GetDesiredIndentation(Document document, int lineNumber, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Formatting
 Imports Microsoft.CodeAnalysis.Formatting.Rules
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
@@ -14,12 +15,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
         Private Class Indenter
             Inherits AbstractIndenter
 
-            Public Sub New(syntaxTree As SyntaxTree,
+            Public Sub New(syntaxFacts As ISyntaxFactsService,
+                           syntaxTree As SyntaxTree,
                            rules As IEnumerable(Of IFormattingRule),
                            optionSet As OptionSet,
                            line As TextLine,
                            cancellationToken As CancellationToken)
-                MyBase.New(syntaxTree, rules, optionSet, line, cancellationToken)
+                MyBase.New(syntaxFacts, syntaxTree, rules, optionSet, line, cancellationToken)
             End Sub
 
             Public Overrides Function GetDesiredIndentation() As IndentationResult?

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.Indenter.vb
@@ -14,12 +14,12 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
         Private Class Indenter
             Inherits AbstractIndenter
 
-            Public Sub New(document As SyntacticDocument,
+            Public Sub New(syntaxTree As SyntaxTree,
                            rules As IEnumerable(Of IFormattingRule),
                            optionSet As OptionSet,
                            line As TextLine,
                            cancellationToken As CancellationToken)
-                MyBase.New(document, rules, optionSet, line, cancellationToken)
+                MyBase.New(syntaxTree, rules, optionSet, line, cancellationToken)
             End Sub
 
             Public Overrides Function GetDesiredIndentation() As IndentationResult?

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -23,9 +23,8 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             Return s_instance
         End Function
 
-        Protected Overrides Async Function GetIndenterAsync(document As Document, lineToBeIndented As TextLine, formattingRules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, cancellationToken As CancellationToken) As Tasks.Task(Of AbstractIndenter)
-            Dim synDocument = Await SyntacticDocument.CreateAsync(document, cancellationToken).ConfigureAwait(False)
-            Return New Indenter(synDocument, formattingRules, optionSet, lineToBeIndented, cancellationToken)
+        Protected Overrides Function GetIndenter(syntaxTree As SyntaxTree, lineToBeIndented As TextLine, formattingRules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, cancellationToken As CancellationToken) As AbstractIndenter
+            Return New Indenter(syntaxTree, formattingRules, optionSet, lineToBeIndented, cancellationToken)
         End Function
 
         Protected Overrides Function ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules As IEnumerable(Of IFormattingRule),

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -6,6 +6,7 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 Imports Microsoft.CodeAnalysis.Formatting.Rules
 Imports Microsoft.CodeAnalysis.Host
 Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.LanguageServices
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.Text.Shared.Extensions
@@ -23,8 +24,13 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
             Return s_instance
         End Function
 
-        Protected Overrides Function GetIndenter(syntaxTree As SyntaxTree, lineToBeIndented As TextLine, formattingRules As IEnumerable(Of IFormattingRule), optionSet As OptionSet, cancellationToken As CancellationToken) As AbstractIndenter
-            Return New Indenter(syntaxTree, formattingRules, optionSet, lineToBeIndented, cancellationToken)
+        Protected Overrides Function GetIndenter(syntaxFacts As ISyntaxFactsService,
+                                                 syntaxTree As SyntaxTree,
+                                                 lineToBeIndented As TextLine,
+                                                 formattingRules As IEnumerable(Of IFormattingRule),
+                                                 optionSet As OptionSet,
+                                                 cancellationToken As CancellationToken) As AbstractIndenter
+            Return New Indenter(syntaxFacts, syntaxTree, formattingRules, optionSet, lineToBeIndented, cancellationToken)
         End Function
 
         Protected Overrides Function ShouldUseSmartTokenFormatterInsteadOfIndenter(formattingRules As IEnumerable(Of IFormattingRule),

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndentProviderTests.vb
@@ -15,7 +15,7 @@ Imports Moq
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Formatting.Indentation
     Public Class SmartIndentProviderTests
-        <Fact>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub GetSmartIndent1()
             Dim provider = New SmartIndentProvider()

--- a/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Formatting/Indentation/SmartIndenterTests.vb
@@ -2001,7 +2001,7 @@ End Module</text>.Value
         End Function
 #End Region
 
-        <Fact>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.SmartIndent)>
         Public Sub TestSmartIndenterConstructorThrows1()
             Assert.Throws(Of ArgumentNullException)(

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentState.cs
@@ -111,6 +111,7 @@ namespace Microsoft.CodeAnalysis
         {
             return new AsyncLazy<TreeAndVersion>(
                 c => FullyParseTreeAsync(newTextSource, cacheKey, filePath, options, languageServices, solutionServices, mode, c),
+                c => FullyParseTree(newTextSource, cacheKey, filePath, options, languageServices, solutionServices, mode, c),
                 cacheResult: true);
         }
 
@@ -127,23 +128,50 @@ namespace Microsoft.CodeAnalysis
             using (Logger.LogBlock(FunctionId.Workspace_Document_State_FullyParseSyntaxTree, s_fullParseLog, filePath, mode, cancellationToken))
             {
                 var textAndVersion = await newTextSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                var text = textAndVersion.Text;
-
-                var treeFactory = languageServices.GetService<ISyntaxTreeFactoryService>();
-
-                var tree = treeFactory.ParseSyntaxTree(filePath, options, text, cancellationToken);
-
-                var root = tree.GetRoot(cancellationToken);
-                if (mode == PreservationMode.PreserveValue && treeFactory.CanCreateRecoverableTree(root))
-                {
-                    tree = treeFactory.CreateRecoverableTree(cacheKey, tree.FilePath, tree.Options, newTextSource, text.Encoding, root);
-                }
-
-                Contract.ThrowIfNull(tree);
-
-                // text version for this document should be unique. use it as a starting point.
-                return TreeAndVersion.Create(tree, textAndVersion.Version);
+                return CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
             }
+        }
+
+        private static TreeAndVersion FullyParseTree(
+            ValueSource<TextAndVersion> newTextSource,
+            ProjectId cacheKey,
+            string filePath,
+            ParseOptions options,
+            HostLanguageServices languageServices,
+            SolutionServices solutionServices,
+            PreservationMode mode,
+            CancellationToken cancellationToken)
+        {
+            using (Logger.LogBlock(FunctionId.Workspace_Document_State_FullyParseSyntaxTree, s_fullParseLog, filePath, mode, cancellationToken))
+            {
+                var textAndVersion = newTextSource.GetValue(cancellationToken);
+                return CreateTreeAndVersion(newTextSource, cacheKey, filePath, options, languageServices, mode, textAndVersion, cancellationToken);
+            }
+        }
+
+        private static TreeAndVersion CreateTreeAndVersion(
+            ValueSource<TextAndVersion> newTextSource, 
+            ProjectId cacheKey, string filePath, 
+            ParseOptions options, HostLanguageServices languageServices, 
+            PreservationMode mode, TextAndVersion textAndVersion, 
+            CancellationToken cancellationToken)
+        {
+            var text = textAndVersion.Text;
+
+            var treeFactory = languageServices.GetService<ISyntaxTreeFactoryService>();
+
+            var tree = treeFactory.ParseSyntaxTree(filePath, options, text, cancellationToken);
+
+            var root = tree.GetRoot(cancellationToken);
+            if (mode == PreservationMode.PreserveValue && treeFactory.CanCreateRecoverableTree(root))
+            {
+                tree = treeFactory.CreateRecoverableTree(cacheKey, tree.FilePath, tree.Options, newTextSource, text.Encoding, root);
+            }
+
+            Contract.ThrowIfNull(tree);
+
+            // text version for this document should be unique. use it as a starting point.
+            return TreeAndVersion.Create(tree, textAndVersion.Version);
         }
 
         private static ValueSource<TreeAndVersion> CreateLazyIncrementallyParsedTree(
@@ -152,6 +180,7 @@ namespace Microsoft.CodeAnalysis
         {
             return new AsyncLazy<TreeAndVersion>(
                 c => IncrementallyParseTreeAsync(oldTreeSource, newTextSource, c),
+                c => IncrementallyParseTree(oldTreeSource, newTextSource, c),
                 cacheResult: true);
         }
 
@@ -165,22 +194,51 @@ namespace Microsoft.CodeAnalysis
                 using (Logger.LogBlock(FunctionId.Workspace_Document_State_IncrementallyParseSyntaxTree, cancellationToken))
                 {
                     var newTextAndVersion = await newTextSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                    var newText = newTextAndVersion.Text;
-
                     var oldTreeAndVersion = await oldTreeSource.GetValueAsync(cancellationToken).ConfigureAwait(false);
-                    var oldTree = oldTreeAndVersion.Tree;
-                    var oldText = await oldTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
-                    var newTree = oldTree.WithChangedText(newText);
-                    Contract.ThrowIfNull(newTree);
-
-                    return MakeNewTreeAndVersion(oldTree, oldText, oldTreeAndVersion.Version, newTree, newText, newTextAndVersion.Version);
+                    return IncrementallyParse(newTextAndVersion, oldTreeAndVersion, cancellationToken);
                 }
             }
             catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
             {
                 throw ExceptionUtilities.Unreachable;
             }
+        }
+
+        private static TreeAndVersion IncrementallyParseTree(
+            ValueSource<TreeAndVersion> oldTreeSource,
+            ValueSource<TextAndVersion> newTextSource,
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (Logger.LogBlock(FunctionId.Workspace_Document_State_IncrementallyParseSyntaxTree, cancellationToken))
+                {
+                    var newTextAndVersion = newTextSource.GetValue(cancellationToken);
+                    var oldTreeAndVersion = oldTreeSource.GetValue(cancellationToken);
+
+                    return IncrementallyParse(newTextAndVersion, oldTreeAndVersion, cancellationToken);
+                }
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
+        private static TreeAndVersion IncrementallyParse(
+            TextAndVersion newTextAndVersion, 
+            TreeAndVersion oldTreeAndVersion,
+            CancellationToken cancellationToken)
+        {
+            var newText = newTextAndVersion.Text;
+            var oldTree = oldTreeAndVersion.Tree;
+
+            var oldText = oldTree.GetText(cancellationToken);
+            var newTree = oldTree.WithChangedText(newText);
+            Contract.ThrowIfNull(newTree);
+
+            return MakeNewTreeAndVersion(oldTree, oldText, oldTreeAndVersion.Version, newTree, newText, newTextAndVersion.Version);
         }
 
         private static TreeAndVersion MakeNewTreeAndVersion(SyntaxTree oldTree, SourceText oldText, VersionStamp oldVersion, SyntaxTree newTree, SourceText newText, VersionStamp newVersion)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11784

This also has the effect of making indentation fully synchronous.

The issue here is that we don't want synchronous command handler features to call out to async code.  This is bad for two reasons:

1. People (i.e. me) make mistakes and attempt to change teh workspace on the async code-path.  This breaks when that async path is not on the UI thread.
2. When we make async calls we're at the mercy of the threadpool.  If it is saturated, or otherwise capricious, our command handler code is blocked until it gets around to running our code.

For sync command handler paths, we want things to execute and complete as quickly as possible.  So we want to avoid async calls from them.