### PR TITLE
Handling remaining PROTOTYPE markers in features/tuples branch

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -761,7 +761,10 @@
     <Compile Include="Syntax\DeclarationStatementSyntax.cs" />
     <Compile Include="Syntax\DelegateDeclarationSyntax.cs" />
     <Compile Include="Syntax\DirectiveTriviaSyntax.cs" />
+    <Compile Include="Syntax\EventFieldDeclarationSyntax.cs" />
     <Compile Include="Syntax\ExpressionStatementSyntax.cs" />
+    <Compile Include="Syntax\FieldDeclarationSyntax.cs" />
+    <Compile Include="Syntax\FixedStatementSyntax.cs" />
     <Compile Include="Syntax\ForEachStatementSyntax.cs" />
     <Compile Include="Syntax\GenericNameSyntax.cs" />
     <Compile Include="Syntax\InternalSyntax\BinaryExpressionSyntax.cs" />

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -73,7 +73,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             foreach (var variable in variables)
             {
-                // PROTOTYPE(tuples) should the dynamic flag always be false?
                 lhsReceivers.Add(TransformCompoundAssignmentLHS(variable, stores, temps, isDynamicAssignment: false));
             }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8558,7 +8558,6 @@ tryAgain:
         /// <summary>
         /// Check ahead for a deconstruction declaration. This requires at least one good-looking variable and the presence of an equals sign.
         /// Doesn't move the cursor.
-        /// PROTOTYPE(tuples) Can this be done without allocations?
         /// </summary>
         private bool IsPossibleDeconstructionDeclaration()
         {

--- a/src/Compilers/CSharp/Portable/Syntax/EventFieldDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/EventFieldDeclarationSyntax.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public sealed partial class EventFieldDeclarationSyntax : BaseFieldDeclarationSyntax
+    {
+        public EventFieldDeclarationSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
+        {
+            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/FieldDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/FieldDeclarationSyntax.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public sealed partial class FieldDeclarationSyntax : BaseFieldDeclarationSyntax
+    {
+        public FieldDeclarationSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
+        {
+            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/FixedStatementSyntax.cs
@@ -1,0 +1,11 @@
+﻿
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public sealed partial class FixedStatementSyntax : StatementSyntax
+    {
+        public FixedStatementSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
+        {
+            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalDeclarationStatementSyntax.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
@@ -11,6 +9,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public LocalDeclarationStatementSyntax Update(SyntaxTokenList modifiers, VariableDeclarationSyntax declaration, SyntaxToken semicolonToken)
         {
             return Update(modifiers, this.RefKeyword, declaration, semicolonToken);
+        }
+
+        public LocalDeclarationStatementSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
+        {
+            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2650,39 +2650,3 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 #endif
     }
 }
-
-// PROTOTYPE(tuples) Move this to a better place
-namespace Microsoft.CodeAnalysis.CSharp.Syntax
-{
-    public sealed partial class EventFieldDeclarationSyntax : BaseFieldDeclarationSyntax
-    {
-        public EventFieldDeclarationSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
-        {
-            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
-        }
-    }
-
-    public sealed partial class FieldDeclarationSyntax : BaseFieldDeclarationSyntax
-    {
-        public FieldDeclarationSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
-        {
-            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
-        }
-    }
-
-    public sealed partial class FixedStatementSyntax : StatementSyntax
-    {
-        public FixedStatementSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
-        {
-            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
-        }
-    }
-
-    public sealed partial class LocalDeclarationStatementSyntax : StatementSyntax
-    {
-        public LocalDeclarationStatementSyntax AddDeclarationVariables(params VariableDeclaratorSyntax[] items)
-        {
-            return this.WithDeclaration(this.Declaration.WithVariables(this.Declaration.Variables.AddRange(items)));
-        }
-    }
-}

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -2938,7 +2938,7 @@ class C
                 );
         }
 
-        [Fact(Skip = "PROTOTYPE(tuples)")]
+        [Fact]
         public void TypelessDeclaration()
         {
             string source = @"
@@ -2950,13 +2950,15 @@ class C
     }
 }
 ";
-            // crash
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
+                // (6,24): error CS8210: Deconstruct assignment requires an expression with a type on the right-hand-side.
+                //         var (x1, x2) = (1, null);
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "(1, null)").WithLocation(6, 24)
                 );
         }
 
-        [Fact(Skip = "PROTOTYPE(tuples)")]
+        [Fact]
         public void InferTypeOfTypelessDeclaration()
         {
             string source = @"
@@ -2969,9 +2971,12 @@ class C
     }
 }
 ";
-            // crash
-            var comp = CompileAndVerify(source, expectedOutput: "1 2 ");
-            comp.VerifyDiagnostics();
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,37): error CS8210: Deconstruct assignment requires an expression with a type on the right-hand-side.
+                //         (var (x1, x2), string x3) = ((1, 2), null);
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "((1, 2), null)").WithLocation(6, 37)
+                );
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -2484,7 +2484,8 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        [Fact(Skip = "PROTOTYPE(tuples)")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/12400")]
+        [WorkItem(12400, "https://github.com/dotnet/roslyn/issues/12400")]
         public void AssignWithPostfixOperator()
         {
             string source = @"
@@ -2513,7 +2514,8 @@ class C
     }
 }
 ";
-            // PROTOTYPE(tuples) we expect "2 hello" instead, which means the evaluation order is wrong
+            // https://github.com/dotnet/roslyn/issues/12400
+            // we expect "2 hello" instead, which means the evaluation order is wrong
             var comp = CompileAndVerify(source, expectedOutput: "1 hello");
             comp.VerifyDiagnostics();
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1285,6 +1285,28 @@ class C
         }
 
         [Fact]
+        public void ErrorRight()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        int x;
+        (x, x) = undeclared;
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular.WithRefsFeature());
+            comp.VerifyDiagnostics(
+                // (7,18): error CS0103: The name 'undeclared' does not exist in the current context
+                //         (x, x) = undeclared;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "undeclared").WithArguments("undeclared").WithLocation(7, 18)
+                );
+        }
+
+        [Fact]
         public void VoidRight()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTest.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTest.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Xunit;
+using Roslyn.Test.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Parsing
 {
@@ -1728,7 +1729,8 @@ class C
             Assert.True(statement.HasErrors);
         }
 
-        [Fact(Skip = "PROTOTYPE(tuples)")]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/12402")]
+        [WorkItem(12402, "https://github.com/dotnet/roslyn/issues/12402")]
         public void ConfusedForWithDeconstruction()
         {
             var text = "for ((int x, var (y, z)) in foo) { }";


### PR DESCRIPTION
Filed the following issues:

- Correct the evaluation order of conversions in deconstructions #12400
- Optimize the parsing ahead for deconstruction-declarations to avoid allocations #12399
- Verify the behavior of dynamic in deconstructions #12398
- Parsing ahead for 'for' and 'foreach' ambiguities should recognize deconstructions #12402
- Support typeless tuple literals in deconstruction declarations #12410

I spent some time today trying to come up with a better solution for the last one, but after discussion with Vlad, I prefer to unblock the merge back to master and resolve the difficult language questions later. For now, I report errors if you try to use typeless tuple literals in a d-declaration (which is better than previous crashing behavior).

@dotnet/roslyn-compiler for review.
Related to https://github.com/dotnet/roslyn/issues/11299