### PR TITLE
Cut short recursion that can occur (by spec!) in the better betterness code.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -2015,11 +2015,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        private const int BetterConversionTargetRecursionLimit = 100;
+
         private BetterResult BetterConversionTarget(
             TypeSymbol type1,
             TypeSymbol type2,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            bool okToDowngradeToNeither;
+            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out okToDowngradeToNeither, BetterConversionTargetRecursionLimit);
+        }
+
+        private BetterResult BetterConversionTargetCore(
+            TypeSymbol type1,
+            TypeSymbol type2,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
-            int betterConversionTargetRecursionLimit = 100)
+            int betterConversionTargetRecursionLimit)
         {
             if (betterConversionTargetRecursionLimit < 0)
             {
@@ -2027,7 +2038,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             bool okToDowngradeToNeither;
-            return BetterConversionTarget(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out okToDowngradeToNeither, betterConversionTargetRecursionLimit - 1);
+            return BetterConversionTargetCore(null, type1, default(Conversion), type2, default(Conversion), ref useSiteDiagnostics, out okToDowngradeToNeither, betterConversionTargetRecursionLimit - 1);
         }
 
         private BetterResult BetterConversionTarget(
@@ -2037,8 +2048,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol type2,
             Conversion conv2,
             ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+            out bool okToDowngradeToNeither)
+        {
+            return BetterConversionTargetCore(node, type1, conv1, type2, conv2, ref useSiteDiagnostics, out okToDowngradeToNeither, BetterConversionTargetRecursionLimit);
+        }
+
+        private BetterResult BetterConversionTargetCore(
+            BoundExpression node,
+            TypeSymbol type1,
+            Conversion conv1,
+            TypeSymbol type2,
+            Conversion conv2,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
             out bool okToDowngradeToNeither,
-            int betterConversionTargetRecursionLimit = 100)
+            int betterConversionTargetRecursionLimit)
         {
             okToDowngradeToNeither = false;
 
@@ -2082,9 +2105,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (type2.OriginalDefinition == task_T)
                     {
                         // - T1 is Task<S1>, T2 is Task<S2>, and S1 is a better conversion target than S2
-                        return BetterConversionTarget(((NamedTypeSymbol)type1).TypeArgumentsNoUseSiteDiagnostics[0],
-                                                      ((NamedTypeSymbol)type2).TypeArgumentsNoUseSiteDiagnostics[0],
-                                                      ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
+                        return BetterConversionTargetCore(((NamedTypeSymbol)type1).TypeArgumentsNoUseSiteDiagnostics[0],
+                                                          ((NamedTypeSymbol)type2).TypeArgumentsNoUseSiteDiagnostics[0],
+                                                          ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
                     }
 
                     // A shortcut, Task<T> type cannot satisfy other rules.
@@ -2134,7 +2157,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (delegateResult == BetterResult.Neither)
                         {
                             //  - D2 has a return type S2, and S1 is a better conversion target than S2
-                            delegateResult = BetterConversionTarget(r1, r2, ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
+                            delegateResult = BetterConversionTargetCore(r1, r2, ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
                         }
 
                         // Downgrade result to Neither if conversion used by the winner isn't actually valid method group conversion.

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -8401,5 +8401,102 @@ class D
             Assert.Equal("void D.M(System.Int32 i)", candidates[0].ToTestDisplayString());
             Assert.Equal("void D.M(System.Double d)", candidates[1].ToTestDisplayString());
         }
+
+        [Fact, WorkItem(12061, "https://github.com/dotnet/roslyn/issues/12061")]
+        public void RecursiveBetterBetterness01()
+        {
+            string source = @"
+delegate Del1 Del1();
+delegate Del2 Del2();
+
+class Program
+{
+    static void Method(Del1 del1) { }
+    static void Method(Del2 del2) { }
+    static void Main()
+    {
+        Method(() => null);
+    }
+}
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (11,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(Del1)' and 'Program.Method(Del2)'
+                //         Method(() => null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(Del1)", "Program.Method(Del2)").WithLocation(11, 9)
+                );
+        }
+
+        [Fact, WorkItem(12061, "https://github.com/dotnet/roslyn/issues/12061")]
+        public void RecursiveBetterBetterness02()
+        {
+            string source = @"
+delegate Del2 Del1();
+delegate Del1 Del2();
+
+class Program
+{
+    static void Method(Del1 del1) { }
+    static void Method(Del2 del2) { }
+    static void Main()
+    {
+        Method(() => null);
+    }
+}
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (11,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(Del1)' and 'Program.Method(Del2)'
+                //         Method(() => null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(Del1)", "Program.Method(Del2)").WithLocation(11, 9)
+                );
+        }
+
+        [Fact, WorkItem(12061, "https://github.com/dotnet/roslyn/issues/12061")]
+        public void RecursiveBetterBetterness03()
+        {
+            string source = @"
+delegate Del2<Del1<T>> Del1<T>();
+delegate Del1<Del2<T>> Del2<T>();
+
+class Program
+{
+    static void Method(Del1<string> del1) { }
+    static void Method(Del2<string> del2) { }
+    static void Main()
+    {
+        Method(() => null);
+    }
+}
+";
+            CreateCompilationWithMscorlib(source).VerifyDiagnostics(
+                // (11,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(Del1<string>)' and 'Program.Method(Del2<string>)'
+                //         Method(() => null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(Del1<string>)", "Program.Method(Del2<string>)").WithLocation(11, 9)
+                );
+        }
+
+        [Fact, WorkItem(12061, "https://github.com/dotnet/roslyn/issues/12061")]
+        public void RecursiveBetterBetterness04()
+        {
+            string source = @"
+using System.Threading.Tasks;
+delegate Task<Del2> Del1();
+delegate Task<Del1> Del2();
+
+class Program
+{
+    static void Method(Del1 del1) { }
+    static void Method(Del2 del2) { }
+    static void Main()
+    {
+        Method(() => null);
+    }
+}
+";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyDiagnostics(
+                // (12,9): error CS0121: The call is ambiguous between the following methods or properties: 'Program.Method(Del1)' and 'Program.Method(Del2)'
+                //         Method(() => null);
+                Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(Del1)", "Program.Method(Del2)").WithLocation(12, 9)
+                );
+        }
     }
 }


### PR DESCRIPTION
This handles the simplest cases that are likely to arise in practice. We simply limit
direct recursion in "better conversion target" to a depth of 100.
See #12061 for the related spec bug. The spec still must be adjusted to say what should happen here,
and the implementation will need to be changed to follow that new specification.

@khyperia @dotnet/roslyn-compiler Please review.