### PR TITLE
Fixing the VB/C# Dynamic Analysis Injector to skip syntax trees that do not have a valid path.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.vb
@@ -35,13 +35,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Do not instrument any methods if CreatePayload is not present.
                 ' Do not instrument CreatePayload if it is part of the current compilation (which occurs only during testing).
+                ' Do not instrument if the syntax node does not have a valid mapped line span.
                 ' CreatePayload will fail at run time with an infinite recursion if it Is instrumented.
-                If createPayload IsNot Nothing AndAlso Not method.Equals(createPayload) Then
+                If createPayload IsNot Nothing AndAlso Not method.Equals(createPayload) AndAlso HasValidMappedLineSpan(methodBody.Syntax) Then
                     Return New DynamicAnalysisInjector(method, methodBody, methodBodyFactory, createPayload, diagnostics, debugDocumentProvider, previous)
                 End If
             End If
 
             Return Nothing
+        End Function
+
+        Private Shared Function HasValidMappedLineSpan(syntax As VisualBasicSyntaxNode) As Boolean
+            Return syntax.GetLocation().GetMappedLineSpan().IsValid
         End Function
 
         Public ReadOnly Property DynamicAnalysisSpans As ImmutableArray(Of SourceSpan)


### PR DESCRIPTION
FYI. @JohnHamby, @dotnet/roslyn-compiler 

The `GetLocation()` function will return a `MyTemplateLocation` object for the `MyTemplate` syntax tree.

The `MyTemplateLocation` type does not override the `GetMappedLineSpan()` method and therefore always returns a `Location` object with a `null` path.

This updates the `AddAnalysisPoint` code to properly handle a `null` path and treat it as equivalent to an `empty` path. It additionally adds an assert that validates the path is only `null` when the location is an instance of `MyTemplateLocation`.

I should note that the path for the entire syntax tree, in the case of MyTemplate, is an empty string.