### PR TITLE
Insert DSRN to its own ExternalAPI directory.

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -8,7 +8,7 @@
     
     <!-- symreader -->
     <MicrosoftDiaSymReaderVersion>1.1.0-beta1-60625-03</MicrosoftDiaSymReaderVersion>
-    <MicrosoftDiaSymReaderNativeVersion>1.4.0-rc2</MicrosoftDiaSymReaderNativeVersion>
+    <MicrosoftDiaSymReaderNativeVersion>1.4.0</MicrosoftDiaSymReaderNativeVersion>
     <MicrosoftDiaSymReaderPortablePdbVersion>1.2.0-beta1-60706-02</MicrosoftDiaSymReaderPortablePdbVersion>
 
     <!-- CoreFX -->

--- a/build/ToolsetPackages/project.json
+++ b/build/ToolsetPackages/project.json
@@ -3,7 +3,7 @@
         "MicroBuild.Core": "0.2.0",
         "Microsoft.NETCore.Platforms": "1.0.1",
         "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
-        "Microsoft.DiaSymReader.Native": "1.4.0-rc2",
+        "Microsoft.DiaSymReader.Native": "1.4.0",
         "Microsoft.Net.Compilers": "1.2.1",
         "Microsoft.Net.RoslynDiagnostics": "1.2.0-beta2",
         "FakeSign": "0.9.2",

--- a/src/Compilers/CSharp/csc/project.json
+++ b/src/Compilers/CSharp/csc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
+    "Microsoft.DiaSymReader.Native": "1.4.0"
   },
   "frameworks": {
     "net46": { }

--- a/src/Compilers/VisualBasic/vbc/project.json
+++ b/src/Compilers/VisualBasic/vbc/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
+    "Microsoft.DiaSymReader.Native": "1.4.0"
   },
   "frameworks": {
     "net46": { }

--- a/src/Setup/DevDivPackages/Dependencies.proj
+++ b/src/Setup/DevDivPackages/Dependencies.proj
@@ -9,13 +9,13 @@
   <ItemGroup>
     <!-- 
       We create new CoreXT packages here for two reasons:
-      1) Package exists on NuGet but has a different structure than what DevDiv projects expect (External=true)         
+      1) Package exists on NuGet but has a different structure than what DevDiv projects expect (External=true)
       2) Package doesn't exist on NuGet, the content is built from Roslyn repo (External=false)
       
       TODO: 
       The goal is to remove all these packages. We need to update DevDiv projects that reference the binaries 
       and/or move the source for the packages to separate repos.
-     -->		
+     -->
     <NuSpec Include="Microsoft.VisualStudio.InteractiveWindow">
       <Version>$(MicrosoftVisualStudioInteractiveWindowVersion)-beta-$(BuildNumberPart1.Trim())-$(BuildNumberPart2.Trim())</Version>
       <External>false</External>
@@ -37,13 +37,14 @@
       <External>true</External>
     </NuSpec>
   </ItemGroup>
-  <ItemGroup>		
+  <ItemGroup>
     <!-- 
       Packages that exist on NuGet and already have structure compatible with DevDiv. 
-    -->		
-    <NuPkg Include="$(NuGetPackageRoot)\Microsoft.DiaSymReader\$(MicrosoftDiaSymReaderVersion)\*.nupkg" />		
-    <NuPkg Include="$(NuGetPackageRoot)\Microsoft.CodeAnalysis.Elfie\$(MicrosoftCodeAnalysisElfieVersion)\*.nupkg" />
+    -->
+    <NuPkg Include="$(NuGetPackageRoot)\Microsoft.DiaSymReader\$(MicrosoftDiaSymReaderVersion)\*.nupkg" />
     <NuPkg Include="$(NuGetPackageRoot)\Microsoft.DiaSymReader.PortablePdb\$(MicrosoftDiaSymReaderPortablePdbVersion)\*.nupkg" />
+    <NuPkg Include="$(NuGetPackageRoot)\Microsoft.DiaSymReader.Native\$(MicrosoftDiaSymReaderNativeVersion)\*.nupkg" />
+    <NuPkg Include="$(NuGetPackageRoot)\Microsoft.CodeAnalysis.Elfie\$(MicrosoftCodeAnalysisElfieVersion)\*.nupkg" />
   </ItemGroup>
   <Target Name="Build" Inputs="@(NuSpec)" Outputs="@(NuSpec->$(PackagesOutDir)\VS.ExternalAPIs.%(NuSpec.Identity).%(Version).nupkg">
     <MakeDir Directories="$(PackagesOutDir)" Condition="!Exists('$(PackagesOutDir)')" />
@@ -55,7 +56,7 @@
     <Exec Command='Pack.cmd "VS.ExternalAPIs.%(NuSpec.Identity).nuspec" %(NuSpec.Version) "$(BaseDir)" "$(PackagesOutDir)"'
           CustomErrorRegularExpression="pack: invalid arguments"/>
   </Target>
-  <Target Name="CopyFiles" Inputs="@(NuPkg)" Outputs="@(NuPkg->$(PackagesOutDir)\%(Filename)%(Extension))" AfterTargets="Build">		
+  <Target Name="CopyFiles" Inputs="@(NuPkg)" Outputs="@(NuPkg->$(PackagesOutDir)\%(Filename)%(Extension))" AfterTargets="Build">
     <Copy SourceFiles="%(NuPkg.Fullpath)" DestinationFolder="$(PackagesOutDir)"/>
   </Target>
   <Target Name="Clean">

--- a/src/Test/PdbUtilities/project.json
+++ b/src/Test/PdbUtilities/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "supports": {},
   "dependencies": {
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"
+    "Microsoft.DiaSymReader.Native": "1.4.0"
   },
   "frameworks": {
     ".NETPortable,Version=v4.5,Profile=Profile7": {}

--- a/src/Test/Utilities/Desktop/project.json
+++ b/src/Test/Utilities/Desktop/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "Microsoft.CodeAnalysis.Test.Resources.Proprietary": "1.2.0-beta1-20160105-04",
-    "Microsoft.DiaSymReader.Native": "1.4.0-rc2"   
+    "Microsoft.DiaSymReader.Native": "1.4.0"   
   },
   "frameworks": {
     "net46": { }


### PR DESCRIPTION
Currently Microsoft.DiaSymReader.Native is inserted into Roslyn directory (thru Roslyn CoreXT package). This change moves it to a separate directory.