### PR TITLE
Added initial support for explicit tuple conversions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Conversions.cs
@@ -364,7 +364,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var argument = arguments[i];
                 var destType = targetElementTypes[i];
-                convertedArguments.Add(CreateConversion(argument, destType, diagnostics));
+
+                HashSet<DiagnosticInfo> useSiteDiagnostics = null;
+                Conversion elementConversion;
+                if (isCast)
+                {
+                    elementConversion = this.Conversions.ClassifyConversionForCast(argument, destType, ref useSiteDiagnostics);
+                }
+                else
+                {
+                    elementConversion = this.Conversions.ClassifyConversionFromExpression(argument, destType, ref useSiteDiagnostics);
+                }
+
+                diagnostics.Add(syntax, useSiteDiagnostics);
+                convertedArguments.Add(CreateConversion(argument.Syntax, argument, elementConversion, isCast, destType, diagnostics));
             }
 
             BoundExpression result = new BoundConvertedTupleLiteral(

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2646,10 +2646,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected void GenerateImplicitConversionError(DiagnosticBag diagnostics, CSharpSyntaxNode syntax,
-            Conversion conversion, BoundExpression expression, TypeSymbol targetType)
+        protected void GenerateImplicitConversionError(
+            DiagnosticBag diagnostics, 
+            CSharpSyntaxNode syntax,
+            Conversion conversion, 
+            BoundExpression operand, 
+            TypeSymbol targetType)
         {
-            Debug.Assert(expression != null);
+            Debug.Assert(operand != null);
             Debug.Assert((object)targetType != null);
 
             if (targetType.TypeKind == TypeKind.Error)
@@ -2657,20 +2661,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            if (expression.Kind == BoundKind.BadExpression)
+            if (operand.Kind == BoundKind.BadExpression)
             {
                 return;
             }
 
-            if (expression.Kind == BoundKind.UnboundLambda)
+            if (operand.Kind == BoundKind.UnboundLambda)
             {
-                GenerateAnonymousFunctionConversionError(diagnostics, syntax, (UnboundLambda)expression, targetType);
+                GenerateAnonymousFunctionConversionError(diagnostics, syntax, (UnboundLambda)operand, targetType);
                 return;
             }
 
-            if (expression.Kind == BoundKind.TupleLiteral)
+            if (operand.Kind == BoundKind.TupleLiteral)
             {
-                var tuple = (BoundTupleLiteral)expression;
+                var tuple = (BoundTupleLiteral)operand;
                 var targetElementTypes = default(ImmutableArray<TypeSymbol>);
 
                 // If target is a tuple or compatible type with the same number of elements,
@@ -2692,14 +2696,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Otherwise it is just a regular conversion failure from T1 to T2.
             }
 
-            var sourceType = expression.Type;
+            var sourceType = operand.Type;
             if ((object)sourceType != null)
             {
-                GenerateImplicitConversionError(diagnostics, this.Compilation, syntax, conversion, sourceType, targetType, expression.ConstantValue);
+                GenerateImplicitConversionError(diagnostics, this.Compilation, syntax, conversion, sourceType, targetType, operand.ConstantValue);
                 return;
             }
             
-            if (expression.IsLiteralNull())
+            if (operand.IsLiteralNull())
             {
                 if (targetType.TypeKind == TypeKind.TypeParameter)
                 {
@@ -2713,9 +2717,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (expression.Kind == BoundKind.MethodGroup)
+            if (operand.Kind == BoundKind.MethodGroup)
             {
-                var methodGroup = (BoundMethodGroup)expression;
+                var methodGroup = (BoundMethodGroup)operand;
                 if (!Conversions.ReportDelegateMethodGroupDiagnostics(this, methodGroup, targetType, diagnostics))
                 {
                     var nodeForSquiggle = syntax;
@@ -2744,7 +2748,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return;
             }
 
-            Debug.Assert(expression.HasAnyErrors && expression.Kind != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
+            Debug.Assert(operand.HasAnyErrors && operand.Kind != BoundKind.UnboundLambda, "Missing a case in implicit conversion error reporting");
         }
 
         private void GenerateImplicitConversionErrorsForTupleLiteralArguments(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversion.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Roslyn.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Utilities;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/Conversions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return result;
             }
 
-            return ClassifyExplicitOnlyConversionFromExpression(sourceExpression, source, destination, ref useSiteDiagnostics);
+            return ClassifyExplicitOnlyConversionFromExpression(sourceExpression, source, destination, ref useSiteDiagnostics, forCast: false);
         }
 
         /// <summary>
@@ -71,12 +71,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)destination != null);
 
             Conversion implicitConversion = ClassifyImplicitConversionFromExpression(source, destination, ref useSiteDiagnostics);
-            if (implicitConversion.Exists && !implicitConversion.IsUserDefined && !implicitConversion.IsDynamic)
+            if (implicitConversion.Exists && !ExplicitConversionMayDifferFromImplicit(implicitConversion))
             {
                 return implicitConversion;
             }
 
-            Conversion explicitConversion = ClassifyExplicitOnlyConversionFromExpression(source, source.Type, destination, ref useSiteDiagnostics);
+            Conversion explicitConversion = ClassifyExplicitOnlyConversionFromExpression(source, source.Type, destination, ref useSiteDiagnostics, forCast: true);
             if (explicitConversion.Exists)
             {
                 return explicitConversion;
@@ -107,6 +107,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             // and for backwards compatibility, we match it.
 
             return implicitConversion.Exists ? implicitConversion : Conversion.NoConversion;
+        }
+
+        /// <summary>
+        /// returns true when implicit conversion is not necessarily the same as explicit conversion
+        /// </summary>
+        private static bool ExplicitConversionMayDifferFromImplicit(Conversion implicitConversion)
+        {
+            switch (implicitConversion.Kind)
+            {
+                case ConversionKind.ImplicitUserDefined:
+                case ConversionKind.ImplicitDynamic:
+                case ConversionKind.ImplicitTuple:
+                case ConversionKind.ImplicitNullable:
+                    return true;
+
+                default:
+                    return false;
+            }
         }
 
         private Conversion ClassifyImplicitBuiltInConversionFromExpression(BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
@@ -369,7 +387,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return false;
         }
 
-        private Conversion ClassifyExplicitOnlyConversionFromExpression(BoundExpression sourceExpression, TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        private Conversion ClassifyExplicitOnlyConversionFromExpression(
+            BoundExpression sourceExpression, 
+            TypeSymbol source, 
+            TypeSymbol destination, 
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics, 
+            bool forCast)
         {
             Debug.Assert(sourceExpression != null || (object)source != null);
             Debug.Assert(sourceExpression == null || (object)sourceExpression.Type == (object)source);
@@ -385,7 +408,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    Conversion conversion = ClassifyExplicitBuiltInOnlyConversion(source, destination, ref useSiteDiagnostics);
+                    Conversion conversion = ClassifyExplicitBuiltInOnlyConversion(source, destination, ref useSiteDiagnostics, forCast);
                     if (conversion.Exists)
                     {
                         return conversion;

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 using System.Diagnostics;
 
@@ -64,7 +65,26 @@ namespace Microsoft.CodeAnalysis.CSharp
     {
         public override object Display
         {
-            get { return (object)this.Type ?? "<tuple>"; }
+            get
+            {
+                var pooledBuilder = PooledStringBuilder.GetInstance();
+                var builder = pooledBuilder.Builder;
+                var arguments = this.Arguments;
+
+
+                builder.Append('(');
+                builder.Append(arguments[0].Display);
+
+                for(int i = 1; i < arguments.Length; i++)
+                {
+                    builder.Append(", ");
+                    builder.Append(arguments[i].Display);
+                }
+
+                builder.Append(')');
+
+                return pooledBuilder.ToStringAndFree();
+            }
         }
     }
 


### PR DESCRIPTION


By itself supporting explicit tuple conversions is fairly trivial. We just apply explicit conversions element-wise. Similar to implicit tuple conversions.

The complicated part is interaction between implicit and explicit conversions. In particular C# permits cases where T converts to U via distinct implicit and explicit conversions. In such and cases a cast in code can act as disambiguator.
```C#
 T t = new T();
 U u = t;          // implicit cast T->U is used
 U u = (U)t;       // explicit cast T->U is preferred
```
In this change we are trying to generalize this rule to tuple conversions. (yet to be confirmed with LDM).
```c#
 (T, T) tt = (new T(), new T());
 (U, U) uu = tt;    			// implicit cast T->U is used
 (U, U) uu = ((U, U))tt			// explicit cast T->U is preferred
 (U, U)? uu = ((U, U)?)tt		// explicit cast T->U is preferred 
```

UNDONE in this change:

- In the last case lowering does not yet match the desired behavior (implicit conversion wins). The work to enable that is tracked by https://github.com/dotnet/roslyn/issues/12064

- Explicit conversions from literals are not supported pending LDM decision.
tracked by https://github.com/dotnet/roslyn/issues/11804

- Now that Conversion can contain nested conversions, just for the IsValid purpose, it would seem to be useful to just store it on the bound conversion nodes and reduce cases where we need to classify casts at lowering.
This could be a big but fairly mechanical change, not affecting any functionality (hopefully) so better be done separately.
As a part of this change it could make sense to make Conversion type more compact, possibly even make it a reference type.
Tracked by https://github.com/dotnet/roslyn/issues/12067

- ConversionBase could use some refactoring. 
Some similar helper are separated between two files, some helpers for conversions from expressions and types and those that handle casts in code are not named uniformly. It is possible there is some duplication.
Makes sense to bundle with #12067 

- Coverage of conversion classification through APIs could be improved. For now there is some coverage coming from preexisting tests, however there would be a need to test some corner case scenarios.
Especially once #12064 and #11804 are resolved and it is confirmed that the whole deal with distributing "Cast In Code" stays.
