### PR TITLE
Move NuGet.exe restore location back to the root

### DIFF
--- a/build/scripts/LoadNuGetInfo.cmd
+++ b/build/scripts/LoadNuGetInfo.cmd
@@ -3,7 +3,7 @@
 REM This is a script that will set environment information about where to find
 REM NuGet.exe, it's version and ensure that it's present on the enlistment.
 set NuGetExeVersion=3.5.0-beta2
-set NuGetExeFolder=%~dp0..\..\Binaries\Download\%NuGetExeVersion%
+set NuGetExeFolder=%~dp0..\..
 set NuGetExe=%NuGetExeFolder%\NuGet.exe
 
 REM Download NuGet.exe if we haven't already


### PR DESCRIPTION
After extensive testing it appears the number of places that assume NuGet.exe is in the root is "at least one more."  Need to unblock the signed build so putting it back in the root temporarily.