### PR TITLE
Adding shortcut paths and ngen tags to setup vsixes

### DIFF
--- a/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="58293943-56F1-4734-82FC-0411DCF49DE1" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Language Services for Visual Studio 15</DisplayName>
     <Description>C# and VB.NET language services for Visual Studio 15.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\VBCSharp\LanguageServices</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />
@@ -11,6 +12,11 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Installer>
+    <Actions>
+      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.EditorFeatures.Next.dll" />
+    </Actions>
+  </Installer>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
     <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />

--- a/src/VisualStudio/Telemetry/source.extension.vsixmanifest
+++ b/src/VisualStudio/Telemetry/source.extension.vsixmanifest
@@ -4,6 +4,7 @@
     <Identity Id="28354cb8-c808-4138-bfce-33aa846bbd51" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Telemetry</DisplayName>
     <Description>Telemetry implementation for Roslyn atop Visual Studio.</Description>
+    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\VBCSharp\Telemetry</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,]" />
@@ -11,6 +12,11 @@
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[14.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
+  <Installer> 
+    <Actions> 
+      <Action Type="Ngen" Path="Microsoft.VisualStudio.LanguageServices.Telemetry.dll" /> 
+    </Actions> 
+  </Installer>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />


### PR DESCRIPTION
These tags were missing from the telemetry vsix and the setup.next vsix.

@brettfo @jasonmalinowski 
@dotnet/roslyn-infrastructure 