### PR TITLE
Relax compiler server spinwait test

### DIFF
--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -162,25 +162,16 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                                           cts.Token);
                 Assert.False(connection.IsCompleted);
                 cts.Cancel();
-                // Give plenty of time for cancellation, in case the machine is very overloaded
-                await Task.WhenAny(connection, Task.Delay(oneSec))
-                    .ConfigureAwait(false);
-                Assert.True(connection.IsCompleted);
-                Assert.True(connection.IsCanceled);
+                await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                    async () => await connection.ConfigureAwait(false)).ConfigureAwait(false);
 
                 // Create server and try again
                 Assert.True(TryCreateServer(_pipeName));
                 Assert.True(client.TryConnectToNamedPipeWithSpinWait((int)oneSec.TotalMilliseconds,
                                                                      default(CancellationToken)));
                 // With infinite timeout
-                connection = Task.Run(() =>
-                    client.TryConnectToNamedPipeWithSpinWait(Timeout.Infinite,
-                                                             default(CancellationToken)));
-                // Give plenty of time for cancellation, in case the machine is very overloaded
-                await Task.WhenAny(connection, Task.Delay(oneSec))
-                    .ConfigureAwait(false);
-                Assert.True(connection.IsCompleted);
-                Assert.True(await connection.ConfigureAwait(false));
+                Assert.True(client.TryConnectToNamedPipeWithSpinWait(Timeout.Infinite,
+                                                                     default(CancellationToken)));
             }
 
             [Fact]


### PR DESCRIPTION
The test fired cancellation then waited 100ms for cancellation to be acknowledged.
There's no guarantee on a heavily loaded machine that cancellation will be
acknowledged in that time frame. This test should be reliable, so 1s should
provide a very high probability that the test is reflective of the spirit behind it
(that the spin wait is cancellable). Fixes #11819 

/cc @cston @dotnet/roslyn-infrastructure @dotnet/roslyn-compiler 

Note: This is a test-only change. 