### PR TITLE
Adjust implementation of SyntaxTreeExtensions.IsLocalVariableDeclarationContext around Out Variable Declarations.

### DIFF
--- a/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
+++ b/src/EditorFeatures/CSharpTest2/Recommendations/VarKeywordRecommenderTests.cs
@@ -232,5 +232,13 @@ $$"));
 @"class C {
     const $$");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.KeywordRecommending)]
+        [WorkItem(12121, "https://github.com/dotnet/roslyn/issues/12121")]
+        public async Task TestAfterOutKeywordInArgument()
+        {
+            await VerifyKeywordAsync(AddInsideMethod(
+@"M(out $$"));
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             if (token.IsKind(SyntaxKind.OutKeyword) &&
                 token.Parent.IsKind(SyntaxKind.Argument) &&
-                ((ArgumentSyntax)token.Parent).Declaration != null)
+                ((ArgumentSyntax)token.Parent).RefOrOutKeyword == token)
             {
                 return true;
             }


### PR DESCRIPTION
Fixes #12121.