### PR TITLE
port of #12041 for microupdate

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_IncrementalAnalyzer.cs
@@ -361,7 +361,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             foreach (var documentId in newAnalysisResult.DocumentIds)
             {
                 var document = project.GetDocument(documentId);
-                Contract.ThrowIfNull(document);
+                if (document == null)
+                {
+                    // it can happen with build synchronization since, in build case, 
+                    // we don't have actual snapshot (we have no idea what sources out of proc build has picked up)
+                    // so we might be out of sync.
+                    // example of such cases will be changing anything about solution while building is going on.
+                    // it can be user explict actions such as unloading project, deleting a file, but also it can be 
+                    // something project system or roslyn workspace does such as populating workspace right after
+                    // solution is loaded.
+                    continue;
+                }
 
                 RaiseDocumentDiagnosticsIfNeeded(document, stateSet, AnalysisKind.NonLocal, oldAnalysisResult, newAnalysisResult, raiseEvents);
 

--- a/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/SolutionCrawlerRegistrationService.cs
@@ -91,7 +91,10 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
                 var coordinator = default(WorkCoordinator);
                 if (!_documentWorkCoordinatorMap.TryGetValue(workspace, out coordinator))
                 {
-                    throw new ArgumentException("workspace");
+                    // this can happen if solution crawler is already unregistered from workspace.
+                    // one of those example will be VS shutting down so roslyn package is disposed but there is a pending
+                    // async operation.
+                    return;
                 }
 
                 // no specific projects or documents provided


### PR DESCRIPTION
we found one more case where documentId can be null

this is same issue as https://github.com/dotnet/roslyn/pull/11697

this PR also fix related issue. https://devdiv.visualstudio.com/DevDiv/_workitems?id=232370&_a=edit

where VS is shutting down but we have async work pending which assumes all info is registered.