### PR TITLE
Add microbuild version number in a centralized location.

### DIFF
--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -30,4 +30,7 @@
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <MicroBuildVersion>0.2.0</MicroBuildVersion>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
related to https://github.com/dotnet/roslyn-internal/pull/1098

Consolidating the microbuild version number into a single place.

@dotnet/roslyn-infrastructure 