### PR TITLE
Preserve trailing trivia in 'Replace Property with Methods'

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -281,6 +281,23 @@ class D
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestComputedPropWithTrailingTrivia()
+        {
+            await TestAsync(
+@"class C
+{
+    int [||]Prop => 1; // Comment
+}",
+@"class C
+{
+    private int GetProp()
+    {
+        return 1; // Comment
+    }
+}", compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
         public async Task TestAbstractProperty()
         {
             await TestAsync(

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -63,7 +63,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
 
         private List<SyntaxNode> ConvertPropertyToMembers(
             SyntaxGenerator generator, 
-            IPropertySymbol property, PropertyDeclarationSyntax propertyDeclaration,
+            IPropertySymbol property,
+            PropertyDeclarationSyntax propertyDeclaration,
             IFieldSymbol propertyBackingField,
             string desiredGetMethodName,
             string desiredSetMethodName,
@@ -134,7 +135,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
 
             if (propertyDeclaration.ExpressionBody != null)
             {
-                statements.Add(generator.ReturnStatement(propertyDeclaration.ExpressionBody.Expression));
+                var returnStatement = SyntaxFactory.ReturnStatement(propertyDeclaration.ExpressionBody.Expression)
+                                                   .WithSemicolonToken(propertyDeclaration.SemicolonToken);
+                statements.Add(returnStatement);
             }
             else
             {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12142