### PR TITLE
Fixing up the Microsoft.Net.Compilers.props file to place the ValidateMSBuildToolsVersion check in an InitialTarget.

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
@@ -1,4 +1,4 @@
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" InitialTargets="ValidateMSBuildToolsVersion" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- The UsingTask, UseSharedCompilation, and ToolPath/Exe variables all interact to 
        choose which compiler path to use and whether or not to use the compiler server.
        If UsingTask and UseSharedCompilation are set then the compiler server next to the
@@ -7,11 +7,13 @@
        not be used and the compiler exe at the ToolPath, if set, will be executed, otherwise
        the executable in the MSBuild install path will be executed. -->
 
-  <Error Text="Microsoft.Net.Compilers is only supported on MSBuild v14.0 and above"
-         Condition="'$(MSBuildToolsVersion)' == '2.0'
-                 OR '$(MSBuildToolsVersion)' == '3.5'
-                 OR '$(MSBuildToolsVersion)' == '4.0'
-                 OR '$(MSBuildToolsVersion)' == '12.0'" />
+  <Target Name="ValidateMSBuildToolsVersion">
+    <Error Text="Microsoft.Net.Compilers is only supported on MSBuild v14.0 and above"
+           Condition="'$(MSBuildToolsVersion)' == '2.0'
+                   OR '$(MSBuildToolsVersion)' == '3.5'
+                   OR '$(MSBuildToolsVersion)' == '4.0'
+                   OR '$(MSBuildToolsVersion)' == '12.0'" />
+  </Target>
 
   <!-- Always use the local build task, even if we just shell out to an exe in case there are
        new properties in the local build task. -->


### PR DESCRIPTION
The exact error message given by MSBuild is:

`The <Error> tag is no longer supported as a child of the <Project> element. Place this tag within a target, and add the name of the target to the "InitialTargets" attribute of the <Project> element.`
