### PR TITLE
Expand condition on our command line generator Tasks

### DIFF
--- a/build/Targets/GenerateCompilerInternals.targets
+++ b/build/Targets/GenerateCompilerInternals.targets
@@ -53,7 +53,7 @@
     Name="GenerateSyntaxModel"
     Inputs="@(SyntaxDefinition);$(VBSyntaxGeneratorToolPath);$(CSharpSyntaxGeneratorToolPath)"
     Outputs="@(SyntaxDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')"
-    Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
+    Condition="'@(SyntaxDefinition)' != '' AND '$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
       <SyntaxGenerator Condition="'$(Language)' == 'VB'">"$(CoreRunExe)" "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
@@ -114,7 +114,7 @@
     Name="GenerateSyntaxModelTests"
     Inputs="@(SyntaxTestDefinition);$(VBSyntaxGeneratorToolPath);$(CSharpSyntaxGeneratorToolPath)"
     Outputs="@(SyntaxTestDefinition -> '$(IntermediateOutputPath)\%(FileName)%(Extension).Generated$(DefaultLanguageSourceExtension)')"
-    Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
+    Condition="'@(SyntaxTestDefinition)' != '' AND '$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
       <SyntaxGenerator Condition="'$(Language)' == 'VB'">"$(CoreRunExe)" "$(VBSyntaxGeneratorToolPath)"</SyntaxGenerator>
@@ -146,7 +146,7 @@
     Name="GenerateBoundTree"
     Inputs="@(BoundTreeDefinition);$(BoundTreeGeneratorToolPath)"
     Outputs="@(BoundTreeDefinition -> '$(IntermediateOutputPath)%(Filename)%(Extension).Generated$(DefaultLanguageSourceExtension)')"
-    Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
+    Condition="'@(BoundTreeDefinition)' != '' AND '$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
       <BoundTreeGenerator>"$(CoreRunExe)" "$(BoundTreeGeneratorToolPath)"</BoundTreeGenerator>
@@ -182,7 +182,7 @@
     Name="GenerateErrorFacts"
     Inputs="@(ErrorCode);$(CSharpErrorFactsGeneratorToolPath);$(VBErrorFactsGeneratorToolPath)"
     Outputs="@(ErrorCode -> '$(IntermediateOutputPath)ErrorFacts.Generated$(DefaultLanguageSourceExtension)')"
-    Condition="'$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
+    Condition="'@(ErrorCode)' != '' AND '$(BuildingProject)' == 'true' AND ('$(Language)' == 'VB' or '$(Language)' == 'C#')"
   >
     <PropertyGroup>
       <ErrorFactsGenerator Condition="'$(Language)' == 'VB'">"$(CoreRunExe)" "$(VBErrorFactsGeneratorToolPath)"</ErrorFactsGenerator>


### PR DESCRIPTION
Expanded the Condition check to verify the input file is non-empty.  Lacking this we get the following spurious entries in our MSBuild output files:

```
GenerateSyntaxModel:
Skipping target "GenerateSyntaxModel" because it has no outputs.
```

Adding the condition removes this entry and makes our build log files just a bit more readable.