### PR TITLE
Don't mention 'switch' so lightbulb text can apply equally to VB and C#

### DIFF
--- a/src/Features/Core/Portable/FeaturesResources.Designer.cs
+++ b/src/Features/Core/Portable/FeaturesResources.Designer.cs
@@ -89,20 +89,20 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add default switch case.
+        ///   Looks up a localized string similar to Add default case.
         /// </summary>
-        internal static string Add_default_switch_case {
+        internal static string Add_default_case {
             get {
-                return ResourceManager.GetString("Add_default_switch_case", resourceCulture);
+                return ResourceManager.GetString("Add_default_case", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Add missing switch cases.
+        ///   Looks up a localized string similar to Add missing cases.
         /// </summary>
-        internal static string Add_missing_switch_cases {
+        internal static string Add_missing_cases {
             get {
-                return ResourceManager.GetString("Add_missing_switch_cases", resourceCulture);
+                return ResourceManager.GetString("Add_missing_cases", resourceCulture);
             }
         }
         

--- a/src/Features/Core/Portable/FeaturesResources.resx
+++ b/src/Features/Core/Portable/FeaturesResources.resx
@@ -1004,14 +1004,14 @@ This version used in: {2}</value>
   <data name="Parameters" xml:space="preserve">
     <value>Parameters:</value>
   </data>
-  <data name="Add_missing_switch_cases" xml:space="preserve">
-    <value>Add missing switch cases</value>
+  <data name="Add_missing_cases" xml:space="preserve">
+    <value>Add missing cases</value>
   </data>
   <data name="Add_both" xml:space="preserve">
     <value>Add both</value>
   </data>
-  <data name="Add_default_switch_case" xml:space="preserve">
-    <value>Add default switch case</value>
+  <data name="Add_default_case" xml:space="preserve">
+    <value>Add default case</value>
   </data>
   <data name="VariadicSignaturehelpitemMustHaveOneParam" xml:space="preserve">
     <value>Variadic SignatureHelpItem must have at least one parameter.</value>

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchCodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             {
                 context.RegisterCodeFix(
                     new MyCodeAction(
-                        FeaturesResources.Add_missing_switch_cases,
+                        FeaturesResources.Add_missing_cases,
                         c => AddMissingSwitchCasesAsync(context, includeMissingCases: true, includeDefaultCase: false)),
                     context.Diagnostics);
             }
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
             {
                 context.RegisterCodeFix(
                     new MyCodeAction(
-                        FeaturesResources.Add_default_switch_case,
+                        FeaturesResources.Add_default_case,
                         c => AddMissingSwitchCasesAsync(context, includeMissingCases: false, includeDefaultCase: true)),
                     context.Diagnostics);
             }

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     internal class PopulateSwitchDiagnosticAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FeaturesResources.Add_missing_switch_cases), FeaturesResources.ResourceManager, typeof(FeaturesResources));
+        private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FeaturesResources.Add_missing_cases), FeaturesResources.ResourceManager, typeof(FeaturesResources));
         private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.PopulateSwitch), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
 
         private static readonly DiagnosticDescriptor s_descriptor = new DiagnosticDescriptor(IDEDiagnosticIds.PopulateSwitchDiagnosticId,


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12235