### PR TITLE
Fix tests in PatternMatchingTests that fails in cultures with differe…

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -177,7 +177,9 @@ public class X
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics(
                 );
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"expression 1 is not String
 expression foo is not Int32
 expression 1 is Int32 1
@@ -186,7 +188,8 @@ expression 1.2 is Double 1.2
 expression 1 is Nullable`1 1
 expression  is not Nullable`1
 expression  is not String";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]
@@ -285,11 +288,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"No for 1
 Yes for 10
 No for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]
@@ -317,11 +323,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"False for 1
 True for 10
 False for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]
@@ -350,11 +359,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"False for 1
 True for 10
 False for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact, WorkItem(8778, "https://github.com/dotnet/roslyn/issues/8778")]
@@ -383,11 +395,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions.WithLocalFunctionsFeature());
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"False for 1
 True for 10
 False for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact, WorkItem(8778, "https://github.com/dotnet/roslyn/issues/8778")]
@@ -418,11 +433,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"False for 1
 True for 10
 False for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]
@@ -489,11 +507,14 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"False for 1
 True for 10
 False for 1.2";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]
@@ -539,7 +560,9 @@ public struct X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
-            var expectedOutput =
+            using (new EnsureEnglishCulture())
+            {
+                var expectedOutput =
 @"one
 int 10
 long 20
@@ -550,7 +573,8 @@ null
 struct X X
 class Exception System.Exception: boo
 ";
-            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+                var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+            }
         }
 
         [Fact]

--- a/src/Test/Utilities/Shared/FX/EnsureEnglishCulture.cs
+++ b/src/Test/Utilities/Shared/FX/EnsureEnglishCulture.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Threading;
+
+namespace Roslyn.Test.Utilities
+{
+    public class EnsureEnglishCulture : IDisposable
+    {
+        public static CultureInfo PreferredOrNull
+        {
+            get
+            {
+                var currentCultureName = CultureInfo.CurrentCulture.Name;
+                if (currentCultureName.Length == 0 || currentCultureName.StartsWith("en", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                return CultureInfo.InvariantCulture;
+            }
+        }
+
+        private bool _needToRestore;
+        private readonly CultureInfo _threadCulture;
+        private readonly int _threadId;
+
+        public EnsureEnglishCulture()
+        {
+            _threadId = Thread.CurrentThread.ManagedThreadId;
+            var preferred = PreferredOrNull;
+
+            if (preferred != null)
+            {
+                _threadCulture = CultureInfo.CurrentCulture;
+                _needToRestore = true;
+
+#if DNX
+                CultureInfo.CurrentCulture = preferred;
+#else
+                Thread.CurrentThread.CurrentCulture = preferred;
+#endif
+            }
+        }
+
+        public void Dispose()
+        {
+            Debug.Assert(_threadId == Thread.CurrentThread.ManagedThreadId);
+
+            if (_needToRestore && _threadId == Thread.CurrentThread.ManagedThreadId)
+            {
+                _needToRestore = false;
+#if DNX
+                CultureInfo.CurrentCulture = _threadCulture;
+#else
+                Thread.CurrentThread.CurrentCulture = _threadCulture;
+#endif
+            }
+        }
+    }
+}

--- a/src/Test/Utilities/Shared/TestUtilities.projitems
+++ b/src/Test/Utilities/Shared/TestUtilities.projitems
@@ -43,6 +43,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)FX\CultureHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\DirectoryHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\EncodingUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FX\EnsureEnglishCulture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\EnsureEnglishUICulture.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\EventWaiter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FX\ImmutableArrayTestExtensions.cs" />


### PR DESCRIPTION
…nt decimal separator than '.'. Fixes #12094 

Output of tests in Norwegian locale after this change:
```
------ Test started: Assembly: Roslyn.Compilers.CSharp.Semantic.UnitTests.dll ------
 
93 passed, 0 failed, 1 skipped (see 'Error List / Messages'), took 8,43 seconds (xUnit.net 2.1.0 build 3179).
```