### PR TITLE
Unload with open documents

### DIFF
--- a/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Workspaces/WorkspaceTests.cs
@@ -365,10 +365,9 @@ class D { }
                 workspace.AddTestProject(project1);
                 workspace.OnDocumentOpened(document.Id, document.GetOpenTextContainer());
 
-                Assert.Throws<ArgumentException>(() => workspace.OnProjectRemoved(project1.Id));
-
-                workspace.OnDocumentClosed(document.Id);
                 workspace.OnProjectRemoved(project1.Id);
+                Assert.False(workspace.IsDocumentOpen(document.Id));
+                Assert.Empty(workspace.CurrentSolution.Projects);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -350,6 +350,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 _hostProjects.Remove(hostProject.Id);
                 _docCookiesToHostProject.Remove(docCookie);
 
+                document.Dispose();
+
                 return;
             }
         }

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioWorkspaceImpl.cs
@@ -877,10 +877,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             // find that one, we can map back to the open buffer and set its active context to
             // the appropriate project.
 
+            // Note that if there is a single head project and it's in the process of being unloaded
+            // there might not be a host project.
             var hostProject = LinkedFileUtilities.GetContextHostProject(sharedHierarchy, ProjectTracker);
-            if (hostProject.Hierarchy == sharedHierarchy)
+            if (hostProject?.Hierarchy == sharedHierarchy)
             {
-                // How?
                 return;
             }
 

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -424,7 +424,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        [Obsolete("Projects can always be removed.  This method will be removed in a future release.")]
         protected virtual void CheckProjectCanBeRemoved(ProjectId projectId)
         {
         }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -414,6 +414,7 @@ namespace Microsoft.CodeAnalysis
             using (_serializationLock.DisposableWait())
             {
                 CheckProjectIsInCurrentSolution(projectId);
+                this.CheckProjectCanBeRemoved(projectId);
 
                 var oldSolution = this.CurrentSolution;
 
@@ -424,6 +425,10 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        /// <summary>
+        /// Currently projects can always be removed, but this method still exists because it's protected and we don't
+        /// want to break people who may have derived from <see cref="Workspace"/> and either called it, or overridden it.
+        /// </summary>
         protected virtual void CheckProjectCanBeRemoved(ProjectId projectId)
         {
         }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace.cs
@@ -414,7 +414,6 @@ namespace Microsoft.CodeAnalysis
             using (_serializationLock.DisposableWait())
             {
                 CheckProjectIsInCurrentSolution(projectId);
-                this.CheckProjectCanBeRemoved(projectId);
 
                 var oldSolution = this.CurrentSolution;
 
@@ -425,9 +424,9 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        [Obsolete("Projects can always be removed.  This method will be removed in a future release.")]
         protected virtual void CheckProjectCanBeRemoved(ProjectId projectId)
         {
-            CheckProjectDoesNotContainOpenDocuments(projectId);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -177,7 +177,6 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
-        [Obsolete("This method will be removed in a future release.")]
         protected void CheckProjectDoesNotContainOpenDocuments(ProjectId projectId)
         {
             if (ProjectHasOpenDocuments(projectId))

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -75,7 +75,9 @@ namespace Microsoft.CodeAnalysis
 
             if (openDocs != null)
             {
-                foreach (var docId in openDocs)
+                // ClearOpenDocument will remove the document from the original set.
+                var copyOfOpenDocs = openDocs.ToList();
+                foreach (var docId in copyOfOpenDocs)
                 {
                     this.ClearOpenDocument(docId);
                 }
@@ -175,6 +177,7 @@ namespace Microsoft.CodeAnalysis
             }
         }
 
+        [Obsolete("This method will be removed in a future release.")]
         protected void CheckProjectDoesNotContainOpenDocuments(ProjectId projectId)
         {
             if (ProjectHasOpenDocuments(projectId))


### PR DESCRIPTION
Support "OnProjectRemoved" calls when the project has open documents

We already had code to deal with this case, we just hit checks before
it which threw. The existing code needed to be modified to not modify
the collection it was enumerating though.

Fixes internal issue 233612. Unloading a project with an open file that is
in a shared project or is linked would hit hit the exception in
CheckProjectCanBeRemoved because it still had Open documents. Normal
projects didn't hit this because the documents were already closed by
RunningDocumentTableEvents.

Also fix a couple of other things I found while debugging