### PR TITLE
Allow async methods to return Task-like types

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -493,10 +493,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundLocalFunctionStatement(node, localSymbol, block, hasErrors);
         }
 
-        private static bool ImplicitReturnIsOkay(MethodSymbol method)
+        private bool ImplicitReturnIsOkay(MethodSymbol method)
         {
-            return method.ReturnsVoid || method.IsIterator ||
-                (method.IsAsync && method.DeclaringCompilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) == method.ReturnType);
+            return method.ReturnsVoid || method.IsIterator || method.IsTaskReturningAsync(this.Compilation);
         }
 
         public BoundStatement BindExpressionStatement(ExpressionStatementSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -1072,31 +1072,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             else
             {
                 // error CS0121: The call is ambiguous between the following methods or properties: 'P.W(A)' and 'P.W(B)'
-                var first = worseResult1.LeastOverriddenMember.OriginalDefinition;
-                var second = worseResult2.LeastOverriddenMember.OriginalDefinition;
-
-                if (first.ContainingNamespace != second.ContainingNamespace)
-                {
-                    diagnostics.Add(new DiagnosticInfoWithSymbols(
-                        ErrorCode.ERR_AmbigCall,
-                        new object[]
-                            {
-                                new FormattedSymbol(first, SymbolDisplayFormat.CSharpErrorMessageFormat),
-                                new FormattedSymbol(second, SymbolDisplayFormat.CSharpErrorMessageFormat)
-                            },
-                        symbols), location);
-                }
-                else
-                {
-                    diagnostics.Add(new DiagnosticInfoWithSymbols(
-                        ErrorCode.ERR_AmbigCall,
-                        new object[]
-                            {
-                                first,
-                                second
-                            },
-                        symbols), location);
-                }
+                diagnostics.Add(
+                    CreateAmbiguousCallDiagnosticInfo(
+                        worseResult1.LeastOverriddenMember.OriginalDefinition,
+                        worseResult2.LeastOverriddenMember.OriginalDefinition,
+                        symbols),
+                    location);
             }
 
             return true;
@@ -1144,31 +1125,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // error CS0121: The call is ambiguous between the following methods or properties:
             // 'P.Ambiguous(object, string)' and 'P.Ambiguous(string, object)'
-            var first = validResult1.LeastOverriddenMember.OriginalDefinition;
-            var second = validResult2.LeastOverriddenMember.OriginalDefinition;
-
-            if (first.ContainingNamespace != second.ContainingNamespace)
-            {
-                diagnostics.Add(new DiagnosticInfoWithSymbols(
-                ErrorCode.ERR_AmbigCall,
-                new object[]
-                    {
-                        new FormattedSymbol(first, SymbolDisplayFormat.CSharpErrorMessageFormat),
-                        new FormattedSymbol(second, SymbolDisplayFormat.CSharpErrorMessageFormat)
-                    },
-                symbols), location);
-            }
-            else
-            {
-                diagnostics.Add(new DiagnosticInfoWithSymbols(
-                ErrorCode.ERR_AmbigCall,
-                new object[]
-                    {
-                        first,
-                        second
-                    },
-                symbols), location);
-            }
+            diagnostics.Add(
+                CreateAmbiguousCallDiagnosticInfo(
+                    validResult1.LeastOverriddenMember.OriginalDefinition,
+                    validResult2.LeastOverriddenMember.OriginalDefinition,
+                    symbols),
+                location);
 
             return true;
         }
@@ -1200,6 +1162,22 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return count;
+        }
+
+        private static DiagnosticInfoWithSymbols CreateAmbiguousCallDiagnosticInfo(Symbol first, Symbol second, ImmutableArray<Symbol> symbols)
+        {
+            var arguments = (first.ContainingNamespace != second.ContainingNamespace) ?
+                new object[]
+                    {
+                            new FormattedSymbol(first, SymbolDisplayFormat.CSharpErrorMessageFormat),
+                            new FormattedSymbol(second, SymbolDisplayFormat.CSharpErrorMessageFormat)
+                    } :
+                new object[]
+                    {
+                            first,
+                            second
+                    };
+            return new DiagnosticInfoWithSymbols(ErrorCode.ERR_AmbigCall, arguments, symbols);
         }
 
         [Conditional("DEBUG")]

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Collections;
 using Roslyn.Utilities;
 
@@ -63,12 +62,19 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         CSharpSyntaxNode IBoundLambdaOrFunction.Syntax { get { return Syntax; } }
 
-        public BoundLambda(CSharpSyntaxNode syntax, BoundBlock body, ImmutableArray<Diagnostic> diagnostics, Binder binder, TypeSymbol type, bool inferReturnType)
-            : this(syntax, (LambdaSymbol)binder.ContainingMemberOrLambda, body, diagnostics, binder, type)
+        public BoundLambda(CSharpSyntaxNode syntax, BoundBlock body, ImmutableArray<Diagnostic> diagnostics, Binder binder, TypeSymbol delegateType, bool inferReturnType)
+            : this(syntax, (LambdaSymbol)binder.ContainingMemberOrLambda, body, diagnostics, binder, delegateType)
         {
             if (inferReturnType)
             {
-                this._inferredReturnType = InferReturnType(this.Body, this.Binder, this.Symbol.IsAsync, ref this._inferredReturnTypeUseSiteDiagnostics, out this._refKind, out this._inferredFromSingleType);
+                this._inferredReturnType = InferReturnType(
+                    this.Body,
+                    this.Binder,
+                    delegateType,
+                    this.Symbol.IsAsync,
+                    ref this._inferredReturnTypeUseSiteDiagnostics,
+                    out this._refKind,
+                    out this._inferredFromSingleType);
 
 #if DEBUG
                 _hasInferredReturnType = true;
@@ -104,7 +110,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return _inferredReturnType;
         }
 
-        private static TypeSymbol InferReturnType(BoundBlock block, Binder binder, bool isAsync, ref HashSet<DiagnosticInfo> useSiteDiagnostics, out RefKind refKind, out bool inferredFromSingleType)
+        private static TypeSymbol InferReturnType(
+            BoundBlock block,
+            Binder binder,
+            TypeSymbol delegateType,
+            bool isAsync,
+            ref HashSet<DiagnosticInfo> useSiteDiagnostics,
+            out RefKind refKind,
+            out bool inferredFromSingleType)
         {
             int numberOfDistinctReturns;
             var resultTypes = BlockReturns.GetReturnTypes(block, out refKind, out numberOfDistinctReturns);
@@ -130,12 +143,28 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return bestResultType;
             }
 
-            // Async:
+            // For async lambdas, the return type is the return type of the
+            // delegate Invoke method if Invoke has a Task-like return type.
+            // Otherwise the return type is Task or Task<T>.
+            NamedTypeSymbol taskType = null;
+            var delegateReturnType = delegateType?.GetDelegateType()?.DelegateInvokeMethod?.ReturnType as NamedTypeSymbol;
+            if ((object)delegateReturnType != null)
+            {
+                NamedTypeSymbol builderType;
+                MethodSymbol createBuilderMethod;
+                if (delegateReturnType.IsCustomTaskType(out builderType, out createBuilderMethod))
+                {
+                    taskType = delegateReturnType;
+                }
+            }
 
             if (resultTypes.IsEmpty)
             {
-                // No return statements have expressions; inferred type Task:
-                return binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                // No return statements have expressions; use delegate InvokeMethod
+                // or infer type Task if delegate type not available.
+                return (object)taskType != null && taskType.Arity == 0 ?
+                    taskType :
+                    binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
             }
 
             if ((object)bestResultType == null || bestResultType.SpecialType == SpecialType.System_Void)
@@ -145,8 +174,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            // Some non-void best type T was found; infer type Task<T>:
-            return binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T).Construct(bestResultType);
+            // Some non-void best type T was found; use delegate InvokeMethod
+            // or infer type Task<T> if delegate type not available.
+            var taskTypeT = (object)taskType != null && taskType.Arity == 1 ?
+                delegateReturnType.ConstructedFrom :
+                binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+            return taskTypeT.Construct(bestResultType);
         }
 
         internal sealed class BlockReturns : BoundTreeWalker
@@ -341,33 +374,35 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static ImmutableArray<ParameterSymbol> DelegateParameters(NamedTypeSymbol delegateType)
+        private static MethodSymbol DelegateInvokeMethod(NamedTypeSymbol delegateType)
         {
-            NamedTypeSymbol d = delegateType.GetDelegateType();
-            return ((object)d == null || (object)d.DelegateInvokeMethod == null) ? ImmutableArray<ParameterSymbol>.Empty : d.DelegateInvokeMethod.Parameters;
+            return delegateType.GetDelegateType()?.DelegateInvokeMethod;
         }
 
-        private static TypeSymbol DelegateReturnType(NamedTypeSymbol delegateType, out RefKind refKind)
+        private static ImmutableArray<ParameterSymbol> DelegateParameters(MethodSymbol invokeMethod)
         {
-            NamedTypeSymbol d = delegateType.GetDelegateType();
-            if ((object)d == null || (object)d.DelegateInvokeMethod == null)
+            return ((object)invokeMethod == null) ? ImmutableArray<ParameterSymbol>.Empty : invokeMethod.Parameters;
+        }
+
+        private static TypeSymbol DelegateReturnType(MethodSymbol invokeMethod, out RefKind refKind)
+        {
+            if ((object)invokeMethod == null)
             {
                 refKind = Microsoft.CodeAnalysis.RefKind.None;
                 return null;
-        }
-            refKind = d.DelegateInvokeMethod.RefKind;
-            return d.DelegateInvokeMethod.ReturnType;
+            }
+            refKind = invokeMethod.RefKind;
+            return invokeMethod.ReturnType;
         }
 
-        private bool DelegateNeedsReturn(NamedTypeSymbol delegateType)
+        private bool DelegateNeedsReturn(MethodSymbol invokeMethod)
         {
-            NamedTypeSymbol d = delegateType.GetDelegateType();
-            if ((object)d == null || (object)d.DelegateInvokeMethod == null || d.DelegateInvokeMethod.ReturnsVoid)
+            if ((object)invokeMethod == null || invokeMethod.ReturnsVoid)
             {
                 return false;
             }
 
-            if (IsAsync && this.binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) == d.DelegateInvokeMethod.ReturnType)
+            if (IsAsync && invokeMethod.ReturnType.IsNonGenericTaskType(this.binder.Compilation))
             {
                 return false;
             }
@@ -377,8 +412,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundLambda ReallyBind(NamedTypeSymbol delegateType)
         {
+            var invokeMethod = DelegateInvokeMethod(delegateType);
             RefKind refKind;
-            var returnType = DelegateReturnType(delegateType, out refKind);
+            var returnType = DelegateReturnType(invokeMethod, out refKind);
 
             LambdaSymbol lambdaSymbol;
             Binder lambdaBodyBinder;
@@ -394,20 +430,26 @@ namespace Microsoft.CodeAnalysis.CSharp
             BoundLambda returnInferenceLambda;
             if (_returnInferenceCache.TryGetValue(cacheKey, out returnInferenceLambda) && returnInferenceLambda.InferredFromSingleType)
             {
-                var lambdaSym = returnInferenceLambda.Symbol;
-                if (lambdaSym.ReturnType == returnType && lambdaSym.RefKind == refKind)
-                {
-                    lambdaSymbol = lambdaSym;
-                    lambdaBodyBinder = returnInferenceLambda.Binder;
-                    block = returnInferenceLambda.Body;
-                    diagnostics.AddRange(returnInferenceLambda.Diagnostics);
+                lambdaSymbol = returnInferenceLambda.Symbol;
+                Debug.Assert(lambdaSymbol.ReturnType == returnType);
+                Debug.Assert(lambdaSymbol.RefKind == refKind);
 
-                    goto haveLambdaBodyAndBinders;
-                }
+                lambdaBodyBinder = returnInferenceLambda.Binder;
+                block = returnInferenceLambda.Body;
+                diagnostics.AddRange(returnInferenceLambda.Diagnostics);
+
+                goto haveLambdaBodyAndBinders;
             }
 
-            var parameters = DelegateParameters(delegateType);
-            lambdaSymbol = new LambdaSymbol(binder.Compilation, binder.ContainingMemberOrLambda, _unboundLambda, parameters, refKind, returnType);
+            var parameters = DelegateParameters(invokeMethod);
+
+            lambdaSymbol = new LambdaSymbol(
+                binder.Compilation,
+                binder.ContainingMemberOrLambda,
+                _unboundLambda,
+                parameters,
+                refKind,
+                returnType);
             lambdaBodyBinder = new ExecutableCodeBinder(_unboundLambda.Syntax, lambdaSymbol, ParameterBinder(lambdaSymbol, binder));
             block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
             ValidateUnsafeParameters(diagnostics, parameters);
@@ -417,7 +459,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool reachableEndpoint = ControlFlowPass.Analyze(binder.Compilation, lambdaSymbol, block, diagnostics);
             if (reachableEndpoint)
             {
-                if (DelegateNeedsReturn(delegateType))
+                if (DelegateNeedsReturn(invokeMethod))
                 {
                     // Not all code paths return a value in {0} of type '{1}'
                     diagnostics.Add(ErrorCode.ERR_AnonymousReturnExpected, lambdaSymbol.Locations[0], this.MessageID.Localize(), delegateType);
@@ -432,8 +474,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if ((object)returnType != null && // Can be null if "delegateType" is not actually a delegate type.
                     returnType.SpecialType != SpecialType.System_Void &&
-                    returnType != binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) &&
-                    returnType.OriginalDefinition != binder.Compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T))
+                    !returnType.IsNonGenericTaskType(binder.Compilation) &&
+                    !returnType.IsGenericTaskType(binder.Compilation))
                 {
                     // Cannot convert async {0} to delegate type '{1}'. An async {0} may return void, Task or Task&lt;T&gt;, none of which are convertible to '{1}'.
                     diagnostics.Add(ErrorCode.ERR_CantConvAsyncAnonFuncReturns, lambdaSymbol.Locations[0], lambdaSymbol.MessageID.Localize(), delegateType);
@@ -443,7 +485,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (IsAsync)
             {
                 Debug.Assert(lambdaSymbol.IsAsync);
-                SourceMemberMethodSymbol.ReportAsyncParameterErrors(lambdaSymbol, diagnostics, lambdaSymbol.Locations[0]);
+                SourceMemberMethodSymbol.ReportAsyncParameterErrors(lambdaSymbol.Parameters, diagnostics, lambdaSymbol.Locations[0]);
             }
 
             var result = new BoundLambda(_unboundLambda.Syntax, block, diagnostics.ToReadOnlyAndFree(), lambdaBodyBinder, delegateType, inferReturnType: false)
@@ -481,7 +523,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         private BoundLambda ReallyInferReturnType(NamedTypeSymbol delegateType)
         {
             var diagnostics = DiagnosticBag.GetInstance();
-            var parameters = DelegateParameters(delegateType);
+            var invokeMethod = DelegateInvokeMethod(delegateType);
+            var parameters = DelegateParameters(invokeMethod);
             var lambdaSymbol = new LambdaSymbol(binder.Compilation, binder.ContainingMemberOrLambda, _unboundLambda, parameters, refKind: Microsoft.CodeAnalysis.RefKind.None, returnType: null);
             Binder lambdaBodyBinder = new ExecutableCodeBinder(_unboundLambda.Syntax, lambdaSymbol, ParameterBinder(lambdaSymbol, binder));
             var block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
@@ -505,27 +548,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 result = ReallyInferReturnType(delegateType);
                 _returnInferenceCache.TryAdd(cacheKey, result);
+
+                // In case the return value of the BoundLambda is distinct from
+                // delegateType, add the BoundLambda to the cache by the
+                // distinct signature as well.
+                _returnInferenceCache.TryAdd(result.Symbol, result);
             }
 
             return result;
         }
 
-        private static MethodSymbol GetCacheKey(NamedTypeSymbol delegateType)
+        private MethodSymbol GetCacheKey(NamedTypeSymbol delegateType)
         {
-            delegateType = delegateType.GetDelegateType();
-
-            if (delegateType != null)
+            var invoke = DelegateInvokeMethod(delegateType);
+            if ((object)invoke != null)
             {
-                var invoke = delegateType.DelegateInvokeMethod;
-                if (invoke != null)
-                {
-                    return invoke;
-                }
+                return invoke;
             }
 
             // delegateType or DelegateInvokeMethod can be null in cases of malformed delegates
-            // in such case we would want something trivial with no parameters, like a fake static ctor
-            return new SynthesizedStaticConstructor(delegateType);
+            // in such case we would want something trivial with no parameters, like a fake static ctor.
+            // Since the containingType of the .cctor must be non-null, System.Object is used.
+            return new SynthesizedStaticConstructor(binder.Compilation.GetSpecialType(SpecialType.System_Object));
         }
 
         public TypeSymbol InferReturnType(NamedTypeSymbol delegateType, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -288,7 +288,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             AsyncQueue<CompilationEvent> eventQueue = null)
             : base(assemblyName, references, SyntaxTreeCommonFeatures(syntaxAndDeclarations.ExternalSyntaxTrees), isSubmission, eventQueue)
         {
-            _wellKnownMemberSignatureComparer = new WellKnownMembersSignatureComparer(this);
+            WellKnownMemberSignatureComparer = new WellKnownMembersSignatureComparer(this);
             _options = options;
 
             this.builtInOperators = new BuiltInOperators(this);

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -286,8 +286,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                                                    ErrorTypeSymbol.UnknownResultType,
                                                                    unexpectedAnonymousFunction.Kind() == SyntaxKind.AnonymousMethodExpression ? MessageID.IDS_AnonMethod : MessageID.IDS_Lambda,
                                                                    unexpectedAnonymousFunction,
-                                                                   isSynthesized: false,
-                                                                   isAsync: false),
+                                                                   isSynthesized: false),
                                                   binder);
             }
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/FlowAnalysisPass.cs
@@ -35,8 +35,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 #endif
             var compilation = method.DeclaringCompilation;
 
-            if (method.ReturnsVoid || method.IsIterator ||
-                (method.IsAsync && compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task) == method.ReturnType))
+            if (method.ReturnsVoid || method.IsIterator || method.IsTaskReturningAsync(compilation))
             {
                 // we don't analyze synthesized void methods.
                 if ((method.IsImplicitlyDeclared && !method.IsScriptInitializer) || Analyze(compilation, method, block, diagnostics))

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -286,22 +286,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Call(receiver, propertySym.GetMethod);
         }
 
-        public BoundExpression Property(BoundExpression receiver, string name)
+        public BoundExpression Property(BoundExpression receiver, PropertySymbol property)
         {
-            // TODO: unroll loop and add diagnostics for failure
-            // TODO: should we use GetBaseProperty() to ensure we generate a call to the overridden method?
-            // TODO: replace this with a mechanism that uses WellKnownMember instead of string names.
-            var property = receiver.Type.GetMembers(name).OfType<PropertySymbol>().Single();
             Debug.Assert(!property.IsStatic);
             return Call(receiver, property.GetMethod); // TODO: should we use property.GetBaseProperty().GetMethod to ensure we generate a call to the overridden method?
-        }
-
-        public BoundExpression Property(NamedTypeSymbol receiver, string name)
-        {
-            // TODO: unroll loop and add diagnostics for failure
-            var property = receiver.GetMembers(name).OfType<PropertySymbol>().Single();
-            Debug.Assert(property.IsStatic);
-            return Call(null, property.GetMethod);
         }
 
         public NamedTypeSymbol SpecialType(SpecialType st)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
     public partial class CSharpCompilation
     {
-        private readonly WellKnownMembersSignatureComparer _wellKnownMemberSignatureComparer;
+        internal readonly WellKnownMembersSignatureComparer WellKnownMemberSignatureComparer;
 
         /// <summary>
         /// An array of cached well known types available for use in this Compilation.
@@ -66,7 +66,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (!type.IsErrorType())
                 {
-                    result = GetRuntimeMember(type, ref descriptor, _wellKnownMemberSignatureComparer, accessWithinOpt: this.Assembly);
+                    result = GetRuntimeMember(type, ref descriptor, WellKnownMemberSignatureComparer, accessWithinOpt: this.Assembly);
                 }
 
                 Interlocked.CompareExchange(ref _lazyWellKnownTypeMembers[(int)member], result, ErrorTypeSymbol.UnknownResultType);
@@ -818,7 +818,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private class WellKnownMembersSignatureComparer : SpecialMembersSignatureComparer
+        internal sealed class WellKnownMembersSignatureComparer : SpecialMembersSignatureComparer
         {
             private readonly CSharpCompilation _compilation;
 

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -239,7 +239,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static readonly MemberSignatureComparer LambdaReturnInferenceCacheComparer = new MemberSignatureComparer(
             considerName: false,                // valid invoke is always called "Invoke"
             considerExplicitlyImplementedInterfaces: false,
-            considerReturnType: false,          // do not care
+            considerReturnType: true,           // to differentiate Task types
             considerTypeConstraints: false,     // valid invoke is never generic
             considerCallingConvention: false,   // valid invoke is never static
             considerRefOutDifference: true,

--- a/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MethodSymbolExtensions.cs
@@ -276,7 +276,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool IsTaskReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
         {
             return method.IsAsync
-                && method.ReturnType == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
+                && method.ReturnType.IsNonGenericTaskType(compilation);
         }
 
         /// <summary>
@@ -285,9 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public static bool IsGenericTaskReturningAsync(this MethodSymbol method, CSharpCompilation compilation)
         {
             return method.IsAsync
-                && (object)method.ReturnType != null
-                && method.ReturnType.Kind == SymbolKind.NamedType
-                && ((NamedTypeSymbol)method.ReturnType).ConstructedFrom == compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T);
+                && method.ReturnType.IsGenericTaskType(compilation);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LambdaSymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -45,8 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol returnType,
             MessageID messageID,
             CSharpSyntaxNode syntax,
-            bool isSynthesized,
-            bool isAsync)
+            bool isSynthesized)
         {
             _containingSymbol = containingSymbol;
             _messageID = messageID;
@@ -54,21 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _refKind = refKind;
             _returnType = returnType;
             _isSynthesized = isSynthesized;
-            _isAsync = isAsync;
             _parameters = parameters.SelectAsArray(CopyParameter, this);
-        }
-
-        internal LambdaSymbol ToContainer(Symbol containingSymbol)
-        {
-            return new LambdaSymbol(
-                containingSymbol,
-                _parameters,
-                _refKind,
-                _returnType,
-                _messageID,
-                _syntax,
-                _isSynthesized,
-                _isAsync);
         }
 
         public MessageID MessageID { get { return _messageID; } }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeMap.cs
@@ -4,10 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
@@ -34,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // mapping contents are read-only hereafter
         }
 
-        internal TypeMap(SmallDictionary<TypeParameterSymbol, TypeWithModifiers> mapping)
+        private TypeMap(SmallDictionary<TypeParameterSymbol, TypeWithModifiers> mapping)
             : base(new SmallDictionary<TypeParameterSymbol, TypeWithModifiers>(mapping, ReferenceEqualityComparer.Instance))
         {
             // mapping contents are read-only hereafter
@@ -47,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 new SmallDictionary<TypeParameterSymbol, TypeWithModifiers>(substituted.TypeSubstitution.Mapping, ReferenceEqualityComparer.Instance) :
                 new SmallDictionary<TypeParameterSymbol, TypeWithModifiers>(ReferenceEqualityComparer.Instance);
         }
+
         internal TypeMap(NamedTypeSymbol containingType, ImmutableArray<TypeParameterSymbol> typeParameters, ImmutableArray<TypeWithModifiers> typeArguments)
             : base(ForType(containingType))
         {

--- a/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
+++ b/src/Compilers/CSharp/Test/Semantic/CSharpCompilerSemanticTest.csproj
@@ -77,6 +77,8 @@
     <Compile Include="FlowAnalysis\RegionAnalysisTests.cs" />
     <Compile Include="FlowAnalysis\StructTests.cs" />
     <Compile Include="FlowAnalysis\TryLockUsingStatementTests.cs" />
+    <Compile Include="Semantics\BindingAsyncTasklikeMoreTests.cs" />
+    <Compile Include="Semantics\BindingAsyncTasklikeTests.cs" />
     <Compile Include="Semantics\ImportsTests.cs" />
     <Compile Include="Semantics\AccessCheckTests.cs" />
     <Compile Include="Semantics\AccessibilityTests.cs" />

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeMoreTests.cs
@@ -1,0 +1,477 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class BindingAsyncTasklikeMoreTests : CompilingTestBase
+    {
+        [Fact]
+        public void AsyncMethod()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static async MyTask F() { await Task.Delay(0); }
+    static async MyTask<T> G<T>(T t) { await Task.Delay(0); return t; }
+    static async MyTask<int> M()
+    {
+        await F();
+        return await G(3);
+    }
+    static void Main()
+    {
+        var i = M().Result;
+        Console.WriteLine(i);
+    }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => new MyTaskMethodBuilder(new MyTask());
+    internal Awaiter GetAwaiter() => new Awaiter();
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct MyTask<T>
+{
+    internal T _result;
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new MyTaskMethodBuilder<T>(new MyTask<T>());
+    public T Result => _result;
+    internal Awaiter GetAwaiter() => new Awaiter(this);
+    internal class Awaiter : INotifyCompletion
+    {
+        private readonly MyTask<T> _task;
+        internal Awaiter(MyTask<T> task) { _task = task; }
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => _task.Result;
+    }
+}
+struct MyTaskMethodBuilder
+{
+    private MyTask _task;
+    internal MyTaskMethodBuilder(MyTask task)
+    {
+        _task = task;
+    }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+    {
+        stateMachine.MoveNext();
+    }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task => _task;
+}
+struct MyTaskMethodBuilder<T>
+{
+    private MyTask<T> _task;
+    internal MyTaskMethodBuilder(MyTask<T> task)
+    {
+        _task = task;
+    }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+    {
+        stateMachine.MoveNext();
+    }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { _task._result = t; }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task => _task;
+}";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            var verifier = CompileAndVerify(compilation, expectedOutput: "3");
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.F()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            method = (MethodSymbol)testData.GetMethodData("C.G<T>(T)").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            verifier.VerifyIL("C.F()",
+@"{
+  // Code size       52 (0x34)
+  .maxstack  2
+  .locals init (C.<F>d__0 V_0,
+                MyTaskMethodBuilder V_1)
+  IL_0000:  newobj     ""C.<F>d__0..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  call       ""MyTaskMethodBuilder MyTask.CreateAsyncMethodBuilder()""
+  IL_000c:  stfld      ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.m1
+  IL_0013:  stfld      ""int C.<F>d__0.<>1__state""
+  IL_0018:  ldloc.0
+  IL_0019:  ldfld      ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_001e:  stloc.1
+  IL_001f:  ldloca.s   V_1
+  IL_0021:  ldloca.s   V_0
+  IL_0023:  call       ""void MyTaskMethodBuilder.Start<C.<F>d__0>(ref C.<F>d__0)""
+  IL_0028:  ldloc.0
+  IL_0029:  ldflda     ""MyTaskMethodBuilder C.<F>d__0.<>t__builder""
+  IL_002e:  call       ""MyTask MyTaskMethodBuilder.Task.get""
+  IL_0033:  ret
+}");
+            verifier.VerifyIL("C.G<T>(T)",
+@"{
+  // Code size       59 (0x3b)
+  .maxstack  2
+  .locals init (C.<G>d__1<T> V_0,
+                MyTaskMethodBuilder<T> V_1)
+  IL_0000:  newobj     ""C.<G>d__1<T>..ctor()""
+  IL_0005:  stloc.0
+  IL_0006:  ldloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  stfld      ""T C.<G>d__1<T>.t""
+  IL_000d:  ldloc.0
+  IL_000e:  call       ""MyTaskMethodBuilder<T> MyTask<T>.CreateAsyncMethodBuilder()""
+  IL_0013:  stfld      ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0018:  ldloc.0
+  IL_0019:  ldc.i4.m1
+  IL_001a:  stfld      ""int C.<G>d__1<T>.<>1__state""
+  IL_001f:  ldloc.0
+  IL_0020:  ldfld      ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0025:  stloc.1
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  ldloca.s   V_0
+  IL_002a:  call       ""void MyTaskMethodBuilder<T>.Start<C.<G>d__1<T>>(ref C.<G>d__1<T>)""
+  IL_002f:  ldloc.0
+  IL_0030:  ldflda     ""MyTaskMethodBuilder<T> C.<G>d__1<T>.<>t__builder""
+  IL_0035:  call       ""MyTask<T> MyTaskMethodBuilder<T>.Task.get""
+  IL_003a:  ret
+}");
+        }
+
+        [Fact]
+        public void AsyncMethodBuilder_MissingMethods()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C
+{
+    static async MyTask F() { await (Task)null; }
+    static async MyTask<T> G<T>(T t) { await (Task)null; return t; }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => new MyTaskMethodBuilder();
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new MyTaskMethodBuilder<T>();
+}
+struct MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+}
+struct MyTaskMethodBuilder<T>
+{
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task { get { return default(MyTask<T>); } }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyEmitDiagnostics(
+                // (6,29): error CS0656: Missing compiler required member 'MyTaskMethodBuilder.Task'
+                //     static async MyTask F() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; }").WithArguments("MyTaskMethodBuilder", "Task").WithLocation(6, 29),
+                // (7,38): error CS0656: Missing compiler required member 'MyTaskMethodBuilder<T>.SetException'
+                //     static async MyTask<T> G<T>(T t) { await (Task)null; return t; }
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ await (Task)null; return t; }").WithArguments("MyTaskMethodBuilder<T>", "SetException").WithLocation(7, 38));
+        }
+
+        [Fact]
+        public void Private()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+#pragma warning disable CS1998
+    static async MyTask F() { }
+    static async MyTask<int> G() { return 3; }
+#pragma warning restore CS1998
+    private class MyTask
+    {
+        public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    }
+    private class MyTask<T>
+    {
+        public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    }
+    private class MyTaskMethodBuilder
+    {
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+        public void SetException(Exception e) { }
+        public void SetResult() { }
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public MyTask Task { get { return null; } }
+    }
+    private class MyTaskMethodBuilder<T>
+    {
+        public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+        public void SetException(Exception e) { }
+        public void SetResult(T t) { }
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+        public MyTask<T> Task { get { return null; } }
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.F()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("C.MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.G()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("C.MyTask<int>", method.ReturnType.ToDisplayString());
+        }
+
+        [Fact]
+        public void AsyncLambda_InferReturnType()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static void F(Func<MyTask> f) { }
+    static void F<T>(Func<MyTask<T>> f) { }
+    static void F(Func<MyTask<string>> f) { }
+    static void M()
+    {
+#pragma warning disable CS1998
+        F(async () => { });
+        F(async () => { return 3; });
+        F(async () => { return string.Empty; });
+#pragma warning restore CS1998
+    }
+}
+class MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+class MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}
+class MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task => default(MyTask);
+}
+class MyTaskMethodBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task => default(MyTask<T>);
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.<>c.<M>b__3_0()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.<>c.<M>b__3_1()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("MyTask<int>", method.ReturnType.ToDisplayString());
+        }
+
+        [Fact]
+        public void AsyncLocalFunction()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static async void M()
+    {
+#pragma warning disable CS1998
+        async MyTask F() { }
+        async MyTask<T> G<T>(T t) => t;
+        await F();
+        await G(3);
+#pragma warning restore CS1998
+    }
+}
+struct MyTask
+{
+    public static MyTaskMethodBuilder CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct MyTask<T>
+{
+    public static MyTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}
+class MyTaskMethodBuilder
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask Task => default(MyTask);
+}
+class MyTaskMethodBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public MyTask<T> Task => default(MyTask<T>);
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyDiagnostics();
+            var testData = verifier.TestData;
+            var method = (MethodSymbol)testData.GetMethodData("C.<M>g__F0_0()").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsTaskReturningAsync(compilation));
+            Assert.Equal("MyTask", method.ReturnType.ToDisplayString());
+            method = (MethodSymbol)testData.GetMethodData("C.<M>g__G0_1<T>(T)").Method;
+            Assert.True(method.IsAsync);
+            Assert.True(method.IsGenericTaskReturningAsync(compilation));
+            Assert.Equal("MyTask<T>", method.ReturnType.ToDisplayString());
+        }
+
+        [Fact]
+        public void NonTaskBuilder()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static async void M()
+    {
+#pragma warning disable CS1998
+        async MyTask F() { };
+        await F();
+#pragma warning restore CS1998
+    }
+}
+struct MyTask
+{
+    public static string CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyEmitDiagnostics(
+                // (8,26): error CS0656: Missing compiler required member 'string.Task'
+                //         async MyTask F() { };
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "{ }").WithArguments("string", "Task").WithLocation(8, 26));
+        }
+
+        [Fact]
+        public void NonTaskBuilderOfT()
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+class C
+{
+    static async void M()
+    {
+#pragma warning disable CS1998
+        async MyTask<T> F<T>(T t) => t;
+        await F(3);
+#pragma warning restore CS1998
+    }
+}
+struct MyTask<T>
+{
+    public static IEquatable<T> CreateAsyncMethodBuilder() => null;
+    internal Awaiter GetAwaiter() => null;
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => default(T);
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib45(source);
+            compilation.VerifyEmitDiagnostics(
+                // (8,35): error CS0656: Missing compiler required member 'IEquatable<T>.Task'
+                //         async MyTask<T> F<T>(T t) => t;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "=> t").WithArguments("System.IEquatable<T>", "Task").WithLocation(8, 35));
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingAsyncTasklikeTests.cs
@@ -1,0 +1,555 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
+{
+    public class BindingAsyncTasklikeTests : CompilingTestBase
+    {
+        [Fact]
+        public void AsyncTasklikeFromBuilderMethod()
+        {
+            var source = @"
+using System.Threading.Tasks;
+class C {
+    async ValueTask f() { await (Task)null; }
+    async ValueTask<int> g() { await (Task)null; return 1; }
+}
+struct ValueTask { public static string CreateAsyncMethodBuilder() => null; }
+struct ValueTask<T> { public static Task<T> CreateAsyncMethodBuilder() => null; }
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics();
+            var methodf = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("f").Single();
+            var methodg = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("g").Single();
+            Assert.True(methodf.IsAsync);
+            Assert.True(methodg.IsAsync);
+        }
+
+        [Fact]
+        public void AsyncTasklikeNotFromDelegate()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main()
+    {
+    }
+
+    static async Task f()
+    {
+        await new Awaitable();
+        await new Unawaitable(); // error: GetAwaiter must be a field not a delegate
+    }
+
+    static async Tasklike g()
+    {
+        await (Task)null;
+    }
+
+    static async UnTasklike h()
+    {
+        await (Task)null;
+    }
+}
+
+class Awaitable
+{
+    public TaskAwaiter GetAwaiter() => (Task.FromResult(1) as Task).GetAwaiter();
+}
+
+class Unawaitable
+{
+    public Func<TaskAwaiter> GetAwaiter = () => (Task.FromResult(1) as Task).GetAwaiter();
+}
+
+public class Tasklike {
+    public static TasklikeMethodBuilder CreateAsyncMethodBuilder() => null;
+}
+
+public class UnTasklike
+{
+    public static Func<UnTasklikeMethodBuilder> CreateAsyncMethodBuilder = () => null;
+}
+
+public class TasklikeMethodBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    private void EnsureTaskBuilder() { }
+    public Tasklike Task => null;
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+
+public class UnTasklikeMethodBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    private void EnsureTaskBuilder() { }
+    public UnTasklike Task => null;
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (15,9): error CS0118: 'GetAwaiter' is a field but is used like a method
+                //         await new Unawaitable(); // error: GetAwaiter must be a field not a delegate
+                Diagnostic(ErrorCode.ERR_BadSKknown, "await new Unawaitable()").WithArguments("GetAwaiter", "field", "method").WithLocation(15, 9),
+                // (23,29): error CS1983: The return type of an async method must be void, Task, Task<T> or other tasklike
+                //     static async UnTasklike h()
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "h").WithLocation(23, 29),
+                // (23,29): error CS0161: 'Program.h()': not all code paths return a value
+                //     static async UnTasklike h()
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "h").WithArguments("Program.h()").WithLocation(23, 29)
+            );
+        }
+
+        private bool VerifyTaskOverloads(string arg, string betterOverload, string worseOverload, bool implicitConversionToTask = false, bool isError = false)
+        {
+            var source =
+@"using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class Program
+{
+    #pragma warning disable CS1998
+    static void Main()
+    {
+        var s = (<<arg>>);
+        Console.Write(s);
+    }
+    <<betterOverload>>
+    <<worseOverload>>
+}
+struct ValueTask
+{
+    public static ValueTaskMethodBuilder CreateAsyncMethodBuilder() => new ValueTaskMethodBuilder();
+    <<implicitConversionToTask>>
+    internal Awaiter GetAwaiter() => new Awaiter();
+    internal class Awaiter : INotifyCompletion
+    {
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal void GetResult() { }
+    }
+}
+struct ValueTask<T>
+{
+    internal T _result;
+    public static ValueTaskMethodBuilder<T> CreateAsyncMethodBuilder() => new ValueTaskMethodBuilder<T>();
+    <<implicitConversionToTaskT>>
+    public T Result => _result;
+    internal Awaiter GetAwaiter() => new Awaiter(this);
+    internal class Awaiter : INotifyCompletion
+    {
+        private ValueTask<T> _task;
+        internal Awaiter(ValueTask<T> task) { _task = task; }
+        public void OnCompleted(Action a) { }
+        internal bool IsCompleted => true;
+        internal T GetResult() => _task.Result;
+    }
+}
+sealed class ValueTaskMethodBuilder
+{
+    private ValueTask _task = new ValueTask();
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+    {
+        stateMachine.MoveNext();
+    }
+    public void SetException(Exception e) { }
+    public void SetResult() { }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public ValueTask Task => _task;
+}
+sealed class ValueTaskMethodBuilder<T>
+{
+    private ValueTask<T> _task = new ValueTask<T>();
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine
+    {
+        stateMachine.MoveNext();
+    }
+    public void SetException(Exception e) { }
+    public void SetResult(T t) { _task._result = t; }
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public ValueTask<T> Task => _task;
+}";
+            source = source.Replace("<<arg>>", arg);
+            source = source.Replace("<<betterOverload>>", (betterOverload != null) ? "static string " + betterOverload + " => \"better\";" : "");
+            source = source.Replace("<<worseOverload>>", (worseOverload != null) ? "static string " + worseOverload + " => \"worse\";" : "");
+            source = source.Replace("<<implicitConversionToTask>>", implicitConversionToTask ? "public static implicit operator Task(ValueTask t) => Task.FromResult(0);" : "");
+            source = source.Replace("<<implicitConversionToTaskT>>", implicitConversionToTask ? "public static implicit operator Task<T>(ValueTask<T> t) => Task.FromResult<T>(t._result);" : "");
+            if (isError)
+            {
+                var compilation = CreateCompilationWithMscorlib45(source);
+                var diagnostics = compilation.GetDiagnostics();
+                Assert.True(diagnostics.Length == 1);
+                Assert.True(diagnostics.First().Code == (int)ErrorCode.ERR_AmbigCall);
+            }
+            else
+            {
+                CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "better");
+            }
+            return true;
+        }
+
+        [Fact]
+        public bool TasklikeA3() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        null);
+
+        [Fact]
+        public void TasklikeA3n() => VerifyTaskOverloads("f(async () => {})",
+                                                         "f(Func<ValueTask> lambda)",
+                                                         null);
+
+        [Fact]
+        public void TasklikeA4() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f<T>(Func<ValueTask<T>> labda)",
+                                                        null);
+
+        [Fact]
+        public void TasklikeA5s() => VerifyTaskOverloads("f(() => 3)",
+                                                         "f<T>(Func<T> lambda)",
+                                                         "f<T>(Func<ValueTask<T>> lambda)");
+
+        [Fact]
+        public void TasklikeA5a() => VerifyTaskOverloads("f(async () => 3)",
+                                                         "f<T>(Func<ValueTask<T>> lambda)",
+                                                         "f<T>(Func<T> lambda)");
+
+        [Fact]
+        public void TasklikeA6() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f(Func<ValueTask<double>> lambda)");
+
+        [Fact]
+        public void TasklikeA7() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<byte>> lambda)",
+                                                        "f(Func<ValueTask<short>> lambda)");
+
+        [Fact]
+        public void TasklikeA8() => VerifyTaskOverloads("f(async () => {})",
+                                                        "f(Func<ValueTask> lambda)",
+                                                        "f(Action lambda)");
+
+        [Fact]
+        public void TasklikeB7_ic0() => VerifyTaskOverloads("f(async () => 3)",
+                                                           "f(Func<ValueTask<int>> lambda)",
+                                                           "f(Func<Task<int>> lambda)",
+                                                           isError: true);
+
+        [Fact]
+        public void TasklikeB7_ic1() => VerifyTaskOverloads("f(async () => 3)",
+                                                            "f(Func<ValueTask<int>> lambda)",
+                                                            "f(Func<Task<int>> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeB7g_ic0() => VerifyTaskOverloads("f(async () => 3)",
+                                                             "f<T>(Func<ValueTask<T>> lambda)",
+                                                             "f<T>(Func<Task<T>> lambda)",
+                                                             isError: true);
+
+        [Fact]
+        public void TasklikeB7g_ic1() => VerifyTaskOverloads("f(async () => 3)",
+                                                             "f<T>(Func<ValueTask<T>> lambda)",
+                                                             "f<T>(Func<Task<T>> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeB7n_ic0() => VerifyTaskOverloads("f(async () => {})",
+                                                             "f(Func<ValueTask> lambda)",
+                                                             "f(Func<Task> lambda)",
+                                                             isError: true);
+
+        [Fact]
+        public void TasklikeB7n_ic1() => VerifyTaskOverloads("f(async () => {})",
+                                                             "f(Func<ValueTask> lambda)",
+                                                             "f(Func<Task> lambda)",
+                                                            implicitConversionToTask: true);
+
+        [Fact]
+        public void TasklikeC1() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f(Func<Task<double>> lambda)");
+
+        [Fact]
+        public void TasklikeC2() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<byte>> lambda)",
+                                                        "f(Func<Task<short>> lambda)");
+
+        [Fact]
+        public void TasklikeC5() => VerifyTaskOverloads("f(async () => 3)",
+                                                        "f(Func<ValueTask<int>> lambda)",
+                                                        "f<T>(Func<Task<T>> lambda)");
+
+        [Fact]
+        public void AsyncTasklikeMethod()
+        {
+            var source = @"
+using System.Threading.Tasks;
+class C {
+    async ValueTask f() { await Task.Delay(0); }
+    async ValueTask<int> g() { await Task.Delay(0); return 1; }
+}
+struct ValueTask { public static ValueTaskMethodBuilder CreateAsyncMethodBuilder() => null; }
+struct ValueTask<T> { public static ValueTaskMethodBuilder<T> CreateAsyncMethodBuilder() => null;}
+class ValueTaskMethodBuilder {}
+class ValueTaskMethodBuilder<T> {}
+";
+            var compilation = CreateCompilationWithMscorlib45(source).VerifyDiagnostics();
+            var methodf = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("f").Single();
+            var methodg = (SourceMethodSymbol)compilation.GlobalNamespace.GetTypeMembers("C").Single().GetMembers("g").Single();
+            Assert.True(methodf.IsAsync);
+            Assert.True(methodg.IsAsync);
+        }
+
+        [Fact]
+        public void NotTasklike()
+        {
+            var source1 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { }
+";
+            CreateCompilationWithMscorlib45(source1).VerifyDiagnostics(
+                // (6,18): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "f").WithLocation(6, 18),
+                // (6,18): error CS0161: 'C.f()': not all code paths return a value
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "f").WithArguments("C.f()").WithLocation(6, 18)
+                );
+
+            var source2 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { }
+";
+            CreateCompilationWithMscorlib45(source2).VerifyDiagnostics(
+                // (6,18): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "f").WithLocation(6, 18),
+                // (6,18): error CS0161: 'C.f()': not all code paths return a value
+                //     async MyTask f() { await (Task)null; }
+                Diagnostic(ErrorCode.ERR_ReturnExpected, "f").WithArguments("C.f()").WithLocation(6, 18)
+                );
+
+            var source3 = @"
+using System.Threading.Tasks;
+class C
+{
+    static void Main() { }
+    async MyTask f() { await (Task)null; }
+}
+public class MyTask { public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder { }
+";
+            CreateCompilationWithMscorlib45(source3).VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void AsyncTasklikeOverloadLambdas()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C {
+    static void Main() {
+        f(async () => { await (Task)null; return 1; });
+        h(async () => { await (Task)null; });
+    }
+    static void f<T>(Func<MyTask<T>> lambda) { }
+    static void f<T>(Func<T> lambda) { }
+    static void f<T>(T arg) { }
+
+    static void h(Func<MyTask> lambda) { }
+    static void h(Func<Task> lambda) { }
+}
+
+public class MyTask<T> { public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder<T> {
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult(T result) { }
+    public void SetException(Exception exception) { }
+    public MyTask<T> Task => default(MyTask<T>);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+
+public class MyTask { public static MyTaskBuilder CreateAsyncMethodBuilder() => null; }
+public class MyTaskBuilder
+{
+    public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void SetResult() { }
+    public void SetException(Exception exception) { }
+    public MyTask Task => default(MyTask);
+    public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : INotifyCompletion where TStateMachine : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine) where TAwaiter : ICriticalNotifyCompletion where TStateMachine : IAsyncStateMachine { }
+}
+";
+            CreateCompilationWithMscorlib45(source).VerifyDiagnostics(
+                // (8,9): error CS0121: The call is ambiguous between the following methods or properties: 'C.h(Func<MyTask>)' and 'C.h(Func<Task>)'
+                //         h(async () => { await (Task)null; });
+                Diagnostic(ErrorCode.ERR_AmbigCall, "h").WithArguments("C.h(System.Func<MyTask>)", "C.h(System.Func<System.Threading.Tasks.Task>)").WithLocation(8, 9)
+                );
+        }
+
+        [Fact]
+        public void AsyncTasklikeInadmissibleArity()
+        {
+            var source = @"
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+class C {
+    async Mismatch2<int,int> g() { await Task.Delay(0); return 1; }
+}
+struct Mismatch2<T,U> { public static Mismatch2MethodBuilder<T> CreateAsyncMethodBuilder() => null; }
+class Mismatch2MethodBuilder<T> {}
+";
+            var comp = CreateCompilationWithMscorlib45(source);
+            comp.VerifyEmitDiagnostics(
+                // (5,30): error CS1983: The return type of an async method must be void, Task or Task<T>
+                //     async Mismatch2<int,int> g() { await Task.Delay(0); return 1; }
+                Diagnostic(ErrorCode.ERR_BadAsyncReturn, "g").WithLocation(5, 30)
+                );
+        }
+
+        [Fact]
+        public void AsyncTasklikeOverloadInvestigations()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static Task<int> arg1 = null;
+    static int arg2 = 0;
+
+    static int f1(MyTask<int> t) => 0;
+    static int f1(Task<int> t) => 1;
+    static int r1 = f1(arg1); // 1
+
+    static void Main()
+    {
+        Console.Write(r1);
+    }
+}
+
+class ValueTask<T>
+{
+    public static ValueTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+    public static implicit operator ValueTask<T>(Task<T> task) => null;
+}
+
+class MyTask<T>
+{
+    public static MyTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+    public static implicit operator MyTask<T>(Task<T> task) => null;
+    public static implicit operator Task<T>(MyTask<T> mytask) => null;
+}
+
+class ValueTaskBuilder<T>
+{
+    public void Start<TSM>(ref TSM sm) where TSM : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine sm) { }
+    public void SetResult(T r) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+    public void AwaitOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+}
+
+class MyTaskBuilder<T>
+{
+    public void Start<TSM>(ref TSM sm) where TSM : IAsyncStateMachine { }
+    public void SetStateMachine(IAsyncStateMachine sm) { }
+    public void SetResult(T r) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+    public void AwaitOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA a, ref TSM sm) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+}
+";
+            CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "1");
+        }
+
+        [Fact]
+        public void AsyncTasklikeBetterness()
+        {
+            var source = @"
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+class Program
+{
+    static char f1(Func<ValueTask<short>> lambda) => 's';
+    static char f1(Func<Task<byte>> lambda) => 'b';
+
+    static char f2(Func<Task<short>> lambda) => 's';
+    static char f2(Func<ValueTask<byte>> lambda) => 'b';
+
+    static char f3(Func<Task<short>> lambda) => 's';
+    static char f3(Func<Task<byte>> lambda) => 'b';
+
+    static char f4(Func<ValueTask<short>> lambda) => 's';
+    static char f4(Func<ValueTask<byte>> lambda) => 'b';
+
+    static void Main()
+    {
+        Console.Write(f1(async () => { await (Task)null; return 9; }));
+        Console.Write(f2(async () => { await (Task)null; return 9; }));
+        Console.Write(f3(async () => { await (Task)null; return 9; }));
+        Console.Write(f4(async () => { await (Task)null; return 9; }));
+    }
+}
+
+public class ValueTask<T>
+{
+    public static ValueTaskBuilder<T> CreateAsyncMethodBuilder() => null;
+}
+
+public class ValueTaskBuilder<T>
+{
+    public void SetStateMachine(IAsyncStateMachine stateMachine) { }
+    public void Start<TSM>(ref TSM stateMachine) where TSM : IAsyncStateMachine { }
+    public void AwaitOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) where TA : INotifyCompletion where TSM : IAsyncStateMachine { }
+    public void AwaitUnsafeOnCompleted<TA, TSM>(ref TA awaiter, ref TSM stateMachine) where TA : ICriticalNotifyCompletion where TSM : IAsyncStateMachine { }
+    public void SetResult(T result) { }
+    public void SetException(Exception ex) { }
+    public ValueTask<T> Task => null;
+}
+";
+            CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v4_0_30316_17626 }, expectedOutput: "bbbb");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturns.cs
@@ -1,18 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Microsoft.CodeAnalysis.Emit;
-using Roslyn.Test.Utilities;
 using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Semantics
 {
-    public class RefLocalsAndReturnsTeats : CompilingTestBase
+    public class RefLocalsAndReturnsTests : CompilingTestBase
     {
         internal static CSharpCompilation CreateCompilationRef(
             string text,

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -660,6 +660,7 @@ Microsoft.CodeAnalysis.Semantics.UnaryOperationKind.UnsignedPrefixIncrement = 77
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation
+const Microsoft.CodeAnalysis.WellKnownMemberNames.CreateAsyncMethodBuilder = "CreateAsyncMethodBuilder" -> string
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.Visit(Microsoft.CodeAnalysis.IOperation operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitAddressOfExpression(Microsoft.CodeAnalysis.Semantics.IAddressOfExpression operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitArgument(Microsoft.CodeAnalysis.Semantics.IArgument operation) -> void

--- a/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
+++ b/src/Compilers/Core/Portable/Symbols/WellKnownMemberNames.cs
@@ -298,5 +298,11 @@ namespace Microsoft.CodeAnalysis
         /// (see C# Specification, §7.7.7.1 Awaitable expressions).
         /// </summary>
         public const string OnCompleted = nameof(OnCompleted);
+
+        /// <summary>
+        /// The required name for the <c>CreateAsyncMethodBuilder</c> method used to
+        /// build a tasklike instance.
+        /// </summary>
+        public const string CreateAsyncMethodBuilder = "CreateAsyncMethodBuilder";
     }
 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -309,6 +309,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext,
         System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine,
 
+        System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetResult,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitOnCompleted,
@@ -316,6 +317,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Start_T,
         System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetStateMachine,
 
+        System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetResult,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__AwaitOnCompleted,
@@ -324,6 +326,7 @@ namespace Microsoft.CodeAnalysis
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetStateMachine,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Task,
 
+        System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetResult,
         System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__AwaitOnCompleted,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -2235,6 +2235,13 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine,
 
+                // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,
+
                 // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
                 (byte)WellKnownType.System_Runtime_CompilerServices_AsyncVoidMethodBuilder,                                 // DeclaringTypeId
@@ -2283,6 +2290,13 @@ namespace Microsoft.CodeAnalysis
                     1,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_IAsyncStateMachine,
+
+                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder,                                 // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder,
 
                 // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
@@ -2339,6 +2353,13 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task,
+                    
+                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create
+                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
+                (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T,                               // DeclaringTypeId
+                0,                                                                                                          // Arity
+                    0,                                                                                                      // Method Signature
+                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T,
 
                 // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException
                 (byte)MemberFlags.Method,                                                                                   // Flags
@@ -3107,12 +3128,14 @@ namespace Microsoft.CodeAnalysis
                 "CallByName",                               // Microsoft_VisualBasic_Interaction__CallByName
                 "MoveNext",                                 // System_Runtime_CompilerServices_IAsyncStateMachine_MoveNext
                 "SetStateMachine",                          // System_Runtime_CompilerServices_IAsyncStateMachine_SetStateMachine
+                "Create",                                   // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitOnCompleted
                 "AwaitUnsafeOnCompleted",                   // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__AwaitUnsafeOnCompleted
                 "Start",                                    // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__Start_T
                 "SetStateMachine",                          // System_Runtime_CompilerServices_AsyncVoidMethodBuilder__SetStateMachine
+                "Create",                                   // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__AwaitOnCompleted
@@ -3120,6 +3143,7 @@ namespace Microsoft.CodeAnalysis
                 "Start",                                    // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Start_T
                 "SetStateMachine",                          // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__SetStateMachine
                 "Task",                                     // System_Runtime_CompilerServices_AsyncTaskMethodBuilder__Task
+                "Create",                                   // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create
                 "SetException",                             // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetException
                 "SetResult",                                // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__SetResult
                 "AwaitOnCompleted",                         // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__AwaitOnCompleted

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AsyncSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.AsyncSymbols.vb
@@ -257,7 +257,7 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestCSAsyncLambaName1() As Task
+        Public Async Function TestCSAsyncLambdaName1() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">
@@ -284,7 +284,7 @@ class Test
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestVBAsyncLambaName1() As Task
+        Public Async Function TestVBAsyncLambdaName1() As Task
             Dim input =
 <Workspace>
     <Project Language="Visual Basic" CommonReferences="true">
@@ -359,7 +359,7 @@ End Class
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.FindReferences)>
-        Public Async Function TestAsyncWithinLamba() As Task
+        Public Async Function TestAsyncWithinLambda() As Task
             Dim input =
 <Workspace>
     <Project Language="C#" CommonReferences="true">


### PR DESCRIPTION
Allow async methods to return types other than `void`, `Task`, or `Task<T>`. Specifically allow `Task`-like types (and `AsyncMethodBuilder` types) if the types contain the expected set of members.

[Based on Lucian's prototype from `features/async-return`.]

Ported PR from `master`: #12434. I will follow up on existing feedback from that PR, making changes here.
