### PR TITLE
Tie language features to the langver flag

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
+++ b/src/Compilers/CSharp/Portable/CSharpParseOptions.cs
@@ -211,25 +211,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal bool IsFeatureEnabled(MessageID feature)
         {
-            switch (feature)
-            {
-                case MessageID.IDS_FeatureBinaryLiteral:
-                case MessageID.IDS_FeatureDigitSeparator:
-                case MessageID.IDS_FeatureLocalFunctions:
-                case MessageID.IDS_FeatureRefLocalsReturns:
-                case MessageID.IDS_FeaturePatternMatching:
-                case MessageID.IDS_FeatureTuples:
-                case MessageID.IDS_FeatureReplace:
-                    // in "demo" mode enable proposed new C# 7 language features.
-                    if (PreprocessorSymbols.Contains("__DEMO__"))
-                    {
-                        return true;
-                    }
-                    break;
-                default:
-                    break;
-            }
-
             string featureFlag = feature.RequiredFeature();
             if (featureFlag != null)
             {

--- a/src/Compilers/CSharp/Portable/Errors/MessageID.cs
+++ b/src/Compilers/CSharp/Portable/Errors/MessageID.cs
@@ -161,25 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         //   (hence the above rule - RequiredVersion throws when RequiredFeature returns non-null)
         internal static string RequiredFeature(this MessageID feature)
         {
-            switch (feature)
-            {
-                case MessageID.IDS_FeatureBinaryLiteral:
-                    return "binaryLiterals";
-                case MessageID.IDS_FeatureDigitSeparator:
-                    return "digitSeparators";
-                case MessageID.IDS_FeatureLocalFunctions:
-                    return "localFunctions";
-                case MessageID.IDS_FeatureRefLocalsReturns:
-                    return "refLocalsAndReturns";
-                case MessageID.IDS_FeaturePatternMatching:
-                    return "patterns";
-                case MessageID.IDS_FeatureTuples:
-                    return "tuples";
-                case MessageID.IDS_FeatureReplace:
-                    return "replace";
-                default:
-                    return null;
-            }
+            return null;
         }
 
         internal static LanguageVersion RequiredVersion(this MessageID feature)
@@ -188,6 +170,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Checks are in the LanguageParser unless otherwise noted.
             switch (feature)
             {
+                // C# 7 features.
+                case MessageID.IDS_FeatureBinaryLiteral:
+                case MessageID.IDS_FeatureDigitSeparator:
+                case MessageID.IDS_FeatureLocalFunctions:
+                case MessageID.IDS_FeatureRefLocalsReturns:
+                case MessageID.IDS_FeaturePatternMatching:
+                case MessageID.IDS_FeatureTuples:
+                case MessageID.IDS_FeatureReplace:
+                    return LanguageVersion.CSharp7;
+
                 // C# 6 features.
                 case MessageID.IDS_FeatureExceptionFilter:
                 case MessageID.IDS_FeatureAutoPropertyInitializer:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
             return (expectedUnoptimizedIL != null) ^ (expectedOptimizedIL != null) ? (unoptimizedVerifier ?? optimizedVerifier) : null;
         }
 
-        private readonly CSharpParseOptions _localFunctionParseOptions = TestOptions.Regular.WithLocalFunctionsFeature();
+        private readonly CSharpParseOptions _localFunctionParseOptions = TestOptions.Regular;
 
         #endregion
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3554,7 +3554,7 @@ Lambda:
             string source = @"
 namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
 ";
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
     // (2,11): error CS7000: Unexpected use of an aliased name
     // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
     Diagnostic(ErrorCode.ERR_UnexpectedAliasedName, "global::").WithLocation(2, 11),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3638,9 +3638,9 @@ namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B 
                 // (2,93): error CS8200: Tuple must contain at least two elements.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(2, 93),
-                // (2,93): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (2,93): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("tuples", "tuples").WithLocation(2, 93),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(2, 93),
                 // (2,95): error CS1022: Type or namespace definition, or end-of-file expected
                 // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
                 Diagnostic(ErrorCode.ERR_EOFExpected, "{").WithLocation(2, 95),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -25,9 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CSharpCompilationOptions options = null,
             bool verify = true)
         {
-            return CompileAndVerifyExperimental(
+            return CompileAndVerify(
                 source,
-                MessageID.IDS_FeatureRefLocalsReturns,
                 expectedOutput,
                 additionalRefs,
                 dependencies,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefLocalTests.cs
@@ -13,31 +13,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.RefLocalsReturns)]
     public class RefLocalTests : CompilingTestBase
     {
-        private CompilationVerifier CompileAndVerifyRef(
-            string source,
-            string expectedOutput = null,
-            MetadataReference[] additionalRefs = null,
-            IEnumerable<ModuleData> dependencies = null,
-            Action<ModuleSymbol> sourceSymbolValidator = null,
-            Action<PEAssembly> assemblyValidator = null,
-            Action<ModuleSymbol> symbolValidator = null,
-            SignatureDescription[] expectedSignatures = null,
-            CSharpCompilationOptions options = null,
-            bool verify = true)
-        {
-            return CompileAndVerify(
-                source,
-                expectedOutput,
-                additionalRefs,
-                dependencies,
-                sourceSymbolValidator,
-                assemblyValidator,
-                symbolValidator,
-                expectedSignatures,
-                options,
-                verify);
-        }
-
         [Fact]
         public void RefAssignArrayAccess()
         {
@@ -51,7 +26,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
 {
   // Code size       15 (0xf)
   .maxstack  2
@@ -79,7 +54,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M(ref int)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M(ref int)", @"
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -105,7 +80,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M(out int)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M(out int)", @"
 {
   // Code size        7 (0x7)
   .maxstack  2
@@ -134,7 +109,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M(ref int)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M(ref int)", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -165,7 +140,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
   .maxstack  1
@@ -198,7 +173,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -269,7 +244,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -359,7 +334,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll);
             comp.VerifyIL("Program<T>.M()", @"
 {
   // Code size       20 (0x14)
@@ -421,7 +396,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -488,7 +463,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       10 (0xa)
@@ -570,7 +545,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll);
             comp.VerifyIL("Program<T>.M()", @"
 {
   // Code size       21 (0x15)
@@ -631,7 +606,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
 {
   // Code size        8 (0x8)
   .maxstack  1
@@ -665,7 +640,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -706,7 +681,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M()", @"
 {
   // Code size       15 (0xf)
   .maxstack  2
@@ -741,7 +716,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size        9 (0x9)
@@ -792,7 +767,7 @@ class Program2
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll);
             comp.VerifyIL("Program2.M(ref Program)", @"
 {
   // Code size       17 (0x11)
@@ -836,7 +811,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M()", @"
 {
   // Code size       13 (0xd)
   .maxstack  1
@@ -873,7 +848,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -944,7 +919,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M()", @"
 {
   // Code size       14 (0xe)
@@ -1041,7 +1016,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program<T>.M()", @"
 {
   // Code size       25 (0x19)
@@ -1111,7 +1086,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       16 (0x10)
   .maxstack  3
@@ -1151,7 +1126,7 @@ class Program
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1228,7 +1203,7 @@ class Program3
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program.M(ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
@@ -1334,7 +1309,7 @@ class Program3<T>
 }
 ";
 
-            var comp = CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false);
+            var comp = CompileAndVerify(text, options: TestOptions.DebugDll, verify: false);
             comp.VerifyIL("Program<T>.M(ref int, ref int, object)", @"
 {
   // Code size       28 (0x1c)
@@ -1414,7 +1389,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll).VerifyIL("Program.M(D)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll).VerifyIL("Program.M(D)", @"
 {
   // Code size        9 (0x9)
   .maxstack  1
@@ -1443,7 +1418,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(D, ref int, ref int, object)", @"
+            CompileAndVerify(text, options: TestOptions.DebugDll, verify: false).VerifyIL("Program.M(D, ref int, ref int, object)", @"
 {
   // Code size       17 (0x11)
   .maxstack  4
@@ -1495,7 +1470,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.UnsafeDebugDll).VerifyIL("Program.Main()", @"
+            CompileAndVerify(text, options: TestOptions.UnsafeDebugDll).VerifyIL("Program.Main()", @"
 {
   // Code size       51 (0x33)
   .maxstack  3
@@ -1564,7 +1539,7 @@ class Program
 }
 ";
 
-            CompileAndVerifyRef(text, options: TestOptions.UnsafeDebugDll).VerifyIL("Program.Main()", @"
+            CompileAndVerify(text, options: TestOptions.UnsafeDebugDll).VerifyIL("Program.Main()", @"
 {
   // Code size       41 (0x29)
   .maxstack  2
@@ -1617,12 +1592,12 @@ class Program
 ";
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (6,9): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (6,9): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int rl = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(6, 9),
-                // (6,22): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 9),
+                // (6,22): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int rl = ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(6, 22)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 22)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -2231,12 +2231,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (4,12): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (4,12): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //     static ref int M()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(4, 12),
-                // (6,16): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(4, 12),
+                // (6,16): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         return ref (new int[1])[0];
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 16)
                 );
         }
 
@@ -2266,12 +2266,12 @@ class Program
 ";
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (4,12): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (4,12): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //     static ref int M()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(4, 12),
-                // (8,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(4, 12),
+                // (8,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int N()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, @"ref int N()
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, @"ref int N()
         {
             ref int NN(ref int arg) => ref arg;
 
@@ -2279,31 +2279,31 @@ class Program
             r += 2;
 
             return ref r;
-        }").WithArguments("local functions", "localFunctions").WithLocation(8, 9),
-                // (8,9): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+        }").WithArguments("local functions", "7").WithLocation(8, 9),
+                // (8,9): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int N()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(8, 9),
-                // (10,13): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(8, 9),
+                // (10,13): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //             ref int NN(ref int arg) => ref arg;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref int NN(ref int arg) => ref arg;").WithArguments("local functions", "localFunctions").WithLocation(10, 13),
-                // (10,13): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref int NN(ref int arg) => ref arg;").WithArguments("local functions", "7").WithLocation(10, 13),
+                // (10,13): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //             ref int NN(ref int arg) => ref arg;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(10, 13),
-                // (10,40): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(10, 13),
+                // (10,40): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //             ref int NN(ref int arg) => ref arg;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(10, 40),
-                // (12,13): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(10, 40),
+                // (12,13): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //             ref var r = ref NN(ref arr[0]);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(12, 13),
-                // (12,25): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(12, 13),
+                // (12,25): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //             ref var r = ref NN(ref arr[0]);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(12, 25),
-                // (15,20): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(12, 25),
+                // (15,20): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //             return ref r;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(15, 20),
-                // (18,16): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(15, 20),
+                // (18,16): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         return ref N();
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(18, 16)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(18, 16)
                 );
         }
 
@@ -2316,9 +2316,9 @@ delegate ref int D();
 
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (2,10): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (2,10): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 // delegate ref int D();
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(2, 10)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(2, 10)
                 );
         }
 
@@ -2337,12 +2337,12 @@ class Program
 
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (6,14): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (6,14): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         for (ref int a = ref d; ;) { }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(6, 14),
-                // (6,26): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 14),
+                // (6,26): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         for (ref int a = ref d; ;) { }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(6, 26)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(6, 26)
                 );
         }
 
@@ -2367,15 +2367,15 @@ class C
 
             var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             comp.VerifyDiagnostics(
-                // (2,10): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                // (2,10): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 // delegate ref int D(int x);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(2, 10),
-                // (11,19): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(2, 10),
+                // (11,19): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         MD((x) => ref i);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(11, 19),
-                // (12,17): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(11, 19),
+                // (12,17): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         MD(x => ref i);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(12, 17)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(12, 17)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenRefReturnTests.cs
@@ -20,9 +20,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             CSharpCompilationOptions options = null,
             bool verify = true)
         {
-            return CompileAndVerifyExperimental(
+            return CompileAndVerify(
                 source,
-                MessageID.IDS_FeatureRefLocalsReturns,
                 expectedOutput: expectedOutput,
                 options: options,
                 verify: verify);
@@ -1519,8 +1518,7 @@ class Program
 }
 ";
 
-            var options = TestOptions.Regular.WithRefsFeature().WithLocalFunctionsFeature();
-            CompileAndVerify(text, parseOptions: options).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular).VerifyIL("Program.M()", @"
 {
   // Code size        6 (0x6)
   .maxstack  1
@@ -1568,8 +1566,7 @@ class Program
 }
 ";
 
-            var options = TestOptions.Regular.WithRefsFeature().WithLocalFunctionsFeature();
-            CompileAndVerify(text, parseOptions: options, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
 {
   // Code size       34 (0x22)
   .maxstack  5
@@ -1644,8 +1641,7 @@ class Program
 }
 ";
 
-            var options = TestOptions.Regular.WithRefsFeature().WithLocalFunctionsFeature();
-            CompileAndVerify(text, parseOptions: options, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
+            CompileAndVerify(text, parseOptions: TestOptions.Regular, expectedOutput: "42", verify: false).VerifyIL("Program.M()", @"
 {
   // Code size       36 (0x24)
   .maxstack  5

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -7079,17 +7079,20 @@ class C
     {
         (int, int) x = (1, 1);
     }
-}
+CS0151ERR_IntegralTypeValueExpected}
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source);
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular6);
             comp.VerifyDiagnostics(
-                // (6,9): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (6,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (int, int) x = (1, 1);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(int, int)").WithArguments("tuples", "tuples").WithLocation(6, 9),
-                // (6,24): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int, int)").WithArguments("tuples", "7").WithLocation(6, 9),
+                // (6,24): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (int, int) x = (1, 1);
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(1, 1)").WithArguments("tuples", "tuples").WithLocation(6, 24)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(1, 1)").WithArguments("tuples", "7").WithLocation(6, 24),
+                // (8,36): error CS1519: Invalid token '}' in class, struct, or interface member declaration
+                // CS0151ERR_IntegralTypeValueExpected}
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "}").WithArguments("}").WithLocation(8, 36)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -210,7 +210,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -246,7 +246,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, 2}
 {0, 0}
 ");
@@ -289,7 +289,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib45AndCSruntime(source, TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib45AndCSruntime(source, TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
 
             var verifier = CompileAndVerify(comp, expectedOutput: @"
 {1, 2}");
@@ -371,7 +371,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 1
 3
 5
@@ -476,7 +476,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,22): error CS1729: '(int a, int b)' does not contain a constructor that takes 3 arguments
                 //         var x0 = new (int a, int b)(1, 2, 3);
@@ -518,7 +518,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "2", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "2", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -551,7 +551,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "{, }", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "{, }", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -584,7 +584,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "{1, {2, {3, 4}}}", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "{1, {2, {3, 4}}}", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -628,7 +628,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"2
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"2
 42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
@@ -674,7 +674,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"2
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"2
 42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
@@ -720,7 +720,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"2
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"2
 42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
@@ -766,7 +766,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"2
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"2
 42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
@@ -820,7 +820,7 @@ class C
 
 " + trivial3uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{1, hello, 2}");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"{1, hello, 2}");
         }
 
         [Fact]
@@ -837,7 +837,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (6,27): error CS0029: Cannot implicitly convert type '(int, string, int)' to '(int, string)'
                 //         (int, string) x = (1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"(1, ""hello"", 2)").WithArguments("(int, string, int)", "(int, string)").WithLocation(6, 27));
@@ -857,7 +857,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (6,27): error CS8206: Tuple with 3 elements cannot be converted to type '(int, string)'.
                 //         (int, string) x = (1, null, 2);
                 Diagnostic(ErrorCode.ERR_ConversionNotTupleCompatible, "(1, null, 2)").WithArguments("3", "(int, string)").WithLocation(6, 27)
@@ -879,7 +879,7 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (6,55): error CS0029: Cannot implicitly convert type 'string' to 'int'
                 //         (int, int, int, int, int, int, int, int) x = ("Alice", 2, 3, 4, 5, 6, 7, 8);
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, @"""Alice""").WithArguments("string", "int").WithLocation(6, 55),
@@ -902,7 +902,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
             comp.VerifyDiagnostics(
                 // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
@@ -943,7 +943,7 @@ class C
     }
 }
 " + trivial2uple;
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"1
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"1
 hello");
         }
 
@@ -960,7 +960,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (6,9): error CS8204: Tuple member names must all be provided, if any one is provided.
                 //         (int, string a) x = (b: 1, "hello", 2);
                 Diagnostic(ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, "(int, string a)").WithLocation(6, 9),
@@ -999,7 +999,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"4");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"4");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
@@ -1056,7 +1056,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -1094,7 +1094,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{42, 42}");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"{42, 42}");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -1159,7 +1159,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -1225,7 +1225,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -1293,7 +1293,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"42");
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.<>c__DisplayClass1_0<T>.<Test>b__0()", @"
 {
@@ -1422,7 +1422,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput:
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput:
 @"System.Action`1[System.Int32]
 1
 True
@@ -1464,7 +1464,7 @@ class C
     }
 }
 " + trivial2uple;
-            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput: @"42", options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
@@ -1580,7 +1580,7 @@ class C
     }
 }
 " + trivial2uple;
-            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{42, 42}", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput: @"{42, 42}", options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
@@ -1723,7 +1723,7 @@ namespace System
     }
 }
 ";
-            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput: @"42", options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
@@ -1867,7 +1867,7 @@ namespace System
     }
 }
 ";
-            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput: @"42", options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
             verifier.VerifyIL("C.<Test>d__1<T>.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
@@ -2011,7 +2011,7 @@ namespace System
     }
 }
 ";
-            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"42", options: TestOptions.ReleaseExe);
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput: @"42", options: TestOptions.ReleaseExe);
             verifier.VerifyDiagnostics();
         }
 
@@ -2128,7 +2128,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput:
+            var comp = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, parseOptions: TestOptions.Regular, expectedOutput:
 @"System.Action`1[System.Int32]
 1
 True
@@ -2171,7 +2171,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            CompileAndVerify(source, expectedOutput: @"42", additionalRefs: new[] { MscorlibRef_v46 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            CompileAndVerify(source, expectedOutput: @"42", additionalRefs: new[] { MscorlibRef_v46 }, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2186,7 +2186,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,9): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         (int, string) x = (1, "hello");
@@ -2214,7 +2214,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular);
             comp.VerifyEmitDiagnostics(
                 // (11,24): error CS8205: Member '.ctor' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (int, int) x = (1, 2);
@@ -2235,7 +2235,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,24): error CS8203: Tuple member names must be unique.
                 //         (int a, string a) x = (b: 1, b: "hello", b: 2);
@@ -2263,7 +2263,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,28): error CS8201: Tuple member name 'Item1' is only allowed at position 1.
                 //         (int Item1, string Item1) x = (Item1: 1, Item1: "hello");
@@ -2293,7 +2293,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,37): error CS8201: Tuple member name 'Item10' is only allowed at position 10.
                 //         (int Item1, int Item01, int Item10) x = (Item01: 1, Item1: 2, Item10: 3);
@@ -2323,7 +2323,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"0
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"0
 null");
         }
 
@@ -2340,7 +2340,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,24): error CS8203: Tuple member names must be unique.
                 //         (int a, string a) x = (b: 1, c: "hello", b: 2);
@@ -2364,7 +2364,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,28): error CS8201: Tuple member name 'Item3' is only allowed at position 3.
                 //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
@@ -2400,7 +2400,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,18): error CS8202: Tuple membername 'CompareTo' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
@@ -2437,7 +2437,7 @@ class C
 }
 ";
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2470,7 +2470,7 @@ class C
                     model.GetDeclaredSymbol(x).ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2503,7 +2503,7 @@ class C
                     model.GetDeclaredSymbol(x).ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2527,7 +2527,7 @@ class C
     }
 }
 ";
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2550,7 +2550,7 @@ class C
     }
 }
 ";
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2571,7 +2571,7 @@ class C
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (10,12): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //     static (T1 first, T2 second) M<T1, T2>()
@@ -2652,7 +2652,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (8,12): error CS0518: Predefined type 'System.ValueTuple`8' is not defined or imported
                 //     static (T1, T2, T3, T4, T5, T6, T7, T8, T9) M<T1, T2, T3, T4, T5, T6, T7, T8, T9>()
@@ -2678,7 +2678,7 @@ class C
     }
 }
 " + trivial2uple;
-            var comp = CompileAndVerify(source, expectedOutput: @"0 False", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"0 False", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2711,7 +2711,7 @@ class C
                      model.GetTypeInfo(node).Type.ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2729,7 +2729,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2747,7 +2747,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2766,7 +2766,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2786,7 +2786,7 @@ static class C
 }
 " + trivial2uple;
 
-            CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2799,7 +2799,7 @@ class C
 }
 " + trivial2uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (4,41): error CS1736: Default parameter value for 'y' must be a compile-time constant
                 //     void M(int x, (int a, string b) y = (42, "Alice"))
                 Diagnostic(ErrorCode.ERR_DefaultValueMustBeConstant, @"(42, ""Alice"")").WithArguments("y").WithLocation(4, 41));
@@ -2822,7 +2822,7 @@ class C
     }
 }
 " + trivial2uple;
-            CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, expectedOutput: @"0 ", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            CompileAndVerify(source, additionalRefs: new[] { SystemCoreRef }, expectedOutput: @"0 ", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2842,7 +2842,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"42 Alice", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2875,7 +2875,7 @@ class C
                      model.GetTypeInfo(node).Type.ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 2 3 4 5 6 7 Alice 2 3 4 5 6 7 Bob 2 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2898,7 +2898,7 @@ class C
 }
 ";
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"1 4 7 Alice 7 Bob 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"1 4 7 Alice 7 Bob 3", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2928,7 +2928,7 @@ class C
                 Assert.Equal("(System.String, System.Int32)", model.GetTypeInfo(node).Type.ToTestDisplayString());
             };
 
-            var verifier = CompileAndVerify(source, expectedOutput: @"Alice 1", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var verifier = CompileAndVerify(source, expectedOutput: @"Alice 1", additionalRefs: new[] { MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             verifier.VerifyDiagnostics();
         }
 
@@ -2950,7 +2950,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"{1, hello}", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"{1, hello}", parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -2992,9 +2992,9 @@ class C3
     }
 }
 ";
-            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular);
+            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular);
+            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -3032,9 +3032,9 @@ class C3
     }
 }
 ";
-            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature(), options: TestOptions.ReleaseExe);
+            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular);
+            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular);
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular, options: TestOptions.ReleaseExe);
 
             var v = CompileAndVerify(comp, expectedOutput:@"
 C1.M
@@ -3075,10 +3075,10 @@ class C3
     }
 }
 ";
-            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1", parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp2 = CreateCompilationWithMscorlib(trivial2uple, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1", parseOptions: TestOptions.Regular);
+            var comp2 = CreateCompilationWithMscorlib(trivial2uple, parseOptions: TestOptions.Regular);
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,17): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         var x = (1, 1);
@@ -3095,10 +3095,10 @@ class C3
     public void M((int, int) x) { }
 }
 ";
-            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1", parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp2 = CreateCompilationWithMscorlib(trivial2uple, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1", parseOptions: TestOptions.Regular);
+            var comp2 = CreateCompilationWithMscorlib(trivial2uple, parseOptions: TestOptions.Regular);
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (4,19): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //     public void M((int, int) x) { }
@@ -3153,9 +3153,9 @@ class C3
 }
 " + trivial2uple;
 
-            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular.WithTuplesFeature());
-            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4 5 5 6 6 True", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp1 = CreateCompilationWithMscorlib(source1, parseOptions: TestOptions.Regular);
+            var comp2 = CreateCompilationWithMscorlib(source2, parseOptions: TestOptions.Regular);
+            var comp = CompileAndVerify(source, expectedOutput: @"1 1 2 2 3 3 4 4 5 5 6 6 True", additionalRefs: new[] { new CSharpCompilationReference(comp1), new CSharpCompilationReference(comp2) }, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -3186,7 +3186,7 @@ namespace System
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,39): error CS0229: Ambiguity between '(string, string).Item1' and '(string, string).Item1'
                 //         System.Console.WriteLine($"{x.Item1}");
@@ -3229,7 +3229,7 @@ namespace System
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,39): error CS8205: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         System.Console.WriteLine($"{x.Item1}");
@@ -3317,7 +3317,7 @@ namespace System
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,39): error CS8205: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         System.Console.WriteLine($"{x.a}");
@@ -3352,7 +3352,7 @@ namespace System
     }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,39): error CS8205: Member 'Item1' was not found on type 'ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         System.Console.WriteLine($"{x.a}");
@@ -3394,7 +3394,7 @@ class C : I
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3423,7 +3423,7 @@ class C : I
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3452,7 +3452,7 @@ class C : I
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"1 7 8", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"1 7 8", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3481,7 +3481,7 @@ class C : I
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3510,7 +3510,7 @@ class C : I
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"5 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3545,7 +3545,7 @@ class C : I<CB, CA>
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: @"CB CA CC", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"CB CA CC", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3581,7 +3581,7 @@ class C2 : I<CB, CA>
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (15,25): error CS0425: The constraints for type parameter 'TC' of method 'C1.M<TC>((CB, (CA, TC)))' must match the constraints for type parameter 'TC' of interface method 'I<CB, CA>.M<TC>((CB, (CA, TC)))'. Consider using an explicit interface implementation instead.
                 //     public (CB, CA, TC) M<TC>((CB, (CA, TC)) arg)
@@ -3619,7 +3619,7 @@ class D : C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3653,7 +3653,7 @@ class D : C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"new base", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"new base", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3675,7 +3675,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (9,40): error CS0111: Type 'C' already defines a member called 'M' with the same parameter types
                 //     public System.ValueTuple<int, int> M(System.ValueTuple<string, string> a)
@@ -3708,7 +3708,7 @@ class C : I
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3733,7 +3733,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput:
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput:
 @"1 2
 3 4");
             comp.VerifyDiagnostics();
@@ -3759,7 +3759,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"1 2", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3783,7 +3783,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"1 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"1 Alice", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3805,7 +3805,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: @"True 1 Alice", parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"True 1 Alice", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -3856,7 +3856,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "12345678901234567890123456789012345", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "12345678901234567890123456789012345", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
         }
 
         [Fact]
@@ -4343,7 +4343,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             var tuple1 = comp.SourceModule.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMember<SourceMemberFieldSymbol>("F").Type;
 
             var intType = comp.GetSpecialType(SpecialType.System_Int32);
@@ -4395,7 +4395,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (10,30): error CS0266: Cannot implicitly convert type '(long, string)' to '(short, string)'. An explicit conversion exists (are you missing a cast?)
                 //         (short, string) x2 = ((long, string))(1, "hello");
@@ -4420,7 +4420,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, hello}");
             
             comp.VerifyIL("C.Main()",
@@ -4469,7 +4469,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (12,20): error CS1525: Invalid expression term ')'
                 //         x = (1, 1, );
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(12, 20),
@@ -4527,7 +4527,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (12,20): error CS1525: Invalid expression term ')'
                 //         x = (1, 1, );
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(12, 20),
@@ -4586,7 +4586,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (12,20): error CS1525: Invalid expression term ')'
                 //         x = (1, 1, );
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(12, 20),
@@ -4642,7 +4642,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (12,21): error CS1525: Invalid expression term ')'
                 //         x = ((1, 1, ), 1);
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(12, 21),
@@ -4704,7 +4704,7 @@ class C
 
 "+ trivial2uple + trivalRemainingTuples; //intentionally not including 3-tuple for usesite errors
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (13,37): error CS1525: Invalid expression term ';'
                 //         x = ((0, 0),1,2,3,4,5,6,7,8,;
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ";").WithArguments(";").WithLocation(13, 37),
@@ -4783,7 +4783,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (8,30): error CS0029: Cannot implicitly convert type 'int' to 'string'
                 //         Func<string> l = ()=>1; // reference
                 Diagnostic(ErrorCode.ERR_NoImplicitConv, "1").WithArguments("int", "string").WithLocation(8, 30),
@@ -4842,7 +4842,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 byte
 byte
 ");
@@ -4878,7 +4878,7 @@ class C
 }
 " + trivial2uple;
 
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (23,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.Test(Func<(Func<short>, int)>)' and 'C.Test(Func<(Func<byte>, int)>)'
                 //         Test(()=>(()=>1, 1));
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Test").WithArguments("C.Test(System.Func<(System.Func<short>, int)>)", "C.Test(System.Func<(System.Func<byte>, int)>)").WithLocation(23, 9)
@@ -4917,7 +4917,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 second
 first
 third
@@ -4955,7 +4955,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 third
 7
 ");
@@ -4987,7 +4987,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.Nullable`1[System.ValueTuple`2[System.Int32,System.Double]]
 {1, 2}
 ");
@@ -5025,7 +5025,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, expectedOutput: @"
 second
 first
 third
@@ -5059,7 +5059,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.Nullable`1[System.ValueTuple`2[System.Int32,System.String]]
 {1, }
 ");
@@ -5090,7 +5090,7 @@ class C
     }
 }
 ";
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput:
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, expectedOutput:
 @"1
 8
 (1, , 1, 2, 3, 4, 5, 6, 7, 8)
@@ -5132,7 +5132,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, expectedOutput: @"
 first
 first
 fourth
@@ -5158,7 +5158,7 @@ class C
 }
 " + trivial2uple;
 
-            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular).VerifyDiagnostics(
                 // (7,29): error CS0266: Cannot implicitly convert type '(long c, long d)' to '(int a, int b)'. An explicit conversion exists (are you missing a cast?)
                 //         (int a, int b) x1 = ((long c, long d))(e: 1, f:2);
                 Diagnostic(ErrorCode.ERR_NoImplicitConvCast, "((long c, long d))(e: 1, f:2)").WithArguments("(long c, long d)", "(int a, int b)").WithLocation(7, 29),
@@ -5185,7 +5185,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular).VerifyDiagnostics(
             );
         }
 
@@ -5202,7 +5202,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5233,7 +5233,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5276,7 +5276,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5305,7 +5305,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5334,7 +5334,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5371,7 +5371,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5405,7 +5405,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5438,7 +5438,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5467,7 +5467,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5502,7 +5502,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5537,7 +5537,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5566,7 +5566,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5595,7 +5595,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5625,7 +5625,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5668,7 +5668,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5698,7 +5698,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5757,7 +5757,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5804,7 +5804,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -5863,7 +5863,7 @@ class C
 }
 " + trivial2uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics();
@@ -5915,7 +5915,7 @@ class C
 }
 " + trivial2uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics(
@@ -5991,7 +5991,7 @@ namespace System
 }
 ";
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics();
@@ -6072,7 +6072,7 @@ namespace System
 }
 ";
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics();
@@ -6155,7 +6155,7 @@ namespace System
 }
 ";
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics();
@@ -6209,7 +6209,7 @@ class C
 }
 " + trivial2uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree, options: TestOptions.ReleaseExe);
 
             comp.VerifyDiagnostics(
@@ -6251,7 +6251,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 second
 first
 third
@@ -6289,7 +6289,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 third
 7
 ");
@@ -6325,7 +6325,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 third
 5
 ");
@@ -6358,7 +6358,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 first
 3
 second
@@ -6395,7 +6395,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 first
 2
 3
@@ -6430,7 +6430,7 @@ class Program
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 2
 ");
         }
@@ -6465,7 +6465,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 1
 1
 2
@@ -6508,7 +6508,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 test1
 {1, 2}
 test2_1
@@ -6559,7 +6559,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 test1
 {1, 2}
 test2_1
@@ -6592,7 +6592,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.ValueType
 ");
         }
@@ -6619,7 +6619,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (10,9): error CS0411: The type arguments for method 'C.Test1<T>(ref T, T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test1(ref t, (ValueType)1);
@@ -6665,7 +6665,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (11,9): error CS0411: The type arguments for method 'C.Test3<T>(ref T, ref T)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test3(ref ab, ref cd);
@@ -6695,7 +6695,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.Object
 System.ValueTuple`2[System.Int32,System.Int32]
 System.ValueTuple`2[System.Int32,System.Int32]
@@ -6725,7 +6725,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.Object
 System.ValueTuple`2[System.Int32,System.Int32]
 System.ValueTuple`2[System.Int32,System.Int32]
@@ -6754,7 +6754,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,9): error CS0411: The type arguments for method 'C.Test1<T, U>((T, U)?, (T, U?))' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test1((a: 1, b: (a: 1, b: 2)), (a: 1, b: (c: 1, d: 2)));
@@ -6787,7 +6787,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.String
 w
 ");
@@ -6819,7 +6819,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 System.Int32
 System.Int64
 System.Object
@@ -6841,7 +6841,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,24): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //         var x = (1, 2, new System.ArgIterator());
@@ -6871,7 +6871,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,17): error CS0610: Field or property cannot be of type 'ArgIterator'
                 //         (int x, System.ArgIterator y) y;
@@ -6891,7 +6891,7 @@ public interface MyInterface {
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (3,21): error CS1002: ; expected
                 //     (int, int) Foo()
@@ -6926,7 +6926,7 @@ class C : I
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{1, hello}
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"{1, hello}
 ");
         }
 
@@ -6958,7 +6958,7 @@ class C : I
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{1, hello}
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"{1, hello}
 1");
         }
 
@@ -6988,7 +6988,7 @@ class C : I<(int, string), (int Alice, string Bob)>
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"{{1, Australia}, {2, Brazil}}");
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"{{1, Australia}, {2, Brazil}}");
         }
 
         [Fact]
@@ -7017,7 +7017,7 @@ class C : I<(int, string, int, string, int, string, int, string), (int A, string
 }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular,
                                         expectedOutput: @"((1, Australia, 2, Brazil, 3, Columbia, 4, Ecuador), (5, France, 6, Germany, 7, Honduras, 8, India))");
         }
 
@@ -7065,7 +7065,7 @@ class D : C, I<(int a, int b), (int c, int d)>
                 Assert.Equal("I<(System.Int32 a, System.Int32 b), (System.Int32 c, System.Int32 d)>", y.AllInterfaces[1].ToTestDisplayString());
             };
 
-            var comp = CompileAndVerify(source, expectedOutput: @"{1, 2} {3, 4}", sourceSymbolValidator: validator, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: @"{1, 2} {3, 4}", sourceSymbolValidator: validator, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -7140,7 +7140,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"1
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"1
 11
 2
 22
@@ -7449,7 +7449,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"31
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"31
 32
 33
 34
@@ -7565,7 +7565,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"41
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"41
 42
 43
 44
@@ -7724,7 +7724,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (8,42): error CS1061: '(int, int)' does not contain a definition for 'a4' and no extension method 'a4' accepting a first argument of type '(int, int)' could be found (are you missing a using directive or an assembly reference?)
                 //         System.Console.WriteLine(v4.Rest.a4);
@@ -7805,7 +7805,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"501
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"501
 502
 503
 504
@@ -8017,7 +8017,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (8,42): error CS1061: '(int, int, int, int, int, int, int, int, int)' does not contain a definition for 'Item10' and no extension method 'Item10' accepting a first argument of type '(int, int, int, int, int, int, int, int, int)' could be found (are you missing a using directive or an assembly reference?)
                 //         System.Console.WriteLine(v5.Rest.Item10);
@@ -8103,7 +8103,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (9,17): error CS8201: Tuple member name 'Item9' is only allowed at position 9.
                 //     static (int Item9, int Item1, int Item2, int Item3, int Item4, int Item5, int Item6, int Item7, int Item8) M7()
@@ -8206,7 +8206,7 @@ class C
 }
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (9,73): error CS8201: Tuple member name 'Item1' is only allowed at position 1.
                 //     static (int a1, int a2, int a3, int a4, int a5, int a6, int a7, int Item1) M8()
@@ -8329,7 +8329,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"1
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"1
 11
 2
 22
@@ -8560,7 +8560,7 @@ namespace System
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (10,18): error CS1525: Invalid expression term 'int'
                 //         var y = (int, int).C9;
@@ -8706,7 +8706,7 @@ partial class C
 }
 " + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
 
             var c = comp.GetTypeByMetadataName("C");
             comp.VerifyDiagnostics(
@@ -8881,7 +8881,7 @@ namespace System
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseExe, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
 
             CompileAndVerify(comp, expectedOutput:
@@ -8950,7 +8950,7 @@ namespace System
 }
 " + trivial2uple + trivalRemainingTuples;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
 
             var c = comp.GetTypeByMetadataName("C");
             comp.VerifyDiagnostics();
@@ -9241,25 +9241,25 @@ public class Test
 
             var comp1 = CreateCompilationWithMscorlib(source2 + source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             UnifyUnderlyingWithTuple_01_AssertCompilation(comp1);
 
             var comp2 = CreateCompilationWithMscorlib(source2, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                                      options: TestOptions.ReleaseDll,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             var comp2CompilationRef = comp2.ToMetadataReference();
             var comp3 = CreateCompilationWithMscorlib45(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, comp2CompilationRef },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             Assert.NotSame(comp2.Assembly, (AssemblySymbol)comp3.GetAssemblyOrModuleSymbol(comp2CompilationRef)); // We are interested in retargeting scenario
             UnifyUnderlyingWithTuple_01_AssertCompilation(comp3);
 
             var comp4 = CreateCompilationWithMscorlib(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, comp2.EmitToImageReference() },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
             UnifyUnderlyingWithTuple_01_AssertCompilation(comp4);
         }
 
@@ -9296,7 +9296,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular,
                                         additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                         expectedOutput:
 @"ValueTuple
@@ -9364,7 +9364,7 @@ class C
 ";
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, 
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,42): error CS1525: Invalid expression term 'int'
                 //         System.Console.WriteLine(nameof((int, int)));
@@ -9409,18 +9409,18 @@ public class Test
 
             var comp1 = CreateCompilationWithMscorlib(source2 + source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             UnifyUnderlyingWithTuple_04_AssertCompilation(comp1);
 
             var comp2 = CreateCompilationWithMscorlib(source2, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                                      options: TestOptions.ReleaseDll,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             var comp2CompilationRef = comp2.ToMetadataReference();
             var comp3 = CreateCompilationWithMscorlib45(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, comp2CompilationRef },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             Assert.NotSame(comp2.Assembly, (AssemblySymbol)comp3.GetAssemblyOrModuleSymbol(comp2CompilationRef)); // We are interested in retargeting scenario
             UnifyUnderlyingWithTuple_04_AssertCompilation(comp3);
@@ -9428,7 +9428,7 @@ public class Test
             // Uncomment this part once tuple names can round-trip through metadata (https://github.com/dotnet/roslyn/issues/11119)
             //var comp4 = CreateCompilationWithMscorlib(source1, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, comp2.EmitToImageReference() },
             //                                         options: TestOptions.ReleaseExe,
-            //                                         parseOptions: TestOptions.Regular.WithTuplesFeature());
+            //                                         parseOptions: TestOptions.Regular);
             //UnifyUnderlyingWithTuple_04_AssertCompilation(comp4);
         }
 
@@ -9546,7 +9546,7 @@ static class Test4
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular,
                                         additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef },
                                         options: TestOptions.ReleaseExe.WithAllowUnsafe(true),
                                         expectedOutput:
@@ -9739,7 +9739,7 @@ interface ITest2<T> : ValueTuple<int, int, int, int, int, int, int, T> where T :
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                                      options: TestOptions.ReleaseExe.WithAllowUnsafe(true),
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             comp.VerifyDiagnostics(
                 // (31,7): error CS0509: 'Test1<T>': cannot derive from sealed type 'ValueTuple<int, int, int, int, int, int, int, T>'
@@ -9843,13 +9843,13 @@ class C
 
             var comp1 = CreateCompilationWithMscorlib(source1, 
                                                      options: TestOptions.ReleaseDll,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             comp1.VerifyDiagnostics();
 
             var comp2 = CreateCompilationWithMscorlib(source2, references: new[] { comp1.ToMetadataReference() },
                                                      options: TestOptions.ReleaseExe,
-                                                     parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                     parseOptions: TestOptions.Regular);
 
             comp2.VerifyDiagnostics(
                 // (7,37): error CS1061: 'ValueTuple<int, int, int, int, int, int, int, (int, int, int, int, int, int, int, int, int)>' does not contain a definition for 'Item8' and no extension method 'Item8' accepting a first argument of type 'ValueTuple<int, int, int, int, int, int, int, (int, int, int, int, int, int, int, int, int)>' could be found (are you missing a using directive or an assembly reference?)
@@ -10082,7 +10082,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular,
                                         options: TestOptions.ReleaseExe.WithAllowUnsafe(true),
                                         expectedOutput:
 @"{1, 3}
@@ -10337,7 +10337,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular,
                                         options: TestOptions.ReleaseExe.WithAllowUnsafe(true),
                                         expectedOutput:
 @"{1, 3}
@@ -10394,7 +10394,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular,
                                         additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef },
                                         options: TestOptions.ReleaseExe,
                                         expectedOutput:
@@ -10467,7 +10467,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: 
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: 
 @"33
 44");
 
@@ -10708,7 +10708,7 @@ namespace System
 }
 ";
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput:
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput:
 @"System.Action`1[System.Int32]
 1
 True
@@ -10873,7 +10873,7 @@ namespace System
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,12): error CS0070: The event '(int, long).E1' can only appear on the left hand side of += or -= (except when used from within the type '(int, long)')
                 //         v1.E1();
@@ -10894,7 +10894,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,19): error CS1525: Invalid expression term 'int'
                 //         if (o is (int, int) t)
@@ -10930,7 +10930,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,15): error CS1001: Identifier expected
                 //         (x, x);
@@ -10958,7 +10958,7 @@ class C
 " + trivial2uple;
 
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,32): error CS1003: Syntax error, '=>' expected
                 //         if (o is (int a, int b)) { }
@@ -10982,7 +10982,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,18): error CS0150: A constant value is expected
                 //         if (o is (1, 2))
@@ -11005,7 +11005,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,19): error CS1525: Invalid expression term 'int'
                 //             case (int, int) tuple: return;
@@ -11037,7 +11037,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,18): error CS0150: A constant value is expected
                 //             case (1, 1): return;
@@ -11060,7 +11060,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature().WithPatternsFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (7,25): error CS1003: Syntax error, ':' expected
                 //             case (1, 1) t: return;
@@ -11083,7 +11083,7 @@ class C
     }
 }
 " + trivial2uple;
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,9): error CS0201: Only assignment, call, increment, decrement, and new object expressions can be used as a statement
                 //         (1, 1);
@@ -11158,7 +11158,7 @@ class TestAttribute : System.Attribute
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), references: new[] { SystemRef });
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, references: new[] { SystemRef });
             comp.VerifyDiagnostics(
                 // (6,32): error CS8206: Type of the tuple element cannot be infered from '<null>'.
                 //         var x0 = new {tuple = (null, null)};
@@ -11249,7 +11249,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), options: TestOptions.ReleaseExe);
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, options: TestOptions.ReleaseExe);
             CompileAndVerify(comp, expectedOutput:
 @"System.ValueTuple`2[System.Int32,System.String] - {1, s}
 System.ValueType - {2, s}
@@ -11264,7 +11264,7 @@ System.ValueTuple`2[System.Int32,System.ValueTuple`2[System.Int32,System.String]
 class Class { void Method() { tuple = (1, ""hello""); } }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), references: new[] { SystemRef });
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, references: new[] { SystemRef });
             comp.VerifyDiagnostics(
                 // (2,31): error CS0103: The name 'tuple' does not exist in the current context
                 // class Class { void Method() { tuple = (1, "hello"); } }
@@ -11296,7 +11296,7 @@ class C
 }
 ";
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
 
             var model = comp.GetSemanticModel(tree, ignoreAccessibility: false);
@@ -11324,7 +11324,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}", parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "{1, 2}", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -11342,7 +11342,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, expectedOutput: "2", parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "2", parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -11360,7 +11360,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "(1, Alice, 2, Brenda, 3, Chloe, 4, Dylan)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "(1, Alice, 2, Brenda, 3, Chloe, 4, Dylan)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -11382,7 +11382,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "1 1 (8) 8 8", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature().WithLocalFunctionsFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "1 1 (8) 8 8", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -11400,7 +11400,7 @@ class C
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (6,83): error CS1503: Argument 8: cannot convert from 'int' to '(int)'
                 //         var x = new (int, int, int, int, int, int, int, int)(1, 2, 3, 4, 5, 6, 7, 8);
@@ -11426,13 +11426,13 @@ class C3
 }
 ";
             var comp1 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp1", 
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             var comp2 = CreateCompilationWithMscorlib(trivial2uple, assemblyName: "comp2", 
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
 
             var comp = CreateCompilationWithMscorlib(source, 
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference() }, 
-                parseOptions: TestOptions.Regular.WithTuplesFeature(), 
+                parseOptions: TestOptions.Regular, 
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
@@ -11443,7 +11443,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source,
                 references: new[] { comp2.ToMetadataReference(), comp1.ToMetadataReference() },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
@@ -11454,7 +11454,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source,
                 references: new[] { comp2.ToMetadataReference(ImmutableArray.Create("alias")), comp1.ToMetadataReference() },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11478,10 +11478,10 @@ public static class C2
 " + trivial2uple;
 
             var comp1 = CreateCompilationWithMscorlibAndSystemCore(source1, assemblyName: "comp1",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp1.VerifyDiagnostics();
             var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, assemblyName: "comp2",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp2.VerifyDiagnostics();
 
             var source3 = @"
@@ -11496,7 +11496,7 @@ class C3
 
             var comp = CreateCompilationWithMscorlib(source3,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference() },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
@@ -11507,7 +11507,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source3,
                             references: new[] { comp1.ToMetadataReference().WithAliases(ImmutableArray.Create("alias")), comp2.ToMetadataReference() },
-                            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                            parseOptions: TestOptions.Regular,
                             options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11528,7 +11528,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source4,
                             references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                            parseOptions: TestOptions.Regular,
                             options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11552,10 +11552,10 @@ public static class C2
 " + trivial2uple + trivial3uple + trivalRemainingTuples;
 
             var comp1 = CreateCompilationWithMscorlibAndSystemCore(source1, assemblyName: "comp1",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp1.VerifyDiagnostics();
             var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, assemblyName: "comp2",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp2.VerifyDiagnostics();
 
             var source3 = @"
@@ -11570,7 +11570,7 @@ class C3
 
             var comp = CreateCompilationWithMscorlib(source3,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference() },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
@@ -11584,7 +11584,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source3,
                             references: new[] { comp1.ToMetadataReference().WithAliases(ImmutableArray.Create("alias")), comp2.ToMetadataReference() },
-                            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                            parseOptions: TestOptions.Regular,
                             options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11605,7 +11605,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source4,
                             references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                            parseOptions: TestOptions.Regular,
                             options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11643,10 +11643,10 @@ namespace NS2
 " + trivial2uple;
 
             var comp1 = CreateCompilationWithMscorlibAndSystemCore(source1, assemblyName: "comp1",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp1.VerifyDiagnostics();
             var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, assemblyName: "comp2",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp2.VerifyDiagnostics();
 
             var source3 = @"
@@ -11665,7 +11665,7 @@ class C3
 
             var comp = CreateCompilationWithMscorlib(source3,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics(
@@ -11688,7 +11688,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source4,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11710,7 +11710,7 @@ class C3
 
             comp = CreateCompilationWithMscorlib(source5,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11742,10 +11742,10 @@ public class C2
 " + trivial2uple;
 
             var comp1 = CreateCompilationWithMscorlibAndSystemCore(source1, assemblyName: "comp1",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp1.VerifyDiagnostics();
             var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, assemblyName: "comp2",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp2.VerifyDiagnostics();
 
 
@@ -11764,7 +11764,7 @@ class C3
 
             var comp = CreateCompilationWithMscorlib(source,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             comp.VerifyDiagnostics();
@@ -11800,10 +11800,10 @@ public class C2
 " + trivial2uple;
 
             var comp1 = CreateCompilationWithMscorlibAndSystemCore(source1, assemblyName: "comp1",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp1.VerifyDiagnostics();
             var comp2 = CreateCompilationWithMscorlibAndSystemCore(source2, assemblyName: "comp2",
-                                                      parseOptions: TestOptions.Regular.WithTuplesFeature());
+                                                      parseOptions: TestOptions.Regular);
             comp2.VerifyDiagnostics();
 
 
@@ -11821,7 +11821,7 @@ class C3
 
             var comp = CreateCompilationWithMscorlib(source,
                 references: new[] { comp1.ToMetadataReference(), comp2.ToMetadataReference().WithAliases(ImmutableArray.Create("alias1")) },
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 options: TestOptions.DebugExe);
 
             CompileAndVerify(comp, expectedOutput:
@@ -11847,7 +11847,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
             //comp.VerifyDiagnostics();
 
@@ -11908,7 +11908,7 @@ class C
 }
 " + trivial2uple + trivial3uple;
 
-            var tree = Parse(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = Parse(source, options: TestOptions.Regular);
             var comp = CreateCompilationWithMscorlib(tree);
             //comp.VerifyDiagnostics();
 
@@ -11973,7 +11973,7 @@ namespace System.Diagnostics
     }
 }
 ";
-            var tupleComp = CreateCompilationWithMscorlib(TestResources.NetFX.ValueTuple.tuplelib_cs + additionalSource, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var tupleComp = CreateCompilationWithMscorlib(TestResources.NetFX.ValueTuple.tuplelib_cs + additionalSource, parseOptions: TestOptions.Regular);
             tupleComp.VerifyDiagnostics();
 
             var source = @"
@@ -11987,7 +11987,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, expectedOutput: "(1, 2)", additionalRefs: new[] { tupleComp.ToMetadataReference() }, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CompileAndVerify(source, expectedOutput: "(1, 2)", additionalRefs: new[] { tupleComp.ToMetadataReference() }, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics();
         }
 
@@ -12032,7 +12032,7 @@ class C
 }
 " ;
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, expectedOutput: @"
 (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
 (2, 2)
@@ -12081,7 +12081,7 @@ class C
 }
 ";
 
-            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular, expectedOutput: @"
 (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12)
 (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
 (2, 2)
@@ -12121,7 +12121,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {2, 2}
 {2, 2}");
             
@@ -12209,7 +12209,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {2, 2}
 {2, 2}");
 
@@ -12297,7 +12297,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {2, 2}
 {2, 2}
 ") ;
@@ -12336,7 +12336,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {2, 2}
 {2, 2}
 ");
@@ -12395,7 +12395,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, 2}
 {3, {4, 5}}
 {6, {7, {8, {9, {10, {11, {12, {13, {14, {15, {16, 17}}}}}}}}}}}");
@@ -12459,7 +12459,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), assemblyName: "ImplicitConversions06Err");
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
             comp.VerifyEmitDiagnostics(
                 // (8,16): error CS0030: Cannot convert type '(int, (int, (int, (int, (int, (int, int))))))' to 'C.C1'
                 //         C1 y = (C1)x;   
@@ -12520,7 +12520,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, {2, {3, {4, {5, 6}}}}}
 ");
         }
@@ -12577,7 +12577,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, {2, {3, {4, {5, 6}}}}}
 ");
         }
@@ -12619,7 +12619,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (10,70): error CS0029: Cannot implicitly convert type 'C.C1' to '(int, (object, (byte, (int?, (long, System.IComparable)?))?))?'
                 //         (int, (object, (byte, (int?, (long, IComparable)?))?))? x1 = y;
@@ -12670,7 +12670,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (14,70): error CS0030: Cannot convert type 'C.C1' to '(int, C.C1)?'
                 //                                                                      ((int, C1)?)
@@ -12711,7 +12711,7 @@ namespace System
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), assemblyName: "ImplicitConversions06Err");
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
             comp.VerifyEmitDiagnostics(
                 // (7,26): error CS8205: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'ImplicitConversions06Err, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (long, long) y = x;   
@@ -12751,7 +12751,7 @@ namespace System
 }
 ";
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), assemblyName: "ImplicitConversions06Err");
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
             comp.VerifyEmitDiagnostics(
                 // (7,26): error CS8205: Member 'Item2' was not found on type 'ValueTuple<T1, T2>' from assembly 'ImplicitConversions06Err, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.
                 //         (byte, byte) y = ((byte, byte))x;   
@@ -12787,7 +12787,7 @@ using System;
 
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {Program+C2, Program+C2}
 ");
         }
@@ -12819,7 +12819,7 @@ using System;
 
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {Program+C2, Program+C2}
 ");
         }
@@ -12843,7 +12843,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {1, 2}
 {3, 4}");
 
@@ -12922,7 +12922,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 {2, 3}
 {, 5}");
 
@@ -13003,7 +13003,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), assemblyName: "ImplicitConversions06Err");
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
             comp.VerifyEmitDiagnostics(
                 // (13,17): error CS0030: Cannot convert type '(<null>, int)' to '(C.C2, C.C2)'
                 //         var z = ((C2, C2))(null, 4); 
@@ -13094,7 +13094,7 @@ class D<T> : C<T>
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 explicit
 original
 
@@ -13158,7 +13158,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), assemblyName: "ImplicitConversions06Err");
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
             comp.VerifyEmitDiagnostics(
                 // (28,13): error CS0457: Ambiguous user defined conversions 'B.implicit operator B(long)' and 'A.implicit operator A(int)' when converting from 'int' to 'B'
                 //         b = (B)x;
@@ -13202,7 +13202,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 first
 first
 first
@@ -13234,7 +13234,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 second
 second
 second
@@ -13271,7 +13271,7 @@ class C
 }
 " + trivial2uple;
 
-            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular.WithTuplesFeature(), expectedOutput: @"
+            var comp = CompileAndVerify(source, parseOptions: TestOptions.Regular, expectedOutput: @"
 first
 second
 second
@@ -13316,7 +13316,7 @@ class Program
 
 " + trivial2uple;
 
-            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular);
             comp.VerifyDiagnostics(
                 // (22,9): error CS0411: The type arguments for method 'Program.Test<T>(Action<T>, Action<T>)' cannot be inferred from the usage. Try specifying the type arguments explicitly.
                 //         Test(z, z1);

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/OperationAnalyzerTests.cs
@@ -13,8 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class OperationAnalyzerTests : CompilingTestBase
     {
-        private readonly static CSharpParseOptions patternParseOptions =
-            TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6).WithPatternsFeature();
+        private readonly static CSharpParseOptions patternParseOptions = TestOptions.Regular;
 
         [Fact]
         public void EmptyArrayCSharp()

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2375,7 +2375,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text.VerifyDiagnostics();
         }
 
         [Fact]
@@ -2400,7 +2400,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact]
@@ -2429,7 +2429,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact]
@@ -2458,7 +2458,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact, WorkItem(1078958, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1078958")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -2375,7 +2375,7 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib45(text.VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2839,9 +2839,9 @@ class Program
 }
 ";
             CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)).VerifyDiagnostics(
-                // (6,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                // (6,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //         void f() { if () const int i = 0; }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "void f() { if () const int i = 0; }").WithArguments("local functions", "localFunctions").WithLocation(6, 9),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "void f() { if () const int i = 0; }").WithArguments("local functions", "7").WithLocation(6, 9),
                 // (6,24): error CS1525: Invalid expression term ')'
                 //         void f() { if () const int i = 0; }
                 Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(6, 24),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/InheritanceBindingTests.cs
@@ -1271,7 +1271,7 @@ class Derived : Base
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (13,29): error CS8893: 'Derived.Method1()' must not return by reference to match overridden member 'Base.Method1()'
     //     public override ref int Method1() { return ref field; }
     Diagnostic(ErrorCode.ERR_CantChangeRefReturnOnOverride, "Method1").WithArguments("Derived.Method1()", "Base.Method1()", "not ").WithLocation(13, 29),
@@ -1417,7 +1417,7 @@ class Derived : Base
     public override ref int Property3 { get { return ref field; } }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (15,29): error CS8893: 'Derived.Proprty1' must not return by reference to match overridden member 'Base.Proprty1'
     //     public override ref int Proprty1 { get { return ref field; } }
     Diagnostic(ErrorCode.ERR_CantChangeRefReturnOnOverride, "Proprty1").WithArguments("Derived.Proprty1", "Base.Proprty1", "not ").WithLocation(15, 29),
@@ -1477,7 +1477,7 @@ class Derived : Base
     public override ref int this[string x, int y] { get { return ref field; } }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (15,29): error CS8893: 'Derived.this[int, int]' must not return by reference to match overridden member 'Base.this[int, int]'
     //     public override ref int this[int x, int y] { get { return ref field; } }
     Diagnostic(ErrorCode.ERR_CantChangeRefReturnOnOverride, "this").WithArguments("Derived.this[int, int]", "Base.this[int, int]", "not ").WithLocation(15, 29),
@@ -2051,7 +2051,7 @@ class Derived : Base
     public override ref object Method6(ref object o) { return ref o; } //wrong by-ref return
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (16,16): warning CS0114: 'Derived.Method3()' hides inherited member 'Base.Method3()'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
     //     public int Method3() { return 0; } //wrong return type
     Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "Method3").WithArguments("Derived.Method3()", "Base.Method3()").WithLocation(16, 16),
@@ -2120,7 +2120,7 @@ class Derived : Base
     public override object Property11 { get { return null; } }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (23,25): error CS1715: 'Derived.Property3': type must be 'object' to match overridden member 'Base.Property3'
     //     public override int Property3 { get; set; } //wrong type
     Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "Property3").WithArguments("Derived.Property3", "Base.Property3", "object").WithLocation(23, 25),
@@ -2225,7 +2225,7 @@ class Derived : Base
     public override object this[string w, int x, string y, int z] { get; }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (36,69): error CS0501: 'Derived.this[string, int, string, int].get' must declare a body because it is not marked abstract, extern, or partial
                 //     public override object this[string w, int x, string y, int z] { get; }
                 Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "get").WithArguments("Derived.this[string, int, string, int].get").WithLocation(36, 69),
@@ -2489,7 +2489,7 @@ class Class : Interface
     public ref object Method4(ref object o) { return ref o; } //wrong by-ref return
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (10,15): error CS8897: 'Class' does not implement interface member 'Interface.Method4(ref object)'. 'Class.Method4(ref object)' cannot implement 'Interface.Method4(ref object)' because it does not return by value
     // class Class : Interface
     Diagnostic(ErrorCode.ERR_CloseUnimplementedInterfaceMemberWrongRefReturn, "Interface").WithArguments("Class", "Interface.Method4(ref object)", "Class.Method4(ref object)", "value").WithLocation(10, 15),
@@ -2542,7 +2542,7 @@ class Class : Interface
     public ref object Property9 { get { return ref o; } }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
     // (17,15): error CS0535: 'Class' does not implement interface member 'Interface.Property2.set'
     // class Class : Interface
     Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "Interface").WithArguments("Class", "Interface.Property2.set").WithLocation(17, 15),
@@ -2604,7 +2604,7 @@ class Class : Interface
     public ref object this[string w, int x, int y, string z] { get { return ref o; } }
 }
 ";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (17,15): error CS0535: 'Class' does not implement interface member 'Interface.this[int, string, string, string].set'
                 // class Class : Interface
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "Interface").WithArguments("Class", "Interface.this[int, string, string, string].set").WithLocation(17, 15),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LambdaTests.cs
@@ -1119,7 +1119,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
 
@@ -1141,7 +1141,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1169,7 +1169,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics();
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics();
         }
 
         [Fact]
@@ -1192,7 +1192,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (11,22): error CS8083: By-reference returns may only be used in by-reference returning methods.
                 //         ME(() => ref i);
                 Diagnostic(ErrorCode.ERR_MustNotHaveRefReturn, "i").WithLocation(11, 22),
@@ -1222,7 +1222,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (9,33): error CS8083: By-reference returns may only be used in by-reference returning methods.
                 //         var e = new E(() => ref i);
                 Diagnostic(ErrorCode.ERR_MustNotHaveRefReturn, "i").WithLocation(9, 33),
@@ -1267,7 +1267,7 @@ class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 // (18,13): error CS8084: By-value returns may only be used in by-value returning methods.
                 //             return i;
                 Diagnostic(ErrorCode.ERR_MustHaveRefReturn, "return").WithLocation(18, 13),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -3717,9 +3717,9 @@ class Program
 ";
             var option = TestOptions.ReleaseExe;
             CreateCompilationWithMscorlib(source, options: option, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)).VerifyDiagnostics(
-                // (6,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
-                //         void Local()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, @"void Local() { }").WithArguments("local functions", "localFunctions").WithLocation(6, 9)
+                // (6,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
+                //         void Local() { }
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "void Local() { }").WithArguments("local functions", "7").WithLocation(6, 9)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
     public class LocalFunctionsTestBase : CSharpTestBase
     {
-        internal static readonly CSharpParseOptions DefaultParseOptions = TestOptions.Regular.WithLocalFunctionsFeature();
+        internal static readonly CSharpParseOptions DefaultParseOptions = TestOptions.Regular;
 
         internal CompilationVerifier VerifyOutput(string source, string output, CSharpCompilationOptions options)
         {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupPositionTests.cs
@@ -48,7 +48,7 @@ class C
                     "System.Type System.Object.GetType()"),
                 s_pop);
 
-            TestLookupNames(text, expectedNames, experimental: true);
+            TestLookupNames(text, expectedNames);
         }
 
         [Fact]
@@ -1528,10 +1528,10 @@ class Derived : Base<int>
         /// For each region of the program, a list of expected names must be provided.  This method
         /// will assert if any region contains different names than expected.
         /// </summary>
-        private static void TestLookupNames(string text, string[][] expectedNames, bool experimental = false)
+        private static void TestLookupNames(string text, string[][] expectedNames)
         {
             int[] keyPositions;
-            var model = GetModelAndKeyPositions(text, out keyPositions, experimental);
+            var model = GetModelAndKeyPositions(text, out keyPositions);
 
             // There should be one more list of expectedNames than there are backticks.
             // Number of key positions = number of backticks + 2 (start and end)
@@ -1555,7 +1555,7 @@ class Derived : Base<int>
         /// Strip the backticks out of "markedText" and record their positions.
         /// Return a SemanticModel for the compiled text.
         /// </summary>
-        private static SemanticModel GetModelAndKeyPositions(string markedText, out int[] keyPositions, bool experimental = false)
+        private static SemanticModel GetModelAndKeyPositions(string markedText, out int[] keyPositions)
         {
             ArrayBuilder<int> keyPositionBuilder = ArrayBuilder<int>.GetInstance();
             StringBuilder textBuilder = new StringBuilder();
@@ -1582,11 +1582,6 @@ class Derived : Base<int>
             var text = textBuilder.ToString();
 
             var parseOptions = TestOptions.RegularWithDocumentationComments;
-            if (experimental)
-            {
-                parseOptions = parseOptions.WithTuplesFeature().WithRefsFeature();
-            }
-
             var compilation = CreateCompilationWithMscorlib(text, parseOptions: parseOptions);
             var tree = compilation.SyntaxTrees[0];
             return compilation.GetSemanticModel(tree);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LookupTests.cs
@@ -17,23 +17,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         #region helpers
 
-        internal List<string> GetLookupNames(string testSrc, bool experimental = false)
+        internal List<string> GetLookupNames(string testSrc)
         {
             var parseOptions = TestOptions.Regular;
-            if (experimental)
-            {
-                parseOptions = parseOptions.WithRefsFeature().WithLocalFunctionsFeature();
-            }
             var compilation = CreateCompilationWithMscorlib45(testSrc, parseOptions: parseOptions);
             var tree = compilation.SyntaxTrees.Single();
             var model = compilation.GetSemanticModel(tree);
             var position = testSrc.Contains("/*<bind>*/") ? GetPositionForBinding(tree) : GetPositionForBinding(testSrc);
             return model.LookupNames(position);
-        }
-
-        internal List<string> GetExperimentalLookupNames(string testSrc)
-        {
-            return GetLookupNames(testSrc, experimental: true);
         }
 
         internal List<ISymbol> GetLookupSymbols(string testSrc, NamespaceOrTypeSymbol container = null, string name = null, int? arity = null, bool isScript = false, IEnumerable<string> globalUsings = null)
@@ -57,7 +48,7 @@ class C
 {
     public int P => /*<bind>*/10/*</bind>*/;
 }";
-            var actual = GetExperimentalLookupNames(text).ListToSortedString();
+            var actual = GetLookupNames(text).ListToSortedString();
 
             var expected_lookupNames = new List<string>
             {
@@ -85,7 +76,7 @@ class C
 {
     public int M() => /*<bind>*/10/*</bind>*/;
 }";
-            var actual = GetExperimentalLookupNames(text).ListToSortedString();
+            var actual = GetLookupNames(text).ListToSortedString();
 
             var expected_lookupNames = new List<string>
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -43,42 +43,55 @@ public class Vec
     public Vec(int x) {}
 }
 ";
-            var regularParseOptions = TestOptions.Regular;
+            var regularParseOptions = TestOptions.Regular6;
             CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: regularParseOptions).VerifyDiagnostics(
-                // (7,18): error CS8058: Feature 'binary literals' is experimental and unsupported; use '/features:binaryLiterals' to enable.
+                // (7,18): error CS8059: Feature 'binary literals' is not available in C# 6.  Please use language version 7 or greater.
                 //         int i1 = 0b001010; // binary literals
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "").WithArguments("binary literals", "binaryLiterals").WithLocation(7, 18),
-                // (8,18): error CS8058: Feature 'digit separators' is experimental and unsupported; use '/features:digitSeparators' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "").WithArguments("binary literals", "7").WithLocation(7, 18),
+                // (8,18): error CS8059: Feature 'digit separators' is not available in C# 6.  Please use language version 7 or greater.
                 //         int i2 = 23_554; // digit separators
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "").WithArguments("digit separators", "digitSeparators").WithLocation(8, 18),
-                // (12,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "").WithArguments("digit separators", "7").WithLocation(8, 18),
+                // (12,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //         int f() => 2;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "int f() => 2;").WithArguments("local functions", "localFunctions").WithLocation(12, 9),
-                // (13,9): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "int f() => 2;").WithArguments("local functions", "7").WithLocation(12, 9),
+                // (13,9): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(13, 9),
-                // (13,22): error CS8058: Feature 'byref locals and returns' is experimental and unsupported; use '/features:refLocalsAndReturns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(13, 9),
+                // (13,22): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
                 //         ref int i3 = ref i1; // ref locals
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "ref").WithArguments("byref locals and returns", "refLocalsAndReturns").WithLocation(13, 22),
-                // (14,20): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(13, 22),
+                // (14,20): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
                 //         string s = o is string k ? k : null; // pattern matching
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "o is string k").WithArguments("pattern matching", "patterns").WithLocation(14, 20),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "o is string k").WithArguments("pattern matching", "7").WithLocation(14, 20),
                 // (12,13): warning CS0168: The variable 'f' is declared but never used
                 //         int f() => 2;
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
                 );
 
             // enables binary literals, digit separators, local functions, ref locals, pattern matching
-            var demoParseOptions = regularParseOptions
-                .WithPreprocessorSymbols(new[] { "__DEMO__" });
+            var demoParseOptions = TestOptions.Regular6;
             CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: demoParseOptions).VerifyDiagnostics(
-                // (8,13): warning CS0219: The variable 'i2' is assigned but its value is never used
+                // (7,18): error CS8059: Feature 'binary literals' is not available in C# 6.  Please use language version 7 or greater.
+                //         int i1 = 0b001010; // binary literals
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "").WithArguments("binary literals", "7").WithLocation(7, 18),
+                // (8,18): error CS8059: Feature 'digit separators' is not available in C# 6.  Please use language version 7 or greater.
                 //         int i2 = 23_554; // digit separators
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i2").WithArguments("i2").WithLocation(8, 13),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "").WithArguments("digit separators", "7").WithLocation(8, 18),
+                // (12,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
+                //         int f() => 2;
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "int f() => 2;").WithArguments("local functions", "7").WithLocation(12, 9),
+                // (13,9): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
+                //         ref int i3 = ref i1; // ref locals
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(13, 9),
+                // (13,22): error CS8059: Feature 'byref locals and returns' is not available in C# 6.  Please use language version 7 or greater.
+                //         ref int i3 = ref i1; // ref locals
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "ref").WithArguments("byref locals and returns", "7").WithLocation(13, 22),
+                // (14,20): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
+                //         string s = o is string k ? k : null; // pattern matching
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "o is string k").WithArguments("pattern matching", "7").WithLocation(14, 20),
                 // (12,13): warning CS0168: The variable 'f' is declared but never used
                 //         int f() => 2;
-                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13)
-                );
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(12, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -14,8 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
     public class PatternMatchingTests : CSharpTestBase
     {
-        private static CSharpParseOptions patternParseOptions =
-            TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6).WithPatternsFeature();
+        private static CSharpParseOptions patternParseOptions = TestOptions.Regular;
 
         [Fact]
         public void DemoModes()
@@ -381,7 +380,7 @@ public class X
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions.WithLocalFunctionsFeature());
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics();
             var expectedOutput =
 @"False for 1
@@ -2401,7 +2400,7 @@ public class X
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions.WithLocalFunctionsFeature());
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             compilation.VerifyDiagnostics(
     // (12,33): error CS1002: ; expected
     //         void f(object o) => let x1 = o;
@@ -2526,7 +2525,7 @@ public class X
     }
 }
 ";
-            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions.WithLocalFunctionsFeature());
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: patternParseOptions);
             CompileAndVerify(compilation, expectedOutput: @"1
 True");
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
@@ -337,12 +337,18 @@ public class Test
 }";
             var comp = CreateCompilationRef(text, references: new[] { MscorlibRef, SystemCoreRef });
             comp.VerifyDiagnostics(
-    // (16,34): error CS8913: Cannot return the range variable 'ch' by reference
-    //             select(D1)(() => ref ch);
-    Diagnostic(ErrorCode.ERR_RefReturnRangeVariable, "ch").WithArguments("ch").WithLocation(16, 34),
-    // (19,34): error CS8913: Cannot return the range variable 's' by reference
-    //             select(D1)(() => ref s.x);
-    Diagnostic(ErrorCode.ERR_RefReturnRangeVariable, "s.x").WithArguments("s").WithLocation(19, 34)
+                // (2,14): error CS0234: The type or namespace name 'Linq' does not exist in the namespace 'System' (are you missing an assembly reference?)
+                // using System.Linq;
+                Diagnostic(ErrorCode.ERR_DottedTypeNameNotFoundInNS, "Linq").WithArguments("Linq", "System").WithLocation(2, 14),
+                // (15,28): error CS1935: Could not find an implementation of the query pattern for source type 'string'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?
+                //         var x = from ch in "qqq"
+                Diagnostic(ErrorCode.ERR_QueryNoProviderStandard, @"""qqq""").WithArguments("string", "Select").WithLocation(15, 28),
+                // (18,27): error CS1935: Could not find an implementation of the query pattern for source type 'Test.S1[]'.  'Select' not found.  Are you missing a reference to 'System.Core.dll' or a using directive for 'System.Linq'?
+                //         var y = from s in new S1[10]
+                Diagnostic(ErrorCode.ERR_QueryNoProviderStandard, "new S1[10]").WithArguments("Test.S1[]", "Select").WithLocation(18, 27),
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System.Linq;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System.Linq;").WithLocation(2, 1)
             );
         }
         

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
@@ -21,7 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
             string assemblyName = "",
             string sourceFileName = "")
         {
-            return CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns, references, options, assemblyName, sourceFileName);
+            return CreateCompilationWithMscorlib45(text);
         }
 
         [Fact]
@@ -839,7 +839,7 @@ public class Test
         }
     }
 }";
-            var options = TestOptions.Regular.WithRefsFeature().WithLocalFunctionsFeature();
+            var options = TestOptions.Regular;
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: options);
             comp.VerifyDiagnostics(
     // (14,13): error CS8894: By-reference returns may only be used in methods that return by reference
@@ -883,7 +883,7 @@ public class Test
         char Moo3(ref char a, ref char b) => r;
     }
 }";
-            var options = TestOptions.Regular.WithRefsFeature().WithLocalFunctionsFeature();
+            var options = TestOptions.Regular;
             var comp = CreateCompilationWithMscorlib45(text, parseOptions: options);
             comp.VerifyDiagnostics(
     // (9,50): error CS8894: By-reference returns may only be used in methods that return by reference

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -2232,7 +2232,7 @@ public class MyClass {
         return 1;
     }
 
-}")
+}", parseOptions: TestOptions.Regular6)
                 .VerifyDiagnostics(
                 // (7,22): error CS0118: 'myTest' is a 'variable' but is used like a 'type'
                 Diagnostic(ErrorCode.ERR_BadSKknown, "myTest").WithArguments("myTest", "variable", "type"));
@@ -4038,7 +4038,9 @@ public class iii
       }
    }
 }";
-            DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
+            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6);
+            DiagnosticsUtils.VerifyErrorCodes(
+                comp,
                 new ErrorDescription[] { new ErrorDescription { Code = (int)ErrorCode.ERR_SwitchGoverningTypeValueExpected, Line = 18, Column = 15 } });
         }
 
@@ -7225,9 +7227,9 @@ class A
 }";
             var comp = CreateCompilationWithMscorlib(new[] { Parse(test, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)) }, new MetadataReference[] { });
             comp.VerifyDiagnostics(
-                // (7,9): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (7,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (a, b) =>
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(a, b)").WithArguments("tuples", "tuples").WithLocation(7, 9),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(a, b)").WithArguments("tuples", "7").WithLocation(7, 9),
                 // (7,16): error CS1001: Identifier expected
                 //         (a, b) =>
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(7, 16),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -7173,7 +7173,7 @@ class A
         x + y; x == 1;
     }
 }";
-            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular).VerifyDiagnostics(
     // (7,16): error CS1001: Identifier expected
     //         (a, b) =>
     Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(7, 16),

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -326,7 +326,7 @@ public class Test
     }
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (9,11): error CS0166: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 // 		switch (test) {
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "test").WithLocation(9, 17));
@@ -348,7 +348,7 @@ class T
     }
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS0166: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(null)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "null").WithLocation(6, 16));
@@ -372,7 +372,7 @@ class T
     public static void M() { }
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS0166: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(M())
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "M()").WithLocation(6, 16));
@@ -394,7 +394,7 @@ class T
     }
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS0166: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(() => {})
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "() => {}").WithLocation(6, 16));
@@ -433,7 +433,7 @@ class Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (17,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(17, 16));
@@ -472,7 +472,7 @@ class Conv
     }
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (17,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(17, 16));
@@ -511,7 +511,7 @@ struct Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (17,10): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(17, 16));
@@ -558,7 +558,7 @@ struct Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (17,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(17, 16)
@@ -610,7 +610,7 @@ struct Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (27,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(27, 16));
@@ -661,7 +661,7 @@ struct Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (27,10): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 // 		switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(27, 16));
@@ -746,7 +746,7 @@ class Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (13,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(13, 16)
@@ -783,7 +783,7 @@ class Conv
     }		
 }";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (14,16): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch(C)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "C").WithLocation(14, 16));
@@ -855,7 +855,7 @@ class C
 }
 ";
 
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,17): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //         switch (o)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "o").WithLocation(6, 17),
@@ -1251,7 +1251,7 @@ class C
 }";
             // Note: Dev10 also reports CS0151 for "b2.F()", although
             // there is an implicit conversion from A2 to int.
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (20,17): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "b1.F()").WithLocation(20, 17));
         }
@@ -1299,7 +1299,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a").WithLocation(28, 20));
@@ -1348,7 +1348,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (22,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(aNullable)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "aNullable"),
@@ -1399,7 +1399,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a"));
@@ -1447,7 +1447,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a"));
@@ -1495,7 +1495,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a").WithLocation(28, 20)
@@ -1544,7 +1544,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a").WithLocation(28, 20)
@@ -1599,7 +1599,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (34,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a"));
@@ -1654,7 +1654,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(aNullable)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "aNullable"),
@@ -1711,7 +1711,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (34,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(a)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a"));
@@ -1766,7 +1766,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (28,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(aNullable)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "aNullable"),
@@ -1830,7 +1830,7 @@ struct A
     }
 }
 ";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (34,20): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch(aNullable)
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "aNullable"),
@@ -1982,7 +1982,7 @@ struct A
         }
     }
 }";
-            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (29,21): error CS0151: A switch expression or case label must be a bool, char, string, integral, enum, or corresponding nullable type
                 //             switch (a) // both operators applicable in non-lifted form -> error
                 Diagnostic(ErrorCode.ERR_SwitchGoverningTypeValueExpected, "a").WithLocation(29, 21)

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -509,9 +509,9 @@ namespace A.B {
                 // (1,19): error CS1002: ; expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
-                // (1,19): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (1,19): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithArguments("tuples", "tuples").WithLocation(1, 19),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithArguments("tuples", "7").WithLocation(1, 19),
                 // (1,20): error CS1031: Type expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_TypeExpected, "*").WithLocation(1, 20),

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -435,7 +435,7 @@ namespace A.B {
              options: TestOptions.ReleaseDll,
              syntaxTrees: new SyntaxTree[] { SyntaxFactory.ParseSyntaxTree(
                     "extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}",
-                    options: TestOptions.Regular.WithTuplesFeature()) },
+                    options: TestOptions.Regular) },
              references: new MetadataReference[] { MscorlibRef, mtref }
              );
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -8505,7 +8505,7 @@ public class Test
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<ParenthesizedLambdaExpressionSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Null(semanticInfo.Type);
             Assert.Equal("?", semanticInfo.ConvertedType.ToTestDisplayString());
@@ -8545,7 +8545,7 @@ public class Test
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Null(semanticInfo.Type);
             Assert.Equal("?", semanticInfo.ConvertedType.ToTestDisplayString());
@@ -8586,7 +8586,7 @@ public class Test
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<LiteralExpressionSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<LiteralExpressionSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Equal("System.Double", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Struct, semanticInfo.Type.TypeKind);
@@ -10897,7 +10897,7 @@ class Program
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<LiteralExpressionSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<LiteralExpressionSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Equal("System.Int32", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Struct, semanticInfo.Type.TypeKind);
@@ -12442,7 +12442,7 @@ struct Conv
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Equal("Conv", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Struct, semanticInfo.Type.TypeKind);
@@ -12476,7 +12476,7 @@ struct Conv
     }
 }
 ";
-            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode);
+            var semanticInfo = GetSemanticInfoForTest<IdentifierNameSyntax>(sourceCode, parseOptions: TestOptions.Regular6);
 
             Assert.Equal("Conv", semanticInfo.Type.ToTestDisplayString());
             Assert.Equal(TypeKind.Struct, semanticInfo.Type.TypeKind);

--- a/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/SymbolDisplay/SymbolDisplayTests.cs
@@ -4499,7 +4499,7 @@ public class C
                 text,
                 findSymbol,
                 format,
-                TestOptions.Regular.WithTuplesFeature(),
+                TestOptions.Regular,
                 "(Int32, String) f",
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.StructName, // Int32
@@ -4531,7 +4531,7 @@ public class C
                 text,
                 findSymbol,
                 format,
-                TestOptions.Regular.WithTuplesFeature(),
+                TestOptions.Regular,
                 "(Int32 x, String y) f",
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.StructName, // Int32
@@ -4569,7 +4569,7 @@ public class C
                 text,
                 findSymbol,
                 format,
-                TestOptions.Regular.WithTuplesFeature(),
+                TestOptions.Regular,
                 "(int, string, bool, byte, long, ulong, short, ushort) f",
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Keyword, // int
@@ -4620,7 +4620,7 @@ class C
                 text,
                 findSymbol,
                 format,
-                TestOptions.Regular.WithTuplesFeature(),
+                TestOptions.Regular,
                 "(int Item1, string Item2) P",
                 SymbolDisplayPartKind.Punctuation,
                 SymbolDisplayPartKind.Keyword, // int

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -530,7 +530,7 @@ class DerivedClass : BaseClass
     public override ref int this[int i] { get { return ref field; } }
 }
 ";
-            var comp = CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(text);
             var global = comp.GlobalNamespace;
 
             var baseClass = (NamedTypeSymbol)global.GetMembers("BaseClass").Single();
@@ -838,7 +838,7 @@ class Base4<U, V> : Base3<U, V>
 {
     public override U Property { set { } }
 }";
-            CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(text).VerifyDiagnostics(
                 Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Base2").WithArguments("Base2<A, B>", "Base<A, B>.Property.get"),
                 Diagnostic(ErrorCode.ERR_UnimplementedAbstractMethod, "Base4").WithArguments("Base4<U, V>", "Base3<U, V>.Method(U, V)"));
         }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ReplaceOriginalTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Symbols
     {
         private static CSharpCompilation CreateCompilationWithMscorlib(string text, CSharpCompilationOptions options = null)
         {
-            return CreateCompilationWithMscorlib(text, options: options, parseOptions: TestOptions.Regular.WithReplaceFeature());
+            return CreateCompilationWithMscorlib(text, options: options, parseOptions: TestOptions.Regular);
         }
         
         [WorkItem(11123, "https://github.com/dotnet/roslyn/issues/11123")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/DelegateTests.cs
@@ -723,7 +723,7 @@ class C
         {
             var source = @"delegate ref int D();";
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(source, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(source);
             comp.VerifyDiagnostics();
 
             var global = comp.GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedMethodTests.cs
@@ -370,12 +370,12 @@ World");
         [Fact]
         public void RefReturningExpressionBodiedMethod()
         {
-            var comp = CreateExperimentalCompilationWithMscorlib45(@"
+            var comp = CreateCompilationWithMscorlib45(@"
 class C
 {
     int field = 0;
     public ref int M() => ref field;
-}", MessageID.IDS_FeatureRefLocalsReturns);
+}");
             comp.VerifyDiagnostics();
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/ExpressionBodiedPropertyTests.cs
@@ -486,12 +486,12 @@ class C
         [Fact]
         public void RefReturningExpressionBodiedProperty()
         {
-            var comp = CreateExperimentalCompilationWithMscorlib45(@"
+            var comp = CreateCompilationWithMscorlib45(@"
 class C
 {
     int field = 0;
     public ref int P => ref field;
-}", MessageID.IDS_FeatureRefLocalsReturns);
+}");
             comp.VerifyDiagnostics();
 
             var global = comp.GlobalNamespace;

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -273,7 +273,7 @@ class A
 ";
 
             // CONSIDER: Roslyn's cascading errors are much uglier than Dev10's.
-            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
     // (4,11): error CS1031: Type expected
     //     const delegate void D();
     Diagnostic(ErrorCode.ERR_TypeExpected, "delegate").WithLocation(4, 11),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -357,9 +357,9 @@ class A
                 // (5,43): error CS8200: Tuple must contain at least two elements.
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 43),
-                // (5,43): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (5,43): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     protected virtual void Finalize const () { }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("tuples", "tuples").WithLocation(5, 43),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(5, 43),
                 // (5,46): error CS1001: Identifier expected
                 //     protected virtual void Finalize const () { }
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 46),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/MethodTests.cs
@@ -288,7 +288,7 @@ public interface A {
 }
 ";
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(text);
             var global = comp.GlobalNamespace;
             var a = global.GetTypeMembers("A", 0).Single();
             var m = a.GetMembers("M").Single() as MethodSymbol;
@@ -471,7 +471,7 @@ namespace N1.N2  {
 }
 ";
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(new[] { text, text1, text2 }, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(new[] { text, text1, text2 });
             Assert.Equal(0, comp.GetDiagnostics().Count());
             var ns = comp.GlobalNamespace.GetMembers("N1").Single() as NamespaceSymbol;
             var ns1 = ns.GetMembers("N2").Single() as NamespaceSymbol;
@@ -642,16 +642,16 @@ namespace N1.N2  {
 }
 ";
 
-            var comp1 = CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp1 = CreateCompilationWithMscorlib45(text);
             var compRef1 = new CSharpCompilationReference(comp1);
 
-            var comp2 = CreateExperimentalCompilationWithMscorlib45(new string[] { text1 }, MessageID.IDS_FeatureRefLocalsReturns, new List<MetadataReference>() { compRef1 }, assemblyName: "Test2");
+            var comp2 = CreateCompilationWithMscorlib45(new string[] { text1 }, new List<MetadataReference>() { compRef1 }, assemblyName: "Test2");
             //Compilation.Create(outputName: "Test2", options: CompilationOptions.Default,
             //                    syntaxTrees: new SyntaxTree[] { SyntaxTree.ParseCompilationUnit(text1) },
             //                    references: new MetadataReference[] { compRef1, GetCorlibReference() });
             var compRef2 = new CSharpCompilationReference(comp2);
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(new string[] { text2 }, MessageID.IDS_FeatureRefLocalsReturns, new List<MetadataReference>() { compRef1, compRef2 }, assemblyName: "Test3");
+            var comp = CreateCompilationWithMscorlib45(new string[] { text2 }, new List<MetadataReference>() { compRef1, compRef2 }, assemblyName: "Test3");
             //Compilation.Create(outputName: "Test3", options: CompilationOptions.Default,
             //                        syntaxTrees: new SyntaxTree[] { SyntaxTree.ParseCompilationUnit(text2) },
             //                        references: new MetadataReference[] { compRef1, compRef2, GetCorlibReference() });
@@ -1638,7 +1638,7 @@ class C : I
 }
 ";
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(text);
 
             var globalNamespace = comp.GlobalNamespace;
 
@@ -2066,7 +2066,7 @@ static class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(source, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
                 // (4,12): error CS8088: Void-returning methods cannot return by reference
                 //     static ref void M() { }
                 Diagnostic(ErrorCode.ERR_VoidReturningMethodCannotReturnByRef, "ref").WithLocation(4, 12));
@@ -2085,7 +2085,7 @@ static class C
 }
 ";
 
-            var parseOptions = TestOptions.Regular.WithLocalFunctionsFeature().WithRefsFeature();
+            var parseOptions = TestOptions.Regular;
             CreateCompilationWithMscorlib45(source, parseOptions: parseOptions).VerifyDiagnostics(
     // (6,18): error CS8898: Void-returning methods cannot return by reference
     //         ref void M() { }
@@ -2105,7 +2105,7 @@ static class C
 }
 ";
 
-            CreateExperimentalCompilationWithMscorlib45(source, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
                 // (4,18): error CS1519: Invalid token 'ref' in class, struct, or interface member declaration
                 //     static async ref int M() { }
                 Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "ref").WithArguments("ref").WithLocation(4, 18),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -306,7 +306,7 @@ Diagnostic(ErrorCode.ERR_AutoPropertyMustHaveGetAccessor, "set").WithArguments("
 {
     public ref int P { get; }
 }";
-            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithRefsFeature());
+            var comp = CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular);
 
             comp.VerifyDiagnostics(
 // (3,20): error CS8080: Auto-implemented properties cannot return by reference
@@ -1742,7 +1742,7 @@ class C : I
 }
 ";
 
-            var comp = CreateExperimentalCompilationWithMscorlib45(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var comp = CreateCompilationWithMscorlib45(text);
 
             var globalNamespace = comp.GlobalNamespace;
 
@@ -2875,7 +2875,7 @@ unsafe class Test
     }
     ";
 
-            CreateExperimentalCompilationWithMscorlib45(source, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
                 // (4,17): error CS8080: Properties with by-reference returns must have a get accessor.
                 //         ref int P { set { } }
                 Diagnostic(ErrorCode.ERR_RefPropertyMustHaveGetAccessor, "P").WithArguments("C.P").WithLocation(4, 17));
@@ -2892,7 +2892,7 @@ unsafe class Test
     }
     ";
 
-            CreateExperimentalCompilationWithMscorlib45(source, MessageID.IDS_FeatureRefLocalsReturns).VerifyDiagnostics(
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
                 // (5,47): error CS8081: Properties with by-reference returns cannot have set accessors.
                 //         ref int P { get { return ref field; } set { } } 
                 Diagnostic(ErrorCode.ERR_RefPropertyCannotHaveSetAccessor, "set").WithArguments("C.P.set").WithLocation(5, 47));

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1034,7 +1034,7 @@ class C
 }";
             // Triage decision was made to have this be a parse error as the grammar specifies it as such.
             // TODO: vsadov, the error recovery would be much nicer here if we consumed "int", bu tneed to consider other cases.
-            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular.WithTuplesFeature()).VerifyDiagnostics(
+            CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular).VerifyDiagnostics(
     // (5,11): error CS1001: Identifier expected
     //     int F<int>() { }  // CS0081
     Diagnostic(ErrorCode.ERR_IdentifierExpected, "int").WithLocation(5, 11),

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -1107,9 +1107,9 @@ class C
                 // (5,15): error CS8200: Tuple must contain at least two elements.
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(5, 15),
-                // (5,15): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (5,15): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     int F<int>() { }  // CS0081
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("tuples", "tuples").WithLocation(5, 15),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(5, 15),
                 // (5,18): error CS1001: Identifier expected
                 //     int F<int>() { }  // CS0081
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(5, 18),

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LexicalTests
     {
         private readonly CSharpParseOptions _options;
+        private readonly CSharpParseOptions _options6;
         private readonly CSharpParseOptions _binaryOptions;
         private readonly CSharpParseOptions _underscoreOptions;
         private readonly CSharpParseOptions _binaryUnderscoreOptions;
@@ -25,6 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public LexicalTests()
         {
             _options = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp3);
+            _options6 = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp6);
             _binaryOptions = _options.WithLanguageVersion(LanguageVersion.CSharp7);
             _underscoreOptions = _options.WithLanguageVersion(LanguageVersion.CSharp7);
             _binaryUnderscoreOptions = _binaryOptions;
@@ -1946,12 +1948,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestNumericBinaryLiteralWithoutFeatureFlag()
         {
             var text = "0b1";
-            var token = LexToken(text);
+            var token = LexToken(text, _options6);
 
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
-            Assert.Equal((int)ErrorCode.ERR_FeatureIsExperimental, errors[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_FeatureNotAvailableInVersion6, errors[0].Code);
             Assert.Equal(text, token.Text);
         }
 
@@ -2604,12 +2606,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestNumericWithUnderscoresWithoutFeatureFlag()
         {
             var text = "1_000";
-            var token = LexToken(text);
+            var token = LexToken(text, _options6);
 
             Assert.Equal(SyntaxKind.NumericLiteralToken, token.Kind());
             var errors = token.Errors();
             Assert.Equal(1, errors.Length);
-            Assert.Equal((int)ErrorCode.ERR_FeatureIsExperimental, errors[0].Code);
+            Assert.Equal((int)ErrorCode.ERR_FeatureNotAvailableInVersion6, errors[0].Code);
             Assert.Equal(text, token.Text);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/LexicalAndXml/LexicalTests.cs
@@ -25,9 +25,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public LexicalTests()
         {
             _options = new CSharpParseOptions(languageVersion: LanguageVersion.CSharp3);
-            _binaryOptions = _options.WithExperimental(MessageID.IDS_FeatureBinaryLiteral);
-            _underscoreOptions = _options.WithExperimental(MessageID.IDS_FeatureDigitSeparator);
-            _binaryUnderscoreOptions = _options.WithExperimental(MessageID.IDS_FeatureBinaryLiteral, MessageID.IDS_FeatureDigitSeparator);
+            _binaryOptions = _options.WithLanguageVersion(LanguageVersion.CSharp7);
+            _underscoreOptions = _options.WithLanguageVersion(LanguageVersion.CSharp7);
+            _binaryUnderscoreOptions = _binaryOptions;
         }
 
         private IEnumerable<SyntaxToken> Lex(string text, CSharpParseOptions options = null)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -1950,7 +1950,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestDelegateWithRefReturnType()
         {
             var text = "delegate ref a b();";
-            var file = this.ParseFileExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var file = this.ParseFile(text);
 
             Assert.NotNull(file);
             Assert.Equal(1, file.Members.Count);
@@ -2422,7 +2422,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestClassMethodWithRefReturn()
         {
             var text = "class a { ref b X() { } }";
-            var file = this.ParseFileExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var file = this.ParseFile(text);
 
             Assert.NotNull(file);
             Assert.Equal(1, file.Members.Count);
@@ -2468,7 +2468,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestClassMethodWithRef()
         {
             var text = "class a { ref }";
-            var file = this.ParseFileExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var file = this.ParseFile(text);
 
             Assert.NotNull(file);
             Assert.Equal(1, file.Members.Count);
@@ -3787,7 +3787,7 @@ class Class1<T>{
         public void TestClassPropertyWithRefReturn()
         {
             var text = "class a { ref b c { get; set; } }";
-            var file = this.ParseFileExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var file = this.ParseFile(text);
 
             Assert.NotNull(file);
             Assert.Equal(1, file.Members.Count);
@@ -4663,7 +4663,7 @@ class Class1<T>{
         public void TestClassIndexerWithRefReturn()
         {
             var text = "class a { ref b this[c d] { get; set; } }";
-            var file = this.ParseFileExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var file = this.ParseFile(text);
 
             Assert.NotNull(file);
             Assert.Equal(1, file.Members.Count);
@@ -5547,7 +5547,7 @@ class C1
     }
 }
 ";
-            var file = this.ParseFile(text, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var file = this.ParseFile(text, parseOptions: TestOptions.Regular);
             Assert.Equal(0, file.Errors().Length);
         }
 
@@ -5568,7 +5568,7 @@ class C1
     }
 }
 ";
-            var file = this.ParseFile(text, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            var file = this.ParseFile(text, parseOptions: TestOptions.Regular);
             Assert.Equal(0, file.Errors().Length);
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ExpressionParsingTests.cs
@@ -22,11 +22,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return SyntaxFactory.ParseExpression(text, options: options);
         }
 
-        private ExpressionSyntax ParseExpressionExperimental(string text, MessageID feature)
-        {
-            return SyntaxFactory.ParseExpression(text, options: TestOptions.Regular.WithExperimental(feature));
-        }
-
         [Fact]
         public void TestEmptyString()
         {
@@ -1181,7 +1176,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestSimpleLambdaWithRefReturn()
         {
             var text = "a => ref b";
-            var expr = this.ParseExpressionExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var expr = this.ParseExpression(text);
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.SimpleLambdaExpression, expr.Kind());
@@ -1240,7 +1235,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestLambdaWithNoParametersAndRefReturn()
         {
             var text = "() => ref b";
-            var expr = this.ParseExpressionExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var expr = this.ParseExpression(text);
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.ParenthesizedLambdaExpression, expr.Kind());
@@ -1386,7 +1381,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestTupleWithTwoArguments()
         {
             var text = "(a, a2)";
-            var expr = this.ParseExpression(text, options: TestOptions.Regular.WithTuplesFeature());
+            var expr = this.ParseExpression(text, options: TestOptions.Regular);
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.TupleExpression, expr.Kind());
@@ -1406,7 +1401,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestTupleWithTwoNamedArguments()
         {
             var text = "(arg1: (a, a2), arg2: a2)";
-            var expr = this.ParseExpression(text, options: TestOptions.Regular.WithTuplesFeature());
+            var expr = this.ParseExpression(text, options: TestOptions.Regular);
 
             Assert.NotNull(expr);
             Assert.Equal(SyntaxKind.TupleExpression, expr.Kind());

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using System.Linq;
 using Xunit;
@@ -26,17 +27,17 @@ class c
     {
         int local() { return 0; }
     }
-}");
+}", parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
             Assert.NotNull(file);
             Assert.False(file.DescendantNodes().Any(n => n.Kind() == SyntaxKind.LocalFunctionStatement && !n.ContainsDiagnostics));
             Assert.True(file.HasErrors);
             file.SyntaxTree.GetDiagnostics().Verify(
-                // (6,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                // (6,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //         int local() => 0;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "int local() => 0;").WithArguments("local functions", "localFunctions").WithLocation(6, 9),
-                // (10,9): error CS8058: Feature 'local functions' is experimental and unsupported; use '/features:localFunctions' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "int local() => 0;").WithArguments("local functions", "7").WithLocation(6, 9),
+                // (10,9): error CS8059: Feature 'local functions' is not available in C# 6.  Please use language version 7 or greater.
                 //         int local() { return 0; }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "int local() { return 0; }").WithArguments("local functions", "localFunctions").WithLocation(10, 9)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "int local() { return 0; }").WithArguments("local functions", "7").WithLocation(10, 9)
                 );
 
             Assert.Equal(0, file.SyntaxTree.Options.Features.Count);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -56,7 +56,7 @@ class c
         {
             // Experimental nodes should only appear when experimental are
             // turned on in parse options
-            var file = ParseFileExperimental(@"
+            var file = ParseFile(@"
 class c
 {
     void m()
@@ -70,7 +70,7 @@ class c
             return 0;
         }
     }
-}", MessageID.IDS_FeatureLocalFunctions);
+}");
 
             Assert.NotNull(file);
             Assert.False(file.HasErrors);
@@ -103,13 +103,13 @@ class c
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/10388")]
         public void LocalFunctionsWithAwait()
         {
-            var file = ParseFileExperimental(@"class c
+            var file = ParseFile(@"class c
 {
     void m1() { await await() => new await(); }
     void m2() { await () => new await(); }
     async void m3() { await () => new await(); }
     void m4() { async await() => new await(); }
-}", MessageID.IDS_FeatureLocalFunctions);
+}");
 
             Assert.NotNull(file);
             var c = (ClassDeclarationSyntax)file.Members.Single();

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/MoreReplaceParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/MoreReplaceParsingTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     {
         protected override SyntaxTree ParseTree(string text, CSharpParseOptions options)
         {
-            return SyntaxFactory.ParseSyntaxTree(text, options: (options ?? TestOptions.Regular).WithReplaceFeature());
+            return SyntaxFactory.ParseSyntaxTree(text, options: (options ?? TestOptions.Regular));
         }
 
         protected override CSharpSyntaxNode ParseNode(string text, CSharpParseOptions options)

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -256,7 +256,7 @@ class A
 }
 ";
 
-            ParseAndValidate(test, TestOptions.Regular.WithTuplesFeature(),
+            ParseAndValidate(test, TestOptions.Regular,
     // (7,16): error CS1001: Identifier expected
     //         (a, b) =>
     Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(7, 16),
@@ -2113,7 +2113,7 @@ namespace x
 }
 ";
             // TODO: this appears to be a severe regression from Dev10, which neatly reported 3 errors.
-            ParseAndValidate(text, TestOptions.Regular.WithTuplesFeature(),
+            ParseAndValidate(text, TestOptions.Regular,
     // (7,21): error CS1031: Type expected
     //             e = new base;   // CS1031, not a type
     Diagnostic(ErrorCode.ERR_TypeExpected, "base").WithLocation(7, 21),
@@ -2240,7 +2240,7 @@ class A
         return null;
     }
 }";
-            ParseAndValidate(test, TestOptions.Regular.WithTuplesFeature(),
+            ParseAndValidate(test, TestOptions.Regular,
     // (4,19): error CS1553: Declaration is not valid; use '+ operator <dest-type> (...' instead
     //     public static int explicit operator ()
     Diagnostic(ErrorCode.ERR_BadOperatorSyntax, "int").WithArguments("+").WithLocation(4, 19),
@@ -3624,7 +3624,7 @@ public class MainClass
     }
 ";
 
-            ParseAndValidate(test, TestOptions.Regular.WithTuplesFeature(),
+            ParseAndValidate(test, TestOptions.Regular,
     // (3,19): error CS1553: Declaration is not valid; use '+ operator <dest-type> (...' instead
     //     public static int implicit operator (foo f) { return 6; }    // Error
     Diagnostic(ErrorCode.ERR_BadOperatorSyntax, "int").WithArguments("+").WithLocation(3, 19),

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -288,9 +288,9 @@ class A
 }
 ";
             ParseAndValidate(test, TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6),
-                // (7,9): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (7,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         (a, b) =>
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(a, b)").WithArguments("tuples", "tuples").WithLocation(7, 9),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(a, b)").WithArguments("tuples", "7").WithLocation(7, 9),
                 // (7,16): error CS1001: Identifier expected
                 //         (a, b) =>
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "=>").WithLocation(7, 16),
@@ -2159,33 +2159,33 @@ namespace x
 ";
             // TODO: this appears to be a severe regression from Dev10, which neatly reported 3 errors.
             ParseAndValidate(text, TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6),
-    // (7,21): error CS1031: Type expected
-    //             e = new base;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_TypeExpected, "base").WithLocation(7, 21),
-    // (7,21): error CS1526: A new expression requires (), [], or {} after type
-    //             e = new base;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_BadNewExpr, "base").WithLocation(7, 21),
-    // (7,21): error CS1002: ; expected
-    //             e = new base;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_SemicolonExpected, "base").WithLocation(7, 21),
-    // (8,21): error CS1031: Type expected
-    //             e = new this;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_TypeExpected, "this").WithLocation(8, 21),
-    // (8,21): error CS1526: A new expression requires (), [], or {} after type
-    //             e = new this;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_BadNewExpr, "this").WithLocation(8, 21),
-    // (8,21): error CS1002: ; expected
-    //             e = new this;   // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_SemicolonExpected, "this").WithLocation(8, 21),
-    // (9,21): error CS8200: Tuple must contain at least two elements.
-    //             e = new ();     // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(9, 21),
-    // (9,21): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
-    //             e = new ();     // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("tuples", "tuples").WithLocation(9, 21),
-    // (9,23): error CS1526: A new expression requires (), [], or {} after type
-    //             e = new ();     // CS1031, not a type
-    Diagnostic(ErrorCode.ERR_BadNewExpr, ";").WithLocation(9, 23)
+                // (7,21): error CS1031: Type expected
+                //             e = new base;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_TypeExpected, "base").WithLocation(7, 21),
+                // (7,21): error CS1526: A new expression requires (), [], or {} after type
+                //             e = new base;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_BadNewExpr, "base").WithLocation(7, 21),
+                // (7,21): error CS1002: ; expected
+                //             e = new base;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "base").WithLocation(7, 21),
+                // (8,21): error CS1031: Type expected
+                //             e = new this;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_TypeExpected, "this").WithLocation(8, 21),
+                // (8,21): error CS1526: A new expression requires (), [], or {} after type
+                //             e = new this;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_BadNewExpr, "this").WithLocation(8, 21),
+                // (8,21): error CS1002: ; expected
+                //             e = new this;   // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "this").WithLocation(8, 21),
+                // (9,21): error CS8200: Tuple must contain at least two elements.
+                //             e = new ();     // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(9, 21),
+                // (9,21): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //             e = new ();     // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(9, 21),
+                // (9,23): error CS1526: A new expression requires (), [], or {} after type
+                //             e = new ();     // CS1031, not a type
+                Diagnostic(ErrorCode.ERR_BadNewExpr, ";").WithLocation(9, 23)
              );
         }
 
@@ -2317,9 +2317,9 @@ class A
                 // (4,41): error CS8200: Tuple must contain at least two elements.
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(4, 41),
-                // (4,41): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
+                // (4,41): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //     public static int explicit operator ()
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "()").WithArguments("tuples", "tuples").WithLocation(4, 41),
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "()").WithArguments("tuples", "7").WithLocation(4, 41),
                 // (4,43): error CS1001: Identifier expected
                 //     public static int explicit operator ()
                 Diagnostic(ErrorCode.ERR_IdentifierExpected, "").WithLocation(4, 43),
@@ -3679,42 +3679,42 @@ public class MainClass
 ";
 
             ParseAndValidate(test, TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6),
-    // (3,19): error CS1553: Declaration is not valid; use '+ operator <dest-type> (...' instead
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_BadOperatorSyntax, "int").WithArguments("+").WithLocation(3, 19),
-    // (3,23): error CS1003: Syntax error, 'operator' expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_SyntaxError, "implicit").WithArguments("operator", "implicit").WithLocation(3, 23),
-    // (3,23): error CS1019: Overloadable unary operator expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_OvlUnaryOperatorExpected, "implicit").WithLocation(3, 23),
-    // (3,32): error CS1003: Syntax error, '(' expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_SyntaxError, "operator").WithArguments("(", "operator").WithLocation(3, 32),
-    // (3,32): error CS1041: Identifier expected; 'operator' is a keyword
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(3, 32),
-    // (3,41): error CS8200: Tuple must contain at least two elements.
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(foo f)").WithLocation(3, 41),
-    // (3,41): error CS8058: Feature 'tuples' is experimental and unsupported; use '/features:tuples' to enable.
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "(foo f)").WithArguments("tuples", "tuples").WithLocation(3, 41),
-    // (3,49): error CS1001: Identifier expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(3, 49),
-    // (3,49): error CS1003: Syntax error, ',' expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_SyntaxError, "{").WithArguments(",", "{").WithLocation(3, 49),
-    // (3,61): error CS1026: ) expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_CloseParenExpected, "}").WithLocation(3, 61),
-    // (3,61): error CS1002: ; expected
-    //     public static int implicit operator (foo f) { return 6; }    // Error
-    Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(3, 61),
-    // (4,1): error CS1022: Type or namespace definition, or end-of-file expected
-    // }
-    Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(4, 1)
+                // (3,19): error CS1553: Declaration is not valid; use '+ operator <dest-type> (...' instead
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_BadOperatorSyntax, "int").WithArguments("+").WithLocation(3, 19),
+                // (3,23): error CS1003: Syntax error, 'operator' expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_SyntaxError, "implicit").WithArguments("operator", "implicit").WithLocation(3, 23),
+                // (3,23): error CS1019: Overloadable unary operator expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_OvlUnaryOperatorExpected, "implicit").WithLocation(3, 23),
+                // (3,32): error CS1003: Syntax error, '(' expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_SyntaxError, "operator").WithArguments("(", "operator").WithLocation(3, 32),
+                // (3,32): error CS1041: Identifier expected; 'operator' is a keyword
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_IdentifierExpectedKW, "operator").WithArguments("", "operator").WithLocation(3, 32),
+                // (3,41): error CS8200: Tuple must contain at least two elements.
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(foo f)").WithLocation(3, 41),
+                // (3,41): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(foo f)").WithArguments("tuples", "7").WithLocation(3, 41),
+                // (3,49): error CS1001: Identifier expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "{").WithLocation(3, 49),
+                // (3,49): error CS1003: Syntax error, ',' expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_SyntaxError, "{").WithArguments(",", "{").WithLocation(3, 49),
+                // (3,61): error CS1026: ) expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "}").WithLocation(3, 61),
+                // (3,61): error CS1002: ; expected
+                //     public static int implicit operator (foo f) { return 6; }    // Error
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "}").WithLocation(3, 61),
+                // (4,1): error CS1022: Type or namespace definition, or end-of-file expected
+                // }
+                Diagnostic(ErrorCode.ERR_EOFExpected, "}").WithLocation(4, 1)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -5259,7 +5259,7 @@ class C
         public void TestSemicolonAfterUntypedLambdaParameter()
         {
             var text = "class c { void m() { var x = (y, ; } }";
-            var file = this.ParseTree(text, options: TestOptions.Regular.WithTuplesFeature());
+            var file = this.ParseTree(text, options: TestOptions.Regular);
 
             Assert.NotNull(file);
             Assert.Equal(text, file.ToFullString());
@@ -5351,7 +5351,7 @@ class C
         public void TestStatementAfterUntypedLambdaParameter()
         {
             var text = "class c { void m() { var x = (y, while (c) { } } }";
-            var file = this.ParseTree(text, options: TestOptions.Regular.WithTuplesFeature());
+            var file = this.ParseTree(text, options: TestOptions.Regular);
 
             Assert.NotNull(file);
             Assert.Equal(text, file.ToFullString());

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -5308,7 +5308,7 @@ class C
             Assert.Equal(SyntaxKind.TupleExpression, ds.Declaration.Variables[0].Initializer.Value.Kind());
 
             Assert.Equal(new [] {
-                                (int)ErrorCode.ERR_FeatureIsExperimental,
+                                (int)ErrorCode.ERR_FeatureNotAvailableInVersion6,
                                 (int)ErrorCode.ERR_InvalidExprTerm,
                                 (int)ErrorCode.ERR_CloseParenExpected
                             }, file.Errors().Select(e => e.Code));
@@ -5381,7 +5381,7 @@ class C
         public void TestStatementAfterUntypedLambdaParameterWithCSharp6()
         {
             var text = "class c { void m() { var x = (y, while (c) { } } }";
-            var file = this.ParseTree(text);
+            var file = this.ParseTree(text, options: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6));
 
             Assert.NotNull(file);
             Assert.Equal(text, file.ToFullString());
@@ -5405,7 +5405,7 @@ class C
             Assert.Equal(SyntaxKind.TupleExpression, ds.Declaration.Variables[0].Initializer.Value.Kind());
 
             Assert.Equal(new [] {
-                                (int)ErrorCode.ERR_FeatureIsExperimental,
+                                (int)ErrorCode.ERR_FeatureNotAvailableInVersion6,
                                 (int)ErrorCode.ERR_InvalidExprTerm,
                                 (int)ErrorCode.ERR_CloseParenExpected,
                                 (int)ErrorCode.ERR_SemicolonExpected

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -33,16 +33,16 @@ class C
     }
 }
 ";
-            CreateCompilationWithMscorlib(test).VerifyDiagnostics(
-                // (9,13): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+            CreateCompilationWithMscorlib(test, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)).VerifyDiagnostics(
+                // (9,13): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
                 //             case 2 when args.Length == 2:
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "case 2 when args.Length == 2:").WithArguments("pattern matching", "patterns").WithLocation(9, 13),
-                // (11,13): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case 2 when args.Length == 2:").WithArguments("pattern matching", "7").WithLocation(9, 13),
+                // (11,13): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
                 //             case string s:
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "case string s:").WithArguments("pattern matching", "patterns").WithLocation(11, 13),
-                // (15,18): error CS8058: Feature 'pattern matching' is experimental and unsupported; use '/features:patterns' to enable.
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "case string s:").WithArguments("pattern matching", "7").WithLocation(11, 13),
+                // (15,18): error CS8059: Feature 'pattern matching' is not available in C# 6.  Please use language version 7 or greater.
                 //         bool b = args[0] is string s;
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "args[0] is string s").WithArguments("pattern matching", "patterns").WithLocation(15, 18)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "args[0] is string s").WithArguments("pattern matching", "7").WithLocation(15, 18)
             );
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ReplaceParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ReplaceParsingTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void ReplaceClass()
         {
-            var root = SyntaxFactory.ParseCompilationUnit("abstract replace override class C { }", options: TestOptions.Regular.WithReplaceFeature());
+            var root = SyntaxFactory.ParseCompilationUnit("abstract replace override class C { }", options: TestOptions.Regular);
             root.Errors().Verify();
             var type = (TypeDeclarationSyntax)root.Members[0];
             Assert.Equal(
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void ReplaceMethod()
         {
-            var root = SyntaxFactory.ParseCompilationUnit("class C { virtual replace protected void M() { } }", options: TestOptions.Regular.WithReplaceFeature());
+            var root = SyntaxFactory.ParseCompilationUnit("class C { virtual replace protected void M() { } }", options: TestOptions.Regular);
             root.Errors().Verify();
             var type = (TypeDeclarationSyntax)root.Members[0];
             Assert.Equal(
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
         private void OriginalInMember(string text, bool inReplace)
         {
-            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular.WithReplaceFeature());
+            var tree = SyntaxFactory.ParseSyntaxTree(text, options: TestOptions.Regular);
             var root = tree.GetCompilationUnitRoot();
             root.Errors().Verify();
             var token = root.DescendantTokens().Where(t => t.Text == "original").Single();
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [WorkItem(11503, "https://github.com/dotnet/roslyn/issues/11503")]
         public void MethodCalledReplace()
         {
-            var root = SyntaxFactory.ParseCompilationUnit("class C { public static object replace() { } }", options: TestOptions.Regular.WithReplaceFeature());
+            var root = SyntaxFactory.ParseCompilationUnit("class C { public static object replace() { } }", options: TestOptions.Regular);
             root.Errors().Verify();
         }
     }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ReplaceParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ReplaceParsingTests.cs
@@ -43,10 +43,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void ReplaceMethodNoFeature()
         {
             var source = "class C { virtual replace protected void M() { } }";
-            CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll).VerifyDiagnostics(
-                // (1,19): error CS8058: Feature 'replaced members' is experimental and unsupported; use '/features:replace' to enable.
+            CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll, parseOptions: TestOptions.Regular.WithLanguageVersion(LanguageVersion.CSharp6)).VerifyDiagnostics(
+                // (1,19): error CS8059: Feature 'replaced members' is not available in C# 6.  Please use language version 7 or greater.
                 // class C { virtual replace protected void M() { } }
-                Diagnostic(ErrorCode.ERR_FeatureIsExperimental, "replace").WithArguments("replaced members", "replace").WithLocation(1, 19)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "replace").WithArguments("replaced members", "7").WithLocation(1, 19)
             );
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/SeparatedSyntaxListParsingTests.cs
@@ -206,7 +206,7 @@ class C
 }
 
 class M<,> { }
-", options: TestOptions.Regular.WithTuplesFeature());
+", options: TestOptions.Regular);
 
             CheckTypeArguments2();
         }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/StatementParsingTests.cs
@@ -16,11 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             return SyntaxFactory.ParseStatement(text, offset, options);
         }
 
-        private StatementSyntax ParseStatementExperimental(string text, MessageID feature)
-        {
-            return ParseStatement(text, offset: 0, options: TestOptions.Regular.WithExperimental(feature));
-        }
-
         [Fact]
         public void TestName()
         {
@@ -209,7 +204,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestLocalDeclarationStatementWithTuple()
         {
             var text = "(int, int) a;";
-            var statement = this.ParseStatement(text, options: TestOptions.Regular.WithTuplesFeature());
+            var statement = this.ParseStatement(text, options: TestOptions.Regular);
 
             (text).ToString();
 
@@ -738,7 +733,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestRefLocalDeclarationStatement()
         {
             var text = "ref T a;";
-            var statement = this.ParseStatementExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var statement = this.ParseStatement(text);
 
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, statement.Kind());
@@ -765,7 +760,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestRefLocalDeclarationStatementWithInitializer()
         {
             var text = "ref T a = ref b;";
-            var statement = this.ParseStatementExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var statement = this.ParseStatement(text);
 
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, statement.Kind());
@@ -798,7 +793,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestRefLocalDeclarationStatementWithMultipleInitializers()
         {
             var text = "ref T a = ref b, c = ref d;";
-            var statement = this.ParseStatementExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var statement = this.ParseStatement(text);
 
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.LocalDeclarationStatement, statement.Kind());
@@ -1639,7 +1634,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestForWithRefVariableDeclaration()
         {
             var text = "for(ref T a = ref b, c = ref d;;) { }";
-            var statement = this.ParseStatementExperimental(text, MessageID.IDS_FeatureRefLocalsReturns);
+            var statement = this.ParseStatement(text);
 
             Assert.NotNull(statement);
             Assert.Equal(SyntaxKind.ForStatement, statement.Kind());
@@ -2635,7 +2630,7 @@ static void Test(int arg1, (byte, byte) arg2)
         }
 }
 ";
-            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular.WithTuplesFeature());
+            var tree = SyntaxFactory.ParseSyntaxTree(source, options: TestOptions.Regular);
             Assert.Equal(false, tree.GetRoot().ContainsDiagnostics);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ValueTupleTests.cs
@@ -23,7 +23,7 @@ class C
     {
         return (1, ""Alice"");
     }
-}", options: TestOptions.Regular.WithTuplesFeature());
+}", options: TestOptions.Regular);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -107,7 +107,7 @@ class C
     (int, int, int, string, string, string, int, int, int) Foo()
     {
     }
-}", options: TestOptions.Regular.WithTuplesFeature());
+}", options: TestOptions.Regular);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -219,7 +219,7 @@ class C
 class C
 {
     var x = ((string, string) a, (int, int) b) => { };
-}", options: TestOptions.Regular.WithTuplesFeature());
+}", options: TestOptions.Regular);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -323,7 +323,7 @@ class C
 class C
 {
     var x = ((string a, string) a, (int, int b) b) => { };
-}", options: TestOptions.Regular.WithTuplesFeature());
+}", options: TestOptions.Regular);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);
@@ -437,7 +437,7 @@ class C
     void Foo((int, string) a)
     {
     }
-}", options: TestOptions.Regular.WithTuplesFeature());
+}", options: TestOptions.Regular);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.ClassDeclaration);

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/SemanticModelTestBase.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/SemanticModelTestBase.cs
@@ -170,9 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         }
 
 
-        protected CompilationUtils.SemanticInfoSummary GetSemanticInfoForTest<TNode>(string testSrc) where TNode : SyntaxNode
+        protected CompilationUtils.SemanticInfoSummary GetSemanticInfoForTest<TNode>(string testSrc, CSharpParseOptions parseOptions = null) where TNode : SyntaxNode
         {
-            var compilation = CreateCompilationWithMscorlib(testSrc, new[] { SystemCoreRef });
+            var compilation = CreateCompilationWithMscorlib(testSrc, new[] { SystemCoreRef }, parseOptions: parseOptions);
             return GetSemanticInfoForTest<TNode>(compilation);
         }
 

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         // document every public member of every test input.
         public static readonly CSharpParseOptions Script = new CSharpParseOptions(kind: SourceCodeKind.Script, documentationMode: DocumentationMode.None);
         public static readonly CSharpParseOptions Regular = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None);
+        public static readonly CSharpParseOptions Regular6 = Regular.WithLanguageVersion(LanguageVersion.CSharp6);
         public static readonly CSharpParseOptions RegularWithDocumentationComments = new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.Diagnose);
 
         public static readonly CSharpCompilationOptions ReleaseDll = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, optimizationLevel: OptimizationLevel.Release).WithExtendedCustomDebugInformation(true);

--- a/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
+++ b/src/Compilers/Test/Utilities/CSharp/TestOptions.cs
@@ -46,31 +46,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return options.WithFeatures(options.Features.Concat(new[] { new KeyValuePair<string, string>("strict", "true") }));
         }
 
-        public static CSharpParseOptions WithLocalFunctionsFeature(this CSharpParseOptions options)
-        {
-            return WithExperimental(options, MessageID.IDS_FeatureLocalFunctions);
-        }
-
-        public static CSharpParseOptions WithRefsFeature(this CSharpParseOptions options)
-        {
-            return WithExperimental(options, MessageID.IDS_FeatureRefLocalsReturns);
-        }
-
-        public static CSharpParseOptions WithTuplesFeature(this CSharpParseOptions options)
-        {
-            return WithExperimental(options, MessageID.IDS_FeatureTuples);
-        }
-
-        public static CSharpParseOptions WithReplaceFeature(this CSharpParseOptions options)
-        {
-            return WithExperimental(options, MessageID.IDS_FeatureReplace);
-        }
-
-        public static CSharpParseOptions WithPatternsFeature(this CSharpParseOptions options)
-        {
-            return WithExperimental(options, MessageID.IDS_FeaturePatternMatching);
-        }
-
         internal static CSharpParseOptions WithExperimental(this CSharpParseOptions options, params MessageID[] features)
         {
             if (features.Length == 0)

--- a/src/EditorFeatures/CSharpTest/BraceHighlighting/BraceHighlightingTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceHighlighting/BraceHighlightingTests.cs
@@ -175,22 +175,22 @@ class C
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestTuples()
         {
-            await TestBraceHighlightingAsync(@" class C { [|(|]int, int[|)|]$$ x = (1, 2); } ", TestOptions.Regular.WithTuplesFeature());
-            await TestBraceHighlightingAsync(@" class C { (int, int) x = [|(|]1, 2[|)|]$$; } ", TestOptions.Regular.WithTuplesFeature());
+            await TestBraceHighlightingAsync(@" class C { [|(|]int, int[|)|]$$ x = (1, 2); } ", TestOptions.Regular);
+            await TestBraceHighlightingAsync(@" class C { (int, int) x = [|(|]1, 2[|)|]$$; } ", TestOptions.Regular);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestNestedTuples()
         {
-            await TestBraceHighlightingAsync(@" class C { ([|(|]int, int[|)|]$$, string) x = ((1, 2), ""hello""; } ", TestOptions.Regular.WithTuplesFeature());
-            await TestBraceHighlightingAsync(@" class C { ((int, int), string) x = ([|(|]1, 2[|)|]$$, ""hello""; } ", TestOptions.Regular.WithTuplesFeature());
+            await TestBraceHighlightingAsync(@" class C { ([|(|]int, int[|)|]$$, string) x = ((1, 2), ""hello""; } ", TestOptions.Regular);
+            await TestBraceHighlightingAsync(@" class C { ((int, int), string) x = ([|(|]1, 2[|)|]$$, ""hello""; } ", TestOptions.Regular);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.BraceHighlighting)]
         public async Task TestTuplesWithGenerics()
         {
-            await TestBraceHighlightingAsync(@" class C { [|(|]Dictionary<int, string>, List<int>[|)|]$$ x = (null, null); } ", TestOptions.Regular.WithTuplesFeature());
-            await TestBraceHighlightingAsync(@" class C { var x = [|(|]new Dictionary<int, string>(), new List<int>()[|)|]$$; } ", TestOptions.Regular.WithTuplesFeature());
+            await TestBraceHighlightingAsync(@" class C { [|(|]Dictionary<int, string>, List<int>[|)|]$$ x = (null, null); } ", TestOptions.Regular);
+            await TestBraceHighlightingAsync(@" class C { var x = [|(|]new Dictionary<int, string>(), new List<int>()[|)|]$$; } ", TestOptions.Regular);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
+++ b/src/EditorFeatures/CSharpTest/BraceMatching/CSharpBraceMatcherTests.cs
@@ -756,7 +756,7 @@ class Program
             var code = @"public class C { $$(int, int, int, int, int, int, int, int) x; }";
             var expected = @"public class C { (int, int, int, int, int, int, int, int[|)|] x; }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -765,7 +765,7 @@ class Program
             var code = @"public class C { (int, int, int, int, int, int, int, int)$$ x; }";
             var expected = @"public class C { [|(|]int, int, int, int, int, int, int, int) x; }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -774,7 +774,7 @@ class Program
             var code = @"public class C { var x = $$(1, 2, 3, 4, 5, 6, 7, 8); }";
             var expected = @"public class C { var x = (1, 2, 3, 4, 5, 6, 7, 8[|)|]; }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -783,7 +783,7 @@ class Program
             var code = @"public class C { var x = (1, 2, 3, 4, 5, 6, 7, 8)$$; }";
             var expected = @"public class C { var x = [|(|]1, 2, 3, 4, 5, 6, 7, 8); }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -792,7 +792,7 @@ class Program
             var code = @"public class C { var x = $$((1, 1, 1), 2, 3, 4, 5, 6, 7, 8); }";
             var expected = @"public class C { var x = ((1, 1, 1), 2, 3, 4, 5, 6, 7, 8[|)|]; }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -801,7 +801,7 @@ class Program
             var code = @"public class C { var x = ($$(1, 1, 1), 2, 3, 4, 5, 6, 7, 8); }";
             var expected = @"public class C { var x = ((1, 1, 1[|)|], 2, 3, 4, 5, 6, 7, 8); }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -810,7 +810,7 @@ class Program
             var code = @"public class C { var x = (1, 2, 3, 4, 5, 6, 7, (8, 8, 8))$$; }";
             var expected = @"public class C { var x = [|(|]1, 2, 3, 4, 5, 6, 7, (8, 8, 8)); }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.BraceMatching)]
@@ -819,7 +819,7 @@ class Program
             var code = @"public class C { var x = ((1, 1, 1)$$, 2, 3, 4, 5, 6, 7, 8); }";
             var expected = @"public class C { var x = ([|(|]1, 1, 1), 2, 3, 4, 5, 6, 7, 8); }";
 
-            await TestAsync(code, expected, TestOptions.Regular.WithTuplesFeature());
+            await TestAsync(code, expected, TestOptions.Regular);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SemanticClassifierTests.cs
@@ -1474,8 +1474,8 @@ class C
         public async Task Tuples()
         {
             await TestAsync(@"class C { (int a, int b) x; }",
-                TestOptions.Regular.WithTuplesFeature(),
-                Options.Script.WithTuplesFeature());
+                TestOptions.Regular,
+                Options.Script);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
+++ b/src/EditorFeatures/CSharpTest/Classification/SyntacticClassifierTests.cs
@@ -3655,8 +3655,8 @@ void M()
         public async Task TupleDeclaration()
         {
             await TestInMethodAsync("(int, string) x",
-                TestOptions.Regular.WithTuplesFeature(),
-                Options.Script.WithTuplesFeature(),
+                TestOptions.Regular,
+                Options.Script,
                 Punctuation.OpenParen,
                 Keyword("int"),
                 Punctuation.Comma,
@@ -3669,8 +3669,8 @@ void M()
         public async Task TupleDeclarationWithNames()
         {
             await TestInMethodAsync("(int a, string b) x",
-                TestOptions.Regular.WithTuplesFeature(),
-                Options.Script.WithTuplesFeature(),
+                TestOptions.Regular,
+                Options.Script,
                 Punctuation.OpenParen,
                 Keyword("int"),
                 Identifier("a"),
@@ -3685,8 +3685,8 @@ void M()
         public async Task TupleLiteral()
         {
             await TestInMethodAsync("var values = (1, 2)",
-                TestOptions.Regular.WithTuplesFeature(),
-                Options.Script.WithTuplesFeature(),
+                TestOptions.Regular,
+                Options.Script,
                 Keyword("var"),
                 Identifier("values"),
                 Operators.Equals,
@@ -3701,8 +3701,8 @@ void M()
         public async Task TupleLiteralWithNames()
         {
             await TestInMethodAsync("var values = (a: 1, b: 2)",
-                TestOptions.Regular.WithTuplesFeature(),
-                Options.Script.WithTuplesFeature(),
+                TestOptions.Regular,
+                Options.Script,
                 Keyword("var"),
                 Identifier("values"),
                 Operators.Equals,

--- a/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/EncapsulateField/EncapsulateFieldTests.cs
@@ -1294,7 +1294,7 @@ class C
     }
 }
 ";
-            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.EncapsulateField), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
@@ -1336,7 +1336,7 @@ class C
     }
 }
 ";
-            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(text, expected, compareTokens: false, index: 1, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -444,7 +444,7 @@ compareTokens: false);
 @"class Program { static void Main ( string [ ] args ) { [| (int, int) x = (1, 2); |]  System . Console . WriteLine ( x.Item1 ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int, int) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.Item1); } private static (int, int) NewMethod() { return (1, 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -456,7 +456,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| (int a, int b) x = (1, 2); |]  System . Console . WriteLine ( x.a ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int a, int b) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.a); } private static (int a, int b) NewMethod() { return (1, 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -468,7 +468,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| (int, int) x = (a: 1, b: 2); |]  System . Console . WriteLine ( x.Item1 ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int, int) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.Item1); } private static (int, int) NewMethod() { return (a: 1, b: 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -480,7 +480,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| (int a, int b) x = (c: 1, d: 2); |]  System . Console . WriteLine ( x.a ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int a, int b) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.a); } private static (int a, int b) NewMethod() { return (c: 1, d: 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -492,7 +492,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| var x = (c: 1, d: 2); |]  System . Console . WriteLine ( x.c ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int c, int d) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.c); } private static (int c, int d) NewMethod() { return (c: 1, d: 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -504,7 +504,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| var x = (c: 1, d: 2); |]  System . Console . WriteLine ( x.c ); } } ",
 @"class Program { static void Main ( string [ ] args ) { object x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.c); } private static object NewMethod() { return (c: 1, d: 2); } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -517,7 +517,7 @@ withScriptOption: true);
 @"class Program { static void Main ( string [ ] args ) { [| var x = new System.ValueTuple<int, int, int, int, int, int, int, (string a, string b)>(1, 2, 3, 4, 5, 6, 7, (a: ""hello"", b: ""world"")); |]  System . Console . WriteLine ( x.c ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { (int, int, int, int, int, int, int, string, string) x = {|Rename:NewMethod|}(); System . Console . WriteLine ( x.c ); } private static (int, int, int, int, int, int, int, string, string) NewMethod() { return new System.ValueTuple<int, int, int, int, int, int, int, (string a, string b)>(1, 2, 3, 4, 5, 6, 7, (a: ""hello"", b: ""world"")); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -208,7 +208,7 @@ index: 2);
 @"class C : [||]B { } class B { public B((int, string) x) { } }",
 @"class C : B { public C((int, string) x) : base(x) { } } class B { public B((int, string) x) { } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -219,7 +219,7 @@ withScriptOption: true);
 @"class C : [||]B { } class B { public B((int a, string b) x) { } }",
 @"class C : B { public C((int a, string b) x) : base(x) { } } class B { public B((int a, string b) x) { } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/AddConstructorParameters/AddConstructorParametersTests.cs
@@ -76,7 +76,7 @@ index: 1);
             await TestAsync(
 @"class Program { [|(int, string) i ; (string, int) s ;|] public Program ( (int, string) i ) { this . i = i ; } } ",
 @"class Program { (int, string) i ; (string, int) s ; public Program ( (int, string) i , (string, int) s ) { this . i = i ; this . s = s ; } } ",
-index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 0, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -85,7 +85,7 @@ index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOptio
             await TestAsync(
 @"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int a, string b) i ) { this . i = i ; } } ",
 @"class Program { (int a, string b) i ; (string c, int d) s ; public Program ( (int a, string b) i , (string c, int d) s ) { this . i = i ; this . s = s ; } } ",
-index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 0, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -93,7 +93,7 @@ index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOptio
         {
             await TestMissingAsync(
 @"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int e, string f) i ) { this . i = i ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -102,7 +102,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
             await TestAsync(
 @"class Program { [|(int, string) i ; (string, int) s ;|] public Program ( (int, string) i ) { this . i = i ; } } ",
 @"class Program { (int, string) i ; (string, int) s ; public Program ( (int, string) i , (string, int) s = default((string, int)) ) { this . i = i ; this . s = s ; } } ",
-index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 1, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -111,7 +111,7 @@ index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOptio
             await TestAsync(
 @"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int a, string b) i ) { this . i = i ; } } ",
 @"class Program { (int a, string b) i ; (string c, int d) s ; public Program ( (int a, string b) i , (string c, int d) s = default((string c, int d)) ) { this . i = i ; this . s = s ; } } ",
-index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 1, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -119,7 +119,7 @@ index: 1, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOptio
         {
             await TestMissingAsync(
 @"class Program { [|(int a, string b) i ; (string c, int d) s ;|] public Program ( (int e, string f) i ) { this . i = i ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -128,7 +128,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
             await TestAsync(
 @"class Program { [|(int?, bool?) i ; (byte?, long?) s ;|] public Program ( (int?, bool?) i ) { this . i = i ; } } ",
 @"class Program { (int?, bool?) i ; (byte?, long?) s ; public Program ( (int?, bool?) i , (byte?, long?) s ) { this . i = i ; this . s = s ; } } ",
-index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 0, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsAddConstructorParameters)]
@@ -137,7 +137,7 @@ index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOptio
             await TestAsync(
 @"class Program { [|(List<int>, List<bool>) i ; (List<byte>, List<long>) s ;|] public Program ( (List<int>, List<bool>) i ) { this . i = i ; } } ",
 @"class Program { (List<int>, List<bool>) i ; (List<byte>, List<long>) s ; public Program ( (List<int>, List<bool>) i , (List<byte>, List<long>) s ) { this . i = i ; this . s = s ; } } ",
-index: 0, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+index: 0, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -189,7 +189,7 @@ index: 1);
 @"using System . Collections . Generic ; class Z { [|(int, string) a ;|] } ",
 @"using System . Collections . Generic ; class Z { (int, string) a ; public Z ( (int, string) a ) { this . a = a ; } } ",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateEqualsAndGetHashCode/GenerateEqualsAndGetHashCodeTests.cs
@@ -194,7 +194,7 @@ index: 0,
 @"using System . Collections . Generic ; class C { [|(int, string) a ;|] } ",
 @"using System . Collections . Generic ; class C { (int, string) a ; public override bool Equals ( object obj ) { var c = obj as C ; return c != null && EqualityComparer < (int, string) > . Default . Equals ( a , c . a ) ; } } ",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -204,7 +204,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
 @"using System . Collections . Generic ; class C { [|(int x, string y) a ;|] } ",
 @"using System . Collections . Generic ; class C { (int x, string y) a ; public override bool Equals ( object obj ) { var c = obj as C ; return c != null && EqualityComparer < (int x, string y) > . Default . Equals ( a , c . a ) ; } } ",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -214,7 +214,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
 @"using System . Collections . Generic ; class Program { [|(int, string) i ;|] } ",
 @"using System . Collections . Generic ; class Program { (int, string) i ; public override int GetHashCode ( ) { return EqualityComparer < (int, string) > . Default . GetHashCode ( i ) ; } } ",
 index: 1,
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateEqualsAndGetHashCode)]
@@ -224,7 +224,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
 @"using System . Collections . Generic ; class Program { [|(int x, string y) i ;|] } ",
 @"using System . Collections . Generic ; class Program { (int x, string y) i ; public override int GetHashCode ( ) { return EqualityComparer < (int x, string y) > . Default . GetHashCode ( i ) ; } } ",
 index: 1,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -13,10 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeRefactorings.Inline
 {
     public class InlineTemporaryTests : AbstractCSharpCodeActionTest
     {
-        private static readonly Dictionary<string, string> s_experimentalFeatures = new Dictionary<string, string> { { MessageID.IDS_FeatureLocalFunctions.RequiredFeature(), "true" }, { MessageID.IDS_FeatureRefLocalsReturns.RequiredFeature(), "true" } };
-        public static readonly CSharpParseOptions ExperimentalParseOptions =
-            new CSharpParseOptions(kind: SourceCodeKind.Regular, documentationMode: DocumentationMode.None, languageVersion: LanguageVersion.CSharp6).WithFeatures(s_experimentalFeatures);
-
         protected override CodeRefactoringProvider CreateCodeRefactoringProvider(Workspace workspace)
         {
             return new InlineTemporaryCodeRefactoringProvider();
@@ -81,9 +77,7 @@ class C
         ref int [||]x = ref arr[2];
         return ref x;
     }
-}",
-                // TODO: propagating features to the project is currently NYI
-                parseOptions: ExperimentalParseOptions);
+}");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -3994,7 +3988,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -4021,7 +4015,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -4047,7 +4041,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2707,7 +2707,7 @@ var expected =
     var i = (1, V).ToString();
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2726,7 +2726,7 @@ var expected =
     var i = p.ToString();
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2745,7 +2745,7 @@ var expected =
     var i = p.ToString();
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2764,7 +2764,7 @@ var expected =
     var i = p.ToString() + p.ToString();
 }";
 
-            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2783,7 +2783,7 @@ var expected =
     var i = p.ToString() + p.ToString();
 }";
 
-            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2802,7 +2802,7 @@ var expected =
     var i = p.ToString() + (c: 1, d: ""hello"").ToString();
 }";
 
-            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2821,10 +2821,10 @@ var expected =
     var i = p.ToString() + p.ToString();
 }";
 
-            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(code, expected, index: 1, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
 
             // no third action available
-            await TestActionCountAsync(code, 2, parseOptions: TestOptions.Regular.WithTuplesFeature());
+            await TestActionCountAsync(code, 2, parseOptions: TestOptions.Regular);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsIntroduceVariable)]
@@ -2836,7 +2836,7 @@ var expected =
                 @"class C { void Foo() { Bar([|(1, ""hello"")|]); Bar((1, ""hello""); } }",
                 @"",
                 index: 3,
-                parseOptions: TestOptions.Regular.WithTuplesFeature(),
+                parseOptions: TestOptions.Regular,
                 withScriptOption: true)
             );
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveDeclarationNearReference/MoveDeclarationNearReferenceTests.cs
@@ -376,7 +376,7 @@ class Program
 @"class C { void M() { (int, string) [||]x; { Console.WriteLine(x); } } }",
 @"class C { void M() { { (int, string) x; Console.WriteLine(x); } } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -387,7 +387,7 @@ withScriptOption: true);
 @"class C { void M() { (int a, string b) [||]x; { Console.WriteLine(x); } } }",
 @"class C { void M() { { (int a, string b) x; Console.WriteLine(x); } } }",
 index: 0,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -430,7 +430,7 @@ index: 1);
             await TestAsync(
 @"class C { (int, string) [||]GetFoo() { } }",
 @"class C { (int, string) Foo { get { } } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -441,7 +441,7 @@ withScriptOption: true);
 @"using System; class C { (int, string) [||]getFoo() { } void setFoo((int, string) i) { } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"using System; class C { (int, string) Foo { get { } set { } } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 1,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -452,7 +452,7 @@ withScriptOption: true);
 @"using System; class C { (int a, string b) [||]getFoo() { } void setFoo((int a, string b) i) { } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"using System; class C { (int a, string b) Foo { get { } set { } } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 1,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -465,7 +465,7 @@ withScriptOption: true);
 @"using System; class C { (int a, string b) [||]getFoo() { } void setFoo((int c, string d) i) { } }",
 @"",
 index: 1,
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true));
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UserDiagnos
             syntaxKindsPatterns.Add(SyntaxKind.OriginalExpression);
 
             var analyzer = new CSharpTrackingDiagnosticAnalyzer();
-            using (var workspace = await TestWorkspace.CreateCSharpAsync(source, TestOptions.Regular.WithLocalFunctionsFeature().WithRefsFeature()))
+            using (var workspace = await TestWorkspace.CreateCSharpAsync(source, TestOptions.Regular))
             {
                 var document = workspace.CurrentSolution.Projects.Single().Documents.Single();
                 AccessSupportedDiagnostics(analyzer);

--- a/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/FullyQualify/FullyQualifyTests.cs
@@ -490,7 +490,7 @@ namespace n2 { namespace Inner { class CAttribute { } } }");
             await TestAsync(
 @"class Class { ([|IDictionary|], string) Method() { Foo(); } }",
 @"class Class { (System.Collections.IDictionary, string) Method() { Foo(); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -500,7 +500,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { ([|IDictionary|] a, string) Method() { Foo(); } }",
 @"class Class { (System.Collections.IDictionary a, string) Method() { Foo(); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -791,7 +791,7 @@ class C
             await TestAsync(
 @"class C { void M() { new [|C|]((1, ""hello""), true); } }",
 @"class C { private (int, string) p; private bool v; public C((int, string) p, bool v) { this.p = p; this.v = v; } void M() { new C((1, ""hello""), true); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -801,7 +801,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|C|]((a: 1, b: ""hello"")); } }",
 @"class C { private (int a, string b) p; public C((int a, string b) p) { this.p = p; } void M() { new C((a: 1, b: ""hello"")); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -809,7 +809,7 @@ withScriptOption: true);
         public async Task TupleWithOneName()
         {
             await TestMissingAsync(@"class C { void M() { new [|C|]((a: 1, ""hello"")); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -819,7 +819,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D(existing: (1, ""hello""))|]; } } class D { private (int, string) existing; }",
 @"class C { void M() { new D(existing: (1, ""hello"")); } } class D { private (int, string) existing; public D((int, string) existing) { this.existing = existing; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -829,7 +829,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D(existing: (a: 1, b: ""hello""))|]; } } class D { private (int a, string b) existing; }",
 @"class C { void M() { new D(existing: (a: 1, b: ""hello"")); } } class D { private (int a, string b) existing; public D((int a, string b) existing) { this.existing = existing; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -839,7 +839,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D(existing: (a: 1, b: ""hello""))|]; } } class D { private (int c, string d) existing; }",
 @"class C { void M() { new D(existing: (a: 1, b: ""hello"")); } } class D { private (int c, string d) existing; public D((int a, string b) existing) { this.existing = existing; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -849,7 +849,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D|]((1, ""hello"")); } } class B { protected B((int, string) x) { } } class D : B { }",
 @"class C { void M() { new D((1, ""hello"")); } } class B { protected B((int, string) x) { } } class D : B { public D((int, string) x) : base(x) { } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -859,7 +859,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D|]((a: 1, b: ""hello"")); } } class B { protected B((int a, string b) x) { } } class D : B { }",
 @"class C { void M() { new D((a: 1, b: ""hello"")); } } class B { protected B((int a, string b) x) { } } class D : B { public D((int a, string b) x) : base(x) { } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -869,7 +869,7 @@ withScriptOption: true);
             await TestAsync(
 @"class C { void M() { new [|D|]((a: 1, b: ""hello"")); } } class B { protected B((int c, string d) x) { } } class D : B { }",
 @"class C { void M() { new D((a: 1, b: ""hello"")); } } class B { protected B((int c, string d) x) { } } class D : B { public D((int c, string d) x) : base(x) { } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -3014,7 +3014,7 @@ class C
                 await TestAsync(
 @"class Class { void Method() { (int, string) d = [|NewMethod|]((1, ""hello"")); } }",
 @"using System; class Class { void Method() { (int, string) d = NewMethod((1, ""hello"")); } private (int, string) NewMethod((int, string) p) { throw new NotImplementedException(); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
             }
 
@@ -3024,7 +3024,7 @@ withScriptOption: true);
                 await TestAsync(
 @"class Class { void Method() { (int a, string b) d = [|NewMethod|]((c: 1, d: ""hello"")); } }",
 @"using System; class Class { void Method() { (int a, string b) d = NewMethod((c: 1, d: ""hello"")); } private (int a, string b) NewMethod((int c, string d) p) { throw new NotImplementedException(); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
             }
 
@@ -3034,7 +3034,7 @@ withScriptOption: true);
                 await TestAsync(
 @"class Class { void Method() { (int a, string) d = [|NewMethod|]((c: 1, ""hello"")); } }",
 @"using System; class Class { void Method() { (int a, string) d = NewMethod((c: 1, ""hello"")); } private (int a, string Item2) NewMethod((int c, string Item2) p) { throw new NotImplementedException(); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -2948,7 +2948,7 @@ class C
             await TestAsync(
 @"class Class { void Method((int, string) i) { Method([|tuple|]); } }",
 @"class Class { private (int, string) tuple; void Method((int, string) i) { Method(tuple); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -2958,7 +2958,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { void Method((int a, string) i) { Method([|tuple|]); } }",
 @"class Class { private (int a, string Item2) tuple; void Method((int a, string) i) { Method(tuple); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -2968,7 +2968,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { void Method() { [|tuple|] = (1, ""hello""); } }",
 @"class Class { private (int, string) tuple; void Method() { tuple = (1, ""hello""); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -2978,7 +2978,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { void Method() { [|tuple|] = (a: 1, ""hello""); } }",
 @"class Class { private (int a, string Item2) tuple; void Method() { tuple = (a: 1, ""hello""); } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -2697,7 +2697,7 @@ index: 1);
             await TestAsync(
 @"interface IInterface { (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) ; } class Class : [|IInterface|] { (int, string) x; } ",
 @"using System; interface IInterface { (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) ; } class Class : IInterface { (int, string) x; public (int, string, int, string, int, string, int, string) Method1 ((int, string, int, string, int, string, int, string) y) { throw new NotImplementedException ( ) ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -2706,7 +2706,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
             await TestAsync(
 @"interface IInterface { (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) ; } class Class : [|IInterface|] { (int, string) x; } ",
 @"using System; interface IInterface { (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) ; } class Class : IInterface { (int, string) x; public (int a, string b, int c, string d, int e, string f, int g, string h) Method1 ((int a, string b, int c, string d, int e, string f, int g, string h) y) { throw new NotImplementedException ( ) ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -2715,7 +2715,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
             await TestAsync(
 @"interface IInterface<TA, TB> { (TA, TB) Method1 ((TA, TB) y) ; } class Class : [|IInterface<(int, string), int>|] { (int, string) x; } ",
 @"using System; interface IInterface<TA, TB> { (TA, TB) Method1 ((TA, TB) y) ; } class Class : IInterface<(int, string), int> { (int, string) x; public ((int, string), int) Method1 (((int, string), int) y) { throw new NotImplementedException ( ) ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -2724,7 +2724,7 @@ parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
             await TestAsync(
 @"interface IInterface<TA, TB> { (TA a, TB b) Method1 ((TA a, TB b) y) ; } class Class : [|IInterface<(int, string), int>|] { (int, string) x; } ",
 @"using System; interface IInterface<TA, TB> { (TA a, TB b) Method1 ((TA a, TB b) y) ; } class Class : IInterface<(int, string), int> { (int, string) x; public ((int, string) a, int b) Method1 (((int, string) a, int b) y) { throw new NotImplementedException ( ) ; } } ",
-parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+parseOptions: TestOptions.Regular, withScriptOption: true);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3843,7 +3843,7 @@ class Program
             await TestAsync(
             @" class C { void Main() { (int, string) tuple = [|((int, string))(1, ""hello"")|]; } }",
             @" class C { void Main() { (int, string) tuple = (1, ""hello""); } }",
-            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            parseOptions: TestOptions.Regular,
             withScriptOption: true);
         }
 
@@ -3853,7 +3853,7 @@ class Program
             await TestAsync(
             @" class C { void Main() { (int a, string) tuple = [|((int, string d))(1, f: ""hello"")|]; } }",
             @" class C { void Main() { (int a, string) tuple = (1, f: ""hello""); } }",
-            parseOptions: TestOptions.Regular.WithTuplesFeature(),
+            parseOptions: TestOptions.Regular,
             withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseAutoProperty/UseAutoPropertyTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.UseAutoProp
             await TestAsync(
 @"class Class { [|(int, string) i|]; (int, string) P { get { return i; } } }",
 @"class Class { (int, string) P { get; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -335,7 +335,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { [|(int a, string b) i|]; (int a, string b) P { get { return i; } } }",
 @"class Class { (int a, string b) P { get; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -344,7 +344,7 @@ withScriptOption: true);
         {
             await TestMissingAsync(
 @"class Class { [|(int a, string b) i|]; (int c, string d) P { get { return i; } } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -354,7 +354,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { [|(int a, string) i|]; (int a, string) P { get { return i; } } }",
 @"class Class { (int a, string) P { get; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -364,7 +364,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { [|(int, string) i = (1, ""hello"")|]; (int, string) P { get { return i; } } }",
 @"class Class { (int, string) P { get; } = (1, ""hello""); }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -374,7 +374,7 @@ withScriptOption: true);
             await TestAsync(
 @"class Class { [|(int, string) i|]; (int, string) P { get { return i; } set { i = value; } } }",
 @"class Class { (int, string) P { get; set; } }",
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -1019,7 +1019,7 @@ class C
 @"class C { static void M() { [|var|] s = (1, ""hello""); } }",
 @"class C { static void M() { (int, string) s = (1, ""hello""); }}",
 options: ExplicitTypeEverywhere(),
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -1030,7 +1030,7 @@ withScriptOption: true);
 @"class C { static void M() { [|var|] s = (a: 1, b: ""hello""); } }",
 @"class C { static void M() { (int a, string b) s = (a: 1, b: ""hello""); }}",
 options: ExplicitTypeEverywhere(),
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -1041,7 +1041,7 @@ withScriptOption: true);
 @"class C { static void M() { [|var|] s = (a: 1, ""hello""); } }",
 @"class C { static void M() { (int a, string Item2) s = (a: 1, ""hello""); }}",
 options: ExplicitTypeEverywhere(),
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseImplicitTypeTests.cs
@@ -1467,10 +1467,10 @@ namespace System
             var before = @"class C { static void M() { [|(int a, string)|] s = (a: 1, ""hello""); } }";
             var after = @"class C { static void M() { var s = (a: 1, ""hello""); } }";
 
-            await TestAsync(before, after, options: ImplicitTypeEverywhere(), parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestAsync(before, after, options: ImplicitTypeEverywhere(), parseOptions: TestOptions.Regular, withScriptOption: true);
 
             // We would rather this refactoring also worked. See https://github.com/dotnet/roslyn/issues/11094
-            await TestMissingAsync(before, options: ImplicitTypeWhereApparent(), parseOptions: TestOptions.Regular.WithTuplesFeature(), withScriptOption: true);
+            await TestMissingAsync(before, options: ImplicitTypeWhereApparent(), parseOptions: TestOptions.Regular, withScriptOption: true);
         }
 
         [WpfFact(Skip = "https://github.com/dotnet/roslyn/issues/11154"), Trait(Traits.Feature, Traits.Features.CodeActionsUseImplicitType)]
@@ -1480,7 +1480,7 @@ namespace System
 @"using System; class C { static void M() { [|ValueTuple<int, int>|] s = ValueTuple.Create(1, 1); } }" + trivial2uple,
 @"using System; class C { static void M() { var s = ValueTuple.Create(1, 1); } }" + trivial2uple,
 options: ImplicitTypeWhereApparent(),
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
 
@@ -1490,7 +1490,7 @@ withScriptOption: true);
             await TestMissingAsync(
 @"class C { static void M() { [|(int, string)|] s = (c: 1, d: ""hello""); } }",
 options: ImplicitTypeEverywhere(),
-parseOptions: TestOptions.Regular.WithTuplesFeature(),
+parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
     }

--- a/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/ExtractMethodTests.LanguageInteraction.cs
@@ -838,8 +838,7 @@ class Program
 
 ";
 
-                var patterns = MessageID.IDS_FeaturePatternMatching.RequiredFeature();
-                await ExpectExtractMethodToFailAsync(code, features: new[] { patterns });
+                await ExpectExtractMethodToFailAsync(code);
             }
 
             #endregion

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
@@ -52,14 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAtRoot_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"$$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAtRoot_Interactive1()
+        public async Task TestAtRoot_Interactive()
         {
             await VerifyKeywordWithRefsAsync(SourceCodeKind.Script,
 @"$$");
@@ -68,29 +61,13 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestNotAfterClass_Interactive()
         {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"class C { }
-$$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAfterClass_Interactive1()
-        {
             await VerifyKeywordWithRefsAsync(SourceCodeKind.Script,
 @"class C { }
 $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAfterGlobalStatement_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"System.Console.WriteLine();
-$$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterGlobalStatement_Interactive1()
+        public async Task TestAfterGlobalStatement_Interactive()
         {
             await VerifyKeywordWithRefsAsync(SourceCodeKind.Script,
 @"System.Console.WriteLine();
@@ -98,15 +75,7 @@ $$");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestNotAfterGlobalVariableDeclaration_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script,
-@"int i = 0;
-$$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterGlobalVariableDeclaration_Interactive1()
+        public async Task TestAfterGlobalVariableDeclaration_Interactive()
         {
             await VerifyKeywordWithRefsAsync(SourceCodeKind.Script,
 @"int i = 0;
@@ -716,12 +685,6 @@ $$");
 
         [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
         public async Task TestAfterStaticPublic_Interactive()
-        {
-            await VerifyAbsenceAsync(SourceCodeKind.Script, @"static public $$");
-        }
-
-        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
-        public async Task TestAfterStaticPublic_Interactive1()
         {
             await VerifyKeywordWithRefsAsync(SourceCodeKind.Script, @"static public $$");
         }

--- a/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/RefKeywordRecommenderTests.cs
@@ -14,11 +14,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             switch (kind)
             {
                 case SourceCodeKind.Regular:
-                    await VerifyWorkerAsync(text, absent: false, options: Options.Regular.WithRefsFeature());
+                    await VerifyWorkerAsync(text, absent: false, options: Options.Regular);
                     break;
 
                 case SourceCodeKind.Script:
-                    await VerifyWorkerAsync(text, absent: false, options: Options.Script.WithRefsFeature());
+                    await VerifyWorkerAsync(text, absent: false, options: Options.Script);
                     break;
             }
         }
@@ -28,11 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Recommendations
             switch (kind)
             {
                 case SourceCodeKind.Regular:
-                    await VerifyWorkerAsync(text, absent: true, options: Options.Regular.WithRefsFeature());
+                    await VerifyWorkerAsync(text, absent: true, options: Options.Regular);
                     break;
 
                 case SourceCodeKind.Script:
-                    await VerifyWorkerAsync(text, absent: true, options: Options.Script.WithRefsFeature());
+                    await VerifyWorkerAsync(text, absent: true, options: Options.Script);
                     break;
             }
         }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RefKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/RefKeywordRecommender.cs
@@ -63,8 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
                 syntaxTree.IsPossibleLambdaParameterModifierContext(position, context.LeftToken, cancellationToken) ||
                 context.TargetToken.IsConstructorOrMethodParameterArgumentContext() ||
                 context.TargetToken.IsXmlCrefParameterModifierContext() ||
-                (syntaxTree.Options.Features.ContainsKey("refLocalsAndReturns") && 
-                    IsValidNewByRefContext(syntaxTree, position, context, cancellationToken));
+                IsValidNewByRefContext(syntaxTree, position, context, cancellationToken);
         }
 
         private bool IsValidNewByRefContext(SyntaxTree syntaxTree, int position, CSharpSyntaxContext context, CancellationToken cancellationToken)


### PR DESCRIPTION
Changes all C# 7.0 features to be tied to `/langver` instead of `/feature`.

