### PR TITLE
Make simplifier remove unneeded parentheses around `this` in cast

### DIFF
--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -570,42 +570,42 @@ class foo
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
-        <Document>
+        <Document><![CDATA[
 using System;
 
-class C : IEquatable&lt;C&gt;
+class C : IEquatable<C>
 {
-    bool IEquatable&lt;C&gt;.Equals(C other)
+    bool IEquatable<C>.Equals(C other)
     {
         return true;
     }
 
     public override bool Equals(object obj)
     {
-        return ((IEquatable&lt;C&gt;){|Simplify:(this)|}).Equals(obj as C);
+        return ((IEquatable<C>){|Simplify:(this)|}).Equals(obj as C);
     }
 }
-        </Document>
+        ]]></Document>
     </Project>
 </Workspace>
 
             Dim expected =
-<code>
+<code><![CDATA[
 using System;
 
-class C : IEquatable&lt;C&gt;
+class C : IEquatable<C>
 {
-    bool IEquatable&lt;C&gt;.Equals(C other)
+    bool IEquatable<C>.Equals(C other)
     {
         return true;
     }
 
     public override bool Equals(object obj)
     {
-        return ((IEquatable&lt;C&gt;)this).Equals(obj as C);
+        return ((IEquatable<C>)this).Equals(obj as C);
     }
 }
-</code>
+]]></code>
 
             Await TestAsync(input, expected)
 

--- a/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
+++ b/src/EditorFeatures/Test2/Simplification/ParenthesisSimplificationTests.vb
@@ -566,6 +566,52 @@ class foo
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
+        Public Async Function TestCSharp_SimplifyParenthesesAroundThisInCastExpression() As Task
+            Dim input =
+<Workspace>
+    <Project Language="C#" CommonReferences="true">
+        <Document>
+using System;
+
+class C : IEquatable&lt;C&gt;
+{
+    bool IEquatable&lt;C&gt;.Equals(C other)
+    {
+        return true;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ((IEquatable&lt;C&gt;){|Simplify:(this)|}).Equals(obj as C);
+    }
+}
+        </Document>
+    </Project>
+</Workspace>
+
+            Dim expected =
+<code>
+using System;
+
+class C : IEquatable&lt;C&gt;
+{
+    bool IEquatable&lt;C&gt;.Equals(C other)
+    {
+        return true;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return ((IEquatable&lt;C&gt;)this).Equals(obj as C);
+    }
+}
+</code>
+
+            Await TestAsync(input, expected)
+
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.Simplification)>
         Public Async Function TestCSharp_SimplifyParenthesesInsideExceptionFilter() As Task
             Dim input =
 <Workspace>

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -65,18 +65,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
-            // Case: (C)(this) -> (C)this
-            if (node.IsParentKind(SyntaxKind.CastExpression) && expression.IsKind(SyntaxKind.ThisExpression))
-            {
-                return true;
-            }
-
             // Handle expression-level ambiguities
             if (RemovalMayIntroduceCastAmbiguity(node) ||
                 RemovalMayIntroduceCommaListAmbiguity(node) ||
                 RemovalMayIntroduceInterpolationAmbiguity(node))
             {
                 return false;
+            }
+
+            // Cases:
+            //   (C)(this) -> (C)this
+            if (node.IsParentKind(SyntaxKind.CastExpression) && expression.IsKind(SyntaxKind.ThisExpression))
+            {
+                return true;
             }
 
             // Cases:

--- a/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ParenthesizedExpressionSyntaxExtensions.cs
@@ -65,6 +65,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 return true;
             }
 
+            // Case: (C)(this) -> (C)this
+            if (node.IsParentKind(SyntaxKind.CastExpression) && expression.IsKind(SyntaxKind.ThisExpression))
+            {
+                return true;
+            }
+
             // Handle expression-level ambiguities
             if (RemovalMayIntroduceCastAmbiguity(node) ||
                 RemovalMayIntroduceCommaListAmbiguity(node) ||


### PR DESCRIPTION
Fixes #12387