### PR TITLE
Manually updating the build version to `1.3.3.0`.

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -32,7 +32,7 @@
       <!-- The user specified a build number, so we should use that. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>$(RoslynSemanticVersion).$(BuildNumber.Split('.')[0])</BuildVersion>
+        <BuildVersion>1.3.3.$(BuildNumber.Split('.')[0])</BuildVersion>
       </PropertyGroup>
     </When>
 
@@ -41,7 +41,7 @@
           This happens if the build template does not pass BuildNumber down to MSBuild. -->
       <PropertyGroup>
         <AssemblyVersion>$(RoslynSemanticVersion).0</AssemblyVersion>
-        <BuildVersion>$(RoslynSemanticVersion).0</BuildVersion>
+        <BuildVersion>1.3.3.0</BuildVersion>
       </PropertyGroup>
     </When>
 


### PR DESCRIPTION
FYI. @Pilchie, @jasonmalinowski, @MattGertz 

@jasonmalinowski has a proper fix against master here: https://github.com/dotnet/roslyn/pull/12151

This is required to unblock internal PR 1134