### PR TITLE
Adjust more places outside of compiler to account for the fact that ArgumentSyntax.Expression can be null.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ConvertToInterpolatedString/ConvertToInterpolatedStringTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ConvertToInterpolatedString/ConvertToInterpolatedStringTests.cs
@@ -520,5 +520,33 @@ public class T
     }
 }");
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestOutVariableDeclaration_01()
+        {
+            await TestMissingAsync(
+@"using System;
+class T
+{
+    void M()
+    {
+        var a = [|string.Format(""{0}"", out int x)|];
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsConvertToInterpolatedString)]
+        public async Task TestOutVariableDeclaration_02()
+        {
+            await TestMissingAsync(
+@"using System;
+class T
+{
+    void M()
+    {
+        var a = [|string.Format(out string x, 1)|];
+    }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplaceMethodWithProperty/ReplaceMethodWithPropertyTests.cs
@@ -468,5 +468,137 @@ index: 1,
 parseOptions: TestOptions.Regular,
 withScriptOption: true));
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestOutVarDeclaration_1()
+        {
+            await TestAsync(
+@"class C
+{
+    // Foo
+    int [||]GetFoo()
+    {
+    }
+    // SetFoo
+    void SetFoo(out int i)
+    {
+    }
+
+    void Test()
+    {
+        SetFoo(out int i);
+    }
+}",
+@"class C
+{
+    // Foo
+    int Foo
+    {
+        get
+        {
+        }
+    }
+
+    // SetFoo
+    void SetFoo(out int i)
+    {
+    }
+
+    void Test()
+    {
+        SetFoo(out int i);
+    }
+}",
+index: 0,
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestOutVarDeclaration_2()
+        {
+            await TestAsync(
+@"class C
+{
+    // Foo
+    int [||]GetFoo()
+    {
+    }
+    // SetFoo
+    void SetFoo(int i)
+    {
+    }
+
+    void Test()
+    {
+        SetFoo(out int i);
+    }
+}",
+@"class C
+{
+    // Foo
+    // SetFoo
+    int Foo
+    {
+        get
+        {
+        }
+
+        set
+        {
+        }
+    }
+
+    void Test()
+    {
+        {|Conflict:Foo|}(out int i);
+    }
+}",
+index: 1,
+compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestOutVarDeclaration_3()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    // Foo
+    int GetFoo()
+    {
+    }
+    // SetFoo
+    void [||]SetFoo(out int i)
+    {
+    }
+
+    void Test()
+    {
+        SetFoo(out int i);
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplaceMethodWithProperty)]
+        public async Task TestOutVarDeclaration_4()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    // Foo
+    int [||]GetFoo(out int i)
+    {
+    }
+    // SetFoo
+    void SetFoo(out int i, int j)
+    {
+    }
+
+    void Test()
+    {
+        var y = GetFoo(out int i);
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
+++ b/src/Features/CSharp/Portable/ReplaceMethodWithProperty/CSharpReplaceMethodWithPropertyService.cs
@@ -213,7 +213,8 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeRefactorings.ReplaceMethodWithProper
         private static Action<SyntaxEditor, InvocationExpressionSyntax, SimpleNameSyntax, SimpleNameSyntax> s_replaceSetReferenceInvocation =
             (editor, invocation, nameNode, newName) =>
             {
-                if (invocation.ArgumentList?.Arguments.Count != 1)
+                if (invocation.ArgumentList?.Arguments.Count != 1 ||
+                    invocation.ArgumentList.Arguments[0].Declaration != null)
                 {
                     var annotation = ConflictAnnotation.Create(FeaturesResources.OnlyMethodsWithASingleArgumentCanBeReplacedWithAProperty);
                     editor.ReplaceNode(nameNode, newName.WithIdentifier(newName.Identifier.WithAdditionalAnnotations(annotation)));

--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -1934,7 +1934,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Only methods with a single argument can be replaced with a property..
+        ///   Looks up a localized string similar to Only methods with a single argument, which is not an out variable declaration, can be replaced with a property..
         /// </summary>
         internal static string OnlyMethodsWithASingleArgumentCanBeReplacedWithAProperty {
             get {

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -871,7 +871,7 @@ Do you want to continue?</value>
     <value>Non-invoked method cannot be replaced with property.</value>
   </data>
   <data name="OnlyMethodsWithASingleArgumentCanBeReplacedWithAProperty" xml:space="preserve">
-    <value>Only methods with a single argument can be replaced with a property.</value>
+    <value>Only methods with a single argument, which is not an out variable declaration, can be replaced with a property.</value>
   </data>
   <data name="ErrorCategory" xml:space="preserve">
     <value>Roslyn.HostError</value>

--- a/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplaceMethodWithProperty/ReplaceMethodWithPropertyCodeRefactoringProvider.cs
@@ -129,7 +129,9 @@ namespace Microsoft.CodeAnalysis.ReplaceMethodWithProperty
         private static bool IsValidSetMethod(IMethodSymbol setMethod, IMethodSymbol getMethod)
         {
             return IsValidSetMethod(setMethod) &&
-                setMethod.Parameters.Length == 1 && Equals(setMethod.Parameters[0].Type, getMethod.ReturnType) &&
+                setMethod.Parameters.Length == 1 &&
+                setMethod.Parameters[0].RefKind == RefKind.None &&
+                Equals(setMethod.Parameters[0].Type, getMethod.ReturnType) &&
                 setMethod.IsAbstract == getMethod.IsAbstract;
         }
 

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -853,7 +853,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
             }
 
             var arg = node as ArgumentSyntax;
-            if (arg != null)
+            if (arg != null && arg.Expression != null)
             {
                 return SyntaxFactory.AttributeArgument(default(NameEqualsSyntax), arg.NameColon, arg.Expression);
             }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -1510,20 +1510,24 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (invocation.ArgumentList.Arguments.Count > 0)
                         {
                             var argumentExpression = invocation.ArgumentList.Arguments[0].Expression;
-                            var argumentTypes = GetTypes(argumentExpression);
-                            var delegateType = argumentTypes.FirstOrDefault().GetDelegateType(this.Compilation);
-                            var typeArg = delegateType?.TypeArguments.Length > 0
-                                ? delegateType.TypeArguments[0]
-                                : this.Compilation.ObjectType;
 
-                            if (IsUnusableType(typeArg) && argumentExpression is LambdaExpressionSyntax)
+                            if (argumentExpression != null)
                             {
-                                typeArg = InferTypeForFirstParameterOfLambda((LambdaExpressionSyntax)argumentExpression) ??
-                                    this.Compilation.ObjectType;
-                            }
+                                var argumentTypes = GetTypes(argumentExpression);
+                                var delegateType = argumentTypes.FirstOrDefault().GetDelegateType(this.Compilation);
+                                var typeArg = delegateType?.TypeArguments.Length > 0
+                                    ? delegateType.TypeArguments[0]
+                                    : this.Compilation.ObjectType;
 
-                            return SpecializedCollections.SingletonEnumerable(
-                                ienumerableType.Construct(typeArg));
+                                if (IsUnusableType(typeArg) && argumentExpression is LambdaExpressionSyntax)
+                                {
+                                    typeArg = InferTypeForFirstParameterOfLambda((LambdaExpressionSyntax)argumentExpression) ??
+                                        this.Compilation.ObjectType;
+                                }
+
+                                return SpecializedCollections.SingletonEnumerable(
+                                    ienumerableType.Construct(typeArg));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
@dotnet/roslyn-ide Please review.