### PR TITLE
Removing the warning supressions for CS7035 and BC42366

### DIFF
--- a/build/Targets/GenerateAssemblyInfo.targets
+++ b/build/Targets/GenerateAssemblyInfo.targets
@@ -17,7 +17,7 @@
       <_Parameter1>$(BuildVersion)</_Parameter1>
     </AssemblyVersionAttribute>
     <AssemblyVersionAttribute Include="System.Reflection.AssemblyInformationalVersionAttribute">
-      <_Parameter1>$(BuildVersion)</_Parameter1>
+      <_Parameter1>$(NuGetPerBuildPreReleaseVersion)</_Parameter1>
     </AssemblyVersionAttribute>
   </ItemGroup>
 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -243,15 +243,6 @@
         <OptionStrict>On</OptionStrict>
         <RootNamespace></RootNamespace>
         <VBRuntime>Embed</VBRuntime>
-
-        <!-- Suppress the following warnings by default for C# projects
-                42366: GeneratedAssemblyInfo_<version>.vb will report this warning if any of the four parts
-                       of the version string (major.minor.build.revision) are above 65535. This breaks for
-                       various build formats involving the current year/month/day. For example it works for
-                       60614 (June 14th, 2016), but breaks for 70614 (June 14th, 2017) and it also breaks
-                       for something like 20160614 (also June 14th, 2016).
-        -->
-        <NoWarn>$(NoWarn);42366</NoWarn>
       </PropertyGroup>
       <ItemGroup>
         <Import Include="Microsoft.VisualBasic" />
@@ -285,13 +276,8 @@
                       the methods are public.  We don't want to duplicate documentation for them
                       and hence suppress this warning until we get closer to release and a more
                       thorough documentation story
-                7035: GeneratedAssemblyInfo_<version>.cs will report this warning if any of the four parts
-                       of the version string (major.minor.build.revision) are above 65535. This breaks for
-                       various build formats involving the current year/month/day. For example it works for
-                       60614 (June 14th, 2016), but breaks for 70614 (June 14th, 2017) and it also breaks
-                       for something like 20160614 (also June 14th, 2016).
         -->
-        <NoWarn>$(NoWarn);1591;7035</NoWarn>
+        <NoWarn>$(NoWarn);1591</NoWarn>
       </PropertyGroup>
       <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
         <DebugSymbols>true</DebugSymbols>

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -31,15 +31,22 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- When a build number is not specified, then we should default back to '0.0' -->
-    <BuildNumber Condition="'$(BuildNumber)' == ''">0.0</BuildNumber>
+    <!-- When a build number is not specified, then we should default back to '00000000.0', which is a build number in the
+         same format as provided by MicroBuild v2, but with all digits set to zero. -->
+    <BuildNumber Condition="'$(BuildNumber)' == ''">00000000.0</BuildNumber>
     <!-- When a build number is specified, it needs to be in the format of 'x.y' -->
     <Error Condition="$(BuildNumber.Split('.').Length) != 2">BuildNumber should have two parts (in the form of 'x.y')</Error>
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Split the build parts out from the BuildNumber -->
-    <BuildNumberPart1>$(BuildNumber.Split('.')[0])</BuildNumberPart1>
+    <!-- Split the build parts out from the BuildNumber which is given to us by MicroBuild in the format of yyyymmdd.nn
+         where BuildNumberPart1 is yyyymmdd (such as 20160615) and BuildNumberPart2 is nn (which represents the nth build 
+         started that day). So the first build of the day, 20160615.1, will produce something similar to BuildNumberPart1: 20160615,
+         BuildNumberPart2: 01; and the 12th build of the day, 20160615.12, will produce BuildNumberPart1: 20160615, BuildNumberPart2: 12 -->
+    <!-- Additionally, in order to match the MicroBuild v1 behavior, we will only take the last five digits of the BuildNumber, so
+         in the case of 20160615, we will set BuildNumberPart1 to 60615. This will begin failing in the 2017 as the BuildVersion only allows
+         each part to be in the range of 0 through 65535. Issue #12038 tracks the fix that needs to happen. -->
+    <BuildNumberPart1>$(BuildNumber.Split('.')[0].Substring(3))</BuildNumberPart1>
     <BuildNumberPart2>$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</BuildNumberPart2>
   </PropertyGroup>
   
@@ -56,7 +63,7 @@
     <When Condition="'$(OfficialBuild)' == 'true' OR '$(SignedBuild)' == 'true'">
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumberPart1)$(BuildNumberPart2)</BuildVersion>
+        <BuildVersion>$(RoslynSemanticVersion).0</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -73,7 +80,7 @@
   </Choose>
 
   <!-- Returns the current build version. Used in .vsixmanifests to substitute our build version into them -->
-  <Target Name="GetBuildVersion" Outputs="$(BuildVersion)" />
+  <Target Name="GetBuildVersion" Outputs="$(RoslynSemanticVersion).$(BuildNumberPart1.Trim())$(BuildNumberPart2.Trim())" />
 
   <!-- NuGet version -->
   <PropertyGroup>
@@ -85,5 +92,5 @@
     <MicrosoftDiaSymReaderPortablePdbVersion>1.1.0-beta1</MicrosoftDiaSymReaderPortablePdbVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion Condition="'$(BuildNumber)' != ''">$(MicrosoftDiaSymReaderPortablePdbVersion)-$(BuildNumber.Split('.')[0])-$(BuildNumber.Split('.')[1].PadLeft(2,'0'))</MicrosoftDiaSymReaderPortablePdbVersion>
   </PropertyGroup>
-  
+
 </Project>


### PR DESCRIPTION
This updates the Build and File version to be compliant (no part of the version is greater than 65535).

This updates the Informational version (which is just a string) to give more detailed information.

This updates the GetBuildVersion task to return a more detailed build version for the VSIXs, so that two different builds will have two different manifest versions (the VSIX version is required to conform to System.Version, which allows each part to be in the range of 0 through `int.Max`).