### PR TITLE
Refactoring of code emitting exported types

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadata.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EmitMetadata.cs
@@ -230,7 +230,18 @@ public class Test : Class1
                 var moduleRefName = reader.GetModuleReference(MetadataTokens.ModuleReferenceHandle(1)).Name;
                 Assert.Equal("netModule1.netmodule", reader.GetString(moduleRefName));
 
-                Assert.Equal(5, reader.GetTableRowCount(TableIndex.ExportedType));
+                var actual = from h in reader.ExportedTypes
+                             let et = reader.GetExportedType(h)
+                             select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{(int)et.Attributes:X4}";
+
+                AssertEx.Equal(new[]
+                {
+                    ".Class1 0x26000001 (AssemblyFile) 0x0001",
+                    ".Class3 0x27000001 (ExportedType) 0x0002",
+                    "NS1.Class4 0x26000001 (AssemblyFile) 0x0001",
+                    ".Class7 0x27000003 (ExportedType) 0x0002",
+                    ".Class2 0x26000002 (AssemblyFile) 0x0001"
+                }, actual);
             });
         }
 

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="InternalUtilities\IncrementalHash.cs" />
+    <Compile Include="PEWriter\ExportedType.cs" />
     <Compile Include="System\Reflection\Blob.cs" />
     <Compile Include="System\Reflection\BlobWriter.cs" />
     <Compile Include="System\Reflection\BlobWriterImpl.cs" />

--- a/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/CommonPEModuleBuilder.cs
@@ -677,7 +677,7 @@ namespace Microsoft.CodeAnalysis.Emit
             return GetTopLevelTypes(context);
         }
 
-        public abstract IEnumerable<Cci.ITypeReference> GetExportedTypes(EmitContext context);
+        public abstract ImmutableArray<Cci.ExportedType> GetExportedTypes(DiagnosticBag diagnostics);
 
         Cci.ITypeReference Cci.IModule.GetPlatformType(Cci.PlatformType platformType, EmitContext context)
         {

--- a/src/Compilers/Core/Portable/PEWriter/Constants.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Constants.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Cci
@@ -29,45 +30,8 @@ namespace Microsoft.Cci
 
         // Non-portable CompilationRelaxations value:
         public const int CompilationRelaxations_NoStringInterning = 0x0008;
-    }
 
-    internal enum TypeFlags : uint
-    {
-        PrivateAccess = 0x00000000,
-        PublicAccess = 0x00000001,
-        NestedPublicAccess = 0x00000002,
-        NestedPrivateAccess = 0x00000003,
-        NestedFamilyAccess = 0x00000004,
-        NestedAssemblyAccess = 0x00000005,
-        NestedFamilyAndAssemblyAccess = 0x00000006,
-        NestedFamilyOrAssemblyAccess = 0x00000007,
-        AccessMask = 0x0000007,
-        NestedMask = 0x00000006,
-
-        AutoLayout = 0x00000000,
-        SequentialLayout = 0x00000008,
-        ExplicitLayout = 0x00000010,
-        LayoutMask = 0x00000018,
-
-        ClassSemantics = 0x00000000,
-        InterfaceSemantics = 0x00000020,
-        AbstractSemantics = 0x00000080,
-        SealedSemantics = 0x00000100,
-        SpecialNameSemantics = 0x00000400,
-
-        ImportImplementation = 0x00001000,
-        SerializableImplementation = 0x00002000,
-        WindowsRuntimeImplementation = 0x00004000,
-        BeforeFieldInitImplementation = 0x00100000,
-        ForwarderImplementation = 0x00200000,
-
-        AnsiString = 0x00000000,
-        UnicodeString = 0x00010000,
-        AutoCharString = 0x00020000,
-        StringMask = 0x00030000,
-
-        RTSpecialNameReserved = 0x00000800,
-        HasSecurityReserved = 0x00040000,
+        public const TypeAttributes TypeAttributes_TypeForwarder = (TypeAttributes)0x00200000;
     }
 
     /// <summary>

--- a/src/Compilers/Core/Portable/PEWriter/Constants.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Constants.cs
@@ -34,6 +34,20 @@ namespace Microsoft.Cci
         public const TypeAttributes TypeAttributes_TypeForwarder = (TypeAttributes)0x00200000;
     }
 
+    internal struct ExportedType
+    {
+        public readonly ITypeReference Type;
+        public readonly bool IsForwarder;
+        public readonly int ParentIndex;
+
+        public ExportedType(ITypeReference type, int parentIndex, bool isForwarder)
+        {
+            Type = type;
+            IsForwarder = isForwarder;
+            ParentIndex = parentIndex;
+        }
+    }
+
     /// <summary>
     /// System.Runtime.InteropServices.VarEnum is obsolete.
     /// </summary>

--- a/src/Compilers/Core/Portable/PEWriter/Constants.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Constants.cs
@@ -34,20 +34,6 @@ namespace Microsoft.Cci
         public const TypeAttributes TypeAttributes_TypeForwarder = (TypeAttributes)0x00200000;
     }
 
-    internal struct ExportedType
-    {
-        public readonly ITypeReference Type;
-        public readonly bool IsForwarder;
-        public readonly int ParentIndex;
-
-        public ExportedType(ITypeReference type, int parentIndex, bool isForwarder)
-        {
-            Type = type;
-            IsForwarder = isForwarder;
-            ParentIndex = parentIndex;
-        }
-    }
-
     /// <summary>
     /// System.Runtime.InteropServices.VarEnum is obsolete.
     /// </summary>

--- a/src/Compilers/Core/Portable/PEWriter/ExportedType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ExportedType.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.Cci
+{
+    /// <summary>
+    /// Info needed when emitting ExportedType table entry.
+    /// </summary>
+    internal struct ExportedType
+    {
+        /// <summary>
+        /// The target type reference. 
+        /// </summary>
+        public readonly ITypeReference Type;
+
+        /// <summary>
+        /// True if this <see cref="ExportedType"/> represents a type forwarder definition,
+        /// false if it represents a type from a linked netmodule.
+        /// </summary>
+        public readonly bool IsForwarder;
+
+        /// <summary>
+        /// If <see cref="Type"/> is a nested type defined in a linked netmodule, 
+        /// the index of the <see cref="ExportedType"/> entry that represents the enclosing type.
+        /// </summary>
+        public readonly int ParentIndex;
+
+        public ExportedType(ITypeReference type, int parentIndex, bool isForwarder)
+        {
+            Type = type;
+            IsForwarder = isForwarder;
+            ParentIndex = parentIndex;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexer.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Cci
             Visit(module.ModuleAttributes);
             Visit(module.GetTopLevelTypes(Context));
 
-            foreach (ITypeReference exportedType in module.GetExportedTypes(Context))
+            foreach (var exportedType in module.GetExportedTypes(Context.Diagnostics))
             {
-                VisitExportedType(exportedType);
+                VisitExportedType(exportedType.Type);
             }
 
             if (module.AsAssembly == null)

--- a/src/Compilers/Core/Portable/PEWriter/Units.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Units.cs
@@ -77,9 +77,10 @@ namespace Microsoft.Cci
         bool GenerateVisualBasicStylePdb { get; }
 
         /// <summary>
-        /// Public types defined in other modules making up this assembly and to which other assemblies may refer to via this assembly.
+        /// Public types defined in other modules making up this assembly and to which other assemblies may refer to via this assembly
+        /// followed by types forwarded to another assembly.
         /// </summary>
-        IEnumerable<ITypeReference> GetExportedTypes(EmitContext context);
+        ImmutableArray<ExportedType> GetExportedTypes(DiagnosticBag diagnostics);
 
         /// <summary>
         /// A list of objects representing persisted instances of types that extend System.Attribute. Provides an extensible way to associate metadata

--- a/src/Compilers/Core/Portable/System/Reflection/Metadata/Ecma335/MetadataBuilder.Tables.cs
+++ b/src/Compilers/Core/Portable/System/Reflection/Metadata/Ecma335/MetadataBuilder.Tables.cs
@@ -699,12 +699,6 @@ namespace Roslyn.Reflection.Metadata.Ecma335
             return MetadataTokens.ExportedTypeHandle(_exportedTypeTable.Count);
         }
 
-        // TODO: remove
-        public uint GetExportedTypeFlags(int rowId)
-        {
-            return _exportedTypeTable[rowId].Flags;
-        }
-
         public DeclarativeSecurityAttributeHandle AddDeclarativeSecurityAttribute(
             EntityHandle parent,
             DeclarativeSecurityAction action,

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/EmitMetadata.vb
@@ -296,7 +296,19 @@ End Class
 
                 Dim moduleRefName = reader.GetModuleReference(reader.GetModuleReferences().Single()).Name
                 Assert.Equal("netModule1.netmodule", reader.GetString(moduleRefName))
-                Assert.Equal(5, reader.GetTableRowCount(TableIndex.ExportedType))
+
+                Dim actual = From h In reader.ExportedTypes
+                             Let et = reader.GetExportedType(h)
+                             Select $"{reader.GetString(et.NamespaceDefinition)}.{reader.GetString(et.Name)} 0x{MetadataTokens.GetToken(et.Implementation):X8} ({et.Implementation.Kind}) 0x{CInt(et.Attributes):X4}"
+
+                AssertEx.Equal(
+                {
+                    "NS1.Class4 0x26000001 (AssemblyFile) 0x0001",
+                    ".Class7 0x27000001 (ExportedType) 0x0002",
+                    ".Class1 0x26000001 (AssemblyFile) 0x0001",
+                    ".Class3 0x27000003 (ExportedType) 0x0002",
+                    ".Class2 0x26000002 (AssemblyFile) 0x0001"
+                }, actual)
             End Using
         End Sub
 


### PR DESCRIPTION
Instead of building ExportedType table in three passes -- enumerating the type symbols, indexing them and writing them into a table while looking up the containing types, calculate all information we need in a single pass and avoid reading from the MetadataBuilder internal table.

Makes the implementation more straightforward and allows us to remove MetadataBuilder.GetExportedTypeFlags API.