### PR TITLE
Add test to ensure that a CompletionService can be acquired

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -157,6 +157,7 @@
     <Compile Include="CodeActions\InvertIf\InvertIfTests.cs" />
     <Compile Include="CodeActions\LambdaSimplifier\LambdaSimplifierTests.cs" />
     <Compile Include="CodeActions\ReplacePropertyWithMethods\ReplacePropertyWithMethodsTests.cs" />
+    <Compile Include="Completion\CompletionServiceTests.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests_NuGet.cs" />
     <Compile Include="Diagnostics\GenerateMethod\GenerateConversionTests.cs" />
     <Compile Include="Diagnostics\MakeMethodSynchronous\MakeMethodSynchronousTests.cs" />

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionServiceTests.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Completion;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Completion
+{
+    public class CompletionServiceTests
+    {
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public void AcquireCompletionService()
+        {
+            var hostServices = MefHostServices.Create(
+                MefHostServices.DefaultAssemblies.Concat(
+                    new[]
+                    {
+                        typeof(CompletionService).Assembly,
+                        typeof(CSharpCompletionService).Assembly
+                    }));
+
+            var workspace = new AdhocWorkspace(hostServices);
+
+            var document = workspace
+                .AddProject("TestProject", LanguageNames.CSharp)
+                .AddDocument("TestDocument.cs", "");
+
+            var service = CompletionService.GetService(document);
+            Assert.NotNull(service);
+        }
+    }
+}

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -138,6 +138,7 @@
     <Compile Include="CodeActions\InvertIf\InvertIfTests.vb" />
     <Compile Include="CodeActions\Preview\PreviewTests.vb" />
     <Compile Include="CodeActions\ReplacePropertyWithMethods\ReplacePropertyWithMethodsTests.vb" />
+    <Compile Include="Completion\CompletionServiceTests.vb" />
     <Compile Include="Diagnostics\AddImport\AddImportTests_NuGet.vb" />
     <Compile Include="Diagnostics\ImplementAbstractClass\ImplementAbstractClassTests_FixAllTests.vb" />
     <Compile Include="Diagnostics\ImplementInterface\ImplementInterfaceTests_FixAllTests.vb" />

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionServiceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionServiceTests.vb
@@ -1,0 +1,26 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Completion
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.Completion
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.Completion
+    Public Class CompletionServiceTests
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Sub AcquireCompletionService()
+            Dim hostServices = MefHostServices.Create(
+                MefHostServices.DefaultAssemblies.Concat({
+                    GetType(CompletionService).Assembly,
+                    GetType(VisualBasicCompletionService).Assembly}))
+
+            Dim workspace = New AdhocWorkspace(hostServices)
+
+            Dim document = workspace _
+                .AddProject("TestProject", LanguageNames.VisualBasic) _
+                .AddDocument("TestDocument.vb", String.Empty)
+
+            Dim service = CompletionService.GetService(document)
+            Assert.NotNull(service)
+        End Sub
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateParameterizedMember/GenerateParameterizedMemberCodeFixProvider.vb
@@ -11,8 +11,7 @@ Imports System.Composition
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateMethod
     <ExportCodeFixProvider(LanguageNames.VisualBasic, Name:=PredefinedCodeFixProviderNames.GenerateMethod), [Shared]>
-    <ExtensionOrder(Before:=PredefinedCodeFixProviderNames.PopulateSwitch)>
-    <ExtensionOrder(After:=PredefinedCodeFixProviderNames.GenerateEvent)>
+    <ExtensionOrder(Before:=PredefinedCodeFixProviderNames.PopulateSwitch, After:=PredefinedCodeFixProviderNames.GenerateEvent)>
     Friend Class GenerateParameterizedMemberCodeFixProvider
         Inherits AbstractGenerateMemberCodeFixProvider
 


### PR DESCRIPTION
Issue #11841 found that, due to a MEF bug, the Features assemblies could not properly be included in a MEF composition. This was worked around by combining [ExtensionOrder] attributes where multiple attributes had been specified. This change adds a tests for C# and VB to ensure that a CompletionService can be acquired from an AdhocWorkspace that is created with MefHostServices that include the Features assemblies.

I verified that these tests fail without the workaound described above, and pass with the workaround in place.

cc @mattwar, @weltkante, @aelij, @dotnet/roslyn-ide 