### PR TITLE
Remove workaround for lack of #7812

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -103,19 +103,6 @@
     </When>
   </Choose>
 
-  <!-- Because https://github.com/dotnet/roslyn/issues/7812 is not yet fixed, the IDE doesn't know if we set the PublicSign
-       flag. As a result, all design-time builds will thing we're real-signing, which causes semantics to get all screwed up.
-       The workaround for now is, for design-time builds only, to pass the DelaySign flag since that's "good enough". This
-       must be done in a target versus conditioning on BuildingProject, since BuildingProject itself is correctly set in a
-       target. -->
-  <Target Name="FixPublicSignFlagForDesignTimeBuilds" BeforeTargets="CoreCompile" Condition="'$(PublicSign)' == 'true'">
-    <PropertyGroup Condition="'$(BuildingProject)' == 'false'">
-      <!-- Turn off PublicSign, because leaving both to true will make the Csc task unhappy -->
-      <PublicSign>false</PublicSign>
-      <DelaySign>true</DelaySign>
-    </PropertyGroup>
-  </Target>
-
   <!-- ====================================================================================
 
          Generation of binding redirects.


### PR DESCRIPTION
We're have required Update 2 for some time, making this unnecessary.

*Review:* @dotnet/roslyn-infrastructure 