### PR TITLE
Fix for nested param/typeparam suggestions

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/XmlDocumentationCommentCompletionProviderTests.cs
@@ -1096,18 +1096,44 @@ public class foo
 }", "!--", "![CDATA[", "completionlist", "example", "exception", "include", "permission", "remarks", "see", "seealso", "summary");
         }
 
-		[WorkItem(8322, "https://github.com/dotnet/roslyn/issues/8322")]
-		[Fact, Trait(Traits.Feature, Traits.Features.Completion)]
-		public async Task PartialTagCompletionNestedTags()
-		{
-			await VerifyItemsExistAsync(@"
+        [WorkItem(8322, "https://github.com/dotnet/roslyn/issues/8322")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task PartialTagCompletionNestedTags()
+        {
+            await VerifyItemsExistAsync(@"
 public class foo
 {
     /// <summary>
-	/// <r$$
-	/// </summary>
+    /// <r$$
+    /// </summary>
     public void bar() { }
 }", "!--", "![CDATA[", "c", "code", "list", "para", "see", "seealso");
-		}
-	}
+        }
+
+        [WorkItem(11487, "https://github.com/dotnet/roslyn/issues/11487")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TypeParamAtTopLevelOnly()
+        {
+            await VerifyItemsAbsentAsync(@"
+/// <summary>
+/// $$
+/// </summary>
+public class Foo<T>
+{
+}", "typeparam name=\"T\"");
+        }
+
+        [WorkItem(11487, "https://github.com/dotnet/roslyn/issues/11487")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task ParamAtTopLevelOnly()
+        {
+            await VerifyItemsAbsentAsync(@"
+/// <summary>
+/// $$
+/// </summary>
+static void Foo(string str)
+{
+}", "param name=\"str\"");
+        }
+    }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/XmlDocCommentCompletionProviderTests.vb
@@ -292,6 +292,53 @@ End Class
             Await VerifyItemIsAbsentAsync(text, "param name=""bar""")
         End Function
 
+        <WorkItem(11487, "https://github.com/dotnet/roslyn/issues/11487")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoRepeatTypeParam() As Task
+            Dim text = "
+Class C(Of T)
+    ''' <typeparam name=""T""></param>
+    ''' <$$
+    Sub Foo(Of T)(bar as T)
+    End Sub
+End Class
+"
+
+            Await VerifyItemIsAbsentAsync(text, "typeparam name=""T""")
+        End Function
+
+        <WorkItem(11487, "https://github.com/dotnet/roslyn/issues/11487")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoNestedParam() As Task
+            Dim text = "
+Class C(Of T)
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
+    Sub Foo(Of T)(bar as T)
+    End Sub
+End Class
+"
+
+            Await VerifyItemIsAbsentAsync(text, "param name=""bar""")
+        End Function
+
+        <WorkItem(11487, "https://github.com/dotnet/roslyn/issues/11487")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestNoNestedTypeParam() As Task
+            Dim text = "
+Class C(Of T)
+    ''' <summary>
+    ''' <$$
+    ''' </summary>
+    Sub Foo(Of T)(bar as T)
+    End Sub
+End Class
+"
+
+            Await VerifyItemIsAbsentAsync(text, "typeparam name=""T""")
+        End Function
+
         <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TestAttributeAfterName() As Task
             Dim text = "

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/XmlDocCommentCompletionProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -13,11 +14,10 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
-using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
-	internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompletionProvider
+    internal partial class XmlDocCommentCompletionProvider : AbstractDocCommentCompletionProvider
     {
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
         {
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
         }
 
         protected override async Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(
-            Document document, int position, TextSpan span,
+            Document document, int position,
             CompletionTrigger trigger, CancellationToken cancellationToken)
         {
             var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
@@ -38,7 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             var items = new List<CompletionItem>();
-            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
 
             var attachedToken = parentTrivia.ParentTrivia.Token;
             if (attachedToken.Kind() == SyntaxKind.None)
@@ -63,9 +62,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 }
             }
 
-            if (declaredSymbol != null)
+            // User is trying to write a name, try to suggest only names.
+            if (token.Parent.IsKind(SyntaxKind.XmlNameAttribute) ||
+                (token.Parent.IsKind(SyntaxKind.IdentifierName) && token.Parent.IsParentKind(SyntaxKind.XmlNameAttribute)))
             {
-                items.AddRange(GetTagsForSymbol(declaredSymbol, span, parentTrivia, token));
+                string parentElementName = null;
+
+                var emptyElement = token.GetAncestor<XmlEmptyElementSyntax>();
+                if (emptyElement != null)
+                {
+                    parentElementName = emptyElement.Name.LocalName.Text;
+                }
+
+                if (parentElementName == ParamRefTagName)
+                {
+                    return GetParamNameItems(declaredSymbol);
+                }
+                else if (parentElementName == TypeParamRefTagName)
+                {
+                    return GetTypeParamNameItems(declaredSymbol);
+                }
             }
 
             if (token.Parent.Kind() == SyntaxKind.XmlEmptyElement || token.Parent.Kind() == SyntaxKind.XmlText ||
@@ -81,7 +97,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 if (token.Parent.Parent.Kind() == SyntaxKind.XmlElement && ((XmlElementSyntax)token.Parent.Parent).StartTag.Name.LocalName.ValueText == ListTagName)
                 {
-                    items.AddRange(GetListItems(span));
+                    items.AddRange(GetListItems());
                 }
 
                 if (token.Parent.IsParentKind(SyntaxKind.XmlEmptyElement) && token.Parent.Parent.IsParentKind(SyntaxKind.XmlElement))
@@ -89,7 +105,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                     var element = (XmlElementSyntax)token.Parent.Parent.Parent;
                     if (element.StartTag.Name.LocalName.ValueText == ListTagName)
                     {
-                        items.AddRange(GetListItems(span));
+                        items.AddRange(GetListItems());
                     }
                 }
 
@@ -101,8 +117,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
                 if (token.Parent.Parent is DocumentationCommentTriviaSyntax ||
                     (token.Parent.Parent.IsKind(SyntaxKind.XmlEmptyElement) && token.Parent.Parent.Parent is DocumentationCommentTriviaSyntax))
                 {
-                    items.AddRange(GetTopLevelSingleUseNames(parentTrivia, span));
+                    items.AddRange(GetTopLevelSingleUseNames(parentTrivia));
                     items.AddRange(GetTopLevelRepeatableItems());
+                    items.AddRange(GetTagsForSymbol(declaredSymbol, parentTrivia));
                 }
             }
 
@@ -112,7 +129,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
                 if (token == startTag.GreaterThanToken && startTag.Name.LocalName.ValueText == ListTagName)
                 {
-                    items.AddRange(GetListItems(span));
+                    items.AddRange(GetListItems());
                 }
 
                 if (token == startTag.GreaterThanToken && startTag.Name.LocalName.ValueText == ListHeaderTagName)
@@ -125,7 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return items;
         }
 
-        private IEnumerable<CompletionItem> GetTopLevelSingleUseNames(DocumentationCommentTriviaSyntax parentTrivia, TextSpan span)
+        private IEnumerable<CompletionItem> GetTopLevelSingleUseNames(DocumentationCommentTriviaSyntax parentTrivia)
         {
             var names = new HashSet<string>(new[] { SummaryTagName, RemarksTagName, ExampleTagName, CompletionListTagName });
 
@@ -149,16 +166,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
         }
 
-        private IEnumerable<CompletionItem> GetTagsForSymbol(ISymbol symbol, TextSpan itemSpan, DocumentationCommentTriviaSyntax trivia, SyntaxToken token)
+        private IEnumerable<CompletionItem> GetTagsForSymbol(ISymbol symbol, DocumentationCommentTriviaSyntax trivia)
         {
             if (symbol is IMethodSymbol)
             {
-                return GetTagsForMethod((IMethodSymbol)symbol, trivia, token);
+                return GetTagsForMethod((IMethodSymbol)symbol, trivia);
             }
 
             if (symbol is IPropertySymbol)
             {
-                return GetTagsForProperty((IPropertySymbol)symbol, trivia, token);
+                return GetTagsForProperty((IPropertySymbol)symbol, trivia);
             }
 
             if (symbol is INamedTypeSymbol)
@@ -199,36 +216,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return null;
         }
 
-        private IEnumerable<CompletionItem> GetTagsForProperty(
-            IPropertySymbol symbol, DocumentationCommentTriviaSyntax trivia, SyntaxToken token)
+        private IEnumerable<CompletionItem> GetTagsForProperty(IPropertySymbol symbol, DocumentationCommentTriviaSyntax trivia)
         {
             var items = new List<CompletionItem>();
 
             if (symbol.IsIndexer)
             {
                 var parameters = symbol.GetParameters().Select(p => p.Name).ToSet();
-
-                // User is trying to write a name, try to suggest only names.
-                if (token.Parent.IsKind(SyntaxKind.XmlNameAttribute) ||
-                    (token.Parent.IsKind(SyntaxKind.IdentifierName) && token.Parent.IsParentKind(SyntaxKind.XmlNameAttribute)))
-                {
-                    string parentElementName = null;
-
-                    var emptyElement = token.GetAncestor<XmlEmptyElementSyntax>();
-                    if (emptyElement != null)
-                    {
-                        parentElementName = emptyElement.Name.LocalName.Text;
-                    }
-
-                    // We're writing the name of a paramref
-                    if (parentElementName == ParamRefTagName)
-                    {
-                        items.AddRange(parameters.Select(CreateCompletionItem));
-                    }
-
-                    return items;
-                }
-
                 RemoveExistingTags(trivia, parameters, x => AttributeSelector(x, ParamTagName));
                 items.AddRange(parameters.Select(p => CreateCompletionItem(FormatParameter(ParamTagName, p))));
             }
@@ -239,38 +233,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return items;
         }
 
-        private IEnumerable<CompletionItem> GetTagsForMethod(
-            IMethodSymbol symbol, DocumentationCommentTriviaSyntax trivia, SyntaxToken token)
+        private IEnumerable<CompletionItem> GetTagsForMethod(IMethodSymbol symbol, DocumentationCommentTriviaSyntax trivia)
         {
             var items = new List<CompletionItem>();
 
             var parameters = symbol.GetParameters().Select(p => p.Name).ToSet();
             var typeParameters = symbol.TypeParameters.Select(t => t.Name).ToSet();
-
-            // User is trying to write a name, try to suggest only names.
-            if (token.Parent.IsKind(SyntaxKind.XmlNameAttribute) ||
-                (token.Parent.IsKind(SyntaxKind.IdentifierName) && token.Parent.IsParentKind(SyntaxKind.XmlNameAttribute)))
-            {
-                string parentElementName = null;
-
-                var emptyElement = token.GetAncestor<XmlEmptyElementSyntax>();
-                if (emptyElement != null)
-                {
-                    parentElementName = emptyElement.Name.LocalName.Text;
-                }
-
-                // We're writing the name of a paramref or typeparamref
-                if (parentElementName == ParamRefTagName)
-                {
-                    items.AddRange(parameters.Select(CreateCompletionItem));
-                }
-                else if (parentElementName == TypeParamRefTagName)
-                {
-                    items.AddRange(typeParameters.Select(CreateCompletionItem));
-                }
-
-                return items;
-            }
 
             RemoveExistingTags(trivia, parameters, x => AttributeSelector(x, ParamTagName));
             RemoveExistingTags(trivia, typeParameters, x => AttributeSelector(x, TypeParamTagName));
@@ -302,6 +270,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             }
 
             return items;
+        }
+
+        protected IEnumerable<CompletionItem> GetParamNameItems(ISymbol declaredSymbol)
+        {
+            var items = declaredSymbol?.GetParameters()
+                                       .Select(parameter => CreateCompletionItem(parameter.Name));
+
+            return items ?? SpecializedCollections.EmptyEnumerable<CompletionItem>();
+        }
+
+        protected IEnumerable<CompletionItem> GetTypeParamNameItems(ISymbol declaredSymbol)
+        {
+            var items = declaredSymbol?.GetTypeParameters()
+                                       .Select(typeParameter => CreateCompletionItem(typeParameter.Name));
+
+            return items ?? SpecializedCollections.EmptyEnumerable<CompletionItem>();
         }
 
         private static CompletionItemRules s_defaultRules = 

--- a/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractDocCommentCompletionProvider.cs
@@ -84,7 +84,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
 
             var items = await GetItemsWorkerAsync(
-                context.Document, context.Position, context.CompletionListSpan, context.Trigger, context.CancellationToken).ConfigureAwait(false);
+                context.Document, context.Position, context.Trigger, context.CancellationToken).ConfigureAwait(false);
 
             if (items != null)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             }
         }
 
-        protected abstract Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(Document document, int position, TextSpan span, CompletionTrigger trigger, CancellationToken cancellationToken);
+        protected abstract Task<IEnumerable<CompletionItem>> GetItemsWorkerAsync(Document document, int position, CompletionTrigger trigger, CancellationToken cancellationToken);
 
         protected CompletionItem GetItem(string n)
         {
@@ -164,7 +164,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return new[] { ExceptionTagName, IncludeTagName, PermissionTagName }.Select(GetItem);
         }
 
-        protected IEnumerable<CompletionItem> GetListItems(TextSpan span)
+        protected IEnumerable<CompletionItem> GetListItems()
         {
             return new[] { ListHeaderTagName, TermTagName, ItemTagName, DescriptionTagName }.Select(GetItem);
         }


### PR DESCRIPTION
Fixes #11487.

This separates out the top-level `param`/`typeparam`-element suggestions from `name`-attribute suggestions, and calls each in the correct context. It also removes a couple of redundant symbol lookups in the VB implementation.