### PR TITLE
Implement type merging in deconstruction with tuple literal

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -337,7 +337,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    if ((object)element.Type == null)
+                    if ((object)mergedType == null)
                     {
                         // a typeless element on the right, matching no variable on the left
                         Error(diagnostics, ErrorCode.ERR_DeconstructRequiresExpression, element.Syntax);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -58,7 +58,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (boundRHS.Kind == BoundKind.TupleLiteral)
                 {
-                    // let's fix it up by making a merged type from the LHS and RHS
+                    // Let's fix the literal up by figuring out its type
+                    // For declarations, that means merging type information from the LHS and RHS
+                    // For assignments, only the LHS side matters since it is necessarily typed
                     TypeSymbol lhsAsTuple = MakeMergedTupleType(checkedVariables, (BoundTupleLiteral)boundRHS, node, diagnostics, Compilation);
                     if (lhsAsTuple != null)
                     {
@@ -288,7 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// For cases where the RHS of a deconstruction-assignment is a tuple literal, we merge type information from both the LHS and RHS.
+        /// For cases where the RHS of a deconstruction-declaration is a tuple literal, we merge type information from both the LHS and RHS.
+        /// For cases where the RHS of a deconstruction-assignment is a tuple literal, the type information from the LHS determines the merged type, since all variables have a type.
         /// Returns null if a merged tuple type could not be fabricated.
         /// </summary>
         private static TypeSymbol MakeMergedTupleType(ArrayBuilder<DeconstructionVariable> lhsVariables, BoundTupleLiteral rhsLiteral, CSharpSyntaxNode syntax, DiagnosticBag diagnostics, CSharpCompilation compilation)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -333,13 +333,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
 
-                if (mergedType == null)
-                {
-                    typesBuilder.Free();
-                    return null;
-                }
-
                 typesBuilder.Add(mergedType);
+            }
+
+            if (typesBuilder.Any(t => t == null))
+            {
+                typesBuilder.Free();
+                return null;
             }
 
             return TupleTypeSymbol.Create(locationOpt: null, elementTypes: typesBuilder.ToImmutableAndFree(), elementLocations: default(ImmutableArray<Location>), elementNames: default(ImmutableArray<string>), compilation: compilation, diagnostics: diagnostics);

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3095,6 +3095,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type information on the left-hand-side &apos;{0}&apos; and right-hand-side &apos;{1}&apos; of the deconstruction was insufficient to infer a merged type..
+        /// </summary>
+        internal static string ERR_DeconstructCouldNotInferMergedType {
+            get {
+                return ResourceManager.GetString("ERR_DeconstructCouldNotInferMergedType", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Deconstruction `var (...)` form disallows a specific type for &apos;var&apos;..
         /// </summary>
         internal static string ERR_DeconstructionVarFormDisallowsSpecificType {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4917,4 +4917,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_ExplicitTupleElementNames" xml:space="preserve">
     <value>Cannot reference 'System.Runtime.CompilerServices.TupleElementNamesAttribute' explicitly. Use the tuple syntax to define tuple names.</value>
   </data>
+  <data name="ERR_DeconstructCouldNotInferMergedType" xml:space="preserve">
+    <value>The type information on the left-hand-side '{0}' and right-hand-side '{1}' of the deconstruction was insufficient to infer a merged type.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1365,6 +1365,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_PredefinedTypeMemberNotFoundInAssembly = 8205,
         ERR_MissingDeconstruct = 8206,
+        ERR_DeconstructCouldNotInferMergedType = 8209,
         ERR_DeconstructRequiresExpression = 8210,
         ERR_DeconstructWrongCardinality = 8211,
         ERR_CannotDeconstructDynamic = 8212,

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3168,22 +3168,26 @@ class C
         }
 
         [Fact]
-        public void TypeMergingWithTooManyRightVariables()
+        public void TypeMergingWithTooManyRightElements()
         {
             string source = @"
 class C
 {
     static void Main()
     {
-        (string x1, var x2) = (null, ""hello"", 3);
+        (string x1, var y1) = (null, ""hello"", 3);
+        (string x2, var y2) = (null, ""hello"", null);
     }
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
                 // (6,9): error CS8211: Cannot deconstruct a tuple of '3' elements into '2' variables.
-                //         (string x1, var x2) = (null, "hello", 3);
-                Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, @"(string x1, var x2) = (null, ""hello"", 3);").WithArguments("3", "2").WithLocation(6, 9)
+                //         (string x1, var y1) = (null, "hello", 3);
+                Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, @"(string x1, var y1) = (null, ""hello"", 3);").WithArguments("3", "2").WithLocation(6, 9),
+                // (7,47): error CS8210: Deconstruct assignment requires an expression with a type on the right-hand-side.
+                //         (string x2, var y2) = (null, "hello", null);
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(7, 47)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3050,6 +3050,29 @@ class C
         }
 
         [Fact]
+        public void TypeMergingWithMultipleAmbiguousVars()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        (string x1, (byte x2, var x3), var x4) = (null, (2, null), null);
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics(
+                // (6,9): error CS8209: The type information on the left-hand-side 'var x3' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                //         (string x1, (byte x2, var x3), var x4) = (null, (2, null), null);
+                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "(string x1, (byte x2, var x3), var x4) = (null, (2, null), null);").WithArguments("var x3", "null").WithLocation(6, 9),
+                // (6,9): error CS8209: The type information on the left-hand-side 'var x4' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                //         (string x1, (byte x2, var x3), var x4) = (null, (2, null), null);
+                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "(string x1, (byte x2, var x3), var x4) = (null, (2, null), null);").WithArguments("var x4", "null").WithLocation(6, 9)
+                );
+        }
+
+        [Fact]
         public void TypeMergingWithTooManyLeftNestings()
         {
             string source = @"


### PR DESCRIPTION
This fix reflects the LDM decision from yesterday to support deconstructions such as `(string x1, byte x2, var x3) = (null, 1, 2);` by hallucinating a tuple type which merges types from both sides and applying it as a conversion on the literal (which means the 1 is seen as a byte and the deconstruction succeeds).

The change is to update the method which figures the target type. It used to only consider the LHS, but now it merges types from both sides. This literal conversion is applied both in declarations and assignments.
There is also a minor tweak to improve the syntax associated with `DeconstructionVariable`, which is visible in the new diagnostics.

@dotnet/roslyn-compiler for review.
Relates to deconstruction work items: https://github.com/dotnet/roslyn/issues/11299
Relates to issue https://github.com/dotnet/roslyn/issues/12410