### PR TITLE
Revert changes to generate release NuGet packages

### DIFF
--- a/build/BuildNuGets.csx
+++ b/build/BuildNuGets.csx
@@ -208,7 +208,7 @@ void GeneratePublishingConfig()
     {
         // nuget:
         var packages = MakeRoslynPackageElements(isRelease: true).Concat(MakePackageElementsForPublishedDependencies(isRelease: true));
-        GeneratePublishingConfig("myget_org-packages.config", packages);
+        GeneratePublishingConfig("nuget_org-packages.config", packages);
     }
     else
     {

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -72,13 +72,10 @@
     </BuildNumberPart2>
 
     <!-- Only set when building RTM with no dependencies on pre-release packages
-    -->
     <NuGetReleaseVersion>$(RoslynSemanticVersion)</NuGetReleaseVersion>
-    <NuGetPerBuildPreReleaseVersion>$(RoslynSemanticVersion)</NuGetPerBuildPreReleaseVersion>
-<!--
+    -->
     <NuGetPreReleaseVersion>$(RoslynSemanticVersion)-beta1</NuGetPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion Condition="'$(BuildNumberSuffix)' != ''">$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
--->
   </PropertyGroup>
   
 </Project>

--- a/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Version.targets
+++ b/src/Debugging/Microsoft.DiaSymReader.PortablePdb/Version.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyVersion>1.1.0</AssemblyVersion>
-    <IsReleaseVersion>true</IsReleaseVersion>
+    <IsReleaseVersion>false</IsReleaseVersion>
   </PropertyGroup>
 
   <Choose>

--- a/src/Dependencies/Microsoft.DiaSymReader/Version.targets
+++ b/src/Dependencies/Microsoft.DiaSymReader/Version.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyVersion>1.0.8</AssemblyVersion>
-    <IsReleaseVersion>true</IsReleaseVersion>
+    <IsReleaseVersion>false</IsReleaseVersion>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
Revert changes to generate release NuGet packages

The build will generate pre-release packages as before recent changes, with a post-build step used to generate release packages.

Reverts changes from bd23fe4fd369 and 169f8e8a8bc8a.