### PR TITLE
Run the compiler server at BelowNormal priority so it doesn't interfere with other processes when saturating the CPU.

### DIFF
--- a/src/Compilers/Server/PortableServer/Program.cs
+++ b/src/Compilers/Server/PortableServer/Program.cs
@@ -1,9 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Net;
-using System.Threading;
-
 namespace Microsoft.CodeAnalysis.CompilerServer
 {
     public class Program

--- a/src/Compilers/Server/ServerShared/BuildServerController.cs
+++ b/src/Compilers/Server/ServerShared/BuildServerController.cs
@@ -1,15 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Globalization;
 using Microsoft.CodeAnalysis.CommandLine;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {
@@ -65,6 +61,11 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         internal int RunServer(string pipeName, IClientConnectionHost clientConnectionHost = null, IDiagnosticListener listener = null, TimeSpan? keepAlive = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            // Run the compiler at below normal priority so that it will not interfere with other
+            // processes when it is saturating the CPU during compile tasks.
+            var thisProcess = Process.GetCurrentProcess();
+            thisProcess.PriorityClass = ProcessPriorityClass.BelowNormal;
+
             keepAlive = keepAlive ?? GetKeepAliveTimeout();
             listener = listener ?? new EmptyDiagnosticListener();
             clientConnectionHost = clientConnectionHost ?? CreateClientConnectionHost(pipeName);

--- a/src/Compilers/Server/ServerShared/ServerDispatcher.cs
+++ b/src/Compilers/Server/ServerShared/ServerDispatcher.cs
@@ -112,7 +112,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 MaybeCreateGCTask();
                 WaitForAnyCompletion(cancellationToken);
                 CheckCompletedTasks(cancellationToken);
-            } while (_connectionList.Count > 0 || _state == State.Running);
+            }
+            while (_connectionList.Count > 0 || _state == State.Running);
         }
 
         private void CheckCompletedTasks(CancellationToken cancellationToken)

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -1,14 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Configuration;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Globalization;

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -5,12 +5,9 @@ extern alias vbc;
 
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Moq;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11942
