### PR TITLE
Move last custom MicroBuild step to Roslyn repo

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -194,6 +194,6 @@ commitPullList.each { isPr ->
 
   def triggerPhraseOnly = false
   def triggerPhraseExtra = "microbuild"
-  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-update3')
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15')
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -16,6 +16,7 @@
     <BranchName Condition="'$(BranchName)' == ''">master</BranchName>
     <SignRoslynArgs>-test</SignRoslynArgs>
     <PublishAssetsArgs>-test</PublishAssetsArgs>
+    <CopyInsertionFileArgs>-test</CopyInsertionFileArgs>
   </PropertyGroup>
 
   <Target Name="Build">
@@ -40,6 +41,8 @@
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)stop-compiler-server.ps1" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)publish-assets.ps1 -binariesPath &quot;$(BinariesPath)&quot; -branchName $(BranchName) -apiKey $(RoslynMyGetApiKey) $(PublishAssetsArgs)" />
+
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)copy-insertion-items.ps1 -binariesPath &quot;$(BinariesPath)&quot; $(CopyInsertionFileArgs)" />
   </Target>
 
 </Project>

--- a/src/Tools/MicroBuild/copy-insertion-items.ps1
+++ b/src/Tools/MicroBuild/copy-insertion-items.ps1
@@ -1,0 +1,52 @@
+Param(
+    [string]$binariesPath = $null,
+    [switch]$test
+)
+set-strictmode -version 2.0
+$ErrorActionPreference="Stop"
+
+try
+{
+    $items = @(
+        "ExpressionEvaluatorPackage.vsix",
+        "Microsoft.VisualStudio.LanguageServices.Telemetry.vsix",
+        "Microsoft.VisualStudio.VsInteractiveWindow.vsix",
+        "Roslyn.VisualStudio.InteractiveComponents.vsix",
+        "Roslyn.VisualStudio.Setup.Interactive.vsix",
+        "Roslyn.VisualStudio.Setup.Next.vsix",
+        "Roslyn.VisualStudio.Setup.vsix",
+        "Microsoft.CodeAnalysis.ExpressionEvaluator.json",
+        "Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.json",
+        "Microsoft.CodeAnalysis.VisualStudio.Setup.json",
+        "Microsoft.CodeAnalysis.VisualStudio.Setup.Next.json",
+        "Microsoft.CodeAnalysis.VisualStudio.Telemetry.json",
+        "Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.json",
+        "Microsoft.CodeAnalysis.VisualStudioInteractiveWindow.json",
+        "Microsoft.CodeAnalysis.LanguageServices.vsman",
+        "Microsoft.CodeAnalysis.Compilers.json",
+        "Microsoft.CodeAnalysis.Compilers.vsix",
+        "Microsoft.CodeAnalysis.Compilers.vsman")
+    $destPath = join-path $binariesPath "Insertion"
+    foreach ($item in $items) 
+    {
+        $sourcePath = join-path $binariesPath $item
+
+        # Many of these files are only produced in the Official MicroBuild runs.  On test runs, which run locally,
+        # we need to guard agains this.
+        if ((-not (test-path $sourcePath)) -and $test)
+        {
+            write-host "Skip copying $sourcePath for test run"
+            continue;
+        }
+
+        write-host "Copying $sourcePath to $destPath"
+        copy $sourcePath $destPath
+    }
+
+    exit 0
+}
+catch [exception]
+{
+    write-host $_.Exception
+    exit -1
+}


### PR DESCRIPTION
This moves the last custom MicroBuild step into the Roslyn repo.  This now gives us fully control over the binaries produced and their final locations in our source.  No need to coordinate changes to the official build with source changes / branches.