### PR TITLE
Add support for an OperationTreeVerifier - test only OperationWalker …

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OperatorTests.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
 using Roslyn.Test.Utilities;
 

--- a/src/Compilers/Core/Portable/Compilation/OperationWalker.cs
+++ b/src/Compilers/Core/Portable/Compilation/OperationWalker.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Semantics
     {
         private int _recursionDepth;
 
-        private void VisitArray<T>(ImmutableArray<T> list) where T : IOperation
+        internal void VisitArray<T>(ImmutableArray<T> list) where T : IOperation
         {
             if (!list.IsDefault)
             {

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/SymbolUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/SymbolUtilities.cs
@@ -87,9 +87,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return text;
         }
 
+        // TODO: Remove this method and fix callsites to directly invoke Microsoft.CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString().
+        //       https://github.com/dotnet/roslyn/issues/11915
         public static string ToTestDisplayString(this ISymbol symbol)
         {
-            return symbol.ToDisplayString(SymbolDisplayFormat.TestFormat);
+            return CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString(symbol);
         }
     }
 }

--- a/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/SymbolUtilities.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -87,9 +86,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return text;
         }
 
+        // TODO: Remove this method and fix callsites to directly invoke Microsoft.CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString().
+        //       https://github.com/dotnet/roslyn/issues/11915
         public static string ToTestDisplayString(this ISymbol symbol)
         {
-            return symbol.ToDisplayString(SymbolDisplayFormat.TestFormat);
+            return CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString(symbol);
         }
     }
 }

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -3,10 +3,6 @@
 Imports System.Collections.Immutable
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
-Imports Microsoft.CodeAnalysis.Text
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Xunit
 
 Friend Module Extensions
@@ -20,9 +16,11 @@ Friend Module Extensions
         Return DirectCast(compilation.GetAssemblyOrModuleSymbol(reference), ModuleSymbol)
     End Function
 
+    ' TODO: Remove this method and fix callsites to directly invoke Microsoft.CodeAnalysis.Test.Extensions.SymbolExtensions.ToTestDisplayString().
+    '       https://github.com/dotnet/roslyn/issues/11915
     <Extension>
-    Public Function ToTestDisplayString(Symbol As ISymbol) As String
-        Return Symbol.ToDisplayString(SymbolDisplayFormat.TestFormat)
+    Public Function ToTestDisplayString(symbol As ISymbol) As String
+        Return Test.Extensions.SymbolExtensions.ToTestDisplayString(symbol)
     End Function
 
     Private Function SplitMemberName(qualifiedName As String) As ImmutableArray(Of String)

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/IOperationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/IOperationTests.vb
@@ -1,15 +1,8 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
-Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics
-Imports Microsoft.CodeAnalysis.UnitTests.Diagnostics.SystemLanguage
 Imports Microsoft.CodeAnalysis.Semantics
-Imports Microsoft.CodeAnalysis.VisualBasic
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.Test.Utilities
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports Roslyn.Test.Utilities
-Imports Xunit
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
 
@@ -77,6 +70,15 @@ End Module
             Dim literal1 As ILiteralExpression = DirectCast(right1, ILiteralExpression)
             Assert.Equal(CInt(literal1.ConstantValue.Value), 10)
 
+            comp.VerifyOperationTree(nodes(0), expectedOperationTree:="
+IExpressionStatement (OperationKind.ExpressionStatement, IsInvalid)
+  IAssignmentExpression (OperationKind.AssignmentExpression, Type: B2, IsInvalid)
+    Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+    Right: IBinaryOperatorExpression (BinaryOperationKind.OperatorMethodAdd) (OperationKind.BinaryOperatorExpression, Type: B2, IsInvalid)
+        Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+        Right: ILiteralExpression (Text: 10) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 10)
+")
+
             ' x = x + y passes semantic analysis.
 
             Assert.Equal("x = x + y", nodes(1).ToString())
@@ -98,6 +100,15 @@ End Module
             Assert.Equal(right2.Kind, OperationKind.LocalReferenceExpression)
             Assert.Equal(DirectCast(right2, ILocalReferenceExpression).Local.Name, "y")
 
+            comp.VerifyOperationTree(nodes(1), expectedOperationTree:="
+IExpressionStatement (OperationKind.ExpressionStatement)
+  IAssignmentExpression (OperationKind.AssignmentExpression, Type: B2)
+    Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+    Right: IBinaryOperatorExpression (BinaryOperationKind.OperatorMethodAdd) (OperatorMethod: Function B2.op_Addition(x As B2, y As B2) As B2) (OperationKind.BinaryOperatorExpression, Type: B2)
+        Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+        Right: ILocalReferenceExpression: y (OperationKind.LocalReferenceExpression, Type: B2)
+")
+
             ' -x fails semantic analysis and does not have an operator method, but the operand is available.
 
             Assert.Equal("x = -x", nodes(2).ToString())
@@ -114,6 +125,14 @@ End Module
             Dim operand3 As IOperation = negate3.Operand
             Assert.Equal(operand3.Kind, OperationKind.LocalReferenceExpression)
             Assert.Equal(DirectCast(operand3, ILocalReferenceExpression).Local.Name, "x")
+
+            comp.VerifyOperationTree(nodes(2), expectedOperationTree:="
+IExpressionStatement (OperationKind.ExpressionStatement, IsInvalid)
+  IAssignmentExpression (OperationKind.AssignmentExpression, Type: B2, IsInvalid)
+    Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+    Right: IUnaryOperatorExpression (UnaryOperationKind.OperatorMethodMinus) (OperationKind.UnaryOperatorExpression, Type: B2, IsInvalid)
+        ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: B2)
+")
         End Sub
 
         <Fact>
@@ -164,6 +183,13 @@ End Module
             Assert.False(assignment1.UsesOperatorMethod)
             Assert.Null(assignment1.OperatorMethod)
 
+            comp.VerifyOperationTree(nodes(0), expectedOperationTree:="
+IExpressionStatement (OperationKind.ExpressionStatement)
+  ICompoundAssignmentExpression (BinaryOperationKind.IntegerAdd) (OperationKind.CompoundAssignmentExpression, Type: System.Int32)
+    Left: ILocalReferenceExpression: x (OperationKind.LocalReferenceExpression, Type: System.Int32)
+    Right: ILocalReferenceExpression: y (OperationKind.LocalReferenceExpression, Type: System.Int32)
+")
+
             ' a += b produces a compound assignment with an operator method add.
 
             Assert.Equal("a += b", nodes(1).ToString())
@@ -182,6 +208,85 @@ End Module
             Assert.True(assignment2.UsesOperatorMethod)
             Assert.NotNull(assignment2.OperatorMethod)
             Assert.Equal(assignment2.OperatorMethod.Name, "op_Addition")
+
+            comp.VerifyOperationTree(nodes(1), expectedOperationTree:="
+IExpressionStatement (OperationKind.ExpressionStatement)
+  ICompoundAssignmentExpression (BinaryOperationKind.OperatorMethodAdd) (OperatorMethod: Function B2.op_Addition(x As B2, y As B2) As B2) (OperationKind.CompoundAssignmentExpression, Type: B2)
+    Left: ILocalReferenceExpression: a (OperationKind.LocalReferenceExpression, Type: B2)
+    Right: ILocalReferenceExpression: b (OperationKind.LocalReferenceExpression, Type: B2)
+")
+        End Sub
+
+        <Fact>
+        Public Sub VerifyOperationTree_IfStatement()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Sub Foo(x as Integer)
+        If x <> 0
+          System.Console.Write(x)
+        End If
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source) _
+                .VerifyOperationTree("Foo", "
+Sub C.Foo(x As System.Int32)
+  IIfStatement (OperationKind.IfStatement)
+    Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerNotEquals) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
+        Left: IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32)
+        Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+    IBlockStatement (1 statements) (OperationKind.BlockStatement)
+      IExpressionStatement (OperationKind.ExpressionStatement)
+        IInvocationExpression (static Sub System.Console.Write(value As System.Int32)) (OperationKind.InvocationExpression, Type: System.Void)
+          IArgument (Matching Parameter: value) (OperationKind.Argument)
+            IParameterReferenceExpression: x (OperationKind.ParameterReferenceExpression, Type: System.Int32)
+")
+        End Sub
+
+        <Fact>
+        Public Sub VerifyOperationTree_ForStatement()
+
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Sub Foo()
+        For i = 0 To 10
+            System.Console.Write(i)
+        Next
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(source) _
+                .VerifyOperationTree("Foo", "
+Sub C.Foo()
+  IForLoopStatement (LoopKind.For) (OperationKind.LoopStatement)
+    Condition: IBinaryOperatorExpression (BinaryOperationKind.IntegerLessThanOrEqual) (OperationKind.BinaryOperatorExpression, Type: System.Boolean)
+        Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+        Right: ILiteralExpression (Text: 10) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 10)
+    Before: IExpressionStatement (OperationKind.ExpressionStatement)
+        IAssignmentExpression (OperationKind.AssignmentExpression, Type: System.Int32)
+          Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+          Right: ILiteralExpression (Text: 0) (OperationKind.LiteralExpression, Type: System.Int32, Constant: 0)
+    AtLoopBottom: IExpressionStatement (OperationKind.ExpressionStatement)
+        ICompoundAssignmentExpression (BinaryOperationKind.IntegerAdd) (OperationKind.CompoundAssignmentExpression, Type: System.Int32)
+          Left: ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+          Right: IConversionExpression (ConversionKind.Basic, Explicit) (OperationKind.ConversionExpression, Type: System.Int32, Constant: 1)
+              ILiteralExpression (OperationKind.LiteralExpression, Type: System.Int32, Constant: 1)
+    IBlockStatement (1 statements) (OperationKind.BlockStatement)
+      IExpressionStatement (OperationKind.ExpressionStatement)
+        IInvocationExpression (static Sub System.Console.Write(value As System.Int32)) (OperationKind.InvocationExpression, Type: System.Void)
+          IArgument (Matching Parameter: value) (OperationKind.Argument)
+            ILocalReferenceExpression: i (OperationKind.LocalReferenceExpression, Type: System.Int32)
+")
         End Sub
     End Class
 End Namespace

--- a/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
+++ b/src/Test/Utilities/Desktop/CommonTestBase.CompilationVerifier.cs
@@ -130,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 _diagnostics = testEnvironment.GetDiagnostics();
                 EmittedAssemblyData = testEnvironment.GetMainImage();
                 EmittedAssemblyPdb = testEnvironment.GetMainPdb();
-                _testData = ((IInternalRuntimeEnvironment) testEnvironment).GetCompilationTestData();
+                _testData = ((IInternalRuntimeEnvironment)testEnvironment).GetCompilationTestData();
 
                 return _compilation.Assembly.Identity.GetDisplayName();
             }
@@ -332,6 +332,16 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
                 {
                     return AssemblyMetadata.Create(moduleMetadata).GetReference(display: display);
                 }
+            }
+
+            public void VerifyOperationTree(string expectedOperationTree, bool skipImplicitlyDeclaredSymbols = false)
+            {
+                _compilation.VerifyOperationTree(expectedOperationTree, skipImplicitlyDeclaredSymbols);
+            }
+
+            public void VerifyOperationTree(string symbolToVerify, string expectedOperationTree, bool skipImplicitlyDeclaredSymbols = false)
+            {
+                _compilation.VerifyOperationTree(symbolToVerify, expectedOperationTree, skipImplicitlyDeclaredSymbols);
             }
         }
     }

--- a/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
+++ b/src/Test/Utilities/Shared/Compilation/CompilationExtensions.cs
@@ -5,13 +5,15 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Metadata;
+using System.Text;
 using System.Threading;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Test.Extensions;
 using Roslyn.Test.Utilities;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.CodeAnalysis.Test.Utilities
 {
@@ -148,5 +150,128 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
             AssertEx.Equal(expectedAssembliesAndAliases, actual, itemInspector: s => '"' + s + '"');
         }
+
+        internal static void VerifyOperationTree(this Compilation compilation, SyntaxNode node, string expectedOperationTree)
+        {
+            var actualTextBuilder = new StringBuilder();
+            SemanticModel model = compilation.GetSemanticModel(node.SyntaxTree);
+            AppendOperationTree(model, node, actualTextBuilder);
+            VerifyOperationTree(expectedOperationTree, actualTextBuilder.ToString());
+        }
+
+        internal static void VerifyOperationTree(this Compilation compilation, string expectedOperationTree, bool skipImplicitlyDeclaredSymbols = false)
+        {
+            VerifyOperationTree(compilation, symbolToVerify: null, expectedOperationTree: expectedOperationTree, skipImplicitlyDeclaredSymbols: skipImplicitlyDeclaredSymbols);
+        }
+
+        internal static void VerifyOperationTree(this Compilation compilation, string symbolToVerify, string expectedOperationTree, bool skipImplicitlyDeclaredSymbols = false)
+        {
+            SyntaxTree tree = compilation.SyntaxTrees.First();
+            SyntaxNode root = tree.GetRoot();
+            SemanticModel model = compilation.GetSemanticModel(tree);
+            var declarations = new List<DeclarationInfo>();
+            model.ComputeDeclarationsInNode(root, getSymbol: true, builder: declarations, cancellationToken: CancellationToken.None);
+
+            var actualTextBuilder = new StringBuilder();
+            foreach (DeclarationInfo declaration in declarations.Where(d => d.DeclaredSymbol != null).OrderBy(d => d.DeclaredSymbol.ToTestDisplayString()))
+            {
+                if (!CanHaveExecutableCodeBlock(declaration.DeclaredSymbol))
+                {
+                    continue;
+                }
+
+                if (skipImplicitlyDeclaredSymbols && declaration.DeclaredSymbol.IsImplicitlyDeclared)
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrEmpty(symbolToVerify) && !declaration.DeclaredSymbol.Name.Equals(symbolToVerify, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                actualTextBuilder.Append(declaration.DeclaredSymbol.ToTestDisplayString());
+
+                if (declaration.ExecutableCodeBlocks.Length == 0)
+                {
+                    actualTextBuilder.Append($" ('0' executable code blocks)");
+                }
+                else
+                {
+                    // Workaround for https://github.com/dotnet/roslyn/issues/11903 - skip the IOperation for EndBlockStatement.
+                    ImmutableArray<SyntaxNode> executableCodeBlocks = declaration.ExecutableCodeBlocks;
+                    if (declaration.DeclaredSymbol.Kind == SymbolKind.Method && compilation.Language == LanguageNames.VisualBasic)
+                    {
+                        executableCodeBlocks = executableCodeBlocks.RemoveAt(executableCodeBlocks.Length - 1);
+                    }
+
+                    foreach (SyntaxNode executableCodeBlock in executableCodeBlocks)
+                    {
+                        actualTextBuilder.Append(Environment.NewLine);
+                        AppendOperationTree(model, executableCodeBlock, actualTextBuilder, initialIndent: 2);
+                    }
+                }               
+
+                actualTextBuilder.Append(Environment.NewLine);
+            }
+
+            VerifyOperationTree(expectedOperationTree, actualTextBuilder.ToString());
+        }
+
+        private static void AppendOperationTree(SemanticModel model, SyntaxNode node, StringBuilder actualTextBuilder, int initialIndent = 0)
+        {
+            IOperation operation = model.GetOperation(node);
+            if (operation != null)
+            {
+                string operationTree = OperationTreeVerifier.GetOperationTree(operation, initialIndent);
+                actualTextBuilder.Append(operationTree);
+            }
+            else
+            {
+                actualTextBuilder.Append($"  SemanticModel.GetOperation() returned NULL for node with text: '{node.ToString()}'");
+            }
+        }
+
+        private static void VerifyOperationTree(string expectedOperationTree, string actualOperationTree)
+        {
+            var assertFailed = false;
+            char[] newLineChars = Environment.NewLine.ToCharArray();
+            string actual = actualOperationTree.Trim(newLineChars);
+            expectedOperationTree = expectedOperationTree.Trim(newLineChars);
+
+            try
+            {
+                Assert.Equal(expectedOperationTree, actual);
+            }
+            catch (EqualException)
+            {
+                assertFailed = true;
+                throw;
+            }
+            finally
+            {
+                if (assertFailed)
+                {
+                    Console.WriteLine($"Actual operation tree:\r\n{actual}\r\n");
+                }
+            }
+        }
+
+        internal static bool CanHaveExecutableCodeBlock(ISymbol symbol)
+        {
+            switch (symbol.Kind)
+            {
+                case SymbolKind.Field:
+                case SymbolKind.Event:
+                case SymbolKind.Method:
+                case SymbolKind.NamedType:
+                case SymbolKind.Property:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
     }
 }

--- a/src/Test/Utilities/Shared/Compilation/OperationTreeVerifier.cs
+++ b/src/Test/Utilities/Shared/Compilation/OperationTreeVerifier.cs
@@ -1,0 +1,1047 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using Microsoft.CodeAnalysis.Semantics;
+using Microsoft.CodeAnalysis.Test.Extensions;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Test.Utilities
+{
+    public sealed class OperationTreeVerifier : OperationWalker
+    {
+        private readonly IOperation _root;
+        private readonly StringBuilder _builder;
+
+        private const string indent = "  ";
+        private string _currentIndent;
+        private bool _pendingIndent;
+
+        public OperationTreeVerifier(IOperation root, int initialIndent)
+        {
+            _root = root;
+            _builder = new StringBuilder();
+
+            _currentIndent = new string(' ', initialIndent);
+            _pendingIndent = true;
+        }
+
+        public static void Verify(IOperation operation, string expectedOperationTree, int initialIndent = 0)
+        {
+            var actual = GetOperationTree(operation, initialIndent);
+            Assert.Equal(expectedOperationTree, actual);
+        }
+
+        public static string GetOperationTree(IOperation operation, int initialIndent = 0)
+        {
+            var walker = new OperationTreeVerifier(operation, initialIndent);
+            walker.Visit(operation);
+            return walker._builder.ToString();
+        }
+
+        #region Logging helpers
+
+        private void LogCommonPropertiesAndNewLine(IOperation operation)
+        {
+            LogString(" (");
+
+            // Kind
+            LogString($"{nameof(OperationKind)}.{operation.Kind}");
+
+            // Type
+            if (ShouldLogType(operation))
+            {
+                LogString(", ");
+                LogType(operation.Type);
+            }
+
+            // ConstantValue
+            if (operation.ConstantValue.HasValue)
+            {
+                LogString(", ");
+                LogConstant(operation.ConstantValue);
+            }
+
+            // IsInvalid
+            if (operation.IsInvalid)
+            {
+                LogString(", IsInvalid");
+            }
+
+            LogString(")");
+            LogNewLine();
+        }
+
+        private static bool ShouldLogType(IOperation operation)
+        {
+            var operationKind = (int)operation.Kind;
+
+            // Expressions
+            if (operationKind >= 0x100 && operationKind < 0x400)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private void LogString(string str)
+        {
+            if (_pendingIndent)
+            {
+                str = _currentIndent + str;
+                _pendingIndent = false;
+            }
+
+            _builder.Append(str);
+        }
+
+        private void LogNewLine()
+        {
+            LogString(Environment.NewLine);
+            _pendingIndent = true;
+        }
+
+        private void Indent()
+        {
+            _currentIndent += indent;
+        }
+
+        private void Unindent()
+        {
+            _currentIndent = _currentIndent.Substring(indent.Length);
+        }
+
+        private void LogConstant(Optional<object> constant, string header = "Constant")
+        {
+            if (constant.HasValue)
+            {
+                LogConstant(constant.Value, header);
+            }
+        }
+
+        private void LogConstant(object constant, string header = "Constant")
+        {
+            var valueStr = constant != null ? constant.ToString() : "null";
+            LogString($"{header}: {valueStr}");
+        }
+
+        private void LogSymbol(ISymbol symbol, string header, bool logDisplayString = true)
+        {
+            if (!string.IsNullOrEmpty(header))
+            {
+                LogString($"{header}: ");
+            }
+
+            var symbolStr = symbol != null ? (logDisplayString ? symbol.ToTestDisplayString() : symbol.Name) : "null";
+            LogString($"{symbolStr}");
+        }
+
+        private void LogType(ITypeSymbol type)
+        {
+            var typeStr = type != null ? type.ToTestDisplayString() : "null";
+            LogString($"Type: {typeStr}");
+        }
+
+        #endregion
+
+        #region Visit methods
+
+        public override void Visit(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return;
+            }
+
+            if (operation != _root)
+            {
+                Indent();
+            }
+
+            base.Visit(operation);
+
+            if (operation != _root)
+            {
+                Unindent();
+            }
+        }
+
+        private void Visit(IOperation operation, string header)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(header));
+
+            if (operation == null)
+            {
+                return;
+            }
+
+            Indent();
+            LogString($"{header}: ");
+            Visit(operation);
+            Unindent();
+        }
+
+        private void VisitArray<T>(ImmutableArray<T> list, string header)
+            where T : IOperation
+        {
+            Debug.Assert(!string.IsNullOrEmpty(header));
+
+            if (list.IsDefaultOrEmpty)
+            {
+                return;
+            }
+
+            Indent();
+            LogString($"{header}: ");
+            VisitArray(list);
+            Unindent();
+        }
+
+        private void VisitInstanceExpression(IOperation instance)
+        {
+            Visit(instance, header: "Instance Receiver");
+        }
+
+        internal override void VisitNoneOperation(IOperation operation)
+        {
+            Assert.True(false, "Encountered an IOperation with `Kind == OperationKind.None` while walking the operation tree.");
+        }
+
+        public override void VisitBlockStatement(IBlockStatement operation)
+        {
+            LogString(nameof(IBlockStatement));
+
+            var statementsStr = $"{operation.Statements.Length} statements";
+            var localStr = !operation.Locals.IsEmpty ? $", {operation.Locals.Length} locals" : string.Empty;
+            LogString($" ({statementsStr}{localStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            if (operation.Statements.IsEmpty)
+            {
+                return;
+            }
+
+            LogLocals(operation.Locals);
+
+            base.VisitBlockStatement(operation);
+        }
+
+        public override void VisitVariableDeclarationStatement(IVariableDeclarationStatement operation)
+        {
+            var variablesCountStr = $"{operation.Variables.Length} variables";
+            LogString($"{nameof(IVariableDeclarationStatement)} ({variablesCountStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitVariableDeclarationStatement(operation);
+        }
+
+        public override void VisitVariableDeclaration(IVariableDeclaration operation)
+        {
+            LogSymbol(operation.Variable, header: nameof(IVariableDeclaration));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.InitialValue, "Initializer");
+        }
+
+        public override void VisitSwitchStatement(ISwitchStatement operation)
+        {
+            var caseCountStr = $"{operation.Cases.Length} cases";
+            LogString($"{nameof(ISwitchStatement)} ({caseCountStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Value, header: "Switch expression");
+            VisitArray(operation.Cases);
+        }
+
+        public override void VisitSwitchCase(ISwitchCase operation)
+        {
+            var caseClauseCountStr = $"{operation.Clauses.Length} case clauses";
+            var statementCountStr = $"{operation.Body.Length} statements";
+            LogString($"{nameof(ISwitchCase)} ({caseClauseCountStr}, {statementCountStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Indent();
+            LogString("Case clauses: ");
+            VisitArray(operation.Clauses);
+            LogString("Body: ");
+            VisitArray(operation.Body);
+            Unindent();
+        }
+
+        public override void VisitWhileUntilLoopStatement(IWhileUntilLoopStatement operation)
+        {
+            LogString(nameof(IWhileUntilLoopStatement));
+
+            LogString($" (IsTopTest: {operation.IsTopTest}, IsWhile: {operation.IsWhile})");
+            LogLoopStatementHeader(operation);
+
+            Visit(operation.Condition, "Condition");
+            VisitLoopStatementBody(operation);
+        }
+
+        public override void VisitForLoopStatement(IForLoopStatement operation)
+        {
+            LogString(nameof(IForLoopStatement));
+            LogLoopStatementHeader(operation);
+
+            Visit(operation.Condition, "Condition");
+            LogLocals(operation.Locals);
+            VisitArray(operation.Before, "Before");
+            VisitArray(operation.AtLoopBottom, "AtLoopBottom");
+            VisitLoopStatementBody(operation);
+        }
+
+        private void LogLocals(IEnumerable<ILocalSymbol> locals)
+        {
+            Indent();
+
+            int localIndex = 1;
+            foreach (var local in locals)
+            {
+                LogSymbol(local, header: $"Local_{localIndex++}");
+                LogNewLine();
+            }
+
+            Unindent();
+        }
+
+        private void LogLoopStatementHeader(ILoopStatement operation)
+        {
+            var kindStr = $"{nameof(LoopKind)}.{operation.LoopKind}";
+            LogString($" ({kindStr})");
+            LogCommonPropertiesAndNewLine(operation);
+        }
+
+        private void VisitLoopStatementBody(ILoopStatement operation, string header = null)
+        {
+            if (header != null)
+            {
+                Visit(operation.Body, header);
+            }
+            else
+            {
+                Visit(operation.Body);
+            }
+        }
+
+        public override void VisitForEachLoopStatement(IForEachLoopStatement operation)
+        {
+            LogString(nameof(IForEachLoopStatement));
+            LogSymbol(operation.IterationVariable, " (Iteration variable");
+            LogString(")");
+
+            LogLoopStatementHeader(operation);
+            Visit(operation.Collection, "Collection");
+            VisitLoopStatementBody(operation);
+        }
+
+        public override void VisitLabelStatement(ILabelStatement operation)
+        {
+            LogString(nameof(ILabelStatement));
+
+            // TODO: Put a better workaround to skip compiler generated labels.
+            if (!operation.Label.IsImplicitlyDeclared)
+            {
+                LogString($" (Label: {operation.Label.Name})");
+            }
+
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitLabelStatement(operation);
+        }
+
+        public override void VisitBranchStatement(IBranchStatement operation)
+        {
+            LogString(nameof(IBranchStatement));
+            var kindStr = $"{nameof(BranchKind)}.{operation.BranchKind}";
+            var labelStr = !operation.Target.IsImplicitlyDeclared ? $", Label: {operation.Target.Name}" : string.Empty;
+            LogString($" ({kindStr}{labelStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitBranchStatement(operation);
+        }
+
+        public override void VisitYieldBreakStatement(IReturnStatement operation)
+        {
+            LogString("YieldBreakStatement");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitYieldBreakStatement(operation);
+        }
+
+        public override void VisitEmptyStatement(IEmptyStatement operation)
+        {
+            LogString(nameof(IEmptyStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitEmptyStatement(operation);
+        }
+
+        public override void VisitThrowStatement(IThrowStatement operation)
+        {
+            LogString(nameof(IThrowStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitThrowStatement(operation);
+        }
+
+        public override void VisitReturnStatement(IReturnStatement operation)
+        {
+            LogString(nameof(IReturnStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitReturnStatement(operation);
+        }
+
+        public override void VisitLockStatement(ILockStatement operation)
+        {
+            LogString(nameof(ILockStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitLockStatement(operation);
+        }
+
+        public override void VisitTryStatement(ITryStatement operation)
+        {
+            LogString(nameof(ITryStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitTryStatement(operation);
+        }
+
+        public override void VisitCatch(ICatchClause operation)
+        {
+            LogString(nameof(ICatchClause));
+            LogString($" (Exception type: {operation.Type?.ToTestDisplayString()}, Exception local: {operation.ExceptionLocal?.ToTestDisplayString()})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitCatch(operation);
+        }
+
+        public override void VisitUsingStatement(IUsingStatement operation)
+        {
+            LogString(nameof(IUsingStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitUsingStatement(operation);
+        }
+
+        public override void VisitFixedStatement(IFixedStatement operation)
+        {
+            LogString(nameof(IFixedStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitFixedStatement(operation);
+        }
+
+        public override void VisitExpressionStatement(IExpressionStatement operation)
+        {
+            LogString(nameof(IExpressionStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitExpressionStatement(operation);
+        }
+
+        public override void VisitWithStatement(IWithStatement operation)
+        {
+            LogString(nameof(IWithStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitWithStatement(operation);
+        }
+
+        public override void VisitStopStatement(IStopStatement operation)
+        {
+            LogString(nameof(IStopStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitStopStatement(operation);
+        }
+
+        public override void VisitEndStatement(IEndStatement operation)
+        {
+            LogString(nameof(IEndStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitEndStatement(operation);
+        }
+
+        public override void VisitInvocationExpression(IInvocationExpression operation)
+        {
+            LogString(nameof(IInvocationExpression));
+
+            var isVirtualStr = operation.IsVirtual ? "virtual " : string.Empty;
+            var isStaticStr = operation.Instance == null ? "static " : string.Empty;
+            var spacing = !operation.IsVirtual && operation.Instance != null ? " " : string.Empty;
+            LogString($" ({isVirtualStr}{isStaticStr}{spacing}");
+            LogSymbol(operation.TargetMethod, header: string.Empty);
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitInstanceExpression(operation.Instance);
+            VisitArguments(operation);
+        }
+
+        private void VisitArguments(IHasArgumentsExpression operation, string header = null)
+        {
+            if (header != null)
+            {
+                VisitArray(operation.ArgumentsInParameterOrder, header);
+            }
+            else
+            {
+                VisitArray(operation.ArgumentsInParameterOrder);
+            }
+        }
+
+        public override void VisitArgument(IArgument operation)
+        {
+            LogString($"{nameof(IArgument)} (");
+            LogSymbol(operation.Parameter, header: "Matching Parameter", logDisplayString: false);
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Value);
+            Visit(operation.InConversion, "InConversion");
+            Visit(operation.OutConversion, "OutConversion");
+        }
+
+        public override void VisitOmittedArgumentExpression(IOmittedArgumentExpression operation)
+        {
+            LogString(nameof(IOmittedArgumentExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitOmittedArgumentExpression(operation);
+        }
+
+        public override void VisitArrayElementReferenceExpression(IArrayElementReferenceExpression operation)
+        {
+            LogString(nameof(IArrayElementReferenceExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.ArrayReference);
+            VisitArray(operation.Indices, "Indices");
+        }
+
+        public override void VisitPointerIndirectionReferenceExpression(IPointerIndirectionReferenceExpression operation)
+        {
+            LogString(nameof(IPointerIndirectionReferenceExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitPointerIndirectionReferenceExpression(operation);
+        }
+
+        public override void VisitLocalReferenceExpression(ILocalReferenceExpression operation)
+        {
+            LogString(nameof(ILocalReferenceExpression));
+            LogString($": {operation.Local.Name}");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitLocalReferenceExpression(operation);
+        }
+
+        public override void VisitParameterReferenceExpression(IParameterReferenceExpression operation)
+        {
+            LogString(nameof(IParameterReferenceExpression));
+            LogString($": {operation.Parameter.Name}");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitParameterReferenceExpression(operation);
+        }
+
+        public override void VisitSyntheticLocalReferenceExpression(ISyntheticLocalReferenceExpression operation)
+        {
+            LogString(nameof(ISyntheticLocalReferenceExpression));
+            var kindStr = $"{nameof(SynthesizedLocalKind)}.{operation.SyntheticLocalKind}";
+            LogString($" ({kindStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitSyntheticLocalReferenceExpression(operation);
+        }
+
+        public override void VisitInstanceReferenceExpression(IInstanceReferenceExpression operation)
+        {
+            LogString(nameof(IInstanceReferenceExpression));
+            var kindStr = $"{nameof(InstanceReferenceKind)}.{operation.InstanceReferenceKind}";
+            LogString($" ({kindStr})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitInstanceReferenceExpression(operation);
+        }
+
+        private void VisitMemberReferenceExpressionCommon(IMemberReferenceExpression operation)
+        {
+            if (operation.Instance == null)
+            {
+                LogString(" (Static)");
+            }
+
+            LogCommonPropertiesAndNewLine(operation);
+            VisitInstanceExpression(operation.Instance);
+        }
+
+        public override void VisitFieldReferenceExpression(IFieldReferenceExpression operation)
+        {
+            LogString(nameof(IFieldReferenceExpression));
+            LogString($": {operation.Field.ToTestDisplayString()}");
+
+            VisitMemberReferenceExpressionCommon(operation);
+        }
+
+        public override void VisitMethodBindingExpression(IMethodBindingExpression operation)
+        {
+            LogString(nameof(IMethodBindingExpression));
+            LogString($": {operation.Method.ToTestDisplayString()}");
+
+            if (operation.IsVirtual)
+            {
+                LogString(" (UsesVirtualSemantics)");
+            }
+
+            VisitMemberReferenceExpressionCommon(operation);
+        }
+
+        public override void VisitPropertyReferenceExpression(IPropertyReferenceExpression operation)
+        {
+            LogString(nameof(IPropertyReferenceExpression));
+            LogString($": {operation.Property.ToTestDisplayString()}");
+
+            VisitMemberReferenceExpressionCommon(operation);
+        }
+
+        public override void VisitEventReferenceExpression(IEventReferenceExpression operation)
+        {
+            LogString(nameof(IEventReferenceExpression));
+            LogString($": {operation.Event.ToTestDisplayString()}");
+
+            VisitMemberReferenceExpressionCommon(operation);
+        }
+
+        public override void VisitEventAssignmentExpression(IEventAssignmentExpression operation)
+        {
+            var kindStr = operation.Adds ? "EventAdd" : "EventRemove";
+            LogString($"{nameof(IEventAssignmentExpression)} ({kindStr})");
+            LogSymbol(operation.Event, header: " (Event: ");
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.EventInstance, header: "Event Instance");
+            Visit(operation.HandlerValue, header: "Handler");
+        }
+
+        public override void VisitConditionalAccessExpression(IConditionalAccessExpression operation)
+        {
+            LogString(nameof(IConditionalAccessExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.ConditionalInstance, header: "Left");
+            Visit(operation.ConditionalValue, header: "Right");
+        }
+
+        public override void VisitConditionalAccessInstanceExpression(IConditionalAccessInstanceExpression operation)
+        {
+            LogString(nameof(IConditionalAccessInstanceExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitConditionalAccessInstanceExpression(operation);
+        }
+
+        public override void VisitPlaceholderExpression(IPlaceholderExpression operation)
+        {
+            LogString(nameof(IPlaceholderExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitPlaceholderExpression(operation);
+        }
+
+        public override void VisitIndexedPropertyReferenceExpression(IIndexedPropertyReferenceExpression operation)
+        {
+            LogString(nameof(IIndexedPropertyReferenceExpression));
+
+            LogString($": {operation.Property.ToTestDisplayString()}");
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitMemberReferenceExpressionCommon(operation);
+        }
+
+        public override void VisitUnaryOperatorExpression(IUnaryOperatorExpression operation)
+        {
+            LogString(nameof(IUnaryOperatorExpression));
+
+            var kindStr = $"{nameof(UnaryOperationKind)}.{operation.UnaryOperationKind}";
+            LogString($" ({kindStr})");
+            LogHasOperatorMethodExpressionCommon(operation);
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitUnaryOperatorExpression(operation);
+        }
+
+        public override void VisitBinaryOperatorExpression(IBinaryOperatorExpression operation)
+        {
+            LogString(nameof(IBinaryOperatorExpression));
+
+            var kindStr = $"{nameof(BinaryOperationKind)}.{operation.BinaryOperationKind}";
+            LogString($" ({kindStr})");
+            LogHasOperatorMethodExpressionCommon(operation);
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.LeftOperand, "Left");
+            Visit(operation.RightOperand, "Right");
+        }
+
+        private void LogHasOperatorMethodExpressionCommon(IHasOperatorMethodExpression operation)
+        {
+            Assert.Equal(operation.UsesOperatorMethod, operation.OperatorMethod != null);
+
+            if (!operation.UsesOperatorMethod)
+            {
+                return;
+            }
+
+            LogSymbol(operation.OperatorMethod, header: " (OperatorMethod");
+            LogString(")");
+        }
+
+        public override void VisitConversionExpression(IConversionExpression operation)
+        {
+            LogString(nameof(IConversionExpression));
+
+            var kindStr = $"{nameof(ConversionKind)}.{operation.ConversionKind}";
+            var isExplicitStr = operation.IsExplicit ? "Explicit" : "Implicit";
+            LogString($" ({kindStr}, {isExplicitStr})");
+
+            LogHasOperatorMethodExpressionCommon(operation);
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitConversionExpression(operation);
+        }
+
+        public override void VisitConditionalChoiceExpression(IConditionalChoiceExpression operation)
+        {
+            LogString(nameof(IConditionalChoiceExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Condition, "Condition");
+            Visit(operation.IfTrueValue, "IfTrue");
+            Visit(operation.IfFalseValue, "IfFalse");
+        }
+
+        public override void VisitNullCoalescingExpression(INullCoalescingExpression operation)
+        {
+            LogString(nameof(INullCoalescingExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.PrimaryOperand, "Left");
+            Visit(operation.SecondaryOperand, "Right");
+        }
+
+        public override void VisitIsTypeExpression(IIsTypeExpression operation)
+        {
+            LogString(nameof(IIsTypeExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitIsTypeExpression(operation);
+
+            Indent();
+            LogType(operation.Type);
+            Unindent();
+        }
+
+        private void LogTypeOperationExpressionCommon(ITypeOperationExpression operation)
+        {
+            LogString(" (");
+            LogType(operation.TypeOperand);
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+        }
+
+        public override void VisitSizeOfExpression(ISizeOfExpression operation)
+        {
+            LogString(nameof(ISizeOfExpression));
+            LogTypeOperationExpressionCommon(operation);
+
+            base.VisitSizeOfExpression(operation);
+        }
+
+        public override void VisitTypeOfExpression(ITypeOfExpression operation)
+        {
+            LogString(nameof(ITypeOfExpression));
+            LogTypeOperationExpressionCommon(operation);
+
+            base.VisitTypeOfExpression(operation);
+        }
+
+        public override void VisitLambdaExpression(ILambdaExpression operation)
+        {
+            LogString(nameof(ILambdaExpression));
+
+            LogSymbol(operation.Signature, header: " (Signature");
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitLambdaExpression(operation);
+        }
+
+        public override void VisitLiteralExpression(ILiteralExpression operation)
+        {
+            LogString(nameof(ILiteralExpression));
+
+            if (operation.ConstantValue.HasValue && operation.ConstantValue.Value.ToString() == operation.Text)
+            {
+                LogString($" (Text: {operation.Text})");
+            }
+
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitLiteralExpression(operation);
+        }
+
+        public override void VisitAwaitExpression(IAwaitExpression operation)
+        {
+            LogString(nameof(IAwaitExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitAwaitExpression(operation);
+        }
+
+        public override void VisitAddressOfExpression(IAddressOfExpression operation)
+        {
+            LogString(nameof(IAddressOfExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitAddressOfExpression(operation);
+        }
+
+        public override void VisitObjectCreationExpression(IObjectCreationExpression operation)
+        {
+            LogString(nameof(IObjectCreationExpression));
+            LogString($" (Constructor: {operation.Constructor.ToTestDisplayString()})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitArguments(operation, "Arguments");
+            VisitArray(operation.MemberInitializers, "Member Initializers");
+        }
+
+        public override void VisitFieldInitializer(IFieldInitializer operation)
+        {
+            LogString(nameof(IFieldInitializer));
+
+            if (operation.InitializedFields.Length <= 1)
+            {
+                if (operation.InitializedFields.Length == 1)
+                {
+                    LogSymbol(operation.InitializedFields[0], header: " (Field");
+                    LogString(")");
+                }
+
+                LogCommonPropertiesAndNewLine(operation);
+            }
+            else
+            {
+                LogString($" ({operation.InitializedFields.Length} initialized fields)");
+                LogCommonPropertiesAndNewLine(operation);
+
+                Indent();
+
+                int index = 1;
+                foreach (var local in operation.InitializedFields)
+                {
+                    LogSymbol(local, header: $"Field_{index++}");
+                    LogNewLine();
+                }
+
+                Unindent();
+            }
+
+            base.VisitFieldInitializer(operation);
+        }
+
+        public override void VisitPropertyInitializer(IPropertyInitializer operation)
+        {
+            LogString(nameof(IPropertyInitializer));
+            LogSymbol(operation.InitializedProperty, header: " (Property");
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitPropertyInitializer(operation);
+        }
+
+        public override void VisitParameterInitializer(IParameterInitializer operation)
+        {
+            LogString(nameof(IParameterInitializer));
+            LogSymbol(operation.Parameter, header: " (Parameter");
+            LogString(")");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitParameterInitializer(operation);
+        }
+
+        public override void VisitArrayCreationExpression(IArrayCreationExpression operation)
+        {
+            LogString(nameof(IArrayCreationExpression));
+            LogString($" (Dimension sizes: {operation.DimensionSizes.Length}, Element Type: {operation.ElementType?.ToTestDisplayString()})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitArrayCreationExpression(operation);
+        }
+
+        public override void VisitArrayInitializer(IArrayInitializer operation)
+        {
+            LogString(nameof(IArrayInitializer));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitArrayInitializer(operation);
+        }
+
+        public override void VisitAssignmentExpression(IAssignmentExpression operation)
+        {
+            LogString(nameof(IAssignmentExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Target, "Left");
+            Visit(operation.Value, "Right");
+        }
+
+        public override void VisitCompoundAssignmentExpression(ICompoundAssignmentExpression operation)
+        {
+            LogString(nameof(ICompoundAssignmentExpression));
+
+            var kindStr = $"{nameof(BinaryOperationKind)}.{operation.BinaryOperationKind}";
+            LogString($" ({kindStr})");
+            LogHasOperatorMethodExpressionCommon(operation);
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Target, "Left");
+            Visit(operation.Value, "Right");
+        }
+
+        public override void VisitIncrementExpression(IIncrementExpression operation)
+        {
+            LogString(nameof(IIncrementExpression));
+
+            var unaryKindStr = $"{nameof(UnaryOperandKind)}.{operation.IncrementOperationKind}";
+            var binaryKindStr = $"{nameof(BinaryOperationKind)}.{operation.BinaryOperationKind}";
+            LogString($" ({unaryKindStr}) ({binaryKindStr})");
+            LogHasOperatorMethodExpressionCommon(operation);
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Target, "Left");
+            Visit(operation.Value, "Right");
+        }
+
+        public override void VisitParenthesizedExpression(IParenthesizedExpression operation)
+        {
+            LogString(nameof(IParenthesizedExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitParenthesizedExpression(operation);
+        }
+
+        public override void VisitLateBoundMemberReferenceExpression(ILateBoundMemberReferenceExpression operation)
+        {
+            LogString(nameof(ILateBoundMemberReferenceExpression));
+            LogString($" (Member name: {operation.MemberName})");
+            LogCommonPropertiesAndNewLine(operation);
+
+            VisitInstanceExpression(operation.Instance);
+        }
+
+        public override void VisitUnboundLambdaExpression(IUnboundLambdaExpression operation)
+        {
+            LogString(nameof(IUnboundLambdaExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitUnboundLambdaExpression(operation);
+        }
+
+        public override void VisitDefaultValueExpression(IDefaultValueExpression operation)
+        {
+            LogString(nameof(IDefaultValueExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitDefaultValueExpression(operation);
+        }
+
+        public override void VisitTypeParameterObjectCreationExpression(ITypeParameterObjectCreationExpression operation)
+        {
+            LogString(nameof(ITypeParameterObjectCreationExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitTypeParameterObjectCreationExpression(operation);
+        }
+
+        public override void VisitInvalidStatement(IInvalidStatement operation)
+        {
+            LogString(nameof(IInvalidStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitInvalidStatement(operation);
+        }
+
+        public override void VisitInvalidExpression(IInvalidExpression operation)
+        {
+            LogString(nameof(IInvalidExpression));
+            LogCommonPropertiesAndNewLine(operation);
+
+            base.VisitInvalidExpression(operation);
+        }
+
+        public override void VisitIfStatement(IIfStatement operation)
+        {
+            LogString(nameof(IIfStatement));
+            LogCommonPropertiesAndNewLine(operation);
+
+            Visit(operation.Condition, "Condition");
+            Visit(operation.IfTrueStatement);
+            Visit(operation.IfFalseStatement);
+        }
+
+        public override void VisitLocalFunctionStatement(IOperation operation)
+        {
+            LogString(nameof(VisitLocalFunctionStatement));
+            LogCommonPropertiesAndNewLine(operation);
+        }
+
+        private void LogCaseClauseCommon(ICaseClause operation)
+        {
+            var kindStr = $"{nameof(CaseKind)}.{operation.CaseKind}";
+            LogString($" ({kindStr})");
+            LogCommonPropertiesAndNewLine(operation);
+        }
+
+        public override void VisitSingleValueCaseClause(ISingleValueCaseClause operation)
+        {
+            LogString(nameof(ISingleValueCaseClause));
+            var kindStr = $"{nameof(BinaryOperationKind)}.{operation.Equality}";
+            LogString($" (Equality operator kind: {kindStr})");
+            LogCaseClauseCommon(operation);
+
+            base.VisitSingleValueCaseClause(operation);
+        }
+
+        public override void VisitRelationalCaseClause(IRelationalCaseClause operation)
+        {
+            LogString(nameof(IRelationalCaseClause));
+            var kindStr = $"{nameof(BinaryOperationKind)}.{operation.Relation}";
+            LogString($" (Relational operator kind: {kindStr})");
+            LogCaseClauseCommon(operation);
+
+            base.VisitRelationalCaseClause(operation);
+        }
+
+        public override void VisitRangeCaseClause(IRangeCaseClause operation)
+        {
+            LogString(nameof(IRangeCaseClause));
+            LogCaseClauseCommon(operation);
+
+            Visit(operation.MinimumValue, "Min");
+            Visit(operation.MaximumValue, "Max");
+        }
+
+        #endregion
+    }
+}

--- a/src/Test/Utilities/Shared/Extensions/SymbolExtensions.cs
+++ b/src/Test/Utilities/Shared/Extensions/SymbolExtensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Test.Extensions
+{
+    internal static class SymbolExtensions
+    {
+        public static string ToTestDisplayString(this ISymbol symbol)
+        {
+            return symbol.ToDisplayString(SymbolDisplayFormat.TestFormat);
+        }
+    }
+}

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -26,6 +26,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationOutputFiles.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\CompilationTestDataExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\IRuntimeEnvironment.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Compilation\OperationTreeVerifier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\TestOperationWalker.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Compilation\VersionTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\DescriptorFactory.cs" />
@@ -37,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\ThrowingDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Diagnostics\TrackingDiagnosticAnalyzer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\SymbolExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\ConsoleOutput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\CultureHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\DirectoryHelper.cs" />


### PR DESCRIPTION
…to dump operation tree.

The dump approach should enable to us to (relatively) easily extend the existing C# and VB binding tests to verify the operation tree.
I have moved the existing IOperation tests to the dump approach and also added couple of additional tests to demonstrate how to write these tests for entire method body operation tree verification.