### PR TITLE
Add option to disable converting metadata to project references

### DIFF
--- a/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
+++ b/src/EditorFeatures/Core/Shared/Options/InternalFeatureOnOffOptions.cs
@@ -68,5 +68,8 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Options
 
         [ExportOption]
         public static readonly Option<bool> FullSolutionAnalysisMemoryMonitor = new Option<bool>(OptionName, "Full Solution Analysis Memory Monitor", defaultValue: true);
+
+        [ExportOption]
+        public static readonly Option<bool> ProjectReferenceConversion = new Option<bool>(OptionName, "Project Reference Conversion", defaultValue: true);
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Notification;
@@ -483,11 +484,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             }
         }
 
+        protected bool CanConvertToProjectReferences
+        {
+            get
+            {
+                if (this.Workspace != null)
+                {
+                    return this.Workspace.Options.GetOption(InternalFeatureOnOffOptions.ProjectReferenceConversion);
+                }
+                else
+                {
+                    return InternalFeatureOnOffOptions.ProjectReferenceConversion.DefaultValue;
+                }
+            }
+        }
+
         protected int AddMetadataReferenceAndTryConvertingToProjectReferenceIfPossible(string filePath, MetadataReferenceProperties properties)
         {
             // If this file is coming from a project, then we should convert it to a project reference instead
             AbstractProject project;
-            if (ProjectTracker.TryGetProjectByBinPath(filePath, out project))
+            if (this.CanConvertToProjectReferences && ProjectTracker.TryGetProjectByBinPath(filePath, out project))
             {
                 var projectReference = new ProjectReference(project.Id, properties.Aliases, properties.EmbedInteropTypes);
                 if (CanAddProjectReference(projectReference))
@@ -1015,23 +1031,26 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         internal void TryProjectConversionForIntroducedOutputPath(string binPath, AbstractProject projectToReference)
         {
-            // We should not already have references for this, since we're only introducing the path for the first time
-            Contract.ThrowIfTrue(_metadataFileNameToConvertedProjectReference.ContainsKey(binPath));
-
-            var metadataReference = TryGetCurrentMetadataReference(binPath);
-            if (metadataReference != null)
+            if (this.CanConvertToProjectReferences)
             {
-                var projectReference = new ProjectReference(
-                    projectToReference.Id,
-                    metadataReference.Properties.Aliases,
-                    metadataReference.Properties.EmbedInteropTypes);
+                // We should not already have references for this, since we're only introducing the path for the first time
+                Contract.ThrowIfTrue(_metadataFileNameToConvertedProjectReference.ContainsKey(binPath));
 
-                if (CanAddProjectReference(projectReference))
+                var metadataReference = TryGetCurrentMetadataReference(binPath);
+                if (metadataReference != null)
                 {
-                    RemoveMetadataReferenceCore(metadataReference, disposeReference: true);
-                    AddProjectReference(projectReference);
+                    var projectReference = new ProjectReference(
+                        projectToReference.Id,
+                        metadataReference.Properties.Aliases,
+                        metadataReference.Properties.EmbedInteropTypes);
 
-                    _metadataFileNameToConvertedProjectReference.Add(binPath, projectReference);
+                    if (CanAddProjectReference(projectReference))
+                    {
+                        RemoveMetadataReferenceCore(metadataReference, disposeReference: true);
+                        AddProjectReference(projectReference);
+
+                        _metadataFileNameToConvertedProjectReference.Add(binPath, projectReference);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix for #11913

This change adds an internal option that is settable via the registry that allows disabling the VS workspace feature of converting metadata references to project references.

@Pilchie @jasonmalinowski please review.

Also @dotnet/roslyn-ide 