### PR TITLE
Print remaining REPL output if it crashes in VS host

### DIFF
--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.RemoteService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             private Thread _readOutputThread;           // nulled on dispose
             private Thread _readErrorOutputThread;      // nulled on dispose
             private InteractiveHost _host;              // nulled on dispose
-            private bool _isDisposed;                   // set to true on dispose
+            private bool _disposing;                    // set to true on dispose
 
             internal RemoteService(InteractiveHost host, Process process, int processId, Service service)
             {
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                 Debug.Assert(service != null);
 
                 _host = host;
-                _isDisposed = false;
+                _disposing = false;
                 this.Process = process;
                 _processId = processId;
                 this.Service = service;
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                         {
                             Process.Exited -= localHandler;
 
-                            if (!IsDisposed)
+                            if (!_disposing)
                             {
                                 await _host.OnProcessExited(Process).ConfigureAwait(false);
                             }
@@ -112,12 +112,10 @@ namespace Microsoft.CodeAnalysis.Interactive
                 }
             }
 
-            private bool IsDisposed => _isDisposed;
-
             internal void Dispose(bool joinThreads)
             {
-                // set _isDisposed so that we don't attempt restart the host anymore:
-                _isDisposed = true;
+                // set _disposing so that we don't attempt restart the host anymore:
+                _disposing = true;
 
                 InitiateTermination(Process, _processId);
 

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         internal Service TryGetService()
         {
-            var initializedService = TryGetOrCreateRemoteServiceAsync(joinThreads: false).Result;
+            var initializedService = TryGetOrCreateRemoteServiceAsync(processPendingOutput: false).Result;
             return initializedService.ServiceOpt?.Service;
         }
 
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         private Task OnProcessExited(Process process)
         {
             ReportProcessExited(process);
-            return TryGetOrCreateRemoteServiceAsync(joinThreads: true);
+            return TryGetOrCreateRemoteServiceAsync(processPendingOutput: true);
         }
 
         private void ReportProcessExited(Process process)
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             }
         }
 
-        private async Task<InitializedRemoteService> TryGetOrCreateRemoteServiceAsync(bool joinThreads)
+        private async Task<InitializedRemoteService> TryGetOrCreateRemoteServiceAsync(bool processPendingOutput)
         {
             try
             {
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     if (previousService == currentRemoteService)
                     {
                         // we replaced the service whose process we know is dead:
-                        currentRemoteService.Dispose(joinThreads: joinThreads);
+                        currentRemoteService.Dispose(processPendingOutput);
                         currentRemoteService = newService;
                     }
                     else
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         {
             try
             {
-                var initializedService = await TryGetOrCreateRemoteServiceAsync(joinThreads: false).ConfigureAwait(false);
+                var initializedService = await TryGetOrCreateRemoteServiceAsync(processPendingOutput: false).ConfigureAwait(false);
                 if (initializedService.ServiceOpt == null)
                 {
                     return default(TResult);
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     oldService.Dispose(joinThreads: false);
                 }
 
-                var initializedService = await TryGetOrCreateRemoteServiceAsync(joinThreads: false).ConfigureAwait(false);
+                var initializedService = await TryGetOrCreateRemoteServiceAsync(processPendingOutput: false).ConfigureAwait(false);
                 if (initializedService.ServiceOpt == null)
                 {
                     return default(RemoteExecutionResult);

--- a/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
+++ b/src/Interactive/Features/Interactive/Core/InteractiveHost.cs
@@ -76,7 +76,7 @@ namespace Microsoft.CodeAnalysis.Interactive
 
         internal Service TryGetService()
         {
-            var initializedService = TryGetOrCreateRemoteServiceAsync().Result;
+            var initializedService = TryGetOrCreateRemoteServiceAsync(joinThreads: false).Result;
             return initializedService.ServiceOpt?.Service;
         }
 
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         private Task OnProcessExited(Process process)
         {
             ReportProcessExited(process);
-            return TryGetOrCreateRemoteServiceAsync();
+            return TryGetOrCreateRemoteServiceAsync(joinThreads: true);
         }
 
         private void ReportProcessExited(Process process)
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.Interactive
             }
         }
 
-        private async Task<InitializedRemoteService> TryGetOrCreateRemoteServiceAsync()
+        private async Task<InitializedRemoteService> TryGetOrCreateRemoteServiceAsync(bool joinThreads)
         {
             try
             {
@@ -357,7 +357,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     if (previousService == currentRemoteService)
                     {
                         // we replaced the service whose process we know is dead:
-                        currentRemoteService.Dispose(joinThreads: false);
+                        currentRemoteService.Dispose(joinThreads: joinThreads);
                         currentRemoteService = newService;
                     }
                     else
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Interactive
         {
             try
             {
-                var initializedService = await TryGetOrCreateRemoteServiceAsync().ConfigureAwait(false);
+                var initializedService = await TryGetOrCreateRemoteServiceAsync(joinThreads: false).ConfigureAwait(false);
                 if (initializedService.ServiceOpt == null)
                 {
                     return default(TResult);
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.Interactive
                     oldService.Dispose(joinThreads: false);
                 }
 
-                var initializedService = await TryGetOrCreateRemoteServiceAsync().ConfigureAwait(false);
+                var initializedService = await TryGetOrCreateRemoteServiceAsync(joinThreads: false).ConfigureAwait(false);
                 if (initializedService.ServiceOpt == null)
                 {
                     return default(RemoteExecutionResult);


### PR DESCRIPTION
In case REPL gets reset due to a user triggered action stdout and stderr will stop being printed to the interactive window.
However, in case REPL crashes (for instance due to stack overflow) then wait until any remaining output is printed to the interactive window.