### PR TITLE
Always insert the insertion text, even when we can't resolve symbols.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -1840,6 +1840,29 @@ class Program
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12254, "https://github.com/dotnet/roslyn/issues/12254")>
+        Public Async Function TestGenericCallOnTypeContainingAnonymousType() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.Linq;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+        new[] { new { x = 1 } }.ToArr$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+
+                state.SendInvokeCompletionList()
+                state.SendTypeChars("(")
+
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                state.AssertMatchesTextStartingAtLine(7, "new[] { new { x = 1 } }.ToArray(")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         Public Async Function TargetTypePreselectionSetterValuey() As Task
             Using state = TestState.CreateCSharpTestState(
                            <Document><![CDATA[

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 }
                 else
                 {
-                    insertionText = selectedItem.DisplayText;
+                    insertionText = SymbolCompletionItem.GetInsertionText(selectedItem);
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12254

This issue occurs because the expression on the left of the dot contained an anonymous type, and we have no way currently to resolve such a type later on.  This caused us to go through a bailout codepath that erroneously chose the 'DisplayText' as the thing to insert instead of the InsertionText.

Note: we still have an issue here that we can't resolve anonymous types.  This leads to other issues like: https://github.com/dotnet/roslyn/issues/12530

