### PR TITLE
Fix target framework for MS.CA.Workspaces.* 

### DIFF
--- a/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Workspaces.Common.nuspec
@@ -29,10 +29,10 @@ Supported Platforms:
   <files>
     <file src="Microsoft.CodeAnalysis.Workspaces.dll" target="lib\portable-net45+win8" />
     <file src="Microsoft.CodeAnalysis.Workspaces.xml" target="lib\portable-net45+win8" />
-    <file src="Microsoft.CodeAnalysis.Workspaces.dll" target="lib\net45" />
-    <file src="Microsoft.CodeAnalysis.Workspaces.xml" target="lib\net45" />
-    <file src="Microsoft.CodeAnalysis.Workspaces.Desktop.dll" target="lib\net45" />
-    <file src="Microsoft.CodeAnalysis.Workspaces.Desktop.xml" target="lib\net45" />
+    <file src="Microsoft.CodeAnalysis.Workspaces.dll" target="lib\net46" />
+    <file src="Microsoft.CodeAnalysis.Workspaces.xml" target="lib\net46" />
+    <file src="Microsoft.CodeAnalysis.Workspaces.Desktop.dll" target="lib\net46" />
+    <file src="Microsoft.CodeAnalysis.Workspaces.Desktop.xml" target="lib\net46" />
     <file src="Microsoft.CodeAnalysis.Workspaces.dll" target="lib\netstandard1.3" />
     <file src="Microsoft.CodeAnalysis.Workspaces.xml" target="lib\netstandard1.3" />
     <file src="$thirdPartyNoticesPath$" target="" />


### PR DESCRIPTION
Fix target framework for MS.CA.Workspaces.* in nuspec for MS.CA.Workspaces.Common to netfx 4.6 since MS.CA.Workspaces.Desktop.dll now targets netfx 4.6.