### PR TITLE
Bump package versions to beta4

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -85,7 +85,7 @@
   <!-- NuGet version -->
   <PropertyGroup>
     <NuGetReleaseVersion>$(RoslynSemanticVersion)</NuGetReleaseVersion>
-    <NuGetPreReleaseVersion>$(RoslynSemanticVersion)-beta3</NuGetPreReleaseVersion>
+    <NuGetPreReleaseVersion>$(RoslynSemanticVersion)-beta4</NuGetPreReleaseVersion>
     <NuGetPerBuildPreReleaseVersion>$(NuGetPreReleaseVersion)-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</NuGetPerBuildPreReleaseVersion>
 
     <!-- TODO: change to a fixed version once we move this component to a separate repo -->


### PR DESCRIPTION
This should have been done as soon as we forked future-stabilization, but we forgot.

*Review:* @dotnet/roslyn-infrastructure, @paulvanbrenk