### PR TITLE
IsEnglishLocal checks CurrentCulture and CurrentUICulture

### DIFF
--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Globalization;
 using System.Text;
 using Xunit;
 
@@ -45,9 +46,10 @@ namespace Roslyn.Test.Utilities
     public class IsEnglishLocal : ExecutionCondition
     {
         public override bool ShouldSkip =>
-            !System.Globalization.CultureInfo.CurrentUICulture.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase);
+            !CultureInfo.CurrentUICulture.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase) ||
+            !CultureInfo.CurrentCulture.Name.StartsWith("en", StringComparison.OrdinalIgnoreCase);
 
-        public override string SkipReason => "Current culture is not en-US";
+        public override string SkipReason => "Current culture is not en";
     }
 
     public class IsRelease : ExecutionCondition


### PR DESCRIPTION
Since some skipped tests require en culture and others require en UI culture, this ensures both groups are skipped when at least one of them is not en.

Fixes #12333