### PR TITLE
Use MemoryStream.TryGetBuffer in EncodedStringText

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
+++ b/src/Compilers/Core/CodeAnalysisTest/CodeAnalysisTest.csproj
@@ -49,6 +49,7 @@
     <Compile Include="PEWriter\UsedNamespaceOrTypeTests.cs" />
     <Compile Include="RealParserTests.cs" />
     <Compile Include="DesktopAnalyzerAssemblyLoaderTests.cs" />
+    <Compile Include="SourceReferenceResolverTests.cs" />
     <Compile Include="SourceFileResolverTest.cs" />
     <Compile Include="Text\LargeTextTests.cs" />
     <Compile Include="Text\SourceTextStreamTests.cs" />

--- a/src/Compilers/Core/CodeAnalysisTest/SourceReferenceResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceReferenceResolverTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [WorkItem(12348, "https://github.com/dotnet/roslyn/issues/12348")]
-        [Fact]
+        [ConditionalFact(typeof(HasMemoryStreamTryGetBuffer))]
         public void IndexCountMemoryStreamInResolver()
         {
             SourceText text = new Resolver("AB", 1, 1).ReadText("ignored");

--- a/src/Compilers/Core/CodeAnalysisTest/SourceReferenceResolverTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/SourceReferenceResolverTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Test.Utilities;
+using System.IO;
+using System.Text;
+using Microsoft.CodeAnalysis.Text;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests
+{
+    public class SourceReferenceResolverTests
+    {
+        private class Resolver : SourceReferenceResolver
+        {
+            private readonly string _s;
+            private readonly int _index;
+            private readonly int _count;
+
+            public Resolver(string s, int index, int count)
+            {
+                _s = s;
+                _index = index;
+                _count = count;
+            }
+
+            public override bool Equals(object other) => ReferenceEquals(this, other);
+            public override int GetHashCode() => 42;
+            public override string ResolveReference(string path, string baseFilePath) => path;
+            public override string NormalizePath(string path, string baseFilePath) => path;
+
+            public override Stream OpenRead(string resolvedPath) => new MemoryStream(
+                Encoding.ASCII.GetBytes(_s), _index, _count, writable: false, publiclyVisible: true);
+        }
+
+        [Fact]
+        public void MemoryStreamInResolver()
+        {
+            SourceText text = new Resolver("AB", 0, 2).ReadText("ignored");
+
+            Assert.Equal("AB", text.ToString());
+        }
+
+        [Fact]
+        public void CountMemoryStreamInResolver()
+        {
+            SourceText text = new Resolver("AB", 0, 1).ReadText("ignored");
+
+            Assert.Equal("A", text.ToString());
+        }
+
+        [WorkItem(12348, "https://github.com/dotnet/roslyn/issues/12348")]
+        [Fact]
+        public void IndexCountMemoryStreamInResolver()
+        {
+            SourceText text = new Resolver("AB", 1, 1).ReadText("ignored");
+
+            Assert.Equal("B", text.ToString());
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -184,9 +184,8 @@ namespace Microsoft.CodeAnalysis.Text
 
                 if (PortableShim.MemoryStream.TryGetBuffer(data, out bufferArraySegment))
                 {
-                    // since we can only return the whole array, make sure it's all used by the MemoryStream
-                    if (bufferArraySegment.Offset == 0 &&
-                        bufferArraySegment.Count == bufferArraySegment.Array.Length)
+                    // since we can't return offset, make sure MemoryStream uses the array from the start
+                    if (bufferArraySegment.Offset == 0)
                     {
                         buffer = bufferArraySegment.Array;
                         return true;

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -189,6 +189,22 @@ namespace Microsoft.CodeAnalysis.Text
                     buffer = bufferArraySegment.Array;
                     return true;
                 }
+
+                buffer = null;
+                return false;
+            }
+
+            try
+            {
+                // on .Net 4.5, TryGetBuffer is not available
+                if (PortableShim.MemoryStream.GetBuffer != null)
+                {
+                    buffer = PortableShim.MemoryStream.GetBuffer(data);
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
             }
 
             buffer = null;

--- a/src/Compilers/Core/Portable/EncodedStringText.cs
+++ b/src/Compilers/Core/Portable/EncodedStringText.cs
@@ -182,14 +182,12 @@ namespace Microsoft.CodeAnalysis.Text
             {
                 ArraySegment<byte> bufferArraySegment;
 
-                if (PortableShim.MemoryStream.TryGetBuffer(data, out bufferArraySegment))
+                // since we can't return offset, make sure MemoryStream uses the array from the start
+                if (PortableShim.MemoryStream.TryGetBuffer(data, out bufferArraySegment) &&
+                    bufferArraySegment.Offset == 0)
                 {
-                    // since we can't return offset, make sure MemoryStream uses the array from the start
-                    if (bufferArraySegment.Offset == 0)
-                    {
-                        buffer = bufferArraySegment.Array;
-                        return true;
-                    }
+                    buffer = bufferArraySegment.Array;
+                    return true;
                 }
             }
 

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -495,11 +495,14 @@ namespace Roslyn.Utilities
 
         internal static class MemoryStream
         {
+            internal delegate bool TryGetBufferDelegate(System.IO.MemoryStream stream, out ArraySegment<byte> buffer);
+
             internal static readonly Type Type = typeof(System.IO.MemoryStream);
 
-            internal static readonly MethodInfo GetBuffer = Type
+            internal static readonly TryGetBufferDelegate TryGetBuffer = Type
                 .GetTypeInfo()
-                .GetDeclaredMethod(nameof(GetBuffer));
+                .GetDeclaredMethod(nameof(TryGetBuffer))
+                .CreateDelegate<TryGetBufferDelegate>();
         }
 
         internal static class XPath

--- a/src/Compilers/Core/Portable/PortableShim.cs
+++ b/src/Compilers/Core/Portable/PortableShim.cs
@@ -499,6 +499,11 @@ namespace Roslyn.Utilities
 
             internal static readonly Type Type = typeof(System.IO.MemoryStream);
 
+            internal static readonly Func<System.IO.MemoryStream, byte[]> GetBuffer = Type
+                .GetTypeInfo()
+                .GetDeclaredMethod(nameof(GetBuffer))
+                .CreateDelegate<Func<System.IO.MemoryStream, byte[]>>();
+
             internal static readonly TryGetBufferDelegate TryGetBuffer = Type
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(TryGetBuffer))

--- a/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Shared/Assert/ConditionalFactAttribute.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using System.Text;
+using System.Reflection;
 using Xunit;
 
 namespace Roslyn.Test.Utilities
@@ -59,5 +61,12 @@ namespace Roslyn.Test.Utilities
 #endif
 
         public override string SkipReason => "Not in release mode.";
+    }
+
+    public class HasMemoryStreamTryGetBuffer : ExecutionCondition
+    {
+        public override bool ShouldSkip => typeof(MemoryStream).GetTypeInfo().GetDeclaredMethod("TryGetBuffer") == null;
+
+        public override string SkipReason => "MemoryStream.TryGetBuffer does not exist.";
     }
 }


### PR DESCRIPTION
Fixes  #12348.

Using GetBuffer, it's not possible to find out if the MemoryStream uses index and offset.

Also switched from MethodInfo to delegate in the portable shim, which is slightly safer and should be more efficient.

cc: @nguerrera 