### PR TITLE
Fix some fast up to date check issues

### DIFF
--- a/build/Targets/ProducesNoOutput.Imports.targets
+++ b/build/Targets/ProducesNoOutput.Imports.targets
@@ -7,8 +7,5 @@
     <TargetPath></TargetPath>    <!-- Prevent projects referencing this from trying to pass us to the compiler -->
   </PropertyGroup>
   
-  <Target Name="CoreCompile" />                               <!-- Prevent Csc from being called -->  
-  <Target Name="GenerateTargetFrameworkMonikerAttribute" />   <!-- Don't generate TFM attribute -->  
   <Target Name="RuntimeImplementationProjectOutputGroup" />   <!-- Group always attempts resolve runtime, regardless of <CopyNuGetImplementations>-->
-  
 </Project>

--- a/build/Targets/ProducesNoOutput.Settings.targets
+++ b/build/Targets/ProducesNoOutput.Settings.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Import Project="Settings.targets" />
+  <Import Project="VSL.Settings.targets" />
 
   <PropertyGroup>
     <IsDeployment Condition="'$(IsDeployment)' == ''">false</IsDeployment>
@@ -14,8 +14,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/Compilers/CSharp/Test/Syntax/project.json
+++ b/src/Compilers/CSharp/Test/Syntax/project.json
@@ -2,7 +2,7 @@
   "dependencies": { },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Compilers/Test/Utilities/CSharp/project.json
+++ b/src/Compilers/Test/Utilities/CSharp/project.json
@@ -3,7 +3,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Interactive/CsiCore/project.json
+++ b/src/Interactive/CsiCore/project.json
@@ -2,7 +2,7 @@
   "dependencies": { },
   "frameworks": {
     "NETCoreApp1.0": {
-      "imports": ["portable-net452", "dotnet"]
+      "imports": "portable-net452"
     }
   },
   "runtimes": {

--- a/src/Interactive/VbiCore/project.json
+++ b/src/Interactive/VbiCore/project.json
@@ -2,7 +2,7 @@
   "dependencies": { },
   "frameworks": {
     "NETCoreApp1.0": {
-      "imports": ["portable-net452", "dotnet"]
+      "imports": "portable-net452"
     }
   },
   "runtimes": {

--- a/src/Scripting/CSharp/project.json
+++ b/src/Scripting/CSharp/project.json
@@ -5,7 +5,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Scripting/CSharpTest/project.json
+++ b/src/Scripting/CSharpTest/project.json
@@ -4,7 +4,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Scripting/Core/project.json
+++ b/src/Scripting/Core/project.json
@@ -21,7 +21,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Scripting/CoreTest/project.json
+++ b/src/Scripting/CoreTest/project.json
@@ -2,7 +2,7 @@
   "dependencies": { },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Scripting/VisualBasic/project.json
+++ b/src/Scripting/VisualBasic/project.json
@@ -4,7 +4,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Scripting/VisualBasicTest/project.json
+++ b/src/Scripting/VisualBasicTest/project.json
@@ -4,7 +4,7 @@
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [ "portable-net452", "dotnet5.4" ]
+      "imports": "portable-net452"
     }
   }
 }

--- a/src/Test/Utilities/Portable/project.json
+++ b/src/Test/Utilities/Portable/project.json
@@ -9,16 +9,14 @@
     "System.Diagnostics.Tools": "4.0.1",
     "System.IO.FileSystem": "4.0.1",
     "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Text.RegularExpressions": "4.1.0",
     "System.Threading.Thread": "4.0.0",
     "System.Xml.XDocument": "4.0.11",
     "System.Xml.XmlDocument": "4.0.1"
   },
   "frameworks": {
     "netstandard1.3": {
-      "imports": [
-        "portable-net452",
-        "dotnet"
-      ]
+      "imports": "portable-net452"
     }
   }
 }


### PR DESCRIPTION
This fixes some, but not all, of the issues causing fast up to date checks to fail. This reduces the number of projects being built if I hit F6 without changes from over a hundred down to around 18 on my machine. There's still more work to do here, but this should at least improve quality of life for people.

*Review:* @dotnet/roslyn-infrastructure, @dotnet/roslyn-ide, @rchande, @tmat, @davkean