### PR TITLE
Update DiaSymReader.Native depenency to 1.4.0-rc2

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -7,7 +7,7 @@
     <SystemReflectionMetadataVersion>1.2.0</SystemReflectionMetadataVersion>
     <SystemCollectionsImmutableVersion>1.1.37</SystemCollectionsImmutableVersion>
     <MicrosoftDiaSymReaderVersion>1.0.7</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.4.0-rc</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.4.0-rc2</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.0.0</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftCodeAnalysisElfieVersion>0.10.6-rc2</MicrosoftCodeAnalysisElfieVersion>
     <ManagedEsentVersion>1.9.2</ManagedEsentVersion>

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -2,7 +2,7 @@
     "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.0",
         "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
-        "Microsoft.DiaSymReader.Native": "1.4.0-rc",
+        "Microsoft.DiaSymReader.Native": "1.4.0-rc2",
         "Microsoft.Net.Compilers": "1.2.1",
         "Microsoft.Net.RoslynDiagnostics": "1.2.0-beta2",
         "FakeSign": "0.9.2",

--- a/src/Compilers/CSharp/csc/project.json
+++ b/src/Compilers/CSharp/csc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc"
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {
     "net45": { }

--- a/src/Compilers/VisualBasic/vbc/project.json
+++ b/src/Compilers/VisualBasic/vbc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc"
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {
     "net45": { }

--- a/src/Test/PdbUtilities/project.json
+++ b/src/Test/PdbUtilities/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc"
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile7": {}

--- a/src/Test/Utilities/Desktop/project.json
+++ b/src/Test/Utilities/Desktop/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc",    
+    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"   
   },
   "frameworks": {
     "net45": { }


### PR DESCRIPTION
Brings in new binaries that work on Nano Server.

Fixes https://github.com/dotnet/roslyn/issues/11592