### PR TITLE
Correct typo in Semantic/ValueTupleTests. #12010

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
@@ -154,7 +154,7 @@ namespace System
             Assert.Equal("T7 System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>.Item7",
                 comp.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__Item7).ToTestDisplayString());
             Assert.Equal("TRest System.ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>.Rest",
-                comp.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__Item7).ToTestDisplayString());
+                comp.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__Rest).ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ValueTupleTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.Semantic.UnitTests.Semantics
 {
-    class ValueTupleTests : CompilingTestBase
+    public class ValueTupleTests : CompilingTestBase
     {
         [Fact]
         public void TestWellKnownMembersForValueTuple()


### PR DESCRIPTION
Fixes #12010 

Test output after change:

```
------ Test started: Assembly: Roslyn.Compilers.CSharp.Semantic.UnitTests.dll ------

2 passed, 0 failed, 0 skipped, took 1,25 seconds (xUnit.net 2.1.0 build 3179).

```