### PR TITLE
Allow PerfTests to control what ITraceManager is used

### DIFF
--- a/src/Test/Perf/Runner/Perf.Runner.csproj
+++ b/src/Test/Perf/Runner/Perf.Runner.csproj
@@ -79,9 +79,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <WCFMetadata Include="Service References\" />
-  </ItemGroup>
-  <ItemGroup>
     <Folder Include="CPC-Consumption\" />
   </ItemGroup>
   <ImportGroup Label="Targets">

--- a/src/Test/Perf/Runner/Perf.Runner.csproj
+++ b/src/Test/Perf/Runner/Perf.Runner.csproj
@@ -54,9 +54,7 @@
   <ItemGroup>
     <Compile Include="Benchview.cs" />
     <Compile Include="Program.cs" />
-    <Compile Include="CPC-Consumption\ScenarioGenerator.cs" />
     <Compile Include="Tools.cs" />
-    <Compile Include="CPC-Consumption\TraceManager.cs" />
     <Compile Include="TraceBackup.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -82,6 +80,9 @@
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="CPC-Consumption\" />
   </ItemGroup>
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\build\Targets\VSL.Imports.targets" />

--- a/src/Test/Perf/Runner/Program.cs
+++ b/src/Test/Perf/Runner/Program.cs
@@ -81,11 +81,11 @@ namespace Runner
                 testInstances.AddRange(tests);
             }
 
-            var traceManager = TraceManagerFactory.GetTraceManager();
 
-            traceManager.Initialize();
             foreach (var test in testInstances)
             {
+                var traceManager = test.GetTraceManager();
+                traceManager.Initialize();
                 test.Setup();
                 traceManager.Setup();
 

--- a/src/Test/Perf/Utilities/ITraceManager.cs
+++ b/src/Test/Perf/Utilities/ITraceManager.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Roslyn.Test.Performance.Utilities
+{
+    public interface ITraceManager
+    {
+        bool HasWarmUpIteration { get; }
+
+        void Initialize();
+        void Cleanup();
+        void EndEvent();
+        void EndScenario();
+        void EndScenarios();
+        void ResetScenarioGenerator();
+        void Setup();
+        void Start();
+        void StartEvent();
+        void StartScenario(string scenarioName, string processName);
+        void StartScenarios();
+        void Stop();
+        void WriteScenarios(string[] scenarios);
+        void WriteScenariosFileToDisk();
+    }
+}

--- a/src/Test/Perf/Utilities/Perf.Utilities.csproj
+++ b/src/Test/Perf/Utilities/Perf.Utilities.csproj
@@ -45,10 +45,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ITraceManager.cs" />
     <Compile Include="Logger.cs" />
     <Compile Include="PerfTestBase.cs" />
     <Compile Include="RelativeDirectory.cs" />
+    <Compile Include="ScenarioGenerator.cs" />
     <Compile Include="TestUtilities.cs" />
+    <Compile Include="TraceManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Test/Perf/Utilities/PerfTestBase.cs
+++ b/src/Test/Perf/Utilities/PerfTestBase.cs
@@ -53,5 +53,10 @@ namespace Roslyn.Test.Performance.Utilities
         /// </summary>
         /// <returns></returns>
         public abstract string[] GetScenarios();
+
+        public virtual ITraceManager GetTraceManager()
+        {
+            return TraceManagerFactory.GetBestTraceManager();
+        }
     }
 }

--- a/src/Test/Perf/Utilities/ScenarioGenerator.cs
+++ b/src/Test/Perf/Utilities/ScenarioGenerator.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace Roslyn.Test.Performance.Runner
+namespace Roslyn.Test.Performance.Utilities
 {
     public class ScenarioGenerator
     {

--- a/src/Test/Perf/Utilities/TraceManager.cs
+++ b/src/Test/Perf/Utilities/TraceManager.cs
@@ -3,11 +3,11 @@ using Roslyn.Test.Performance.Utilities;
 using System.IO;
 using static Roslyn.Test.Performance.Utilities.TestUtilities;
 
-namespace Roslyn.Test.Performance.Runner
+namespace Roslyn.Test.Performance.Utilities
 {
     public class TraceManagerFactory
     {
-        public static ITraceManager GetTraceManager()
+        public static ITraceManager GetBestTraceManager()
         {
             var cpcFullPath = Path.Combine(TestUtilities.GetCPCDirectoryPath(), "CPC.exe");
             var scenarioPath = TestUtilities.GetCPCDirectoryPath();
@@ -22,26 +22,11 @@ namespace Roslyn.Test.Performance.Runner
                 return new NoOpTraceManager();
             }
         }
-    }
 
-    public interface ITraceManager
-    {
-        bool HasWarmUpIteration { get; }
-
-        void Initialize();
-        void Cleanup();
-        void EndEvent();
-        void EndScenario();
-        void EndScenarios();
-        void ResetScenarioGenerator();
-        void Setup();
-        void Start();
-        void StartEvent();
-        void StartScenario(string scenarioName, string processName);
-        void StartScenarios();
-        void Stop();
-        void WriteScenarios(string[] scenarios);
-        void WriteScenariosFileToDisk();
+        public static ITraceManager NoOpTraceManager()
+        {
+            return new NoOpTraceManager();
+        }
     }
 
     public class TraceManager : ITraceManager


### PR DESCRIPTION
The C# typing test (closed) doesn't use CPC, so it needs to be able to provide a NoOpTraceManager.