### PR TITLE
throw is not a possible expression

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8645,7 +8645,6 @@ tryAgain:
                 case SyntaxKind.NewKeyword:
                 case SyntaxKind.DelegateKeyword:
                 case SyntaxKind.ColonColonToken: // bad aliased name
-                case SyntaxKind.ThrowKeyword:
                     return true;
                 case SyntaxKind.IdentifierToken:
                     // Specifically allow the from contextual keyword, because it can always be the start of an

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserRegressionTests.cs
@@ -98,5 +98,14 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
             var line = endLinePosition.Line;
             var lines2 = line + 1;
         }
+
+        [WorkItem(12197, "https://github.com/dotnet/roslyn/issues/12197")]
+        [Fact]
+        public void ThrowInInvocationCompletes()
+        {
+            var code = "SomeMethod(throw new Exception())";
+
+            SyntaxFactory.ParseExpression(code);
+        }
     }
 }


### PR DESCRIPTION
This was causing infinite loop for code like `F(throw`.

Fixes #12197