### PR TITLE
MicroBuild validation

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -180,3 +180,20 @@ commitPullList.each { isPr ->
   Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-update3')
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
+
+// Microbuild
+commitPullList.each { isPr ->
+  def jobName = Utilities.getFullJobName(projectName, "microbuild", isPr)
+  def myJob = job(jobName) {
+    description('MicroBuild test')
+    label('windows-roslyn')
+    steps {
+      batchFile(""".\\src\\Tools\\MicroBuild\\cibuild.cmd""")
+    }
+  }
+
+  def triggerPhraseOnly = false
+  def triggerPhraseExtra = "microbuild"
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-update3')
+  addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
+}

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -31,7 +31,7 @@
     <MSBuild Projects="$(ProjectDir)src\NuGet\NuGet.proj" />
     <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep2.proj" />
 
-    <MSBuild Projects="$(ProjectDir)BuildAndTest.proj" Targets="Test" />
+    <MSBuild Projects="$(ProjectDir)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' == ''" />
 
     <!-- Insertion scripts currently look for a sentinel file on the drop share to determine that the build was green
          and ready to be inserted -->

--- a/src/Tools/MicroBuild/cibuild.cmd
+++ b/src/Tools/MicroBuild/cibuild.cmd
@@ -1,0 +1,12 @@
+@setlocal enabledelayedexpansion
+
+pushd %~dp0
+call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\Tools\VsDevCmd.bat" || goto :BuildFailed
+msbuild /nodereuse:false /p:Configuration=Release /p:SkipTest=true Build.proj || goto :BuildFailed
+popd
+
+exit /b 0
+
+:BuildFailed
+echo Build failed with ERRORLEVEL %ERRORLEVEL%
+exit /b 1


### PR DESCRIPTION
Now that the majority of our MicroBuild steps are in the open we can verify them at commit time.  This will guard us against more late night scrambles to fix the official build.