### PR TITLE
Generate list of packages for nuget.org

### DIFF
--- a/src/NuGet/Releases/1.3.0.packages
+++ b/src/NuGet/Releases/1.3.0.packages
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis" />
+  <package id="Microsoft.CodeAnalysis.Common" />
+  <package id="Microsoft.CodeAnalysis.Compilers" />
+  <package id="Microsoft.CodeAnalysis.CSharp" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Features" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Scripting" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" />
+  <package id="Microsoft.CodeAnalysis.Features" />
+  <package id="Microsoft.CodeAnalysis.Scripting" />
+  <package id="Microsoft.CodeAnalysis.Scripting.Common" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Features" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" />
+  <package id="Microsoft.DiaSymReader.PortablePdb" />
+  <package id="Microsoft.Net.Compilers" />
+  <package id="Microsoft.Net.Compilers.netcore" />
+  <package id="Microsoft.VisualStudio.LanguageServices" />
+</packages>


### PR DESCRIPTION
Generate list of packages for nuget.org

The list is currently unused but should be used by `BuildNuGets.csx` when generating release packages.

Note: The list does not include:
```
Microsoft.CodeAnalysis.Test.Resources.Proprietary
Microsoft.CodeAnalysis.VisualBasic.Scripting
Microsoft.Net.CSharp.Interactive.netcore
```
and the list does include:
```
Microsoft.Net.Compilers.netcore
```