### PR TITLE
Fix PublicKeyToken used for framework references

### DIFF
--- a/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -17,10 +17,10 @@
     <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis.VisualBasic, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
       <MaxVersion>$(AssemblyVersion)</MaxVersion>
     </SuggestedBindingRedirects>
-    <SuggestedBindingRedirects Include="System.Collections.Immutable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
+    <SuggestedBindingRedirects Include="System.Collections.Immutable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <MaxVersion>$(SystemCollectionsImmutableVersion.Split('-')[0])</MaxVersion>
     </SuggestedBindingRedirects>
-    <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
+    <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <MaxVersion>$(SystemReflectionMetadataVersion.Split('-')[0])</MaxVersion>
     </SuggestedBindingRedirects>
   </ItemGroup>


### PR DESCRIPTION
These are built with the core framework key, not the key Roslyn uses.

*Review:* @dotnet/roslyn-compiler, @dotnet/roslyn-analysis