### PR TITLE
Display analyzer assemblies with no applicable diagnostic analyzers t…

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -460,6 +460,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             return _analyzers.ContainsKey(fullPath);
         }
 
+        /// <summary>
+        /// Returns a map from full path to <see cref="VisualStudioAnalyzer"/>.
+        /// </summary>
+        public ImmutableDictionary<string, VisualStudioAnalyzer> GetProjectAnalyzersMap() => _analyzers.ToImmutableDictionary();
+
         private static string GetAssemblyName(string outputPath)
         {
             Contract.Requires(outputPath != null);


### PR DESCRIPTION
…owards the end of analyzers list in solution explorer

For most cases, these are analyzer depedencies with no analyzers.
For few cases, these might be analyzer assemblies with no analyzers applicable for the given project langauge.
For few other cases these might be analyzer assemblies whose diagnostic analyzers could not be instantiated for some reason, and hence have no rules.

We still display such analyzers in the solution explorer so the user is aware that the project file contains these analyzer references, but display them towards the end to avoid clutter.

Fixes https://github.com/dotnet/roslyn/issues/12047