### PR TITLE
Ensure the right binder is used to bind initializer of implicitly typed variable.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2200,18 +2200,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             SourceLocalSymbol localSymbol = this.LookupLocal(argumentSyntax.Identifier);
 
-            // In error scenarios with misplaced code, it is possible we can't bind the local declaration.
-            // This occurs through the semantic model.  In that case concoct a plausible result.
             if ((object)localSymbol == null)
             {
-                localSymbol = SourceLocalSymbol.MakeLocal(
-                    ContainingMemberOrLambda,
-                    this,
-                    RefKind.None,
-                    typeSyntax,
-                    argumentSyntax.Identifier,
-                    LocalDeclarationKind.RegularVariable,
-                    initializer: null);
+                // We should have the right binder in the chain, cannot continue otherwise.
+                throw ExceptionUtilities.Unreachable;
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -13120,7 +13120,7 @@ public class Cls
                 );
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/12266")]
+        [Fact]
         [WorkItem(12266, "https://github.com/dotnet/roslyn/issues/12266")]
         public void LocalVariableTypeInferenceAndOutVar_01()
         {
@@ -13153,7 +13153,7 @@ public class Cls
             Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/12266")]
+        [Fact]
         [WorkItem(12266, "https://github.com/dotnet/roslyn/issues/12266")]
         public void LocalVariableTypeInferenceAndOutVar_02()
         {
@@ -13182,6 +13182,109 @@ public class Cls
             var model = compilation.GetSemanticModel(tree);
 
             var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y").Single();
+
+            Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        [WorkItem(12266, "https://github.com/dotnet/roslyn/issues/12266")]
+        public void LocalVariableTypeInferenceAndOutVar_03()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        var y = Test1(out var x) + x;
+        System.Console.WriteLine(y);
+    }
+
+    static int Test1(out int x)
+    {
+        x = 123;
+        return 124;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text,
+                                                            options: TestOptions.ReleaseExe,
+                                                            parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput: @"247").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y").Single();
+
+            Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        [WorkItem(12266, "https://github.com/dotnet/roslyn/issues/12266")]
+        public void LocalVariableTypeInferenceAndOutVar_04()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        for (var y = Test1(out var x) + x; y != 0 ; y = 0)
+        {
+            System.Console.WriteLine(y);
+        }
+    }
+
+    static int Test1(out int x)
+    {
+        x = 123;
+        return 124;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text,
+                                                            options: TestOptions.ReleaseExe,
+                                                            parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput: @"247").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y").Last();
+
+            Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
+        }
+        
+        [Fact]
+        [WorkItem(12266, "https://github.com/dotnet/roslyn/issues/12266")]
+        public void LocalVariableTypeInferenceAndOutVar_05()
+        {
+            var text = @"
+public class Cls
+{
+    public static void Main()
+    {
+        foreach (var y in new [] {Test1(out var x) + x})
+        {
+            System.Console.WriteLine(y);
+        }
+    }
+
+    static int Test1(out int x)
+    {
+        x = 123;
+        return 124;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(text,
+                                                            options: TestOptions.ReleaseExe,
+                                                            parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput: @"247").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y").Last();
 
             Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
         }


### PR DESCRIPTION
Fixes #12266.

@dotnet/roslyn-compiler Please review.