### PR TITLE
Fix up NuGetTargetMoniker for CoreClr-targeting projects

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -190,7 +190,7 @@
                      '$(TargetFrameworkVersion)' == 'v5.0'">
       <!-- Treat portable exes as CoreClr-targeting-exes -->
       <PropertyGroup Condition="'$(OutputType)' == 'Exe'">
-        <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
+        <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>
         <BaseNuGetRuntimeIdentifier Condition="'$(OS)' == 'Windows_NT'">win7</BaseNuGetRuntimeIdentifier>
       </PropertyGroup>
 


### PR DESCRIPTION
This got switched during the MicroBuild merge somehow. This switches
it back.

*Review:* @dotnet/roslyn-infrastructure