### PR TITLE
Fix the startup settings for Roslyn.csproj

### DIFF
--- a/src/Deployment/Roslyn.csproj
+++ b/src/Deployment/Roslyn.csproj
@@ -28,6 +28,11 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix RoslynDev /log</StartArguments>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Compilers\Extension\CompilerExtension.csproj">
       <Project>{43026D51-3083-4850-928D-07E1883D5B1A}</Project>


### PR DESCRIPTION
The old settings caused the project to be run but,
as a VSIX project, it could not be run. Instead, this
changes the project to start a new copy of devenv with
the VSIX in a new hive.

/cc @jmarolf @jasonmalinowski @dotnet/roslyn-infrastructure @dotnet/roslyn-ide 