### PR TITLE
Generalize the version update script, add support for LKG

### DIFF
--- a/dependencies.xml
+++ b/dependencies.xml
@@ -1,0 +1,10 @@
+<!--
+  Lists dotnet repos containing packages this repo depends on.
+  The latest and LKG versions of these dependencies are maintained on github.com/dotnet/versions.
+-->
+<dependencies>
+  <repo name="corefx" channel="release/1.0.0" commonVersionSuffix="CoreFXVersionSuffix"/>
+  <repo name="coreclr" channel="release/1.0.0" commonVersionSuffix="CoreClrVersionSuffix" />
+  <repo name="projectk-tfs" channel="release/1.0.0" />
+  <repo name="symreader" channel="netcore1.0" />
+</dependencies>


### PR DESCRIPTION
Adds file dependencies.xml which describes the package repositories our repo depends on and where to fetch their versions from. 

To update all project.json files and version variables to the version all teams sync on we can now just run
```C#
csi build\scripts\update_dependencies.csx /lkg
```
