### PR TITLE
Don't deploy VSIX during perf correctness run

### DIFF
--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -80,7 +80,7 @@ if defined TestDeterminism (
 )
 
 if defined TestPerfCorrectness (
-    msbuild %MSBuildAdditionalCommandLineArgs% Roslyn.sln /p:Configuration=%BuildConfiguration% || goto :BuildFailed
+    msbuild %MSBuildAdditionalCommandLineArgs% Roslyn.sln /p:Configuration=%BuildConfiguration% /p:DeployExtension=false || goto :BuildFailed
     .\Binaries\%BuildConfiguration%\Roslyn.Test.Performance.Runner.exe --ci-test || goto :BuildFailed
     exit /b 0
 )


### PR DESCRIPTION
There is a long standing bug in the VS SDK which causes builds to fail on deployment errors.  There are no actual deployment issues, the deployment step itself simply fails.  This hits the perf correctness suite pretty regularly and adds no value.  Disabling.