### PR TITLE
Fix stack overflow in VB F1 Help visitor.

### DIFF
--- a/src/VisualStudio/Core/Test/Help/HelpTests.vb
+++ b/src/VisualStudio/Core/Test/Help/HelpTests.vb
@@ -2146,6 +2146,32 @@ End Module]]></a>.Value, "System.Linq.Enumerable")
     End Sub
 End Module]]></a>.Value, "vb.String")
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function CaretAfterMemberAccessDot() As Task
+            Await TestAsync(<a><![CDATA[Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim x = (2).[||]ToString()
+    End Sub
+End Module]]></a>.Value, "System.Int32.ToString")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.F1Help)>
+        Public Async Function CaretBeforeMemberAccessDot() As Task
+            Await TestAsync(<a><![CDATA[Imports System
+Imports System.Collections.Generic
+Imports System.Linq
+
+Module Program
+    Sub Main(args As String())
+        Dim x = (2)[||].ToString()
+    End Sub
+End Module]]></a>.Value, "System.Int32.ToString")
+        End Function
     End Class
 End Namespace
 

--- a/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Help/VisualBasicHelpContextService.Visitor.vb
@@ -853,11 +853,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Help
             End Sub
 
             Public Overrides Sub VisitMemberAccessExpression(node As MemberAccessExpressionSyntax)
-                If _span.Start <= node.OperatorToken.Span.Start Then
-                    Visit(node.Expression)
-                Else
-                    Visit(node.Name)
-                End If
+                node.Name.Accept(Me)
             End Sub
 
             Public Overrides Sub VisitCTypeExpression(node As CTypeExpressionSyntax)


### PR DESCRIPTION
The visitor automatically visits a node's parent if the node doesn't produce a string.
Visit the Name of a MemberAccessExpression in a way that won't visit the parent.