### PR TITLE
Fixing crash with ValueTuple alias when VT is missing (#12032), more tests.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1468,7 +1468,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static TypeSymbol TransformToTupleIfCompatible(TypeSymbol target)
         {
-            if (target.IsTupleCompatible())
+            if (target.IsTupleCompatible() && !target.IsErrorType())
             {
                 return TupleTypeSymbol.Create((NamedTypeSymbol)target);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1468,7 +1468,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public static TypeSymbol TransformToTupleIfCompatible(TypeSymbol target)
         {
-            if (target.IsTupleCompatible() && !target.IsErrorType())
+            if (!target.IsErrorType() && target.IsTupleCompatible())
             {
                 return TupleTypeSymbol.Create((NamedTypeSymbol)target);
             }


### PR DESCRIPTION
Fixes #12032 (crash when looking up static members and VT alias is aliased by missing)

Resolves #11302 (no repro, no crash)
Resolves #12082 (no repro, conversion to tuple of dynamic elements works)
Opened #12468 (allow invoking a ref-return var method with workaround)
Adds some tests 

@dotnet/roslyn-compiler for review for preview 4.