### PR TITLE
Fix building of pre-release NuGet packages

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -58,8 +58,7 @@
 
   <!-- NuGet version -->
   <PropertyGroup>
-    <BuildNumberSuffix Condition="('$(BUILD_BUILDNUMBER)' != '')
-                     and ($(BUILD_BUILDNUMBER.Split('_').Length) == 2)">$(BUILD_BUILDNUMBER.Split('_')[1])</BuildNumberSuffix>
+    <BuildNumberSuffix>$(BUILD_BUILDNUMBER)</BuildNumberSuffix>
     <BuildNumberPart1 Condition="'$(BuildNumberSuffix)' != ''">
       $(BuildNumberSuffix.Split('.')[0])
     </BuildNumberPart1>


### PR DESCRIPTION
Build numbers used to be QueueName_BuildNumber, but that's no longer the
case. It's now just a build number and that's it.

*Review:* @dotnet/roslyn-infrastructure