### PR TITLE
[Salsa] Fix InvalidOperationException when attempting to validate a breakpoint location in a script block

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.VsLanguageDebugInfo.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractLanguageService`3.VsLanguageDebugInfo.cs
@@ -285,7 +285,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     {
                         var point = snapshot.GetPoint(iLine, iCol);
                         var length = 0;
-                        if (pCodeSpan != null && pCodeSpan.Length > 0)
+                        if (pCodeSpan != null && pCodeSpan.Length > 0 && pCodeSpan[0].iEndLine < snapshot.LineCount)
                         {
                             // If we have a non-empty span then it means that the debugger is asking us to adjust an
                             // existing span.  In Everett we didn't do this so we had some good and some bad


### PR DESCRIPTION
Issue: an InvalidOperationException can occur in Salsa when setting a breakpoint in a script block.  This exception is caught but it means the TSLS never gets the request to resolve the breakpoint and thus the breakpoint cannot be set.

The pCodeSpan that is passed to AbstractLanguageService`3.VsLanguageDebugInfo's ValidateBreakpointLocationWorker contains the iStartLine and iEndline for the full HTML document. The snapshot textbuffer is actually only the contained language document though (JS script block).  This means the attempt to get the span from the snapshot can fail because the span endline can be larger then the snapshot line count.

Fix: add a check to ensure the span endline is less than the snapshot line count before attempting to get the snapshot.
