### PR TITLE
Fixing some semantic model and refactoring issues with deconstruction

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     FailRemainingInferences(checkedVariables, diagnostics);
 
                     return new BoundDeconstructionAssignmentOperator(
-                                node, FlattenDeconstructVariables(checkedVariables), boundRHS,
+                                node, isDeclaration, FlattenDeconstructVariables(checkedVariables), boundRHS,
                                 ImmutableArray<BoundDeconstructionDeconstructStep>.Empty, ImmutableArray<BoundDeconstructionAssignmentStep>.Empty,
                                 voidType, hasErrors: true);
                 }
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var assignments = assignmentSteps.ToImmutableAndFree();
 
             FailRemainingInferences(checkedVariables, diagnostics);
-            return new BoundDeconstructionAssignmentOperator(node, FlattenDeconstructVariables(checkedVariables), boundRHS, deconstructions, assignments, voidType, hasErrors: hasErrors);
+            return new BoundDeconstructionAssignmentOperator(node, isDeclaration, FlattenDeconstructVariables(checkedVariables), boundRHS, deconstructions, assignments, voidType, hasErrors: hasErrors);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -396,6 +396,8 @@
     <!-- Non-null type is required for this node kind -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="disallow"/>
 
+    <Field Name="IsDeclaration" Type="bool"/>
+
     <!-- Various assignable expressions, in a flat structure (no nesting) -->
     <Field Name="LeftVariables" Type="ImmutableArray&lt;BoundExpression&gt;"/>
 

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -255,6 +255,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw ExceptionUtilities.Unreachable;
             }
 
+            public override BoundNode VisitDeconstructionAssignmentOperator(BoundDeconstructionAssignmentOperator node)
+            {
+                // For deconstruction declarations, the BoundLocals in the LeftVariables should not be added to the map
+                if (!node.IsDeclaration)
+                {
+                    VisitList(node.LeftVariables);
+                }
+
+                Visit(node.Right);
+                // don't map the deconstruction, conversion or assignment steps
+                return null;
+            }
+
+            public override BoundNode VisitForEachStatement(BoundForEachStatement node)
+            {
+                Visit(node.IterationVariableType);
+                Visit(node.Expression);
+                Visit(node.Body);
+                // don't map the deconstruction steps
+                return null;
+            }
+
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
             {
                 return false;

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.NodeMapBuilder.cs
@@ -268,15 +268,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            public override BoundNode VisitForEachStatement(BoundForEachStatement node)
-            {
-                Visit(node.IterationVariableType);
-                Visit(node.Expression);
-                Visit(node.Body);
-                // don't map the deconstruction steps
-                return null;
-            }
-
             protected override bool ConvertInsufficientExecutionStackExceptionToCancelledByStackGuardException()
             {
                 return false;

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -520,5 +520,28 @@ index: 0,
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
+        public async Task TestDeconstruction()
+        {
+            // PROTOTYPE(tuples) This test fails
+            await TestAsync(
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = [| (1, 2); |]  System . Console . WriteLine ( x ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = {|Rename:NewMethod|}(); System . Console . WriteLine ( x ); } private static (int, int) NewMethod() { return (1, 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
+index: 0,
+parseOptions: TestOptions.Regular,
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
+        public async Task TestDeconstruction2()
+        {
+            await TestAsync(
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = (1, 2); int z = [| 3; |]  System . Console . WriteLine ( z ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = (1, 2); int z = {|Rename:NewMethod|}(); System . Console . WriteLine ( z ); } private static int NewMethod() { return 3; } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
+index: 0,
+parseOptions: TestOptions.Regular,
+withScriptOption: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -524,9 +524,8 @@ withScriptOption: true);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         public async Task TestDeconstruction()
         {
-            // PROTOTYPE(tuples) This test fails
             await TestAsync(
-@"class Program { static void Main ( string [ ] args ) { var (x, y) = [| (1, 2); |]  System . Console . WriteLine ( x ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = [| (1, 2) |];  System . Console . WriteLine ( x ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { var (x, y) = {|Rename:NewMethod|}(); System . Console . WriteLine ( x ); } private static (int, int) NewMethod() { return (1, 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
 parseOptions: TestOptions.Regular,
@@ -537,7 +536,7 @@ withScriptOption: true);
         public async Task TestDeconstruction2()
         {
             await TestAsync(
-@"class Program { static void Main ( string [ ] args ) { var (x, y) = (1, 2); int z = [| 3; |]  System . Console . WriteLine ( z ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"class Program { static void Main ( string [ ] args ) { var (x, y) = (1, 2); var z = [| 3; |]  System . Console . WriteLine ( z ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
 @"class Program { static void Main ( string [ ] args ) { var (x, y) = (1, 2); int z = {|Rename:NewMethod|}(); System . Console . WriteLine ( z ); } private static int NewMethod() { return 3; } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
 index: 0,
 parseOptions: TestOptions.Regular,

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4059,14 +4059,13 @@ class C
     }
 }";
 
-            // PROTOTYPE(tuples) The extra parens should be removed
             var expected = @"
 using System;
 class C
 {
     public void M()
     {
-        var (x1, x2) = (new C());
+        var (x1, x2) = new C();
         var x3 = new C();
     }
 }";

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -3988,7 +3988,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -4015,7 +4015,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
@@ -4041,7 +4041,37 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false, parseOptions: TestOptions.Regular, withScriptOption: true);
+            await TestAsync(code, expected, index: 0, compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        public async Task Deconstruction()
+        {
+            var code = @"
+using System;
+class C
+{
+    public void M()
+    {
+        var [||]temp = new C();
+        var (x1, x2) = temp;
+        var x3 = temp;
+    }
+}";
+
+            // PROTOTYPE(tuples) The extra parens should be removed
+            var expected = @"
+using System;
+class C
+{
+    public void M()
+    {
+        var (x1, x2) = (new C());
+        var x3 = new C();
+    }
+}";
+
+            await TestAsync(code, expected, index: 0, compareTokens: false);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4070,7 +4070,7 @@ class C
     }
 }";
 
-            await TestAsync(code, expected, index: 0, compareTokens: false);
+            await TestAsync(code, expected, index: 0);
         }
     }
 }

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -61,9 +61,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 {
                     node = (LocalDeclarationStatementSyntax)base.VisitLocalDeclarationStatement(node);
 
+                    if (node.Declaration.IsDeconstructionDeclaration)
+                    {// PROTOTYPE(tuples)
+                        return node;
+                    }
+
                     var list = new List<VariableDeclaratorSyntax>();
                     var triviaList = new List<SyntaxTrivia>();
-
                     // go through each var decls in decl statement
                     foreach (var variable in node.Declaration.Variables)
                     {

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.CallSiteContainerRewriter.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                     node = (LocalDeclarationStatementSyntax)base.VisitLocalDeclarationStatement(node);
 
                     if (node.Declaration.IsDeconstructionDeclaration)
-                    {// PROTOTYPE(tuples)
+                    {
                         return node;
                     }
 

--- a/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
+++ b/src/Features/CSharp/Portable/ExtractMethod/CSharpMethodExtractor.CSharpCodeGenerator.cs
@@ -310,9 +310,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExtractMethod
                 foreach (var statement in statements)
                 {
                     var declarationStatement = statement as LocalDeclarationStatementSyntax;
-                    if (declarationStatement == null)
+                    if (declarationStatement == null || declarationStatement.Declaration.IsDeconstructionDeclaration)
                     {
-                        // if given statement is not decl statement, do nothing.
+                        // if given statement is not decl statement, or if it is a deconstruction-declaration, do nothing.
                         yield return statement;
                         continue;
                     }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/BoundNodeClassWriter.cs
@@ -1165,8 +1165,10 @@ namespace BoundTreeGenerator
                     {
                         WriteLine("public override BoundNode Visit{0}({1} node)", StripBound(node.Name), node.Name);
                         Brace();
-                        foreach (Field field in AllFields(node).Where(f => IsDerivedOrListOfDerived("BoundNode", f.Type)))
+                        foreach (Field field in AllFields(node).Where(f => IsDerivedOrListOfDerived("BoundNode", f.Type) && !SkipInVisitor(f)))
+                        {
                             WriteLine("this.Visit{1}(node.{0});", field.Name, IsNodeList(field.Type) ? "List" : "");
+                        }
                         WriteLine("return null;");
                         Unbrace();
                     }
@@ -1344,7 +1346,14 @@ namespace BoundTreeGenerator
                             foreach (Field field in AllNodeOrNodeListFields(node))
                             {
                                 hadField = true;
-                                WriteLine("{3} {0} = ({3})this.Visit{2}(node.{1});", ToCamelCase(field.Name), field.Name, IsNodeList(field.Type) ? "List" : "", field.Type);
+                                if (SkipInVisitor(field))
+                                {
+                                    WriteLine("{2} {0} = node.{1};", ToCamelCase(field.Name), field.Name, field.Type);
+                                }
+                                else
+                                {
+                                    WriteLine("{3} {0} = ({3})this.Visit{2}(node.{1});", ToCamelCase(field.Name), field.Name, IsNodeList(field.Type) ? "List" : "", field.Type);
+                                }
                             }
                             foreach (Field field in AllTypeFields(node))
                             {

--- a/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ExpressionSyntaxExtensions.cs
@@ -471,6 +471,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
+            if (expression is TupleExpressionSyntax)
+            {
+                return true;
+            }
+
             if (!(expression is ObjectCreationExpressionSyntax) && !(expression is AnonymousObjectCreationExpressionSyntax))
             {
                 var symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             // Easy statement-level cases:
             //   var y = (x);           -> var y = x;
+            //   var (y, z) = (x);      -> var (y, z) = x;
             //   if ((x))               -> if (x)
             //   return (x);            -> return x;
             //   yield return (x);      -> yield return x;
@@ -49,6 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
             //   using ((x))            -> using (x)
             //   catch when ((x))       -> catch when (x)
             if ((node.IsParentKind(SyntaxKind.EqualsValueClause) && ((EqualsValueClauseSyntax)node.Parent).Value == node) ||
+                (node.IsParentKind(SyntaxKind.VariableDeconstructionDeclarator) && ((VariableDeconstructionDeclaratorSyntax)node.Parent).Value == node) ||
                 (node.IsParentKind(SyntaxKind.IfStatement) && ((IfStatementSyntax)node.Parent).Condition == node) ||
                 (node.IsParentKind(SyntaxKind.ReturnStatement) && ((ReturnStatementSyntax)node.Parent).Expression == node) ||
                 (node.IsParentKind(SyntaxKind.YieldReturnStatement) && ((YieldStatementSyntax)node.Parent).Expression == node) ||


### PR DESCRIPTION
There are few issues fixed:

- code getting swallowed while extracting method

```C#
// comment
var (x1, x2) = (1, 2);
var x3 = 3; // extract method on "3" causes the two lines above to disappear
```
- value of d-declaration not picked up for extract method and extract local

```C#
var (x1, x2) = [| (1, 2) |]; // not extract method or extract local refactoring available
```

- when inlining a temporary variable into a deconstruction declaration, superfluous parens were left around:

```C#
// var temp = new C();
var (x1, x2) = (new C()); // after inlining temp, there are extra parens
```

CC @dotnet/roslyn-ide @dotnet/roslyn-compiler for review.
Related to https://github.com/dotnet/roslyn/issues/11299