### PR TITLE
Splitting a statement onto multiple lines, for readability.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -89,7 +89,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(synthesizedLocal == null);
 
                 synthesizedLocal = _methodPayload;
-                return previousPrologue == null ?_factory.StatementList(payloadInitialization, payloadIf, _methodEntryInstrumentation) : _factory.StatementList(payloadInitialization, payloadIf, _methodEntryInstrumentation, previousPrologue);
+
+                return previousPrologue == null
+                     ? _factory.StatementList(payloadInitialization, payloadIf, _methodEntryInstrumentation)
+                     : _factory.StatementList(payloadInitialization, payloadIf, _methodEntryInstrumentation, previousPrologue);
             }
 
             synthesizedLocal = null;


### PR DESCRIPTION
This fixes a small readability issue in #11930