### PR TITLE
Allow async methods to return Task-like types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -494,10 +494,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundLocalFunctionStatement(node, localSymbol, block, hasErrors);
         }
 
-        private static bool ImplicitReturnIsOkay(MethodSymbol method)
+        private bool ImplicitReturnIsOkay(MethodSymbol method)
         {
-            return method.ReturnsVoid || method.IsIterator ||
-                (method.IsAsync && method.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) == method.ReturnType);
+            return method.ReturnsVoid || method.IsIterator || method.IsTaskReturningAsync(this.Compilation);
         }
 
         public BoundStatement BindExpressionStatement(ExpressionStatementSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -1209,7 +1209,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // implicit conversion from EX to PX, and for at least one argument, the conversion from
             // EX to PX is better than the conversion from EX to QX.
 
-            bool allSame = true; // Are all parameter types equivalent by identify conversions?
+            bool allSame = true; // Are all parameter types equivalent by identify conversions, ignoring Task-like differences?
             int i;
             for (i = 0; i < arguments.Count; ++i)
             {
@@ -1252,9 +1252,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                        out okToDowngradeToNeither);
                 }
 
+                var type1Normalized = type1.NormalizeTaskTypes(Compilation);
+                var type2Normalized = type2.NormalizeTaskTypes(Compilation);
+
                 if (r == BetterResult.Neither)
                 {
-                    if (allSame && Conversions.ClassifyImplicitConversion(type1, type2, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
+                    if (allSame && Conversions.ClassifyImplicitConversion(type1Normalized, type2Normalized, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
                     {
                         allSame = false;
                     }
@@ -1263,16 +1266,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     continue;
                 }
 
-                if (!considerRefKinds || Conversions.ClassifyImplicitConversion(type1, type2, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
+                if (Conversions.ClassifyImplicitConversion(type1Normalized, type2Normalized, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
                 {
-                    // If considerRefKinds is false, conversion between parameter types isn't classified by the if condition.
-                    // This assert is here to verify the assumption that the conversion is never an identity in that case and
-                    // we can skip classification as an optimization.
-                    Debug.Assert(considerRefKinds || Conversions.ClassifyImplicitConversion(type1, type2, ref useSiteDiagnostics).Kind != ConversionKind.Identity);
                     allSame = false;
                 }
 
-                // One of them was better. Does that contradict a previous result or add a new fact?
+                // One of them was better, even if identical up to Task-likeness. Does that contradict a previous result or add a new fact?
                 if (result == BetterResult.Neither)
                 {
                     if (!(ignoreDowngradableToNeither && okToDowngradeToNeither))
@@ -1336,7 +1335,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // In case the parameter type sequences {P1, P2, …, PN} and {Q1, Q2, …, QN} are
-            // equivalent (i.e. each Pi has an identity conversion to the corresponding Qi), the
+            // equivalent ignoring Task-like differences (i.e. each Pi has an identity conversion to the corresponding Qi), the
             // following tie-breaking rules are applied, in order, to determine the better function
             // member. 
 
@@ -1370,7 +1369,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var type1 = GetParameterType(i, m1.Result, m1.LeastOverriddenMember.GetParameters(), out refKind1);
                     var type2 = GetParameterType(i, m2.Result, m2.LeastOverriddenMember.GetParameters(), out refKind2);
 
-                    if (Conversions.ClassifyImplicitConversion(type1, type2, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
+                    var type1Normalized = type1.NormalizeTaskTypes(Compilation);
+                    var type2Normalized = type2.NormalizeTaskTypes(Compilation);
+
+                    if (Conversions.ClassifyImplicitConversion(type1Normalized, type2Normalized, ref useSiteDiagnostics).Kind != ConversionKind.Identity)
                     {
                         allSame = false;
                         break;
@@ -1702,9 +1704,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // We should not have gotten here unless there were identity conversions between the
-            // two types.
-
-            Debug.Assert(n1.OriginalDefinition == n2.OriginalDefinition);
+            // two types, or they are different Task-likes. We don't have a Compilation here to verify
+            // Task-like however.
+            //Debug.Assert(n1.OriginalDefinition == n2.OriginalDefinition);
 
             var allTypeArgs1 = ArrayBuilder<TypeSymbol>.GetInstance();
             var allTypeArgs2 = ArrayBuilder<TypeSymbol>.GetInstance();
@@ -1808,19 +1810,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool t1MatchesExactly = ExpressionMatchExactly(node, t1, ref useSiteDiagnostics);
             bool t2MatchesExactly = ExpressionMatchExactly(node, t2, ref useSiteDiagnostics);
 
-            if (t1MatchesExactly)
+            if (t1MatchesExactly && !t2MatchesExactly)
             {
-                if (t2MatchesExactly)
-                {
-                    // both exactly match expression
-                    return BetterResult.Neither;
-                }
-
                 // - E exactly matches T1
                 okToDowngradeToNeither = lambdaOpt != null && CanDowngradeConversionFromLambdaToNeither(BetterResult.Left, lambdaOpt, t1, t2, ref useSiteDiagnostics, false);
                 return BetterResult.Left;
             }
-            else if (t2MatchesExactly)
+            else if (t2MatchesExactly && !t1MatchesExactly)
             {
                 // - E exactly matches T1
                 okToDowngradeToNeither = lambdaOpt != null && CanDowngradeConversionFromLambdaToNeither(BetterResult.Right, lambdaOpt, t1, t2, ref useSiteDiagnostics, false);
@@ -1874,7 +1870,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (lambda.Symbol.IsAsync)
                 {
                     // Dig through Task<...> for an async lambda.
-                    if (y.OriginalDefinition == Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T))
+                    if (y.OriginalDefinition.IsGenericTaskType(Compilation))
                     {
                         y = ((NamedTypeSymbol)y).TypeArgumentsNoUseSiteDiagnostics[0];
                     }
@@ -2096,28 +2092,26 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return BetterResult.Right;
             }
 
-            var task_T = Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+            bool type1IsGenericTask = type1.OriginalDefinition.IsGenericTaskType(Compilation);
+            bool type2IsGenericTask = type2.OriginalDefinition.IsGenericTaskType(Compilation);
 
-            if ((object)task_T != null)
+            if (type1IsGenericTask)
             {
-                if (type1.OriginalDefinition == task_T)
+                if (type2IsGenericTask)
                 {
-                    if (type2.OriginalDefinition == task_T)
-                    {
-                        // - T1 is Task<S1>, T2 is Task<S2>, and S1 is a better conversion target than S2
-                        return BetterConversionTargetCore(((NamedTypeSymbol)type1).TypeArgumentsNoUseSiteDiagnostics[0],
-                                                          ((NamedTypeSymbol)type2).TypeArgumentsNoUseSiteDiagnostics[0],
-                                                          ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
-                    }
+                    // - T1 is Task<S1>, T2 is Task<S2>, and S1 is a better conversion target than S2
+                    return BetterConversionTargetCore(((NamedTypeSymbol)type1).TypeArgumentsNoUseSiteDiagnostics[0],
+                                                      ((NamedTypeSymbol)type2).TypeArgumentsNoUseSiteDiagnostics[0],
+                                                      ref useSiteDiagnostics, betterConversionTargetRecursionLimit);
+                }
 
-                    // A shortcut, Task<T> type cannot satisfy other rules.
-                    return BetterResult.Neither;
-                }
-                else if (type2.OriginalDefinition == task_T)
-                {
-                    // A shortcut, Task<T> type cannot satisfy other rules.
-                    return BetterResult.Neither;
-                }
+                // A shortcut, Task<T> type cannot satisfy other rules.
+                return BetterResult.Neither;
+            }
+            else if (type2IsGenericTask)
+            {
+                // A shortcut, Task<T> type cannot satisfy other rules.
+                return BetterResult.Neither;
             }
 
             NamedTypeSymbol d1;

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -567,22 +567,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        private static MethodSymbol GetCacheKey(NamedTypeSymbol delegateType)
+        private MethodSymbol GetCacheKey(NamedTypeSymbol delegateType)
         {
-            delegateType = delegateType.GetDelegateType();
-
-            if (delegateType != null)
+            var invoke = DelegateInvokeMethod(delegateType);
+            if ((object)invoke != null)
             {
-                var invoke = delegateType.DelegateInvokeMethod;
-                if (invoke != null)
-                {
-                    return invoke;
-                }
+                return invoke;
             }
 
             // delegateType or DelegateInvokeMethod can be null in cases of malformed delegates
-            // in such case we would want something trivial with no parameters, like a fake static ctor
-            return new SynthesizedStaticConstructor(delegateType);
+            // in such case we would want something trivial with no parameters, like a fake static ctor.
+            // Since the containingType of the .cctor must be non-null, System.Object is used.
+            return new SynthesizedStaticConstructor(binder.Compilation.GetSpecialType(SpecialType.System_Object));
         }
 
         public TypeSymbol InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -281,8 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                                    ErrorTypeSymbol.UnknownResultType,
                                                                    unexpectedAnonymousFunction.Kind() == SyntaxKind.AnonymousMethodExpression ? MessageID.IDS_AnonMethod : MessageID.IDS_Lambda,
                                                                    unexpectedAnonymousFunction,
-                                                                   isSynthesized: false,
-                                                                   isAsync: false),
+                                                                   isSynthesized: false),
                                                   binder);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -35,8 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
             var compilation = method.DeclaringCompilation;
 
-            if (method.ReturnsVoid || method.IsIterator ||
-                (method.IsAsync && compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) == method.ReturnType))
+            if (method.ReturnsVoid || method.IsIterator || method.IsTaskReturningAsync(compilation))
             {
                 // we don't analyze synthesized void methods.
                 if ((method.IsImplicitlyDeclared && !method.IsScriptInitializer) || Analyze(compilation, method, block, diagnostics))

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodBuilderMemberCollection.cs
@@ -265,7 +265,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private static Symbol GetMember(NamedTypeSymbol containingType, MemberDescriptor descriptor)
         {
-            // PROTOTYPE(tasklike): Look on base types.
             // PROTOTYPE(tasklike): Compare kind.
             // PROTOTYPE(tasklike): Compare signatures.
             // PROTOTYPE(tasklike): Compare constraints.

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -286,22 +286,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(receiver, propertySym.GetMethod);
         }
 
-        public BoundExpression Property(BoundExpression receiver, string name)
+        public BoundExpression Property(BoundExpression receiver, PropertySymbol property)
         {
-            // TODO: unroll loop and add diagnostics for failure
-            // TODO: should we use GetBaseProperty() to ensure we generate a call to the overridden method?
-            // TODO: replace this with a mechanism that uses WellKnownMember instead of string names.
-            var property = receiver.Type.GetMembers(name).OfType<PropertySymbol>().Single();
             Debug.Assert(!property.IsStatic);
             return Call(receiver, property.GetMethod); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
-        }
-
-        public BoundExpression Property(NamedTypeSymbol receiver, string name)
-        {
-            // TODO: unroll loop and add diagnostics for failure
-            var property = receiver.GetMembers(name).OfType<PropertySymbol>().Single();
-            Debug.Assert(property.IsStatic);
-            return Call(null, property.GetMethod);
         }
 
         public NamedTypeSymbol SpecialType(SpecialType st)

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static readonly MemberSignatureComparer LambdaReturnInferenceCacheComparer = new MemberSignatureComparer(
             considerName: false,                // valid invoke is always called "Invoke"
             considerExplicitlyImplementedInterfaces: false,
-            considerReturnType: false,          // do not care
+            considerReturnType: true,          // to differentiate Task types
             considerTypeConstraints: false,     // valid invoke is never generic
             considerCallingConvention: false,   // valid invoke is never static
             considerRefOutDifference: true,

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -279,7 +279,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool IsTaskReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
         {
             return method.IsAsync
-                && method.ReturnType == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                && method.ReturnType.IsNonGenericTaskType(compilation);
         }
 
         /// <summary>
@@ -288,9 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool IsGenericTaskReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
         {
             return method.IsAsync
-                && (object)method.ReturnType != null
-                && method.ReturnType.Kind == SymbolKind.NamedType
-                && ((NamedTypeSymbol)method.ReturnType).ConstructedFrom == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+                && method.ReturnType.IsGenericTaskType(compilation);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -2,34 +2,65 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reflection;
+using System.Threading;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
-using System.Diagnostics;
-using System.Threading;
-using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
     internal class LocalFunctionSymbol : MethodSymbol
     {
+        private sealed class ParametersAndDiagnostics
+        {
+            internal readonly ImmutableArray<ParameterSymbol> Parameters;
+            internal readonly bool IsVararg;
+            internal readonly ImmutableArray<Diagnostic> Diagnostics;
+
+            internal ParametersAndDiagnostics(ImmutableArray<ParameterSymbol> parameters, bool isVararg, ImmutableArray<Diagnostic> diagnostics)
+            {
+                Parameters = parameters;
+                IsVararg = isVararg;
+                Diagnostics = diagnostics;
+            }
+        }
+
+        private sealed class TypeParameterConstraintsAndDiagnostics
+        {
+            internal readonly ImmutableArray<TypeParameterConstraintClause> ConstraintClauses;
+            internal readonly ImmutableArray<Diagnostic> Diagnostics;
+
+            internal TypeParameterConstraintsAndDiagnostics(ImmutableArray<TypeParameterConstraintClause> constraintClauses, ImmutableArray<Diagnostic> diagnostics)
+            {
+                ConstraintClauses = constraintClauses;
+                Diagnostics = diagnostics;
+            }
+        }
+
+        private sealed class ReturnTypeAndDiagnostics
+        {
+            internal readonly TypeSymbol ReturnType;
+            internal readonly ImmutableArray<Diagnostic> Diagnostics;
+
+            internal ReturnTypeAndDiagnostics(TypeSymbol returnType, ImmutableArray<Diagnostic> diagnostics)
+            {
+                ReturnType = returnType;
+                Diagnostics = diagnostics;
+            }
+        }
+
         private readonly Binder _binder;
         private readonly LocalFunctionStatementSyntax _syntax;
         private readonly Symbol _containingSymbol;
         private readonly DeclarationModifiers _declarationModifiers;
         private readonly ImmutableArray<TypeParameterSymbol> _typeParameters;
-        private ImmutableArray<ParameterSymbol> _parameters;
-        private ImmutableArray<TypeParameterConstraintClause> _lazyTypeParameterConstraints;
         private readonly RefKind _refKind;
-        private TypeSymbol _returnType;
-        private bool _isVararg;
+        private ParametersAndDiagnostics _lazyParametersAndDiagnostics;
+        private TypeParameterConstraintsAndDiagnostics _lazyTypeParameterConstraintsAndDiagnostics;
+        private ReturnTypeAndDiagnostics _lazyReturnTypeAndDiagnostics;
         private TypeSymbol _iteratorElementType;
-
-        // TODO: Find a better way to report diagnostics.
-        // We can't put binding in the constructor, as it creates infinite recursion.
-        // We can't report to Compilation.DeclarationDiagnostics as it's already too late and they will be dropped.
-        // The current system is to dump diagnostics into this field, and then grab them out again in Binder_Statements.BindLocalFunctionStatement
         private ImmutableArray<Diagnostic> _diagnostics;
 
         public LocalFunctionSymbol(
@@ -78,22 +109,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (!diags.IsDefault)
             {
                 addTo.AddRange(diags);
-            }
-        }
-
-        private void AddDiagnostics(ImmutableArray<Diagnostic> diagnostics)
-        {
-            // Atomic update operation. Applies a function (Concat) to a variable repeatedly, until it "gets through" (isn't in a race condition with another concat)
-            var oldDiags = _diagnostics;
-            while (true)
-            {
-                var newDiags = oldDiags.IsDefault ? diagnostics : oldDiags.Concat(diagnostics);
-                var overwriteDiags = ImmutableInterlocked.InterlockedCompareExchange(ref _diagnostics, newDiags, oldDiags);
-                if (overwriteDiags == oldDiags)
+                addTo.AddRange(_lazyParametersAndDiagnostics.Diagnostics);
+                if (_lazyTypeParameterConstraintsAndDiagnostics != null)
                 {
-                    break;
+                    addTo.AddRange(_lazyTypeParameterConstraintsAndDiagnostics.Diagnostics);
                 }
-                oldDiags = overwriteDiags;
+                addTo.AddRange(_lazyReturnTypeAndDiagnostics.Diagnostics);
             }
         }
 
@@ -102,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 ComputeParameters();
-                return _isVararg;
+                return _lazyParametersAndDiagnostics.IsVararg;
             }
         }
 
@@ -111,32 +132,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 ComputeParameters();
-                return _parameters;
+                return _lazyParametersAndDiagnostics.Parameters;
             }
         }
 
         private void ComputeParameters()
         {
-            if (!_parameters.IsDefault)
+            if (_lazyParametersAndDiagnostics != null)
             {
                 return;
             }
+
             var diagnostics = DiagnosticBag.GetInstance();
             SyntaxToken arglistToken;
-            _parameters = ParameterHelpers.MakeParameters(_binder, this, _syntax.ParameterList, true, out arglistToken, diagnostics, true);
-            _isVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
-            if (diagnostics.IsEmptyWithoutResolution)
+            var parameters = ParameterHelpers.MakeParameters(_binder, this, _syntax.ParameterList, true, out arglistToken, diagnostics, true);
+            var isVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
+            if (IsAsync && diagnostics.IsEmptyWithoutResolution)
             {
-                SourceMemberMethodSymbol.ReportAsyncParameterErrors(this, diagnostics, this.Locations[0]);
+                SourceMemberMethodSymbol.ReportAsyncParameterErrors(parameters, diagnostics, this.Locations[0]);
             }
-            AddDiagnostics(diagnostics.ToReadOnlyAndFree());
+            var value = new ParametersAndDiagnostics(parameters, isVararg, diagnostics.ToReadOnlyAndFree());
+            Interlocked.CompareExchange(ref _lazyParametersAndDiagnostics, value, null);
         }
 
         public override TypeSymbol ReturnType
         {
             get
             {
-                return ComputeReturnType();
+                ComputeReturnType();
+                return _lazyReturnTypeAndDiagnostics.ReturnType;
             }
         }
 
@@ -148,39 +172,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal TypeSymbol ComputeReturnType()
+        internal void ComputeReturnType()
         {
-            if (_returnType != null)
+            if (_lazyReturnTypeAndDiagnostics != null)
             {
-                return _returnType;
+                return;
             }
 
             var diagnostics = DiagnosticBag.GetInstance();
             TypeSymbol returnType = _binder.BindType(_syntax.ReturnType, diagnostics);
-            var raceReturnType = Interlocked.CompareExchange(ref _returnType, returnType, null);
-            if (raceReturnType != null)
-            {
-                diagnostics.Free();
-                return raceReturnType;
-            }
-            if (this.IsAsync && !this.IsGenericTaskReturningAsync(_binder.Compilation) && !this.IsTaskReturningAsync(_binder.Compilation) && !this.IsVoidReturningAsync())
+            if (IsAsync &&
+                returnType.SpecialType != SpecialType.System_Void &&
+                !returnType.IsNonGenericTaskType(_binder.Compilation) &&
+                !returnType.IsGenericTaskType(_binder.Compilation))
             {
                 // The return type of an async method must be void, Task or Task<T>
                 diagnostics.Add(ErrorCode.ERR_BadAsyncReturn, this.Locations[0]);
             }
-
-            if (this.RefKind != RefKind.None && returnType.SpecialType == SpecialType.System_Void)
+            if (_refKind != RefKind.None && returnType.SpecialType == SpecialType.System_Void)
             {
                 diagnostics.Add(ErrorCode.ERR_VoidReturningMethodCannotReturnByRef, this.Locations[0]);
             }
-
-            // TODO: note there is a race condition here that will ultimately need to be fixed.
-            // Specifically, the Interlocked.CompareExchange above succeeds, and will be seen by
-            // other threads, before the diagnostics have been recorded in this symbol, below.
-            // We can resolve this with a lock around this method and any other methods that
-            // manipulate _diagnostics, directly or indirectly.
-            AddDiagnostics(diagnostics.ToReadOnlyAndFree());
-            return returnType;
+            var value = new ReturnTypeAndDiagnostics(returnType, diagnostics.ToReadOnlyAndFree());
+            Interlocked.CompareExchange(ref _lazyReturnTypeAndDiagnostics, value, null);
         }
 
         public override bool ReturnsVoid => ReturnType?.SpecialType == SpecialType.System_Void;
@@ -228,14 +242,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool HidesBaseMethodsByName => false;
 
-
         public override ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations => ImmutableArray<MethodSymbol>.Empty;
-
 
         public override ImmutableArray<Location> Locations => ImmutableArray.Create(_syntax.Identifier.GetLocation());
 
         public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray.Create(_syntax.GetReference());
-
 
         internal override bool GenerateDebugInfo => true;
 
@@ -245,12 +256,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override ObsoleteAttributeData ObsoleteAttributeData => null;
 
-
         internal override MarshalPseudoCustomAttributeData ReturnValueMarshallingInformation => null;
 
         internal override CallingConvention CallingConvention => CallingConvention.Default;
 
         internal override bool HasDeclarativeSecurity => false;
+
         internal override bool RequiresSecurityObject => false;
 
         public override Symbol AssociatedSymbol => null;
@@ -358,17 +369,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private TypeParameterConstraintClause GetTypeParameterConstraintClause(int ordinal)
         {
-            if (_lazyTypeParameterConstraints.IsDefault)
+            if (_lazyTypeParameterConstraintsAndDiagnostics == null)
             {
                 var diagnostics = DiagnosticBag.GetInstance();
-                if (ImmutableInterlocked.InterlockedInitialize(ref _lazyTypeParameterConstraints, MakeTypeParameterConstraints(diagnostics)))
-                {
-                    AddDiagnostics(diagnostics.ToReadOnly());
-                }
-                diagnostics.Free();
+                var constraints = MakeTypeParameterConstraints(diagnostics);
+                var value = new TypeParameterConstraintsAndDiagnostics(constraints, diagnostics.ToReadOnlyAndFree());
+                Interlocked.CompareExchange(ref _lazyTypeParameterConstraintsAndDiagnostics, value, null);
             }
 
-            var clauses = _lazyTypeParameterConstraints;
+            var clauses = _lazyTypeParameterConstraintsAndDiagnostics.ConstraintClauses;
             return (clauses.Length > 0) ? clauses[ordinal] : null;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberMethodSymbol.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // evaluating the constraints may depend on accessing this method from
             // the container (comparing this method to others to find overrides for
             // instance). Constraints are checked in AfterAddingTypeMembersChecks.
-            var signatureBinder = withTypeParamsBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.SuppressConstraintChecks, this);
+            var signatureBinder = GetSignatureBinder(withTypeParamsBinder);
 
             _lazyParameters = ParameterHelpers.MakeParameters(signatureBinder, this, syntax.ParameterList, true, out arglistToken, diagnostics, false);
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
@@ -326,25 +326,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // This is also used for async lambdas.  Probably not the best place to locate this method, but where else could it go?
-        internal static void ReportAsyncParameterErrors(MethodSymbol method, DiagnosticBag diagnostics, Location location)
+        internal static void ReportAsyncParameterErrors(ImmutableArray<ParameterSymbol> parameters, DiagnosticBag diagnostics, Location location)
         {
-            if (method.IsAsync)
+            foreach (var parameter in parameters)
             {
-                foreach (var parameter in method.Parameters)
+                var loc = parameter.Locations.Any() ? parameter.Locations[0] : location;
+                if (parameter.RefKind != RefKind.None)
                 {
-                    var loc = parameter.Locations.Any() ? parameter.Locations[0] : location;
-                    if (parameter.RefKind != RefKind.None)
-                    {
-                        diagnostics.Add(ErrorCode.ERR_BadAsyncArgType, loc);
-                    }
-                    else if (parameter.Type.IsUnsafe())
-                    {
-                        diagnostics.Add(ErrorCode.ERR_UnsafeAsyncArgType, loc);
-                    }
-                    else if (parameter.Type.IsRestrictedType())
-                    {
-                        diagnostics.Add(ErrorCode.ERR_BadSpecialByRefLocal, loc, parameter.Type);
-                    }
+                    diagnostics.Add(ErrorCode.ERR_BadAsyncArgType, loc);
+                }
+                else if (parameter.Type.IsUnsafe())
+                {
+                    diagnostics.Add(ErrorCode.ERR_UnsafeAsyncArgType, loc);
+                }
+                else if (parameter.Type.IsRestrictedType())
+                {
+                    diagnostics.Add(ErrorCode.ERR_BadSpecialByRefLocal, loc, parameter.Type);
                 }
             }
         }
@@ -357,20 +354,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (!this.IsAsync)
             {
-                if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
-                {
-                    if (IsPartialDefinition && (object)PartialImplementationPart == null)
-                    {
-                        DeclaringCompilation.SymbolDeclaredEvent(this);
-                    }
-
-                    state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
-                }
-                else
-                {
-                    state.SpinWaitComplete(CompletionPart.FinishAsyncMethodChecks, cancellationToken);
-                }
-
+                CompleteAsyncMethodChecks(diagnosticsOpt: null, cancellationToken: cancellationToken);
                 return;
             }
 
@@ -401,28 +385,49 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             if (diagnostics.IsEmptyWithoutResolution)
             {
-                ReportAsyncParameterErrors(this, diagnostics, errorLocation);
+                ReportAsyncParameterErrors(_lazyParameters, diagnostics, errorLocation);
             }
 
+            CompleteAsyncMethodChecks(diagnostics, cancellationToken);
+            diagnostics.Free();
+        }
+
+        private void CompleteAsyncMethodChecks(DiagnosticBag diagnosticsOpt, CancellationToken cancellationToken)
+        {
             if (state.NotePartComplete(CompletionPart.StartAsyncMethodChecks))
             {
-                AddDeclarationDiagnostics(diagnostics);
-                if (IsPartialDefinition) DeclaringCompilation.SymbolDeclaredEvent(this);
+                if (diagnosticsOpt != null)
+                {
+                    AddDeclarationDiagnostics(diagnosticsOpt);
+                }
+                if (IsPartialDefinition && (object)PartialImplementationPart == null)
+                {
+                    DeclaringCompilation.SymbolDeclaredEvent(this);
+                }
                 state.NotePartComplete(CompletionPart.FinishAsyncMethodChecks);
             }
             else
             {
                 state.SpinWaitComplete(CompletionPart.FinishAsyncMethodChecks, cancellationToken);
             }
-
-            diagnostics.Free();
         }
 
         protected override void MethodChecks(DiagnosticBag diagnostics)
         {
             var syntax = GetSyntax();
-            var withTypeParamsBinder = this.DeclaringCompilation.GetBinderFactory(syntax.SyntaxTree).GetBinder(syntax.ReturnType, syntax, this);
-            MethodChecks(syntax, withTypeParamsBinder, diagnostics);
+            var binder = GetReturnTypeBinder();
+            MethodChecks(syntax, binder, diagnostics);
+        }
+
+        private Binder GetReturnTypeBinder()
+        {
+            var syntax = GetSyntax();
+            return this.DeclaringCompilation.GetBinderFactory(syntax.SyntaxTree).GetBinder(syntax.ReturnType, syntax, this);
+        }
+
+        private Binder GetSignatureBinder(Binder withTypeParamsBinder)
+        {
+            return withTypeParamsBinder.WithAdditionalFlagsAndContainingMemberOrLambda(BinderFlags.SuppressConstraintChecks, this);
         }
 
         internal MethodDeclarationSyntax GetSyntax()

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
             else
             {
-                var taskType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                var taskType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task); // PROTOTYPE(tasklike)
 #if DEBUG
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
                 Debug.Assert(taskType.IsErrorType() || initializerMethod.ReturnType.IsDerivedFrom(taskType, ignoreDynamic: true, useSiteDiagnostics: ref useSiteDiagnostics));

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -3143,9 +3143,9 @@ class C
                 // (4,20): error CS0518: Predefined type 'System.Runtime.CompilerServices.AsyncVoidMethodBuilder' is not defined or imported
                 //     async void M() {}
                 Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "{}").WithArguments("System.Runtime.CompilerServices.AsyncVoidMethodBuilder").WithLocation(4, 20),
-                // (4,20): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncVoidMethodBuilder.SetException'
+                // (4,20): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncVoidMethodBuilder.Create'
                 //     async void M() {}
-                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{}").WithArguments("System.Runtime.CompilerServices.AsyncVoidMethodBuilder", "SetException").WithLocation(4, 20),
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{}").WithArguments("System.Runtime.CompilerServices.AsyncVoidMethodBuilder", "Create").WithLocation(4, 20),
                 // (4,20): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext'
                 //     async void M() {}
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{}").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "MoveNext").WithLocation(4, 20),

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncTests.cs
@@ -3155,6 +3155,285 @@ class C
         }
 
         [Fact]
+        public void PresentAsyncTasklikeBuilderMethod()
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    async ValueTask f() { await (Task)null; }
+    async ValueTask<int> g() { await (Task)null; return 1; }
+}
+struct ValueTask { public static ValueTaskMethodBuilder CreateAsyncMethodBuilder() => null; }
+struct ValueTask<T> { public static ValueTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;}
+class ValueTaskMethodBuilder
+{
+    public ValueTask Task { get; }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void SetException(System.Exception exception) { }
+    public void SetResult() { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+}
+class ValueTaskMethodBuilder<T>
+{
+    public ValueTask<T> Task { get; }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void SetException(System.Exception exception) { }
+    public void SetResult(T result) { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+}
+";
+            var v = CompileAndVerify(source, null, options: TestOptions.ReleaseDll);
+            v.VerifyIL("C.g",
+@"{
+  // Code size       45 (0x2d)
+  .maxstack  2
+  .locals init (C.<g>d__1 V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  call       ""ValueTaskMethodBuilder<int> ValueTask<int>.CreateAsyncMethodBuilder()""
+  IL_0007:  stfld      ""ValueTaskMethodBuilder<int> C.<g>d__1.<>t__builder""
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldc.i4.m1
+  IL_000f:  stfld      ""int C.<g>d__1.<>1__state""
+  IL_0014:  ldloc.0
+  IL_0015:  ldfld      ""ValueTaskMethodBuilder<int> C.<g>d__1.<>t__builder""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  callvirt   ""void ValueTaskMethodBuilder<int>.Start<C.<g>d__1>(ref C.<g>d__1)""
+  IL_0021:  ldloc.0
+  IL_0022:  ldfld      ""ValueTaskMethodBuilder<int> C.<g>d__1.<>t__builder""
+  IL_0027:  callvirt   ""ValueTask<int> ValueTaskMethodBuilder<int>.Task.get""
+  IL_002c:  ret
+}");
+            v.VerifyIL("C.f",
+@"{
+  // Code size       45 (0x2d)
+  .maxstack  2
+  .locals init (C.<f>d__0 V_0)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  call       ""ValueTaskMethodBuilder ValueTask.CreateAsyncMethodBuilder()""
+  IL_0007:  stfld      ""ValueTaskMethodBuilder C.<f>d__0.<>t__builder""
+  IL_000c:  ldloca.s   V_0
+  IL_000e:  ldc.i4.m1
+  IL_000f:  stfld      ""int C.<f>d__0.<>1__state""
+  IL_0014:  ldloc.0
+  IL_0015:  ldfld      ""ValueTaskMethodBuilder C.<f>d__0.<>t__builder""
+  IL_001a:  ldloca.s   V_0
+  IL_001c:  callvirt   ""void ValueTaskMethodBuilder.Start<C.<f>d__0>(ref C.<f>d__0)""
+  IL_0021:  ldloc.0
+  IL_0022:  ldfld      ""ValueTaskMethodBuilder C.<f>d__0.<>t__builder""
+  IL_0027:  callvirt   ""ValueTask ValueTaskMethodBuilder.Task.get""
+  IL_002c:  ret
+}");
+        }
+
+        [Fact]
+        public void AsyncTasklikeLambdaOverloads()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main()
+    {
+        f(async () => { await (Task)null; });
+        g(async () => { await (Task)null; });
+        k(async () => { await (Task)null; });
+    }
+
+    static void f(Func<MyTask> lambda) { }
+    static void g(Func<Task> lambda) { }
+    static void k<T>(Func<T> lambda) { }
+}
+class MyTask { public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+class MyTaskBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    public MyTask Task => default(MyTask);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            var v = CompileAndVerify(source, null, options: TestOptions.ReleaseDll);
+            v.VerifyIL("C.Main", @"
+{
+  // Code size      109 (0x6d)
+  .maxstack  2
+  IL_0000:  ldsfld     ""System.Func<MyTask> C.<>c.<>9__0_0""
+  IL_0005:  dup
+  IL_0006:  brtrue.s   IL_001f
+  IL_0008:  pop
+  IL_0009:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_000e:  ldftn      ""MyTask C.<>c.<Main>b__0_0()""
+  IL_0014:  newobj     ""System.Func<MyTask>..ctor(object, System.IntPtr)""
+  IL_0019:  dup
+  IL_001a:  stsfld     ""System.Func<MyTask> C.<>c.<>9__0_0""
+  IL_001f:  call       ""void C.f(System.Func<MyTask>)""
+  IL_0024:  ldsfld     ""System.Func<System.Threading.Tasks.Task> C.<>c.<>9__0_1""
+  IL_0029:  dup
+  IL_002a:  brtrue.s   IL_0043
+  IL_002c:  pop
+  IL_002d:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_0032:  ldftn      ""System.Threading.Tasks.Task C.<>c.<Main>b__0_1()""
+  IL_0038:  newobj     ""System.Func<System.Threading.Tasks.Task>..ctor(object, System.IntPtr)""
+  IL_003d:  dup
+  IL_003e:  stsfld     ""System.Func<System.Threading.Tasks.Task> C.<>c.<>9__0_1""
+  IL_0043:  call       ""void C.g(System.Func<System.Threading.Tasks.Task>)""
+  IL_0048:  ldsfld     ""System.Func<System.Threading.Tasks.Task> C.<>c.<>9__0_2""
+  IL_004d:  dup
+  IL_004e:  brtrue.s   IL_0067
+  IL_0050:  pop
+  IL_0051:  ldsfld     ""C.<>c C.<>c.<>9""
+  IL_0056:  ldftn      ""System.Threading.Tasks.Task C.<>c.<Main>b__0_2()""
+  IL_005c:  newobj     ""System.Func<System.Threading.Tasks.Task>..ctor(object, System.IntPtr)""
+  IL_0061:  dup
+  IL_0062:  stsfld     ""System.Func<System.Threading.Tasks.Task> C.<>c.<>9__0_2""
+  IL_0067:  call       ""void C.k<System.Threading.Tasks.Task>(System.Func<System.Threading.Tasks.Task>)""
+  IL_006c:  ret
+}");
+        }
+
+        [Fact]
+        public void AsyncTasklikeIncompleteBuilder()
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async ValueTask0 f() { await Task.Delay(0); }
+    async ValueTask1 g() { await Task.Delay(0); }
+    async ValueTask2 h() { await Task.Delay(0); }
+}
+struct ValueTask0 { public static ValueTaskMethodBuilder0 CreateAsyncMethodBuilder() => null; }
+struct ValueTask1 { public static ValueTaskMethodBuilder1 CreateAsyncMethodBuilder() => null; }
+struct ValueTask2 { public static ValueTaskMethodBuilder2 CreateAsyncMethodBuilder() => null; }
+class ValueTaskMethodBuilder0 { }
+class ValueTaskMethodBuilder1 { public void SetException(System.Exception ex) { } }
+class ValueTaskMethodBuilder2 { public void SetException(System.Exception ex) { } public void SetResult() { } }
+";
+
+            var comp = CreateCompilation(source, options: TestOptions.DebugExe);
+            comp.VerifyEmitDiagnostics(
+                // (7,26): error CS0656: Missing compiler required member 'ValueTaskMethodBuilder0.SetException'
+                //     async ValueTask0 f() { await Task.Delay(0); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.Delay(0); }").WithArguments("ValueTaskMethodBuilder0", "SetException").WithLocation(7, 26),
+                // (8,26): error CS0656: Missing compiler required member 'ValueTaskMethodBuilder1.SetResult'
+                //     async ValueTask1 g() { await Task.Delay(0); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.Delay(0); }").WithArguments("ValueTaskMethodBuilder1", "SetResult").WithLocation(8, 26),
+                // (9,26): error CS0656: Missing compiler required member 'ValueTaskMethodBuilder2.AwaitOnCompleted'
+                //     async ValueTask2 h() { await Task.Delay(0); }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await Task.Delay(0); }").WithArguments("ValueTaskMethodBuilder2", "AwaitOnCompleted").WithLocation(9, 26)
+                );
+        }
+
+        // PROTOTYPE(tasklike): InvalidOperationException constructing Builder.
+        //[Fact]
+        public void AsyncTasklikeBuilderArityMismatch()
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C {
+    async Mismatch1<int> f() { await (Task)null; return 1; }
+    async Mismatch2 g() { await (Task)null; return 1; }
+}
+struct Mismatch1<T> { public static Mismatch1MethodBuilder CreateAsyncMethodBuilder() => null; }
+struct Mismatch2 { public static Mismatch2MethodBuilder<int> CreateAsyncMethodBuilder() => null; }
+class Mismatch1MethodBuilder { }
+class Mismatch2MethodBuilder<T> {}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+            comp.VerifyEmitDiagnostics(
+                // (6,26): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async Mismatch2<int> g() { await (Task)null; return 1; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "g").WithLocation(6, 26),
+                // (5,26): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async Mismatch1<int> f() { await (Task)null; return 1; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "f").WithLocation(5, 26)
+                );
+        }
+
+        // PROTOTYPE(tasklike): Compare constraints.
+        //[Fact]
+        public void AsyncTasklikeBuilderConstraints()
+        {
+            var source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+
+class MyTask {  public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+
+interface I { }
+
+class MyTaskBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TSM>(ref TSM stateMachine) where TSM : I { }
+    public void AwaitOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception ex) { }
+    public MyTask Task => null;
+}
+";
+
+            var comp1 = CreateCompilation(source1, options: TestOptions.DebugExe);
+            comp1.VerifyEmitDiagnostics(
+                // (8,22): error CS0656: Missing compiler required member 'MyTaskBuilder.Start'
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; }").WithArguments("MyTaskBuilder", "Start").WithLocation(8, 22)
+                );
+
+            var source2 = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+
+class MyTask {  public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+
+class MyTaskBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TSM>(ref TSM stateMachine) where TSM : IAsyncStateMachine { }
+    public void AwaitOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception ex) { }
+    public MyTask Task => null;
+}
+";
+
+            var comp2 = CreateCompilation(source2, options: TestOptions.DebugExe);
+            comp2.VerifyEmitDiagnostics(
+                // (8,22): error CS0656: Missing compiler required member 'MyTaskBuilder.AwaitUnsafeOnCompleted'
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; }").WithArguments("MyTaskBuilder", "AwaitUnsafeOnCompleted").WithLocation(8, 22)
+                );
+        }
+
+        [Fact]
         [WorkItem(868822, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/868822")]
         public void AsyncDelegates()
         {
@@ -4029,6 +4308,9 @@ class C
             compilation.VerifyEmitDiagnostics(
                 // warning CS8021: No value for RuntimeMetadataVersion found. No assembly containing System.Object was found nor was a value for RuntimeMetadataVersion specified through options.
                 Diagnostic(ErrorCode.WRN_NoRuntimeMetadataVersion).WithLocation(1, 1),
+                // (62,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder.Create'
+                //     async Task GetNumber(Task task) { await task; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.AsyncTaskMethodBuilder", "Create").WithLocation(62, 37),
                 // (62,37): error CS0656: Missing compiler required member 'System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext'
                 //     async Task GetNumber(Task task) { await task; }
                 Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await task; }").WithArguments("System.Runtime.CompilerServices.IAsyncStateMachine", "MoveNext").WithLocation(62, 37),

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -77,6 +77,7 @@
     <Compile Include="FlowAnalysis\StructTests.cs" />
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.cs" />
     <Compile Include="Semantics\BindingAsyncTasklikeMoreTests.cs" />
+    <Compile Include="Semantics\BindingAsyncTasklikeTests.cs" />
     <Compile Include="Semantics\ImportsTests.cs" />
     <Compile Include="Semantics\AccessCheckTests.cs" />
     <Compile Include="Semantics\AccessibilityTests.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -76,6 +76,7 @@
     <Compile Include="FlowAnalysis\RegionAnalysisTests.cs" />
     <Compile Include="FlowAnalysis\StructTests.cs" />
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.cs" />
+    <Compile Include="Semantics\BindingAsyncTasklikeMoreTests.cs" />
     <Compile Include="Semantics\ImportsTests.cs" />
     <Compile Include="Semantics\AccessCheckTests.cs" />
     <Compile Include="Semantics\AccessibilityTests.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
@@ -1,0 +1,422 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class BindingAsyncTasklikeMoreTests : CompilingTestBase
+    {
+        [Fact]
+        public void AsyncMethod()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static async MyTask F() { await (Task)null; }
+    static async MyTask<T> G<T>(T t) { await (Task)null; return t; }
+    static async MyTask<int> M()
+    {
+        await F();
+        return await G(3);
+    }
+    static void Main()
+    {
+        var i = M().Result;
+        Console.WriteLine(i);
+    }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => new MyTaskMethodBuilder();
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new MyTaskMethodBuilder<T>();
+    public T Result => default(T);
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}
+struct MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task { get { return default(MyTask); } }
+}
+struct MyTaskMethodBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task { get { return default(MyTask<T>); } }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "0");
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.F()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            method = (MethodSymbol)testData.GetMethodData("C.G<T>(T)").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            verifier.VerifyIL("C.F()",
+@"{
+  // Code size       52 (0x34)
+  .maxstack  2
+  .locals init (C.<F>d__0 V_0,
+                MyTaskMethodBuilder V_1)
+  IL_0000:  newobj     ""C.<F>d__0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  call       ""MyTaskMethodBuilder MyTask.CreateAsyncMethodBuilder()""
+  IL_000c:  stfld      ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.m1
+  IL_0013:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0018:  ldloc.0
+  IL_0019:  ldfld      ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_001e:  stloc.1
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  call       ""void MyTaskMethodBuilder.Start<C.<F>d__0>(ref C.<F>d__0)""
+  IL_0028:  ldloc.0
+  IL_0029:  ldflda     ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_002e:  call       ""MyTask MyTaskMethodBuilder.Task.get""
+  IL_0033:  ret
+}");
+            verifier.VerifyIL("C.G<T>(T)",
+@"{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  .locals init (C.<G>d__1<T> V_0,
+                MyTaskMethodBuilder<T> V_1)
+  IL_0000:  newobj     ""C.<G>d__1<T>..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""T C.<G>d__1<T>.t""
+  IL_000d:  ldloc.0
+  IL_000e:  call       ""MyTaskMethodBuilder<T> MyTask<T>.CreateAsyncMethodBuilder()""
+  IL_0013:  stfld      ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<G>d__1<T>.<>1__state""
+  IL_001f:  ldloc.0
+  IL_0020:  ldfld      ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0025:  stloc.1
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  ldloca.s   V_0
+  IL_002a:  call       ""void MyTaskMethodBuilder<T>.Start<C.<G>d__1<T>>(ref C.<G>d__1<T>)""
+  IL_002f:  ldloc.0
+  IL_0030:  ldflda     ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0035:  call       ""MyTask<T> MyTaskMethodBuilder<T>.Task.get""
+  IL_003a:  ret
+}");
+        }
+
+        [Fact]
+        public void AsyncMethodBuilder_MissingMethods()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static async MyTask F() { await (Task)null; }
+    static async MyTask<T> G<T>(T t) { await (Task)null; return t; }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => new MyTaskMethodBuilder();
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new MyTaskMethodBuilder<T>();
+}
+struct MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+}
+struct MyTaskMethodBuilder<T>
+{
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task { get { return default(MyTask<T>); } }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyEmitDiagnostics(
+                // (6,29): error CS0656: Missing compiler required member 'MyTaskMethodBuilder.AwaitOnCompleted'
+                //     static async MyTask F() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; }").WithArguments("MyTaskMethodBuilder", "AwaitOnCompleted").WithLocation(6, 29),
+                // (7,38): error CS0656: Missing compiler required member 'MyTaskMethodBuilder<T>.SetException'
+                //     static async MyTask<T> G<T>(T t) { await (Task)null; return t; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; return t; }").WithArguments("MyTaskMethodBuilder<T>", "SetException").WithLocation(7, 38));
+        }
+
+        [Fact]
+        public void Private()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+#pragma warning disable CS1998
+    static async MyTask F() { }
+    static async MyTask<int> G() { return 3; }
+#pragma warning restore CS1998
+    private class MyTask
+    {
+        public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    }
+    private class MyTask<T>
+    {
+        public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    }
+    private class MyTaskMethodBuilder
+    {
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+        public void SetException(Exception e) { }
+        public void SetResult() { }
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public MyTask Task { get { return null; } }
+    }
+    private class MyTaskMethodBuilder<T>
+    {
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+        public void SetException(Exception e) { }
+        public void SetResult(T t) { }
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public MyTask<T> Task { get { return null; } }
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.F()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("C.MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.G()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("C.MyTask<int>", method.ReturnType.ToDisplayString());
+        }
+
+        [Fact]
+        public void AsyncLambda_InferReturnType()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static void F(Func<MyTask> f) { }
+    static void F<T>(Func<MyTask<T>> f) { }
+    static void F(Func<MyTask<string>> f) { }
+    static void M()
+    {
+#pragma warning disable CS1998
+        F(async () => { });
+        F(async () => { return 3; });
+        F(async () => { return string.Empty; });
+#pragma warning restore CS1998
+    }
+}
+class MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+class MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}
+class MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task => default(MyTask);
+}
+class MyTaskMethodBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task => default(MyTask<T>);
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.<>c.<M>b__3_0()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.<>c.<M>b__3_1()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("MyTask<int>", method.ReturnType.ToDisplayString());
+        }
+
+        [Fact]
+        public void AsyncLocalFunction()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static async void M()
+    {
+#pragma warning disable CS1998
+        async MyTask F() { }
+        async MyTask<T> G<T>(T t) => t;
+        await F();
+        await G(3);
+#pragma warning restore CS1998
+    }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}
+class MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task => default(MyTask);
+}
+class MyTaskMethodBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task => default(MyTask<T>);
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.<M>g__F0_0()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.<M>g__G0_1<T>(T)").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("MyTask<T>", method.ReturnType.ToDisplayString());
+        }
+
+        // PROTOTYPE(task): InvalidOperationException constructing Builder.
+        //[Fact]
+        public void NonTaskBuilder()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static async void M()
+    {
+#pragma warning disable CS1998
+        async MyTask<T> F<T>(T t) => t;
+        await F(3);
+#pragma warning restore CS1998
+    }
+}
+struct MyTask<T>
+{
+    public static string CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyEmitDiagnostics();
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
@@ -1,0 +1,549 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class BindingAsyncTasklikeTests : CompilingTestBase
+    {
+        [Fact]
+        public void AsyncTasklikeFromBuilderMethod()
+        {
+            var source = @"
+using System.Threading.Tasks;
+class C {
+    async ValueTask f() { await (Task)null; }
+    async ValueTask<int> g() { await (Task)null; return 1; }
+}
+struct ValueTask { public static string CreateAsyncMethodBuilder() => null; }
+struct ValueTask<T> { public static Task<T> CreateAsyncMethodBuilder() => null; }
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics();
+            var methodf = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("f").Single();
+            var methodg = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("g").Single();
+            Assert.True(methodf.IsAsync);
+            Assert.True(methodg.IsAsync);
+        }
+
+        [Fact]
+        public void AsyncTasklikeNotFromDelegate()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main()
+    {
+    }
+
+    static async Task f()
+    {
+        await new Awaitable();
+        await new Unawaitable(); // error: GetAwaiter must be a field not a delegate
+    }
+
+    static async Tasklike g()
+    {
+        await (Task)null;
+    }
+
+    static async UnTasklike h()
+    {
+        await (Task)null;
+    }
+}
+
+class Awaitable
+{
+    public TaskAwaiter GetAwaiter() => (Task.FromResult(1) as Task).GetAwaiter();
+}
+
+class Unawaitable
+{
+    public Func<TaskAwaiter> GetAwaiter = () => (Task.FromResult(1) as Task).GetAwaiter();
+}
+
+public class Tasklike {
+    public static TasklikeMethodBuilder CreateAsyncMethodBuilder() => null;
+}
+
+public class UnTasklike
+{
+    public static Func<UnTasklikeMethodBuilder> CreateAsyncMethodBuilder = () => null;
+}
+
+public class TasklikeMethodBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    private void EnsureTaskBuilder() { }
+    public Tasklike Task => null;
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+
+public class UnTasklikeMethodBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    private void EnsureTaskBuilder() { }
+    public UnTasklike Task => null;
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (15,9): error CS0118: 'GetAwaiter' is a field but is used like a method
+                //         await new Unawaitable(); // error: GetAwaiter must be a field not a delegate
+                Diagnostic(ErrorCode.ERR_BadSKknown, "await new Unawaitable()").WithArguments("GetAwaiter", "field", "method").WithLocation(15, 9),
+                // (23,29): error CS1983: The return type of an async method must be void, Task, Task<T> or other tasklike
+                //     static async UnTasklike h()
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "h").WithLocation(23, 29),
+                // (23,29): error CS0161: 'Program.h()': not all code paths return a value
+                //     static async UnTasklike h()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "h").WithArguments("Program.h()").WithLocation(23, 29)
+            );
+        }
+
+        private bool VerifyTaskOverloads(string arg, string betterOverload, string worseOverload, bool implicitConversionToTask = false, bool isError = false)
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class Program
+{
+    #pragma warning disable CS1998
+    static void Main()
+    {
+        var s = (<<arg>>);
+        Console.Write(s);
+    }
+    <<betterOverload>>
+    <<worseOverload>>
+}
+struct ValueTask
+{
+    public static ValueTaskMethodBuilder CreateAsyncMethodBuilder() => new ValueTaskMethodBuilder();
+    <<implicitConversionToTask>>
+    internal Awaiter GetAwaiter() => new Awaiter();
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct ValueTask<T>
+{
+    internal T _result;
+    public static ValueTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new ValueTaskMethodBuilder<T>();
+    <<implicitConversionToTaskT>>
+    public T Result => _result;
+    internal Awaiter GetAwaiter() => new Awaiter(this);
+    internal class Awaiter : INotifyCompletion
+    {
+        private ValueTask<T> _task;
+        internal Awaiter(ValueTask<T> task) { _task = task; }
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => _task.Result;
+    }
+}
+sealed class ValueTaskMethodBuilder
+{
+    private ValueTask _task = new ValueTask();
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public ValueTask Task => _task;
+}
+sealed class ValueTaskMethodBuilder<T>
+{
+    private ValueTask<T> _task = new ValueTask<T>();
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { _task._result = t; }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public ValueTask<T> Task => _task;
+}";
+            source = source.Replace("<<arg>>", arg);
+            source = source.Replace("<<betterOverload>>", (betterOverload != null) ? "static string " + betterOverload + " => \"better\";" : "");
+            source = source.Replace("<<worseOverload>>", (worseOverload != null) ? "static string " + worseOverload + " => \"worse\";" : "");
+            source = source.Replace("<<implicitConversionToTask>>", implicitConversionToTask ? "public static implicit operator Task(ValueTask t) => Task.FromResult(0);" : "");
+            source = source.Replace("<<implicitConversionToTaskT>>", implicitConversionToTask ? "public static implicit operator Task<T>(ValueTask<T> t) => Task.FromResult<T>(t._result);" : "");
+            if (isError)
+            {
+                var compilation = CreateCompilationWithMscorlib45(source);
+                var diagnostics = compilation.GetDiagnostics();
+                Assert.True(diagnostics.Length == 1);
+                Assert.True(diagnostics.First().Code == (int)ErrorCode.ERR_AmbigCall);
+            }
+            else
+            {
+                CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "better");
+            }
+            return true;
+        }
+
+        [Fact]
+        public bool TasklikeA3() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        null);
+
+        [Fact]
+        public void TasklikeA3n() => VerifyTaskOverloads("f(async () => {})",
+                                                         "f(Func<ValueTask> lambda)",
+                                                         null);
+
+        [Fact]
+        public void TasklikeA4() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f<T>(Func<ValueTask<T>> labda)",
+                                                        null);
+
+        [Fact]
+        public void TasklikeA5s() => VerifyTaskOverloads("f(() => 3)",
+                                                         "f<T>(Func<T> lambda)",
+                                                         "f<T>(Func<ValueTask<T>> lambda)");
+
+        [Fact]
+        public void TasklikeA5a() => VerifyTaskOverloads("f(async () => 3)",
+                                                         "f<T>(Func<ValueTask<T>> lambda)",
+                                                         "f<T>(Func<T> lambda)");
+
+        [Fact]
+        public void TasklikeA6() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f(Func<ValueTask<double>> lambda)");
+
+        [Fact]
+        public void TasklikeA7() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<byte>> lambda)",
+                                                        "f(Func<ValueTask<short>> lambda)");
+
+        [Fact]
+        public void TasklikeA8() => VerifyTaskOverloads("f(async () => {})",
+                                                        "f(Func<ValueTask> lambda)",
+                                                        "f(Action lambda)");
+
+        [Fact]
+        public void TasklikeB7_ic0() => VerifyTaskOverloads("f(async () => 3)",
+                                                           "f(Func<ValueTask<int>> lambda)",
+                                                           "f(Func<Task<int>> lambda)",
+                                                           isError: true);
+
+        [Fact]
+        public void TasklikeB7_ic1() => VerifyTaskOverloads("f(async () => 3)",
+                                                            "f(Func<ValueTask<int>> lambda)",
+                                                            "f(Func<Task<int>> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeB7g_ic0() => VerifyTaskOverloads("f(async () => 3)",
+                                                             "f<T>(Func<ValueTask<T>> lambda)",
+                                                             "f<T>(Func<Task<T>> lambda)",
+                                                             isError: true);
+
+        [Fact]
+        public void TasklikeB7g_ic1() => VerifyTaskOverloads("f(async () => 3)",
+                                                             "f<T>(Func<ValueTask<T>> lambda)",
+                                                             "f<T>(Func<Task<T>> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeB7n_ic0() => VerifyTaskOverloads("f(async () => {})",
+                                                             "f(Func<ValueTask> lambda)",
+                                                             "f(Func<Task> lambda)",
+                                                             isError: true);
+
+        [Fact]
+        public void TasklikeB7n_ic1() => VerifyTaskOverloads("f(async () => {})",
+                                                             "f(Func<ValueTask> lambda)",
+                                                             "f(Func<Task> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeC1() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f(Func<Task<double>> lambda)");
+
+        [Fact]
+        public void TasklikeC2() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<byte>> lambda)",
+                                                        "f(Func<Task<short>> lambda)");
+
+        [Fact]
+        public void TasklikeC5() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f<T>(Func<Task<T>> lambda)");
+
+        [Fact]
+        public void AsyncTasklikeMethod()
+        {
+            var source = @"
+using System.Threading.Tasks;
+class C {
+    async ValueTask f() { await Task.Delay(0); }
+    async ValueTask<int> g() { await Task.Delay(0); return 1; }
+}
+struct ValueTask { public static ValueTaskMethodBuilder CreateAsyncMethodBuilder() => null; }
+struct ValueTask<T> { public static ValueTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;}
+class ValueTaskMethodBuilder {}
+class ValueTaskMethodBuilder<T> {}
+";
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics();
+            var methodf = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("f").Single();
+            var methodg = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("g").Single();
+            Assert.True(methodf.IsAsync);
+            Assert.True(methodg.IsAsync);
+        }
+
+        [Fact]
+        public void NotTasklike()
+        {
+            var source1 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { }
+";
+            CreateCompilationWithMscorlib45(source1).VerifyDiagnostics(
+                // (6,18): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "f").WithLocation(6, 18),
+                // (6,18): error CS0161: 'C.f()': not all code paths return a value
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "f").WithArguments("C.f()").WithLocation(6, 18)
+                );
+
+            var source2 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { }
+";
+            CreateCompilationWithMscorlib45(source2).VerifyDiagnostics(
+                // (6,18): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "f").WithLocation(6, 18),
+                // (6,18): error CS0161: 'C.f()': not all code paths return a value
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "f").WithArguments("C.f()").WithLocation(6, 18)
+                );
+
+            var source3 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder { }
+";
+            CreateCompilationWithMscorlib45(source3).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AsyncTasklikeOverloadLambdas()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C {
+    static void Main() {
+        f(async () => { await (Task)null; return 1; });
+        h(async () => { await (Task)null; });
+    }
+    static void f<T>(Func<MyTask<T>> lambda) { }
+    static void f<T>(Func<T> lambda) { }
+    static void f<T>(T arg) { }
+
+    static void h(Func<MyTask> lambda) { }
+    static void h(Func<Task> lambda) { }
+}
+
+public class MyTask<T> { public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder<T> {
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult(T result) { }
+    public void SetException(Exception exception) { }
+    public MyTask<T> Task => default(MyTask<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+
+public class MyTask { public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    public MyTask Task => default(MyTask);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (8,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.h(Func<MyTask>)' and 'C.h(Func<Task>)'
+                //         h(async () => { await (Task)null; });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "h").WithArguments("C.h(System.Func<MyTask>)", "C.h(System.Func<System.Threading.Tasks.Task>)").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        public void AsyncTasklikeInadmissibleArity()
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C {
+    async Mismatch2<int,int> g() { await Task.Delay(0); return 1; }
+}
+struct Mismatch2<T,U> { public static Mismatch2MethodBuilder<T> CreateAsyncMethodBuilder() => null; }
+class Mismatch2MethodBuilder<T> {}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+            comp.VerifyEmitDiagnostics(
+                // (5,30): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async Mismatch2<int,int> g() { await Task.Delay(0); return 1; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "g").WithLocation(5, 30)
+                );
+        }
+
+        [Fact]
+        public void AsyncTasklikeOverloadInvestigations()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static Task<int> arg1 = null;
+    static int arg2 = 0;
+
+    static int f1(MyTask<int> t) => 0;
+    static int f1(Task<int> t) => 1;
+    static int r1 = f1(arg1); // 1
+
+    static void Main()
+    {
+        Console.Write(r1);
+    }
+}
+
+class ValueTask<T>
+{
+    public static ValueTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+    public static implicit operator ValueTask<T>(Task<T> task) => null;
+}
+
+class MyTask<T>
+{
+    public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+    public static implicit operator MyTask<T>(Task<T> task) => null;
+    public static implicit operator Task<T>(MyTask<T> mytask) => null;
+}
+
+class ValueTaskBuilder<T>
+{
+    public void Start<TSM>(ref TSM sm) where TSM : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine sm) { }
+    public void SetResult(T r) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+    public void AwaitOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+}
+
+class MyTaskBuilder<T>
+{
+    public void Start<TSM>(ref TSM sm) where TSM : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine sm) { }
+    public void SetResult(T r) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+    public void AwaitOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+}
+";
+            CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "1");
+        }
+
+        [Fact]
+        public void AsyncTasklikeBetterness()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static char f1(Func<ValueTask<short>> lambda) => 's';
+    static char f1(Func<Task<byte>> lambda) => 'b';
+
+    static char f2(Func<Task<short>> lambda) => 's';
+    static char f2(Func<ValueTask<byte>> lambda) => 'b';
+
+    static char f3(Func<Task<short>> lambda) => 's';
+    static char f3(Func<Task<byte>> lambda) => 'b';
+
+    static char f4(Func<ValueTask<short>> lambda) => 's';
+    static char f4(Func<ValueTask<byte>> lambda) => 'b';
+
+    static void Main()
+    {
+        Console.Write(f1(async () => { await (Task)null; return 9; }));
+        Console.Write(f2(async () => { await (Task)null; return 9; }));
+        Console.Write(f3(async () => { await (Task)null; return 9; }));
+        Console.Write(f4(async () => { await (Task)null; return 9; }));
+    }
+}
+
+public class ValueTask<T>
+{
+    public static ValueTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+}
+
+public class ValueTaskBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TSM>(ref TSM stateMachine) where TSM : IAsyncStateMachine { }
+    public void AwaitOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+    public void SetResult(T result) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+}
+";
+            CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "bbbb");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -472,6 +472,173 @@ Diagnostic(ErrorCode.ERR_AmbigCall, "M1").WithArguments("P.M1(System.Threading.T
         }
 
         [Fact]
+        public void BetterTasklikeType()
+        {
+            string source1 = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main()
+    {
+        h(async () => { await (Task)null; return 1; });
+    }
+    static void h<T>(Func<Task<T>> lambda) { }
+    static void h<T>(Func<MyTask<T>> lambda) { }
+}
+public class MyTask<T> {  public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder<T>
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult(T result) { }
+    public void SetException(Exception exception) { }
+    public MyTask<T> Task => default(MyTask<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source1).VerifyDiagnostics(
+                // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.h<T>(Func<Task<T>>)' and 'C.h<T>(Func<MyTask<T>>)'
+                //         h(async () => { await (Task)null; return 1; });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "h").WithArguments("C.h<T>(System.Func<System.Threading.Tasks.Task<T>>)", "C.h<T>(System.Func<MyTask<T>>)").WithLocation(9, 9)
+                );
+
+            string source2 = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static void Main()
+    {
+        k(async () => { await (Task)null; return 1; });
+    }
+    static void k<T>(Func<YourTask<T>> lambda) { }
+    static void k<T>(Func<MyTask<T>> lambda) { }
+}
+public class MyTask<T> {  public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder<T>
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult(T result) { }
+    public void SetException(Exception exception) { }
+    public MyTask<T> Task => default(MyTask<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+
+public class YourTask<T> {  public static YourTaskBuilder<T> CreateAsyncMethodBuilder() => null; }
+public class YourTaskBuilder<T>
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult(T result) { }
+    public void SetException(Exception exception) { }
+    public YourTask<T> Task => default(YourTask<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source2).VerifyDiagnostics(
+                // (9,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.k<T>(Func<YourTask<T>>)' and 'C.k<T>(Func<MyTask<T>>)'
+                //         k(async () => { await (Task)null; return 1; });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "k").WithArguments("C.k<T>(System.Func<YourTask<T>>)", "C.k<T>(System.Func<MyTask<T>>)").WithLocation(9, 9)
+                );
+        }
+
+        // PROTOTYPE(tasklike): Use VisitType or similar to cover all cases.
+        //[Fact]
+        public void NormalizeTaskTypes()
+        {
+            string source =
+@"class A<T>
+{
+    internal struct B<U> { }
+}
+unsafe class C<T, U>
+{
+#pragma warning disable CS0169
+    static MyTask F0;
+    static MyTask<T> F1;
+    static A<MyTask<MyTask>[]>.B<C<int, MyTask[]>> F2;
+    static int* F3;
+#pragma warning restore CS0169
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => new MyTaskMethodBuilder();
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new MyTaskMethodBuilder<T>();
+}
+struct MyTaskMethodBuilder
+{
+}
+struct MyTaskMethodBuilder<T>
+{
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.UnsafeDebugDll);
+            compilation.VerifyDiagnostics();
+
+            var type = compilation.GetMember<FieldSymbol>("C.F0").Type;
+            Assert.Equal("MyTask", type.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.Task", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+
+            type = compilation.GetMember<FieldSymbol>("C.F1").Type;
+            Assert.Equal("MyTask<T>", type.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.Task<T>", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+
+            type = compilation.GetMember<FieldSymbol>("C.F2").Type;
+            Assert.Equal("A<MyTask<MyTask>[]>.B<C<System.Int32, MyTask[]>>", type.ToTestDisplayString());
+            Assert.Equal("A<System.Threading.Tasks.Task<System.Threading.Tasks.Task>[]>.B<C<System.Int32, System.Threading.Tasks.Task[]>>", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+
+            type = compilation.GetMember<FieldSymbol>("C.F3").Type;
+            Assert.Equal("System.Int32*", type.ToTestDisplayString());
+            Assert.Equal("System.Int32*", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void NormalizeTaskTypes_Nested()
+        {
+            string source =
+@"class C<T, U>
+{
+#pragma warning disable CS0169
+    static MyTask<U> F0;
+    static C<U, object>.MyTask F1;
+#pragma warning restore CS0169
+    class MyTask
+    {
+        public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    }
+    class MyTask<V>
+    {
+        public static MyTaskMethodBuilder<V> CreateAsyncMethodBuilder() => null;
+    }
+    class MyTaskMethodBuilder
+    {
+    }
+    class MyTaskMethodBuilder<V>
+    {
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyDiagnostics();
+
+            var type = compilation.GetMember<FieldSymbol>("C.F0").Type;
+            Assert.Equal("C<T, U>.MyTask<U>", type.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.Task<U>", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+
+            type = compilation.GetMember<FieldSymbol>("C.F1").Type;
+            Assert.Equal("C<U, System.Object>.MyTask", type.ToTestDisplayString());
+            Assert.Equal("System.Threading.Tasks.Task", type.NormalizeTaskTypes(compilation).ToTestDisplayString());
+        }
+
+        [Fact]
         public void BetterDelegateType_01()
         {
             string source1 = @"
@@ -7530,15 +7697,7 @@ namespace ConsoleApplication2
 ";
 
             var compilation = CreateCompilationWithMscorlib(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
-    // (23,26): error CS0121: The call is ambiguous between the following methods or properties: 'Foo.IfNotNull<T, U>(T, Func<T, U>, params U[])' and 'Foo.IfNotNull<T, U>(T?, Func<T, U>)'
-    //             var d1 = val.IfNotNull(v => v / 100);
-    Diagnostic(ErrorCode.ERR_AmbigCall, "IfNotNull").WithArguments("ConsoleApplication2.Foo.IfNotNull<T, U>(T, System.Func<T, U>, params U[])", "ConsoleApplication2.Foo.IfNotNull<T, U>(T?, System.Func<T, U>)").WithLocation(23, 26),
-    // (24,26): error CS0121: The call is ambiguous between the following methods or properties: 'Foo.IfNotNull<T, U>(T, Func<T, U>, params U[])' and 'Foo.IfNotNull<T, U>(T?, Func<T, U>)'
-    //             var d2 = Foo.IfNotNull(val, v => v / 100);
-    Diagnostic(ErrorCode.ERR_AmbigCall, "IfNotNull").WithArguments("ConsoleApplication2.Foo.IfNotNull<T, U>(T, System.Func<T, U>, params U[])", "ConsoleApplication2.Foo.IfNotNull<T, U>(T?, System.Func<T, U>)").WithLocation(24, 26)
-                );
+            compilation.VerifyDiagnostics();
         }
 
         [Fact, WorkItem(1081302, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1081302"), WorkItem(371, "Devdiv")]
@@ -7574,15 +7733,7 @@ namespace ConsoleApplication2
 ";
 
             var compilation = CreateCompilationWithMscorlib(source1, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
-
-            compilation.VerifyDiagnostics(
-    // (23,26): error CS0121: The call is ambiguous between the following methods or properties: 'Foo.IfNotNull<T, U>(T?, Func<T, U>)' and 'Foo.IfNotNull<T, U>(T, Func<T, U>, params U[])'
-    //             var d1 = val.IfNotNull(v => v / 100);
-    Diagnostic(ErrorCode.ERR_AmbigCall, "IfNotNull").WithArguments("ConsoleApplication2.Foo.IfNotNull<T, U>(T?, System.Func<T, U>)", "ConsoleApplication2.Foo.IfNotNull<T, U>(T, System.Func<T, U>, params U[])").WithLocation(23, 26),
-    // (24,26): error CS0121: The call is ambiguous between the following methods or properties: 'Foo.IfNotNull<T, U>(T?, Func<T, U>)' and 'Foo.IfNotNull<T, U>(T, Func<T, U>, params U[])'
-    //             var d2 = Foo.IfNotNull(val, v => v / 100);
-    Diagnostic(ErrorCode.ERR_AmbigCall, "IfNotNull").WithArguments("ConsoleApplication2.Foo.IfNotNull<T, U>(T?, System.Func<T, U>)", "ConsoleApplication2.Foo.IfNotNull<T, U>(T, System.Func<T, U>, params U[])").WithLocation(24, 26)
-                );
+            compilation.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Test.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
-    public class RefLocalsAndReturnsTeats : CompilingTestBase
+    public class RefLocalsAndReturnsTests : CompilingTestBase
     {
         internal static CSharpCompilation CreateCompilationRef(
             string text,

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -660,6 +660,7 @@ Microsoft.CodeAnalysis.Semantics.UnaryOperationKind.UnsignedPrefixIncrement = 77
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation
+const Microsoft.CodeAnalysis.WellKnownMemberNames.CreateAsyncMethodBuilder = "CreateAsyncMethodBuilder" -> string
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.Visit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitAddressOfExpression(Microsoft.CodeAnalysis.Semantics.IAddressOfExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitArgument(Microsoft.CodeAnalysis.Semantics.IArgument operation) -> void

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -298,5 +298,11 @@ namespace Microsoft.CodeAnalysis
         /// (see C# Specification, §7.7.7.1 Awaitable expressions).
         /// </summary>
         public const string OnCompleted = nameof(OnCompleted);
+
+        /// <summary>
+        /// The required name for the <c>CreateAsyncMethodBuilder</c> method used to
+        /// build a tasklike instance.
+        /// </summary>
+        public const string CreateAsyncMethodBuilder = "CreateAsyncMethodBuilder";
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -309,6 +309,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext,
         System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine,
 
+        System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetResult,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitOnCompleted,
@@ -316,6 +317,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Start_T,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetStateMachine,
 
+        System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetResult,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__AwaitOnCompleted,
@@ -324,6 +326,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetStateMachine,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Task,
 
+        System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetResult,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__AwaitOnCompleted,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2235,6 +2235,13 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine,
 
+                // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,
+
                 // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
                 (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,                                 // DeclaringTypeId
@@ -2283,6 +2290,13 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine,
+
+                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder,
 
                 // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
@@ -2339,6 +2353,13 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task,
+                    
+                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T,                               // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T,
 
                 // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
@@ -3098,12 +3119,14 @@ namespace Microsoft.CodeAnalysis
                 "CallByName",                               // Microsoft_VisualBasic_Interaction__CallByName
                 "MoveNext",                                 // System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext
                 "SetStateMachine",                          // System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine
+                "Create",                                   // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitOnCompleted
                 "AwaitUnsafeOnCompleted",                   // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitUnsafeOnCompleted
                 "Start",                                    // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Start_T
                 "SetStateMachine",                          // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetStateMachine
+                "Create",                                   // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__AwaitOnCompleted
@@ -3111,6 +3134,7 @@ namespace Microsoft.CodeAnalysis
                 "Start",                                    // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Start_T
                 "SetStateMachine",                          // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetStateMachine
                 "Task",                                     // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Task
+                "Create",                                   // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__AwaitOnCompleted

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AsyncSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AsyncSymbols.vb
@@ -257,7 +257,7 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSAsyncLambaName1() As Task
+        Public Async Function TestCSAsyncLambdaName1() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -284,7 +284,7 @@ class Test
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestVBAsyncLambaName1() As Task
+        Public Async Function TestVBAsyncLambdaName1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -359,7 +359,7 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestAsyncWithinLamba() As Task
+        Public Async Function TestAsyncWithinLambda() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">


### PR DESCRIPTION
Allow async methods to return types other than `void`, `Task`, or `Task<T>`. Specifically allow `Task`-like types (and `AsyncMethodBuilder` types) if the types contain an expected set of members.

Next: Compare full signature including type constraints when looking up members. (Currently, lookup is by name only.) And add more tests.

[Thanks to Lucian for prototyping this feature.] 