### PR TITLE
Fix a null reference in BaseFormattingRule...

### DIFF
--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTestBase.cs
@@ -269,5 +269,18 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Formatting
             new List<TextSpan> { span },
             baseIndentation: baseIndentation);
         }
+
+        /// <summary>
+        /// Asserts formatting on an arbitrary <see cref="SyntaxNode"/> that is not part of a <see cref="SyntaxTree"/> 
+        /// </summary>
+        /// <param name="node">the <see cref="SyntaxNode"/> to format.</param>
+        /// <remarks>uses an <see cref="AdhocWorkspace"/> for formatting context, since the <paramref name="node"/> is not associated with a <see cref="SyntaxTree"/> </remarks>
+        protected async Task AssertFormatOnArbitraryNodeAsync(SyntaxNode node, string expected)
+        {
+            var result = await Formatter.FormatAsync(node, new AdhocWorkspace());
+            var actual = result.GetText().ToString();
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
 using Microsoft.CodeAnalysis.Editor.Options;
@@ -533,8 +534,6 @@ class Program
 }";
             await AssertFormatAfterTypeCharAsync(code, expected);
         }
-
-
 
         [WorkItem(449, "https://github.com/dotnet/roslyn/issues/449")]
         [WorkItem(1077103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1077103")]
@@ -1375,6 +1374,18 @@ class C : Attribute
     }
 }";
             await AssertFormatAfterTypeCharAsync(code, expected);
+        }
+
+        [WorkItem(11642, "https://github.com/dotnet/roslyn/issues/11642")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task FormatArbitraryNodeParenthesizedLambdaExpression()
+        {
+            // code equivalent to an expression synthesized like so:
+            // ParenthesizedExpression(ParenthesizedLambdaExpression(ParameterList(), Block()))
+            var code = @"(()=>{})";
+            var node = SyntaxFactory.ParseExpression(code);
+            var expected = @"(() => { })";
+            await AssertFormatOnArbitraryNodeAsync(node, expected);
         }
 
         private static async Task AssertFormatAfterTypeCharAsync(string code, string expected, Dictionary<OptionKey, object> changedOptionSet = null)

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/BaseFormattingRule.cs
@@ -257,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
         private bool SomeParentHasMissingCloseBrace(SyntaxNode node)
         {
-            while (node.Kind() != SyntaxKind.CompilationUnit)
+            while (node != null && node.Kind() != SyntaxKind.CompilationUnit)
             {
                 var bracePair = node.GetBracePair();
                 if (bracePair.Item2.IsMissing)


### PR DESCRIPTION
... that was introduced with PR #4644

Method `SomeParentHasMissingCloseBrace` expects a fully formed node that
has a compilation unit, which a roslyn document would have, but this
code is also in a formatter public api path, that can possibly take `an
arbitrary` syntax node that may not be associated with a syntaxtree or a
compilation unit.

The fix is simple, it adds a missing null check to this method.

Fixes #11642 