### PR TITLE
Restore the old IIndentationService.

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/CSharpIndentationService.cs
@@ -21,7 +21,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
 {
-    [ExportLanguageService(typeof(IIndentationService), LanguageNames.CSharp), Shared]
+    [ExportLanguageService(typeof(ISynchronousIndentationService), LanguageNames.CSharp), Shared]
     internal partial class CSharpIndentationService : AbstractIndentationService
     {
         private static readonly IFormattingRule s_instance = new FormattingRule();

--- a/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
+++ b/src/EditorFeatures/CSharp/SplitStringLiteral/SplitStringLiteralCommandHandler.StringSplitter.cs
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.SplitStringLiteral
             {
                 var newDocument = Document.WithSyntaxRoot(newRoot);
 
-                var indentationService = newDocument.GetLanguageService<IIndentationService>();
+                var indentationService = newDocument.GetLanguageService<ISynchronousIndentationService>();
                 var originalLineNumber = SourceText.Lines.GetLineFromPosition(CursorPosition).LineNumber;
                 var desiredIndentation = indentationService.GetDesiredIndentation(
                     newDocument, originalLineNumber + 1, CancellationToken);

--- a/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/Formatting/Indentation/AbstractSmartTokenFormatterCommandHandler.cs
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Formatting.Indentation
                 return;
             }
 
-            var indentationService = document.GetLanguageService<IIndentationService>();
+            var indentationService = document.GetLanguageService<ISynchronousIndentationService>();
             var indentation = indentationService.GetDesiredIndentation(document,
                 currentPosition.GetContainingLine().LineNumber, cancellationToken);
 

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/AbstractIndentationService.cs
@@ -13,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.SmartIndent
 {
-    internal abstract partial class AbstractIndentationService : IIndentationService
+    internal abstract partial class AbstractIndentationService : ISynchronousIndentationService
     {
         protected abstract IFormattingRule GetSpecializedIndentationFormattingRule();
 

--- a/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
+++ b/src/EditorFeatures/Core/Implementation/SmartIndent/IIndentationService.cs
@@ -40,6 +40,11 @@ namespace Microsoft.CodeAnalysis.Editor
 
     internal interface IIndentationService : ILanguageService
     {
+        Task<IndentationResult?> GetDesiredIndentation(Document document, int lineNumber, CancellationToken cancellationToken);
+    }
+
+    internal interface ISynchronousIndentationService : ILanguageService
+    {
         IndentationResult? GetDesiredIndentation(Document document, int lineNumber, CancellationToken cancellationToken);
     }
 }

--- a/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
+++ b/src/EditorFeatures/VisualBasic/Formatting/Indentation/VisualBasicIndentationService.vb
@@ -14,7 +14,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.Text
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.Formatting.Indentation
-    <ExportLanguageService(GetType(IIndentationService), LanguageNames.VisualBasic), [Shared]>
+    <ExportLanguageService(GetType(ISynchronousIndentationService), LanguageNames.VisualBasic), [Shared]>
     Partial Friend Class VisualBasicIndentationService
         Inherits AbstractIndentationService
 


### PR DESCRIPTION
I forgot that typescript is using htis API.  We can't change it until we come up with a plan with them on how to absorb such a change.

For now, Indentation follows hte pattern of outlining.  There is a sync interface and an async interface.  We look for the sync interface first and use it if it is available.  If not, we fall back to the async interface.