### PR TITLE
fix crash due to result existing both in compiler and ide side.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.Executor.cs
@@ -309,7 +309,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                         }
 
                         // merge the result to existing one.
-                        result = result.Add(analyzer, builder.ToResult());
+                        // there can be existing one from compiler driver with empty set. overwrite it with
+                        // ide one.
+                        result = result.SetItem(analyzer, builder.ToResult());
                     }
 
                     return result;


### PR DESCRIPTION
this can happen since we don't filter out ide only analyzer when creating compiler driver
which is okay since it will become noop for compiler driver. filtering is basically more work.