### PR TITLE
disable workspace document events on project disconnect

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -381,6 +381,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return _documents.Values.ToImmutableArrayOrEmpty();
         }
 
+        public IEnumerable<IVisualStudioHostDocument> GetCurrentAdditionalDocuments()
+        {
+            return _additionalDocuments.Values.ToImmutableArrayOrEmpty();
+        }
+
         public bool ContainsFile(string moniker)
         {
             return _documentMonikers.ContainsKey(moniker);
@@ -977,11 +982,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 // Unsubscribe IVsHierarchyEvents
                 DisconnectHierarchyEvents();
 
+                var wasPushing = _pushingChangesToWorkspaceHosts;
+
+                // disable pushing down to workspaces, so we don't get redundant workspace document removed events
+                _pushingChangesToWorkspaceHosts = false;
+
                 // The project is going away, so let's remove ourselves from the host. First, we
                 // close and dispose of any remaining documents
                 foreach (var document in this.GetCurrentDocuments())
                 {
                     UninitializeDocument(document);
+                }
+
+                foreach (var document in this.GetCurrentAdditionalDocuments())
+                {
+                    UninitializeAdditionalDocument(document);
                 }
 
                 // Dispose metadata references.
@@ -1009,7 +1024,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
                 ClearAnalyzerRuleSet();
 
+                // reinstate pushing down to workspace, so the workspace project remove event fires
+                _pushingChangesToWorkspaceHosts = wasPushing;
+
                 this.ProjectTracker.RemoveProject(this);
+
+                _pushingChangesToWorkspaceHosts = false;
             }
         }
 


### PR DESCRIPTION
Fixes #11912 

This change disables all redundant workspace events from firing when a VS project is being removed/unloaded.

@Pilchie @jasonmalinowski please review.