### PR TITLE
Fix remaining fast up to date check issues

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -223,6 +223,10 @@
     </PropertyGroup>
   </Target>
 
+  <!-- For our projects that specify multiple targets in the project.json to work around https://github.com/dotnet/roslyn/issues/12458,
+       we need to also silence a NuGet generated warning -->
+  <Target Name="EmitMSBuildWarning"></Target>
+
   <!-- ====================================================================================
 
          Support for a IncludeInVSIXLocalOnly Content metadata

--- a/src/Compilers/CSharp/CscCore/project.json
+++ b/src/Compilers/CSharp/CscCore/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": { },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Compilers/Core/MSBuildTask/Desktop/MSBuildTask.Desktop.csproj
+++ b/src/Compilers/Core/MSBuildTask/Desktop/MSBuildTask.Desktop.csproj
@@ -23,6 +23,14 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\Shared\Microsoft.CSharp.Core.targets">
+      <Link>Microsoft.CSharp.Core.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Shared\Microsoft.VisualBasic.Core.targets">
+      <Link>Microsoft.VisualBasic.Core.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
+++ b/src/Compilers/Core/MSBuildTask/Portable/MSBuildTask.csproj
@@ -28,6 +28,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <None Include="..\Shared\Microsoft.CSharp.Core.targets">
+      <Link>Microsoft.CSharp.Core.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Shared\Microsoft.VisualBasic.Core.targets">
+      <Link>Microsoft.VisualBasic.Core.targets</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="project.json" />
     <!-- A reference to the entire .NET Framework is automatically included -->
   </ItemGroup>

--- a/src/Compilers/Core/MSBuildTask/Shared/MSBuildTask.Shared.projitems
+++ b/src/Compilers/Core/MSBuildTask/Shared/MSBuildTask.Shared.projitems
@@ -29,12 +29,4 @@
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)Microsoft.CSharp.Core.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="$(MSBuildThisFileDirectory)Microsoft.VisualBasic.Core.targets">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 </Project>

--- a/src/Compilers/Server/PortableServer/project.json
+++ b/src/Compilers/Server/PortableServer/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": { },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Compilers/VisualBasic/VbcCore/project.json
+++ b/src/Compilers/VisualBasic/VbcCore/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": { },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Deployment/Roslyn.csproj
+++ b/src/Deployment/Roslyn.csproj
@@ -17,8 +17,6 @@
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <ImportVSSDKTargets>true</ImportVSSDKTargets>
     <CreateVsixContainer>True</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>

--- a/src/Interactive/CsiCore/project.json
+++ b/src/Interactive/CsiCore/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": { },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Interactive/VbiCore/project.json
+++ b/src/Interactive/VbiCore/project.json
@@ -1,6 +1,10 @@
 ﻿{
   "dependencies": { },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Test/DeployCoreClrTestRuntime/project.json
+++ b/src/Test/DeployCoreClrTestRuntime/project.json
@@ -3,6 +3,10 @@
     "xunit.console.netcore": "1.0.2-prerelease-00104"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": [ "portable-net452", "dotnet" ]
+    },
     "NETCoreApp1.0": {
       "imports": [ "portable-net452", "dotnet" ]
     }

--- a/src/Test/Perf/tests/Perf.Tests.csproj
+++ b/src/Test/Perf/tests/Perf.Tests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="CopyTestFiles" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Label="Settings">
     <Import Project="..\..\..\..\build\Targets\VSL.Settings.targets" />
   </ImportGroup>
@@ -9,18 +9,19 @@
     <ProjectGuid>{DA0D2A70-A2F9-4654-A99A-3227EDF54FF1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Roslyn.Test.Performance</RootNamespace>
-    <AssemblyName>Roslyn.Test.Performance.Utilities</AssemblyName>
+    <RootNamespace>Roslyn.Test.Performance.Tests</RootNamespace>
+    <AssemblyName>Roslyn.Test.Performance.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <OutDir>$(OutDir)\Perf\Tests\</OutDir>
+    <Nonshipping>true</Nonshipping>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\Perf\tests</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -29,7 +30,6 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\Perf\tests</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -49,13 +49,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <TestFiles Include=".\**\*.*" Exclude=".\Perf.Tests.csproj" />
+    <Content Include="**\*.*" Exclude="$(MSBuildThisFile)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
-
-  <Target Name="CopyTestFiles">
-    <Copy SourceFiles="@(TestFiles)" DestinationFiles="@(TestFiles->'$(OutputPath)\Perf\tests\%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
-
   <ImportGroup Label="Targets">
     <Import Project="..\..\..\..\build\Targets\VSL.Imports.targets" />
   </ImportGroup>

--- a/src/Tools/CommonCoreClrRuntime/project.json
+++ b/src/Tools/CommonCoreClrRuntime/project.json
@@ -5,6 +5,10 @@
     "System.Runtime": "4.1.0"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Tools/CommonNetCoreReferences/project.json
+++ b/src/Tools/CommonNetCoreReferences/project.json
@@ -49,6 +49,10 @@
     "System.Xml.XPath.XDocument": "4.0.1"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "netcoreapp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Tools/Source/CompilerGeneratorTools/DeployCompilerGeneratorToolsRuntime/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/DeployCompilerGeneratorToolsRuntime/project.json
@@ -6,6 +6,10 @@
     "Microsoft.NETCore.TestHost": "1.0.0"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": {
+      "imports": "portable-net452"
+    },
     "NETCoreApp1.0": {
       "imports": "portable-net452"
     }

--- a/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/BoundTreeGenerator/project.json
@@ -6,6 +6,8 @@
     "System.Xml.XmlSerializer": "4.0.11"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": { },
     "NETCoreApp1.0": { }
   },
   "runtimes": {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpErrorFactsGenerator/project.json
@@ -4,6 +4,8 @@
     "NETStandard.Library": "1.6.0",
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": { },
     "NETCoreApp1.0": { }
   },
   "runtimes": {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/CSharpSyntaxGenerator/project.json
@@ -6,6 +6,8 @@
     "System.Xml.XmlSerializer": "4.0.11"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": { },
     "NETCoreApp1.0": { }
   },
   "runtimes": {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicErrorFactsGenerator/project.json
@@ -4,6 +4,8 @@
     "NETStandard.Library": "1.6.0"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": { },
     "NETCoreApp1.0": { }
   },
   "runtimes": {

--- a/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/project.json
+++ b/src/Tools/Source/CompilerGeneratorTools/Source/VisualBasicSyntaxGenerator/project.json
@@ -6,6 +6,8 @@
     "System.Security.Cryptography.Algorithms": "4.2.0"
   },
   "frameworks": {
+    // We don't actually target netstandard1.6; this is to work around https://github.com/dotnet/roslyn/issues/12458
+    "netstandard1.6": { },
     "NETCoreApp1.0": { }
   },
   "runtimes": {


### PR DESCRIPTION
With these workarounds, I'm able to do an incremental F6 in Visual Studio and it says everything is up to date. 

#12461 and #12458 have been filed tracking the two portable flavor issues I ran into. Internal bugs 239691 and 239697 have been filed on the two other native project system bugs.

*Review*: @TyOverby, @rchande, @jaredpar, @dotnet/roslyn-infrastructure, @tmat