### PR TITLE
Adjust various places outside of compiler to account for the fact that ArgumentSyntax.Expression can be null.

### DIFF
--- a/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
+++ b/src/EditorFeatures/CSharp/UseAutoProperty/UseAutoPropertyAnalyzer.cs
@@ -46,12 +46,15 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UseAutoProperty
                 return;
             }
 
-            var cancellationToken = context.CancellationToken;
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(argument.Expression, cancellationToken);
-            AddIneligibleField(symbolInfo.Symbol, ineligibleFields);
-            foreach (var symbol in symbolInfo.CandidateSymbols)
+            if (argument.Expression != null)
             {
-                AddIneligibleField(symbol, ineligibleFields);
+                var cancellationToken = context.CancellationToken;
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(argument.Expression, cancellationToken);
+                AddIneligibleField(symbolInfo.Symbol, ineligibleFields);
+                foreach (var symbol in symbolInfo.CandidateSymbols)
+                {
+                    AddIneligibleField(symbol, ineligibleFields);
+                }
             }
         }
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -872,5 +872,49 @@ withScriptOption: true);
 parseOptions: TestOptions.Regular.WithTuplesFeature(),
 withScriptOption: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ImplicitlyTyped()
+        {
+            await TestAsync(
+@"class C { void M() { new [|C|](out var a); } }",
+@"class C { public C(out object a) { a = null; } void M() { new C(out var a); } }",
+parseOptions: TestOptions.Regular.WithOutVarFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ImplicitlyTyped_NamedArgument()
+        {
+            await TestAsync(
+@"class C { void M() { new C([|b|]: out var a); } }",
+@"class C { public C(out object b) { b = null; } void M() { new C(b: out var a); } }",
+parseOptions: TestOptions.Regular.WithOutVarFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ExplicitlyTyped()
+        {
+            await TestAsync(
+@"class C { void M() { new [|C|](out int a); } }",
+@"class C { public C(out int a) { a = 0; } void M() { new C(out int a); } }",
+parseOptions: TestOptions.Regular.WithOutVarFeature(),
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ExplicitlyTyped_NamedArgument()
+        {
+            await TestAsync(
+@"class C { void M() { new C([|b|]: out int a); } }",
+@"class C { public C(out int b) { b = 0; } void M() { new C(b: out int a); } }",
+parseOptions: TestOptions.Regular.WithOutVarFeature(),
+withScriptOption: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -3009,5 +3009,41 @@ withScriptOption: true);
 parseOptions: TestOptions.Regular.WithTuplesFeature(),
 withScriptOption: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ImplicitlyTyped()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|Undefined|](out var c); } }",
+@"using System; class Class { void Method() { Undefined(out var c); } private void Undefined(out object c) { throw new NotImplementedException(); } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ExplicitlyTyped()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|Undefined|](out int c); } }",
+@"using System; class Class { void Method() { Undefined(out int c); } private void Undefined(out int c) { throw new NotImplementedException(); } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ImplicitlyTyped_NamedArgument()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|Undefined|](a: out var c); } }",
+@"using System; class Class { void Method() { Undefined(a: out var c); } private void Undefined(out object a) { throw new NotImplementedException(); } }");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [WorkItem(12147, "https://github.com/dotnet/roslyn/issues/12147")]
+        public async Task TestOutVariableDeclaration_ExplicitlyTyped_NamedArgument()
+        {
+            await TestAsync(
+@"class Class { void Method() { [|Undefined|](a: out int c); } }",
+@"using System; class Class { void Method() { Undefined(a: out int c); } private void Undefined(out int a) { throw new NotImplementedException(); } }");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
+++ b/src/Features/CSharp/Portable/ChangeSignature/UnifiedArgumentSyntax.cs
@@ -62,16 +62,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ChangeSignature
             return new UnifiedArgumentSyntax(_argument.WithAdditionalAnnotations(annotation));
         }
 
-        public SyntaxNode Expression
-        {
-            get
-            {
-                return _argument.IsKind(SyntaxKind.Argument)
-                    ? ((ArgumentSyntax)_argument).Expression
-                    : ((AttributeArgumentSyntax)_argument).Expression;
-            }
-        }
-
         public bool IsDefault
         {
             get

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpUnboundIdentifiersDiagnosticAnalyzer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
             {
                 for (int i = 0; i < constructor.Parameters.Length; i++)
                 {
-                    var typeInfo = model.GetTypeInfo(args[i].Expression);
+                    var typeInfo = model.GetTypeInfo(args[i].Expression ?? args[i].Declaration.Type);
                     if (!constructor.Parameters[i].Type.Equals(typeInfo.ConvertedType))
                     {
                         return false;

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateConstructor/CSharpGenerateConstructorService.cs
@@ -200,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateConstructor
         protected override ITypeSymbol GetArgumentType(
             SemanticModel semanticModel, ArgumentSyntax argument, CancellationToken cancellationToken)
         {
-            return semanticModel.GetType(argument.Expression, cancellationToken);
+            return argument.DetermineParameterType(semanticModel, cancellationToken);
         }
 
         protected override ITypeSymbol GetAttributeArgumentType(

--- a/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
+++ b/src/Features/CSharp/Portable/GenerateMember/GenerateParameterizedMember/CSharpGenerateParameterizedMemberService.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateMember.GenerateMethod
                 var semanticModel = this.Document.SemanticModel;
                 foreach (var argument in _invocationExpression.ArgumentList.Arguments)
                 {
-                    var type = semanticModel.GetType(argument.Expression, cancellationToken);
+                    var type = argument.DetermineParameterType(semanticModel, cancellationToken);
                     type.GetReferencedTypeParameters(result);
                 }
 

--- a/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
+++ b/src/Features/CSharp/Portable/GenerateType/CSharpGenerateTypeService.cs
@@ -395,7 +395,8 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
 
                     // Get the Method symbol for the Delegate to be created
                     if (generateTypeServiceStateOptions.IsDelegateAllowed &&
-                        objectCreationExpressionOpt.ArgumentList.Arguments.Count == 1)
+                        objectCreationExpressionOpt.ArgumentList.Arguments.Count == 1 &&
+                        objectCreationExpressionOpt.ArgumentList.Arguments[0].Expression != null)
                     {
                         generateTypeServiceStateOptions.DelegateCreationMethodSymbol = GetMethodSymbolIfPresent(semanticModel, objectCreationExpressionOpt.ArgumentList.Arguments[0].Expression, cancellationToken);
                     }
@@ -945,7 +946,7 @@ namespace Microsoft.CodeAnalysis.CSharp.GenerateType
                 newObjectCreation = (ObjectCreationExpressionSyntax)newNode.GetAnnotatedNodes(s_annotation).Single();
                 var symbolInfo = speculativeModel.GetSymbolInfo(newObjectCreation, cancellationToken);
                 var parameterTypes = newObjectCreation.ArgumentList.Arguments.Select(
-                    a => speculativeModel.GetTypeInfo(a.Expression, cancellationToken).ConvertedType).ToList();
+                    a => a.DetermineParameterType(speculativeModel, cancellationToken)).ToList();
 
                 return GenerateConstructorHelpers.GetDelegatingConstructor(
                     document, symbolInfo, candidates, namedType, parameterTypes);

--- a/src/VisualStudio/CSharp/Impl/CodeModel/MethodXml/MethodXmlBuilder.cs
+++ b/src/VisualStudio/CSharp/Impl/CodeModel/MethodXml/MethodXmlBuilder.cs
@@ -586,7 +586,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.MethodXml
 
                 foreach (var argument in elementAccessExpression.ArgumentList.Arguments)
                 {
-                    if (!TryGenerateExpression(argument.Expression))
+                    if (argument.Expression == null || !TryGenerateExpression(argument.Expression))
                     {
                         return false;
                     }
@@ -600,7 +600,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.CodeModel.MethodXml
         {
             using (ArgumentTag())
             {
-                return TryGenerateExpression(argument.Expression);
+                return argument.Expression != null && TryGenerateExpression(argument.Expression);
             }
         }
 

--- a/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService_ExpressionTermCollector.cs
+++ b/src/VisualStudio/CSharp/Impl/Debugging/CSharpProximityExpressionsService_ExpressionTermCollector.cs
@@ -396,10 +396,13 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Debugging
             {
                 var flags = ExpressionType.Invalid;
 
-                AddSubExpressionTerms(arg.Expression, terms, ref flags);
-                if (IsValidTerm(flags))
+                if (arg.Expression != null)
                 {
-                    terms.Add(ConvertToString(arg.Expression));
+                    AddSubExpressionTerms(arg.Expression, terms, ref flags);
+                    if (IsValidTerm(flags))
+                    {
+                        terms.Add(ConvertToString(arg.Expression));
+                    }
                 }
 
                 validExpr &= IsValidExpression(flags);

--- a/src/Workspaces/CSharp/Portable/Extensions/ArgumentSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ArgumentSyntaxExtensions.cs
@@ -105,9 +105,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             SemanticModel semanticModel,
             CancellationToken cancellationToken)
         {
+            TypeInfo typeInfo;
+
+            if (argument.Declaration != null)
+            {
+                typeInfo = semanticModel.GetTypeInfo(argument.Declaration.Type);
+                return typeInfo.Type?.IsErrorType() == false ? typeInfo.Type : semanticModel.Compilation.ObjectType;
+            }
+
             // If a parameter appears to have a void return type, then just use 'object'
             // instead.
-            var typeInfo = semanticModel.GetTypeInfo(argument.Expression, cancellationToken);
+            typeInfo = semanticModel.GetTypeInfo(argument.Expression, cancellationToken);
             if (typeInfo.Type != null && typeInfo.Type.SpecialType == SpecialType.System_Void)
             {
                 return semanticModel.Compilation.ObjectType;

--- a/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
@@ -181,6 +181,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return argument.NameColon.Name.Identifier.ValueText;
             }
 
+            if (argument.Declaration != null)
+            {
+                return argument.Declaration.Variables.First().Identifier.ValueText.ToCamelCase();
+            }
+
             return semanticModel.GenerateNameForExpression(argument.Expression);
         }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxNodeExtensions.cs
@@ -1133,51 +1133,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             return SpecializedCollections.EmptyEnumerable<MemberDeclarationSyntax>();
         }
 
-        public static IEnumerable<SyntaxNode> GetBodies(this SyntaxNode node)
-        {
-            var constructor = node as ConstructorDeclarationSyntax;
-            if (constructor != null)
-            {
-                var result = SpecializedCollections.SingletonEnumerable<SyntaxNode>(constructor.Body).WhereNotNull();
-                var initializer = constructor.Initializer;
-                if (initializer != null)
-                {
-                    result = result.Concat(initializer.ArgumentList.Arguments.Select(a => (SyntaxNode)a.Expression).WhereNotNull());
-                }
-
-                return result;
-            }
-
-            var method = node as BaseMethodDeclarationSyntax;
-            if (method != null)
-            {
-                return SpecializedCollections.SingletonEnumerable<SyntaxNode>(method.Body).WhereNotNull();
-            }
-
-            var property = node as BasePropertyDeclarationSyntax;
-            if (property != null && property.AccessorList != null)
-            {
-                return property.AccessorList.Accessors.Select(a => a.Body).WhereNotNull();
-            }
-
-            var @enum = node as EnumMemberDeclarationSyntax;
-            if (@enum != null)
-            {
-                if (@enum.EqualsValue != null)
-                {
-                    return SpecializedCollections.SingletonEnumerable(@enum.EqualsValue.Value).WhereNotNull();
-                }
-            }
-
-            var field = node as BaseFieldDeclarationSyntax;
-            if (field != null)
-            {
-                return field.Declaration.Variables.Where(v => v.Initializer != null).Select(v => v.Initializer.Value).WhereNotNull();
-            }
-
-            return SpecializedCollections.EmptyEnumerable<SyntaxNode>();
-        }
-
         public static ConditionalAccessExpressionSyntax GetParentConditionalAccessExpression(this SyntaxNode node)
         {
             var parent = node.Parent;

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpExtensionMethodReducer.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpExtensionMethodReducer.cs
@@ -53,22 +53,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     {
                         MemberAccessExpressionSyntax newMemberAccess = null;
                         var invocationExpressionNodeExpression = node.Expression;
+                        var expression = argumentList.Arguments[0].Expression;
 
-                        if (node.Expression.Kind() == SyntaxKind.SimpleMemberAccessExpression)
+                        if (expression != null)
                         {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, argumentList.Arguments[0].Expression, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).OperatorToken, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).Name);
-                        }
-                        else if (node.Expression.Kind() == SyntaxKind.IdentifierName)
-                        {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, argumentList.Arguments[0].Expression, (IdentifierNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
-                        }
-                        else if (node.Expression.Kind() == SyntaxKind.GenericName)
-                        {
-                            newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, argumentList.Arguments[0].Expression, (GenericNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
-                        }
-                        else
-                        {
-                            Debug.Assert(false, "The expression kind is not MemberAccessExpression or IdentifierName or GenericName to be converted to Member Access Expression for Ext Method Reduction");
+                            if (node.Expression.Kind() == SyntaxKind.SimpleMemberAccessExpression)
+                            {
+                                newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).OperatorToken, ((MemberAccessExpressionSyntax)invocationExpressionNodeExpression).Name);
+                            }
+                            else if (node.Expression.Kind() == SyntaxKind.IdentifierName)
+                            {
+                                newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, (IdentifierNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
+                            }
+                            else if (node.Expression.Kind() == SyntaxKind.GenericName)
+                            {
+                                newMemberAccess = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expression, (GenericNameSyntax)invocationExpressionNodeExpression.WithoutLeadingTrivia());
+                            }
+                            else
+                            {
+                                Debug.Assert(false, "The expression kind is not MemberAccessExpression or IdentifierName or GenericName to be converted to Member Access Expression for Ext Method Reduction");
+                            }
                         }
 
                         if (newMemberAccess == null)

--- a/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
+++ b/src/Workspaces/CSharp/Portable/Simplification/CSharpSimplificationService.Expander.cs
@@ -266,14 +266,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
 
                 var newArgument = (ArgumentSyntax)base.VisitArgument(node);
 
-                var argumentType = _semanticModel.GetTypeInfo(node.Expression).ConvertedType;
-                if (argumentType != null &&
-                    !IsPassedToDelegateCreationExpression(node, argumentType))
+                if (node.Expression != null)
                 {
-                    ExpressionSyntax newArgumentExpressionWithCast;
-                    if (TryCastTo(argumentType, node.Expression, newArgument.Expression, out newArgumentExpressionWithCast))
+                    var argumentType = _semanticModel.GetTypeInfo(node.Expression).ConvertedType;
+                    if (argumentType != null &&
+                        !IsPassedToDelegateCreationExpression(node, argumentType))
                     {
-                        return newArgument.WithExpression(newArgumentExpressionWithCast);
+                        ExpressionSyntax newArgumentExpressionWithCast;
+                        if (TryCastTo(argumentType, node.Expression, newArgument.Expression, out newArgumentExpressionWithCast))
+                        {
+                            return newArgument.WithExpression(newArgumentExpressionWithCast);
+                        }
                     }
                 }
 
@@ -764,9 +767,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Simplification
                     {
                         foreach (var argument in invocationExpression.ArgumentList.Arguments)
                         {
-                            if (argument != null && argument.Expression != null)
+                            if (argument != null)
                             {
-                                var typeinfo = semanticModel.GetTypeInfo(argument.Expression);
+                                var typeinfo = semanticModel.GetTypeInfo(argument.Expression ?? argument.Declaration.Type);
                                 if (typeinfo.Type != null && typeinfo.Type.TypeKind == TypeKind.Dynamic)
                                 {
                                     return true;


### PR DESCRIPTION
Fixes #12147.

@dotnet/roslyn-ide Please review. 