### PR TITLE
Don't invoke SignFiles if there's no files to sign

### DIFF
--- a/build/Targets/Signing.targets
+++ b/build/Targets/Signing.targets
@@ -29,7 +29,8 @@
     <SignFiles Files="@(FilesToSign)"
                BinariesDirectory="$(OutDir)"
                IntermediatesDirectory="$(IntermediateOutputPath)"
-               Type="$(SignType)" />
+               Type="$(SignType)"
+               Condition="'@(FilesToSign)' != ''"/>
   </Target>
 
   <Target Name="SignVsix"  Condition="'$(ProducingSignedVsix)' == 'true'" DependsOnTargets="CreateVsixContainer">


### PR DESCRIPTION
This silences a build warning.

*Review:* @dotnet/roslyn-ide