### PR TITLE
Updating 'GenerateCompilerExecutableBindingRedirects' to produce version numbers with 4 parts.

### DIFF
--- a/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
+++ b/build/Targets/GenerateCompilerExecutableBindingRedirects.targets
@@ -17,11 +17,16 @@
     <SuggestedBindingRedirects Include="Microsoft.CodeAnalysis.VisualBasic, Version=0.0.0.0, Culture=neutral, PublicKeyToken=$(PublicKeyToken)">
       <MaxVersion>$(AssemblyVersion)</MaxVersion>
     </SuggestedBindingRedirects>
+    <!-- System.Collections.Immutable and System.Reflection.Metadata have a package version that is only three parts instead
+         of the normal four (such as 1.2.0 instead of 1.2.0.0). Binding redirects that do not have exactly four version parts
+         are ignored and as such, we need the special handling below to ensure we end up with four parts to the build version. -->
+    <!-- Please note that this will break if the package version is ever changed from 3 parts. A better, but much more complicated
+         fix would be to check the number of version parts detected and adjust appropriately. -->
     <SuggestedBindingRedirects Include="System.Collections.Immutable, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <MaxVersion>$(SystemCollectionsImmutableVersion.Split('-')[0])</MaxVersion>
+      <MaxVersion>$(SystemCollectionsImmutableVersion.Split('-')[0]).0</MaxVersion>
     </SuggestedBindingRedirects>
     <SuggestedBindingRedirects Include="System.Reflection.Metadata, Version=0.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <MaxVersion>$(SystemReflectionMetadataVersion.Split('-')[0])</MaxVersion>
+      <MaxVersion>$(SystemReflectionMetadataVersion.Split('-')[0]).0</MaxVersion>
     </SuggestedBindingRedirects>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
FYI. @jasonmalinowski, @jaredpar, @agocke, @dotnet/roslyn-infrastructure 

Basically, binding redirects are completely ignored unless the version number has four parts.

System.Collections.Immutable and System.Reflection.Metadata currently have three parts, so the generated binding redirects do not work.

This is the simplest fix possible and just updates it to have the fourth part.

As indicated in the comment, a smarter fix would be to detect the number of version parts and update the number appropriately. However, doing such is significantly more complicated.