### PR TITLE
[Do Not Review] Utilise multi line string literals in VB unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,5 @@ $RECYCLE.BIN/
 
 # Visual Studio Code
 .vscode/
+/errors.txt
+/Roslyn-ErrorReport.exe

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -22,11 +22,8 @@ Public MustInherit Class BasicTestBase
     End Function
 
     Private Function Translate(action As Action(Of ModuleSymbol)) As Action(Of IModuleSymbol)
-        If action IsNot Nothing Then
-            Return Sub(m) action(DirectCast(m, ModuleSymbol))
-        Else
-            Return Nothing
-        End If
+        If action Is Nothing Then Return Nothing
+        Return Sub(m) action(DirectCast(m, ModuleSymbol))
     End Function
 
     ' TODO (tomat): TestEmitOptions.All
@@ -173,6 +170,38 @@ Public MustInherit Class BasicTestBase
             verify)
     End Function
 
+    '' NEW TARGET
+    'Friend Shadows Function CompileAndVerify(
+    '    source As String,
+    '    allReferences As IEnumerable(Of MetadataReference),
+    '    Optional expectedOutput As String = Nothing,
+    '    Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
+    '    Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
+    '    Optional validator As Action(Of PEAssembly) = Nothing,
+    '    Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
+    '    Optional expectedSignatures As SignatureDescription() = Nothing,
+    '    Optional options As VisualBasicCompilationOptions = Nothing,
+    '    Optional parseOptions As VisualBasicParseOptions = Nothing,
+    '    Optional verify As Boolean = True
+    ') As CompilationVerifier
+
+    '    If options Is Nothing Then
+    '        options = If(expectedOutput Is Nothing, TestOptions.ReleaseDll, TestOptions.ReleaseExe)
+    '    End If
+
+    '    Dim compilation = CompilationUtils.CreateCompilationWithReferences(source, references:=allReferences, options:=options, parseOptions:=parseOptions)
+
+    '    Return MyBase.CompileAndVerify(
+    '        compilation,
+    '        Nothing,
+    '        dependencies,
+    '        Translate(sourceSymbolValidator),
+    '        validator,
+    '        Translate(symbolValidator),
+    '        expectedSignatures,
+    '        expectedOutput,
+    '        verify)
+    'End Function
     Friend Shadows Function CompileAndVerifyOnWin8Only(
         source As XElement,
         allReferences As IEnumerable(Of MetadataReference),
@@ -199,6 +228,34 @@ Public MustInherit Class BasicTestBase
             parseOptions,
             verify:=OSVersion.IsWin8)
     End Function
+
+    '' NEW TARGET
+    'Friend Shadows Function CompileAndVerifyOnWin8Only(
+    '    source As String,
+    '    allReferences As IEnumerable(Of MetadataReference),
+    '    Optional expectedOutput As String = Nothing,
+    '    Optional dependencies As IEnumerable(Of ModuleData) = Nothing,
+    '    Optional sourceSymbolValidator As Action(Of ModuleSymbol) = Nothing,
+    '    Optional validator As Action(Of PEAssembly) = Nothing,
+    '    Optional symbolValidator As Action(Of ModuleSymbol) = Nothing,
+    '    Optional expectedSignatures As SignatureDescription() = Nothing,
+    '    Optional options As VisualBasicCompilationOptions = Nothing,
+    '    Optional parseOptions As VisualBasicParseOptions = Nothing,
+    '    Optional verify As Boolean = True
+    ') As CompilationVerifier
+    '    Return Me.CompileAndVerify(
+    '        source,
+    '        allReferences,
+    '        If(OSVersion.IsWin8, expectedOutput, Nothing),
+    '        dependencies,
+    '        sourceSymbolValidator,
+    '        validator,
+    '        symbolValidator,
+    '        expectedSignatures,
+    '        options,
+    '        parseOptions,
+    '        verify:=OSVersion.IsWin8)
+    'End Function
 
     ' TODO (tomat): TestEmitOptions.All
     Friend Shadows Function CompileAndVerifyOnWin8Only(
@@ -352,23 +409,20 @@ Public MustInherit Class BasicTestBaseBase
             End Function)
     End Function
 
-    Protected Overrides ReadOnly Property CompilationOptionsReleaseDll As CompilationOptions
-        Get
-            Return TestOptions.ReleaseDll
-        End Get
-    End Property
+    Protected Overrides ReadOnly Property CompilationOptionsReleaseDll As CompilationOptions = TestOptions.ReleaseDll
 
     Protected Overrides Function GetCompilationForEmit(
-        source As IEnumerable(Of String),
-        additionalRefs As IEnumerable(Of MetadataReference),
-        options As CompilationOptions,
-        parseOptions As ParseOptions
-    ) As Compilation
+                                                         source As IEnumerable(Of String),
+                                                         additionalRefs As IEnumerable(Of MetadataReference),
+                                                         options As CompilationOptions,
+                                                         parseOptions As ParseOptions
+                                                      ) As Compilation
         Return VisualBasicCompilation.Create(
-            GetUniqueName(),
-            syntaxTrees:=source.Select(Function(t) VisualBasicSyntaxTree.ParseText(t, options:=DirectCast(parseOptions, VisualBasicParseOptions))),
-            references:=If(additionalRefs IsNot Nothing, DefaultVbReferences.Concat(additionalRefs), DefaultVbReferences),
-            options:=DirectCast(options, VisualBasicCompilationOptions))
+                                              GetUniqueName(),
+                                              syntaxTrees:=source.Select(Function(t) VisualBasicSyntaxTree.ParseText(t, options:=DirectCast(parseOptions, VisualBasicParseOptions))),
+                                               references:=If(additionalRefs IsNot Nothing, DefaultVbReferences.Concat(additionalRefs), DefaultVbReferences),
+                                                  options:=DirectCast(options, VisualBasicCompilationOptions)
+                                            )
     End Function
 
     Public Shared Function CreateSubmission(code As String,
@@ -425,7 +479,7 @@ Public MustInherit Class BasicTestBaseBase
                </sequencePoints>
     End Function
 
-    Public Shared ReadOnly ClassesWithReadWriteProperties As XCData = <![CDATA[
+    Public Shared ReadOnly ClassesWithReadWriteProperties As String = "
 .class public auto ansi beforefieldinit B
        extends [mscorlib]System.Object
 {
@@ -630,7 +684,7 @@ Public MustInherit Class BasicTestBaseBase
     .get instance int32 D2::get_P_rw_rw_r()
   } // end of property D2::P_rw_rw_r
 } // end of class D2
-]]>
+"
 
     Public Class NameSyntaxFinder
         Inherits VisualBasicSyntaxWalker

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -470,7 +470,7 @@ Public MustInherit Class BasicTestBaseBase
 
     Public Shared Shadows Function GetSequencePoints(pdbXml As XElement) As XElement
         Return <sequencePoints>
-                   <%= From entry In pdbXml.<methods>.<method>.<sequencePoints>.<entry>.AsParallel
+                   <%= From entry In pdbXml.<methods>.<method>.<sequencePoints>.<entry>
                        Select <entry
                                   startLine=<%= entry.@startLine %>
                                   startColumn=<%= entry.@startColumn %>
@@ -754,7 +754,7 @@ Public MustInherit Class BasicTestBaseBase
         Private ReadOnly _kinds As New HashSet(Of SyntaxKind)(SyntaxFacts.EqualityComparer)
 
         Public Shared Function FindNodes(Of T As SyntaxNode)(node As SyntaxNode, ParamArray kinds() As SyntaxKind) As List(Of T)
-            Return New List(Of T)(From s In FindNodes(node, kinds).AsParallel Select DirectCast(s, T))
+            Return New List(Of T)(From s In FindNodes(node, kinds) Select DirectCast(s, T))
         End Function
 
         Public Shared Function FindNodes(node As SyntaxNode, ParamArray kinds() As SyntaxKind) As List(Of SyntaxNode)

--- a/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/BasicTestBase.vb
@@ -470,7 +470,7 @@ Public MustInherit Class BasicTestBaseBase
 
     Public Shared Shadows Function GetSequencePoints(pdbXml As XElement) As XElement
         Return <sequencePoints>
-                   <%= From entry In pdbXml.<methods>.<method>.<sequencePoints>.<entry>
+                   <%= From entry In pdbXml.<methods>.<method>.<sequencePoints>.<entry>.AsParallel
                        Select <entry
                                   startLine=<%= entry.@startLine %>
                                   startColumn=<%= entry.@startColumn %>
@@ -696,9 +696,8 @@ Public MustInherit Class BasicTestBaseBase
         Public Overrides Sub DefaultVisit(node As SyntaxNode)
             Dim name = TryCast(node, NameSyntax)
             If name IsNot Nothing Then
-                Me._names.Add(name)
+                _names.Add(name)
             End If
-
             MyBase.DefaultVisit(node)
         End Sub
 
@@ -721,7 +720,7 @@ Public MustInherit Class BasicTestBaseBase
         Public Overrides Sub DefaultVisit(node As SyntaxNode)
             Dim expr = TryCast(node, ExpressionSyntax)
             If expr IsNot Nothing Then
-                Me._expressions.Add(expr)
+                _expressions.Add(expr)
             End If
 
             MyBase.DefaultVisit(node)
@@ -744,18 +743,18 @@ Public MustInherit Class BasicTestBaseBase
         End Sub
 
         Public Overrides Sub DefaultVisit(node As SyntaxNode)
-            If node IsNot Nothing AndAlso Me._kinds.Contains(node.Kind) Then
-                Me._nodes.Add(node)
+            If node IsNot Nothing AndAlso _kinds.Contains(node.Kind) Then
+                _nodes.Add(node)
             End If
 
             MyBase.DefaultVisit(node)
         End Sub
 
-        Private ReadOnly _nodes As New List(Of SyntaxNode)
+        Private ReadOnly _nodes As New List(Of SyntaxNode)(16)
         Private ReadOnly _kinds As New HashSet(Of SyntaxKind)(SyntaxFacts.EqualityComparer)
 
         Public Shared Function FindNodes(Of T As SyntaxNode)(node As SyntaxNode, ParamArray kinds() As SyntaxKind) As List(Of T)
-            Return New List(Of T)(From s In FindNodes(node, kinds) Select DirectCast(s, T))
+            Return New List(Of T)(From s In FindNodes(node, kinds).AsParallel Select DirectCast(s, T))
         End Function
 
         Public Shared Function FindNodes(node As SyntaxNode, ParamArray kinds() As SyntaxKind) As List(Of SyntaxNode)

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -1185,11 +1185,7 @@ Friend Module CompilationUtils
     Public Function VerifyIsGlobal(globalNS1 As ISymbol, Optional expected As Boolean = True) As NamespaceSymbol
         Dim nsSymbol = DirectCast(globalNS1, NamespaceSymbol)
         Assert.NotNull(nsSymbol)
-        If (expected) Then
-            Assert.True(nsSymbol.IsGlobalNamespace)
-        Else
-            Assert.False(nsSymbol.IsGlobalNamespace)
-        End If
+        Assert.Equal(expected, nsSymbol.IsGlobalNamespace)
         Return nsSymbol
     End Function
 
@@ -1214,13 +1210,14 @@ Friend Module CompilationUtils
     End Sub
 
     Public Function SortAndMergeStrings(ParamArray strings As String()) As String
+        If strings Is Nothing OrElse strings.Count = 0 Then Return String.Empty
+        If strings.Length = 1 Then Return strings(0)
         Array.Sort(strings)
-        Dim builder = New StringBuilder
-        For Each str In strings
-            If builder.Length > 0 Then
-                builder.AppendLine()
-            End If
-            builder.Append(str)
+        Dim builder As New StringBuilder(strings(0))
+        Dim e = strings.Length - 1
+        For i = 1 To e
+            builder.AppendLine()
+            builder.Append(strings(i))
         Next
         Return builder.ToString
     End Function

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -15,31 +15,31 @@ Imports Xunit
 
 Friend Module CompilationUtils
 
-    Public Function CreateCompilation(trees As IEnumerable(Of SyntaxTree),
-                                      Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                      Optional options As VisualBasicCompilationOptions = Nothing,
-                                      Optional assemblyName As String = Nothing) As VisualBasicCompilation
-        If options Is Nothing Then
-            options = TestOptions.ReleaseDll
-        End If
+    Public Function CreateCompilation(
+                                       trees As IEnumerable(Of SyntaxTree),
+                              Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                              Optional options As VisualBasicCompilationOptions = Nothing,
+                              Optional assemblyName As String = Nothing
+                                     ) As VisualBasicCompilation
 
+        options = If(options, TestOptions.ReleaseDll)
         ' Using single-threaded build if debugger attached, to simplify debugging.
-        If Debugger.IsAttached Then
-            options = options.WithConcurrentBuild(False)
-        End If
-
+        If Debugger.IsAttached Then options = options.WithConcurrentBuild(False)
         Return VisualBasicCompilation.Create(
-                If(assemblyName, GetUniqueName()),
-                trees,
-                references,
-                options)
+                                               If(assemblyName, GetUniqueName()),
+                                               trees,
+                                               references,
+                                               options
+                                            )
     End Function
 
-    Public Function CreateCompilationWithMscorlib(sourceTrees As IEnumerable(Of String),
-                                                  Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                  Optional options As VisualBasicCompilationOptions = Nothing,
-                                                  Optional assemblyName As String = Nothing,
-                                                  Optional parseOptions As VisualBasicParseOptions = Nothing) As VisualBasicCompilation
+    Public Function CreateCompilationWithMscorlib(
+                                                   sourceTrees As IEnumerable(Of String),
+                                          Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                          Optional options As VisualBasicCompilationOptions = Nothing,
+                                          Optional assemblyName As String = Nothing,
+                                          Optional parseOptions As VisualBasicParseOptions = Nothing
+                                                 ) As VisualBasicCompilation
 
         Dim syntaxTrees = sourceTrees.Select(Function(s) VisualBasicSyntaxTree.ParseText(s, parseOptions))
         Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
@@ -52,9 +52,11 @@ Friend Module CompilationUtils
         Return VisualBasicCompilation.Create(If(assemblyName, "Test"), syntaxTrees, metadataReferences, options)
     End Function
 
-    Public Function CreateCompilationWithMscorlib(sourceTrees As IEnumerable(Of SyntaxTree),
-                                                  Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                  Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+    Public Function CreateCompilationWithMscorlib(
+                                                   sourceTrees As IEnumerable(Of SyntaxTree),
+                                          Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                          Optional options As VisualBasicCompilationOptions = Nothing
+                                                 ) As VisualBasicCompilation
 
         Dim metadataReferences = If(references Is Nothing, {MscorlibRef}, {MscorlibRef}.Concat(references))
 
@@ -66,16 +68,21 @@ Friend Module CompilationUtils
         Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, metadataReferences, options)
     End Function
 
-    Public Function CreateCompilationWithMscorlib45(sourceTrees As IEnumerable(Of SyntaxTree),
-                                                    Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                    Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+    Public Function CreateCompilationWithMscorlib45(
+                                                     sourceTrees As IEnumerable(Of SyntaxTree),
+                                            Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                            Optional options As VisualBasicCompilationOptions = Nothing
+                                                   ) As VisualBasicCompilation
         Dim additionalRefs = {MscorlibRef_v4_0_30316_17626}
         Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, If(references Is Nothing, additionalRefs, additionalRefs.Concat(references)), options)
     End Function
 
-    Public Function CreateCompilationWithMscorlib45AndVBRuntime(sourceTrees As IEnumerable(Of SyntaxTree),
-                                                                Optional references As IEnumerable(Of MetadataReference) = Nothing,
-                                                                Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+    Public Function CreateCompilationWithMscorlib45AndVBRuntime(
+                                                                 sourceTrees As IEnumerable(Of SyntaxTree),
+                                                        Optional references As IEnumerable(Of MetadataReference) = Nothing,
+                                                        Optional options As VisualBasicCompilationOptions = Nothing
+                                                               ) As VisualBasicCompilation
+
         Dim additionalRefs = {MscorlibRef_v4_0_30316_17626, MsvbRef_v4_0_30319_17929}
         Return VisualBasicCompilation.Create(GetUniqueName(), sourceTrees, If(references Is Nothing, additionalRefs, additionalRefs.Concat(references)), options)
     End Function
@@ -255,9 +262,7 @@ Friend Module CompilationUtils
             options = TestOptions.ReleaseDll
 
             ' Using single-threaded build if debugger attached, to simplify debugging.
-            If Debugger.IsAttached Then
-                options = options.WithConcurrentBuild(False)
-            End If
+            If Debugger.IsAttached Then options = options.WithConcurrentBuild(False)
         End If
 
 #If Test_IOperation_Interface Then
@@ -283,10 +288,11 @@ Friend Module CompilationUtils
     End Function
 
     Public Function CreateCompilation(
-            identity As AssemblyIdentity,
-            sources() As String,
-            references() As MetadataReference,
-            Optional options As VisualBasicCompilationOptions = Nothing) As VisualBasicCompilation
+                                       identity As AssemblyIdentity,
+                                       sources() As String,
+                                       references() As MetadataReference,
+                              Optional options As VisualBasicCompilationOptions = Nothing
+                                     ) As VisualBasicCompilation
 
         Dim trees = If(sources Is Nothing, Nothing, sources.Select(AddressOf VisualBasicSyntaxTree.ParseText).ToArray())
         Dim c = VisualBasicCompilation.Create(identity.Name, trees, references, options)
@@ -347,36 +353,40 @@ Friend Module CompilationUtils
     ''' <param name="ilSource"></param>
     ''' <returns></returns>
     ''' <remarks></remarks>
-    Public Function CreateCompilationWithCustomILSource(sources As XElement,
-                                                        ilSource As String,
-                                                        Optional options As VisualBasicCompilationOptions = Nothing,
-                                                        Optional ByRef spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
-                                                        Optional includeVbRuntime As Boolean = False,
-                                                        Optional includeSystemCore As Boolean = False,
-                                                        Optional appendDefaultHeader As Boolean = True,
-                                                        Optional parseOptions As VisualBasicParseOptions = Nothing,
-                                                        <Out> Optional ByRef ilReference As MetadataReference = Nothing,
-                                                        <Out> Optional ByRef ilImage As ImmutableArray(Of Byte) = Nothing
-    ) As VisualBasicCompilation
-        Dim references As New List(Of MetadataReference)
-        If includeVbRuntime Then
-            references.Add(MsvbRef)
-        End If
-        If includeSystemCore Then
-            references.Add(SystemCoreRef)
-        End If
+    Public Function CreateCompilationWithCustomILSource(
+                                                         sources As XElement,
+                                                         ilSource As String,
+                                                Optional options As VisualBasicCompilationOptions = Nothing,
+                                          ByRef Optional spans As IEnumerable(Of IEnumerable(Of TextSpan)) = Nothing,
+                                                Optional includeVbRuntime As Boolean = False,
+                                                Optional includeSystemCore As Boolean = False,
+                                                Optional appendDefaultHeader As Boolean = True,
+                                                Optional parseOptions As VisualBasicParseOptions = Nothing,
+                                    <Out> ByRef Optional ilReference As MetadataReference = Nothing,
+                                    <Out> ByRef Optional ilImage As ImmutableArray(Of Byte) = Nothing
+                                                       ) As VisualBasicCompilation
 
-        If ilSource Is Nothing Then
-            Return CreateCompilationWithMscorlibAndReferences(sources, references, options, spans, parseOptions)
-        End If
+        Dim references As New List(Of MetadataReference)
+
+        If includeVbRuntime Then references.Add(MsvbRef)
+
+        If includeSystemCore Then references.Add(SystemCoreRef)
+
+        If ilSource Is Nothing Then Return CreateCompilationWithMscorlibAndReferences(sources, references, options, spans, parseOptions)
 
         ilReference = CreateReferenceFromIlCode(ilSource, appendDefaultHeader, ilImage)
+
         references.Add(ilReference)
 
         Return CreateCompilationWithMscorlibAndReferences(sources, references, options, spans, parseOptions)
     End Function
 
-    Public Function CreateReferenceFromIlCode(ilSource As String, Optional appendDefaultHeader As Boolean = True, <Out> Optional ByRef ilImage As ImmutableArray(Of Byte) = Nothing) As MetadataReference
+    Public Function CreateReferenceFromIlCode(
+                                               ilSource As String,
+                                      Optional appendDefaultHeader As Boolean = True,
+                          <Out> ByRef Optional ilImage As ImmutableArray(Of Byte) = Nothing
+                                             ) As MetadataReference
+
         Using reference = IlasmUtilities.CreateTempAssembly(ilSource, appendDefaultHeader)
             ilImage = ImmutableArray.Create(File.ReadAllBytes(reference.Path))
         End Using
@@ -397,7 +407,12 @@ Friend Module CompilationUtils
         Return s
     End Function
 
-    Public Function FindBindingText(Of TNode As SyntaxNode)(compilation As Compilation, fileName As String, Optional which As Integer = 0) As TNode
+    Public Function FindBindingText(Of TNode As SyntaxNode)(
+                                                             compilation As Compilation,
+                                                             fileName As String,
+                                                    Optional which As Integer = 0
+                                                           ) As TNode
+
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
 
         Dim bindText As String = Nothing
@@ -426,7 +441,13 @@ Friend Module CompilationUtils
         Return DirectCast(node, TNode)
     End Function
 
-    Public Function FindBindingTextPosition(compilation As Compilation, fileName As String, ByRef bindText As String, Optional which As Integer = 0) As Integer
+    Public Function FindBindingTextPosition(
+                                             compilation As Compilation,
+                                             fileName As String,
+                                       ByRef bindText As String,
+                                    Optional which As Integer = 0
+                                           ) As Integer
+
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
 
         Dim bindMarker As String
@@ -470,7 +491,12 @@ Friend Module CompilationUtils
         Return FindBindingTextPosition(compilation, fileName, bindText)
     End Function
 
-    Public Function FindBindingStartText(Of TNode As SyntaxNode)(compilation As Compilation, fileName As String, Optional which As Integer = 0) As TNode
+    Public Function FindBindingStartText(Of TNode As SyntaxNode)(
+                                                                  compilation As Compilation,
+                                                                  fileName As String,
+                                                         Optional which As Integer = 0
+                                                                ) As TNode
+
         Dim tree = (From t In compilation.SyntaxTrees Where t.FilePath = fileName).Single()
 
         Dim bindText As String = Nothing
@@ -503,42 +529,46 @@ Friend Module CompilationUtils
     End Class
 
     <Extension()>
-    Public Function GetSemanticInfoSummary(model As SemanticModel, node As SyntaxNode) As SemanticInfoSummary
+    Public Function GetSemanticInfoSummary(
+                                            model As SemanticModel,
+                                            node As SyntaxNode
+                                          ) As SemanticInfoSummary
+
         Dim summary As New SemanticInfoSummary
+        With summary
+            ' The information that is available varies by the type of the syntax node.
+            Dim semanticModel = DirectCast(model, VBSemanticModel)
+            Dim symbolInfo As SymbolInfo
+            If TypeOf node Is ExpressionSyntax Then
+                symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, ExpressionSyntax))
+                .MemberGroup = semanticModel.GetMemberGroup(DirectCast(node, ExpressionSyntax))
+                .ConstantValue = semanticModel.GetConstantValue(DirectCast(node, ExpressionSyntax))
+                Dim typeInfo = semanticModel.GetTypeInfo(DirectCast(node, ExpressionSyntax))
+                .Type = DirectCast(typeInfo.Type, TypeSymbol)
+                .ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
+                .ImplicitConversion = semanticModel.GetConversion(DirectCast(node, ExpressionSyntax))
+            ElseIf TypeOf node Is AttributeSyntax Then
+                symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, AttributeSyntax))
+                .MemberGroup = semanticModel.GetMemberGroup(DirectCast(node, AttributeSyntax))
+                Dim typeInfo = semanticModel.GetTypeInfo(DirectCast(node, AttributeSyntax))
+                .Type = DirectCast(typeInfo.Type, TypeSymbol)
+                .ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
+                .ImplicitConversion = semanticModel.GetConversion(DirectCast(node, AttributeSyntax))
+            ElseIf TypeOf node Is QueryClauseSyntax Then
+                symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, QueryClauseSyntax))
+            Else
+                Throw New NotSupportedException("Type of syntax node is not supported by GetSemanticInfo")
+            End If
+            Assert.NotNull(symbolInfo)
+            .Symbol = DirectCast(symbolInfo.Symbol, Symbol)
+            .CandidateReason = symbolInfo.CandidateReason
+            .CandidateSymbols = symbolInfo.CandidateSymbols
+            .AllSymbols = symbolInfo.GetAllSymbols()
 
-        ' The information that is available varies by the type of the syntax node.
-        Dim semanticModel = DirectCast(model, VBSemanticModel)
-        Dim symbolInfo As SymbolInfo
-        If TypeOf node Is ExpressionSyntax Then
-            symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, ExpressionSyntax))
-            summary.MemberGroup = semanticModel.GetMemberGroup(DirectCast(node, ExpressionSyntax))
-            summary.ConstantValue = semanticModel.GetConstantValue(DirectCast(node, ExpressionSyntax))
-            Dim typeInfo = semanticModel.GetTypeInfo(DirectCast(node, ExpressionSyntax))
-            summary.Type = DirectCast(typeInfo.Type, TypeSymbol)
-            summary.ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
-            summary.ImplicitConversion = semanticModel.GetConversion(DirectCast(node, ExpressionSyntax))
-        ElseIf TypeOf node Is AttributeSyntax Then
-            symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, AttributeSyntax))
-            summary.MemberGroup = semanticModel.GetMemberGroup(DirectCast(node, AttributeSyntax))
-            Dim typeInfo = semanticModel.GetTypeInfo(DirectCast(node, AttributeSyntax))
-            summary.Type = DirectCast(typeInfo.Type, TypeSymbol)
-            summary.ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
-            summary.ImplicitConversion = semanticModel.GetConversion(DirectCast(node, AttributeSyntax))
-        ElseIf TypeOf node Is QueryClauseSyntax Then
-            symbolInfo = semanticModel.GetSymbolInfo(DirectCast(node, QueryClauseSyntax))
-        Else
-            Throw New NotSupportedException("Type of syntax node is not supported by GetSemanticInfo")
-        End If
-        Assert.NotNull(symbolInfo)
-        summary.Symbol = DirectCast(symbolInfo.Symbol, Symbol)
-        summary.CandidateReason = symbolInfo.CandidateReason
-        summary.CandidateSymbols = symbolInfo.CandidateSymbols
-        summary.AllSymbols = symbolInfo.GetAllSymbols()
-
-        If TypeOf node Is IdentifierNameSyntax Then
-            summary.Alias = semanticModel.GetAliasInfo(DirectCast(node, IdentifierNameSyntax))
-        End If
-
+            If TypeOf node Is IdentifierNameSyntax Then
+                summary.Alias = semanticModel.GetAliasInfo(DirectCast(node, IdentifierNameSyntax))
+            End If
+        End With
         Return summary
     End Function
 
@@ -547,27 +577,27 @@ Friend Module CompilationUtils
         Dim summary As New SemanticInfoSummary
 
         ' The information that is available varies by the type of the syntax node.
+        With summary
+            Dim semanticModel = DirectCast(model, VBSemanticModel)
+            Dim symbolInfo As SymbolInfo
+            symbolInfo = semanticModel.GetSpeculativeSymbolInfo(position, expression, bindingOption)
+            .MemberGroup = semanticModel.GetSpeculativeMemberGroup(position, expression)
+            .ConstantValue = semanticModel.GetSpeculativeConstantValue(position, expression)
+            Dim typeInfo = semanticModel.GetSpeculativeTypeInfo(position, expression, bindingOption)
+            .Type = DirectCast(typeInfo.Type, TypeSymbol)
+            .ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
+            .ImplicitConversion = semanticModel.GetSpeculativeConversion(position, expression, bindingOption)
 
-        Dim semanticModel = DirectCast(model, VBSemanticModel)
-        Dim symbolInfo As SymbolInfo
-        symbolInfo = semanticModel.GetSpeculativeSymbolInfo(position, expression, bindingOption)
-        summary.MemberGroup = semanticModel.GetSpeculativeMemberGroup(position, expression)
-        summary.ConstantValue = semanticModel.GetSpeculativeConstantValue(position, expression)
-        Dim typeInfo = semanticModel.GetSpeculativeTypeInfo(position, expression, bindingOption)
-        summary.Type = DirectCast(typeInfo.Type, TypeSymbol)
-        summary.ConvertedType = DirectCast(typeInfo.ConvertedType, TypeSymbol)
-        summary.ImplicitConversion = semanticModel.GetSpeculativeConversion(position, expression, bindingOption)
+            Assert.NotNull(symbolInfo)
+            .Symbol = DirectCast(symbolInfo.Symbol, Symbol)
+            .CandidateReason = symbolInfo.CandidateReason
+            .CandidateSymbols = symbolInfo.CandidateSymbols
+            .AllSymbols = symbolInfo.GetAllSymbols()
 
-        Assert.NotNull(symbolInfo)
-        summary.Symbol = DirectCast(symbolInfo.Symbol, Symbol)
-        summary.CandidateReason = symbolInfo.CandidateReason
-        summary.CandidateSymbols = symbolInfo.CandidateSymbols
-        summary.AllSymbols = symbolInfo.GetAllSymbols()
-
-        If TypeOf expression Is IdentifierNameSyntax Then
-            summary.Alias = semanticModel.GetSpeculativeAliasInfo(position, DirectCast(expression, IdentifierNameSyntax), bindingOption)
-        End If
-
+            If TypeOf expression Is IdentifierNameSyntax Then
+                .Alias = semanticModel.GetSpeculativeAliasInfo(position, DirectCast(expression, IdentifierNameSyntax), bindingOption)
+            End If
+        End With
         Return summary
     End Function
 
@@ -616,7 +646,12 @@ Friend Module CompilationUtils
     ''' </param>
     ''' <returns></returns>
     ''' <remarks></remarks>
-    Public Function CreateParseTreeAndSpans(programElement As XElement, Optional parseOptions As VisualBasicParseOptions = Nothing) As Tuple(Of SyntaxTree, IList(Of TextSpan))
+    Public Function CreateParseTreeAndSpans(
+                                             programElement As XElement,
+                                    Optional parseOptions As VisualBasicParseOptions = Nothing
+                                           ) As Tuple(Of SyntaxTree, IList(Of TextSpan))
+
+
         Dim codeWithMarker As String = FilterString(programElement.Value)
         Dim codeWithoutMarker As String = Nothing
         Dim spans As IList(Of TextSpan) = Nothing
@@ -681,11 +716,11 @@ Friend Module CompilationUtils
         Dim currentSymbol As Symbol = compilation.GlobalNamespace
 
         For Each name In names
-            Assert.True(TypeOf currentSymbol Is NamespaceOrTypeSymbol, String.Format("{0} does not have members", currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)))
+            Assert.True(TypeOf currentSymbol Is NamespaceOrTypeSymbol, $"{currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)} does not have members")
             Dim currentContainer = DirectCast(currentSymbol, NamespaceOrTypeSymbol)
             Dim members = currentContainer.GetMembers(name)
-            Assert.True(members.Any(), String.Format("No members named {0} inside {1}", name, currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)))
-            Assert.True(members.Length() <= 1, String.Format("Multiple members named {0} inside {1}", name, currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)))
+            Assert.True(members.Any(), $"No members named {name} inside {currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)}")
+            Assert.True(members.Length() <= 1, $"Multiple members named {name} inside {currentSymbol.ToDisplayString(SymbolDisplayFormat.TestFormat)}")
             currentSymbol = members.First()
         Next
 
@@ -733,11 +768,11 @@ Friend Module CompilationUtils
     <Extension()>
     Public Sub AssertNoErrors(errors As ImmutableArray(Of Diagnostic))
         Dim diags As ImmutableArray(Of Diagnostic) = errors.WhereAsArray(Function(e) e.Severity = DiagnosticSeverity.Error)
-
-        If diags.Length > 0 Then
+        Dim diagCount = diags.Length
+        If diagCount > 0 Then
             Console.WriteLine("Unexpected errors found:")
-            For Each d In diags
-                Console.WriteLine(ErrorText(d))
+            For d = 0 To diagCount - 1
+                Console.WriteLine(ErrorText(diags(d)))
             Next
             Assert.True(False, "Should not have any errors")
         End If
@@ -771,9 +806,7 @@ Friend Module CompilationUtils
     ''' <remarks></remarks>
     <Extension()>
     Public Sub AssertTheseCompileDiagnostics(compilation As Compilation, Optional errs As XElement = Nothing, Optional suppressInfos As Boolean = True)
-        If errs Is Nothing Then
-            errs = <errors/>
-        End If
+        errs = If(errs, <errors/>)
         AssertTheseDiagnostics(DirectCast(compilation, VisualBasicCompilation).GetDiagnostics(CompilationStage.Compile), errs, suppressInfos)
     End Sub
 
@@ -787,9 +820,8 @@ Friend Module CompilationUtils
     ''' <remarks></remarks>
     <Extension()>
     Public Sub AssertTheseEmitDiagnostics(compilation As Compilation, Optional errs As XElement = Nothing, Optional suppressInfos As Boolean = True)
-        If errs Is Nothing Then
-            errs = <errors/>
-        End If
+        errs = If(errs, <errors/>)
+
         Using assemblyStream As New MemoryStream()
             Using pdbStream As New MemoryStream()
                 Dim diagnostics = compilation.Emit(assemblyStream, pdbStream:=pdbStream).Diagnostics
@@ -813,9 +845,8 @@ Friend Module CompilationUtils
     ''' <remarks></remarks>
     <Extension()>
     Public Sub AssertTheseDiagnostics(compilation As Compilation, Optional errs As XElement = Nothing, Optional suppressInfos As Boolean = True)
-        If errs Is Nothing Then
-            errs = <errors/>
-        End If
+        errs = If(errs, <errors/>)
+
         AssertTheseDiagnostics(DirectCast(compilation, VisualBasicCompilation).GetDiagnostics(CompilationStage.Compile), errs, suppressInfos)
     End Sub
 
@@ -852,48 +883,50 @@ Friend Module CompilationUtils
         If expectedText <> actualText Then
 
             Dim messages As New StringBuilder
-            messages.AppendLine()
+            With messages
+                .AppendLine()
 
-            If actualText.StartsWith(expectedText, StringComparison.Ordinal) AndAlso actualText.Substring(expectedText.Length).Trim().Length > 0 Then
-                messages.AppendLine("UNEXPECTED ERROR MESSAGES:")
-                messages.AppendLine(actualText.Substring(expectedText.Length))
+                If actualText.StartsWith(expectedText, StringComparison.Ordinal) AndAlso actualText.Substring(expectedText.Length).Trim().Length > 0 Then
+                    .AppendLine("UNEXPECTED ERROR MESSAGES:")
+                    .AppendLine(actualText.Substring(expectedText.Length))
 
-                Assert.True(False, messages.ToString())
-            Else
-                Dim expectedLines = expectedText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
-                Dim actualLines = actualText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
-
-                Dim appendedLines As Integer = 0
-
-                messages.AppendLine("MISSING ERROR MESSAGES:")
-                For Each l In expectedLines
-                    If Not actualLines.Contains(l) Then
-                        messages.AppendLine(l)
-                        appendedLines += 1
-                    End If
-                Next
-
-                messages.AppendLine("UNEXPECTED ERROR MESSAGES:")
-                For Each l In actualLines
-                    If Not expectedLines.Contains(l) Then
-                        messages.AppendLine(l)
-                        appendedLines += 1
-                    End If
-                Next
-
-                If appendedLines > 0 Then
                     Assert.True(False, messages.ToString())
                 Else
-                    CompareLineByLine(expectedText, actualText)
-                End If
+                    Dim expectedLines = expectedText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
+                    Dim actualLines = actualText.Split({vbCrLf}, StringSplitOptions.RemoveEmptyEntries)
 
-            End If
+                    Dim appendedLines As Integer = 0
+
+                    .AppendLine("MISSING ERROR MESSAGES:")
+                    For Each l In expectedLines
+                        If Not actualLines.Contains(l) Then
+                            .AppendLine(l)
+                            appendedLines += 1
+                        End If
+                    Next
+
+                    .AppendLine("UNEXPECTED ERROR MESSAGES:")
+                    For Each l In actualLines
+                        If Not expectedLines.Contains(l) Then
+                            .AppendLine(l)
+                            appendedLines += 1
+                        End If
+                    Next
+
+                    If appendedLines > 0 Then
+                        Assert.True(False, messages.ToString())
+                    Else
+                        CompareLineByLine(expectedText, actualText)
+                    End If
+
+                End If
+            End With
         End If
     End Sub
 
     Private Sub CompareLineByLine(expected As String, actual As String)
-        Dim expectedReader = New StringReader(expected)
-        Dim actualReader = New StringReader(actual)
+        Dim expectedReader As New StringReader(expected)
+        Dim actualReader As New StringReader(actual)
 
         Dim expectedBuilder As New StringBuilder()
         Dim actualBuilder As New StringBuilder()

--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -882,7 +882,9 @@ Friend Module CompilationUtils
         Dim actualText = DumpAllDiagnostics(errors.ToArray(), suppressInfos)
         If expectedText <> actualText Then
 
-            Dim messages As New StringBuilder
+            Static messages As StringBuilder = Nothing
+            messages = If(messages, New StringBuilder(256))
+            messages.Length = 0
             With messages
                 .AppendLine()
 
@@ -928,8 +930,10 @@ Friend Module CompilationUtils
         Dim expectedReader As New StringReader(expected)
         Dim actualReader As New StringReader(actual)
 
-        Dim expectedBuilder As New StringBuilder()
-        Dim actualBuilder As New StringBuilder()
+        Static expectedBuilder As StringBuilder = Nothing : expectedBuilder = If(expectedBuilder, New StringBuilder())
+        expectedBuilder.Length = 0
+        Dim actualBuilder As StringBuilder = Nothing : actualBuilder = If(actualBuilder, New StringBuilder())
+        actualBuilder.Length = 0
         Dim expectedLine = expectedReader.ReadLine()
         Dim actualLine = actualReader.ReadLine()
 
@@ -1148,9 +1152,9 @@ Friend Module CompilationUtils
         Loop
 
         If (isDistinct) Then
-            symType = (From temp In symType Distinct Select temp Order By temp.ToDisplayString()).ToList()
+            symType = (From temp In symType Distinct Order By temp.ToDisplayString()).ToList()
         Else
-            symType = (From temp In symType Select temp Order By temp.ToDisplayString()).ToList()
+            symType = (From temp In symType Order By temp.ToDisplayString()).ToList()
         End If
         Return symType
 
@@ -1165,7 +1169,7 @@ Friend Module CompilationUtils
         Dim bindings1 = compilation.GetSemanticModel(tree)
         Dim symbols = GetTypeSymbol(compilation, treeName, symbolName, isDistinct)
         Assert.Equal(ExpectedDispName.Count, symbols.Count)
-        ExpectedDispName = (From temp In ExpectedDispName Select temp Order By temp).ToArray()
+        ExpectedDispName = (From temp In ExpectedDispName Order By temp).ToArray()
         Dim count = 0
         For Each item In symbols
             Assert.NotNull(item)

--- a/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/Extensions.vb
@@ -65,9 +65,9 @@ Friend Module Extensions
         Dim lastContainer As NamespaceOrTypeSymbol = Nothing
         Dim members = GetMembers(container, qualifiedName, lastContainer)
         If members.Length = 0 Then
-            Assert.True(False, "Available members:" & vbCrLf + String.Join(vbCrLf, lastContainer.GetMembers()))
+            Assert.True(False, "Available members:" & vbCrLf & String.Join(vbCrLf, lastContainer.GetMembers()))
         ElseIf members.Length > 1 Then
-            Assert.True(False, "Found multiple members of specified name:" & vbCrLf + String.Join(vbCrLf, members))
+            Assert.True(False, "Found multiple members of specified name:" & vbCrLf & String.Join(vbCrLf, members))
         End If
 
         Return members.Single()
@@ -117,7 +117,7 @@ Friend Module Extensions
     <Extension>
     Friend Function GetFieldNamesAndTypes(this As ModuleSymbol, qualifiedTypeName As String) As String()
         Dim type = DirectCast(this.GlobalNamespace.GetMember(qualifiedName:=qualifiedTypeName), NamedTypeSymbol)
-        Return type.GetMembers().OfType(Of FieldSymbol)().Select(Of String)(Function(f) f.Name + ": " + f.Type.ToDisplayString(SymbolDisplayFormat.TestFormat)).ToArray()
+        Return type.GetMembers().OfType(Of FieldSymbol)().AsParallel.AsOrdered.Select(Of String)(Function(f) f.Name & ": " & f.Type.ToDisplayString(SymbolDisplayFormat.TestFormat)).ToArray()
     End Function
 
     <Extension>

--- a/src/Compilers/Test/Utilities/VisualBasic/MetadataHelpers.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MetadataHelpers.vb
@@ -22,7 +22,7 @@ Friend Module MetadataTestHelpers
     End Function
 
     Friend Function GetSymbolsForReferences(references As Object(), Optional importInternals As Boolean = False) As AssemblySymbol()
-        Dim refs As New List(Of MetadataReference)
+        Dim refs As New List(Of MetadataReference)(references.Length)
 
         For Each r In references
             Dim bytes = TryCast(r, Byte())

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -53,15 +53,15 @@ Friend Class MockNamespaceSymbol
     End Function
 
     Public Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
-        Return _children.Where(Function(ns) IdentifierComparison.Equals(ns.Name, name)).ToArray().AsImmutableOrNull
+        Return _children.Where(Function(ns) IdentifierComparison.Equals(ns.Name, name)).AsImmutableOrNull
     End Function
 
     Public Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)
-        Return (From c In _children Where TypeOf c Is NamedTypeSymbol Select DirectCast(c, NamedTypeSymbol)).ToArray().AsImmutableOrNull()
+        Return (From c In _children Where TypeOf c Is NamedTypeSymbol Select DirectCast(c, NamedTypeSymbol)).AsImmutableOrNull()
     End Function
 
     Public Overrides Function GetTypeMembers(name As String) As ImmutableArray(Of NamedTypeSymbol)
-        Return (From c In _children Where TypeOf c Is NamedTypeSymbol AndAlso IdentifierComparison.Equals(c.Name, name) Select DirectCast(c, NamedTypeSymbol)).ToArray.AsImmutableOrNull
+        Return (From c In _children Where TypeOf c Is NamedTypeSymbol AndAlso IdentifierComparison.Equals(c.Name, name) Select DirectCast(c, NamedTypeSymbol)).AsImmutableOrNull
     End Function
 
     Public Overrides ReadOnly Property ContainingSymbol As Symbol
@@ -226,15 +226,15 @@ Friend Class MockNamedTypeSymbol
     End Function
 
     Public Overloads Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
-        Return (From sym In _children Where IdentifierComparison.Equals(sym.Name, name) Select sym).ToArray.AsImmutableOrNull
+        Return (From sym In _children Where IdentifierComparison.Equals(sym.Name, name) Select sym).AsImmutableOrNull
     End Function
 
     Public Overloads Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)
-        Return (From sym In _children Where TypeOf sym Is NamedTypeSymbol Select DirectCast(sym, NamedTypeSymbol)).ToArray().AsImmutableOrNull()
+        Return (From sym In _children Where TypeOf sym Is NamedTypeSymbol Select DirectCast(sym, NamedTypeSymbol)).AsImmutableOrNull()
     End Function
 
     Public Overloads Overrides Function GetTypeMembers(name As String) As ImmutableArray(Of NamedTypeSymbol)
-        Return (From sym In _children Where TypeOf sym Is NamedTypeSymbol AndAlso IdentifierComparison.Equals(sym.Name, name) Select DirectCast(sym, NamedTypeSymbol)).ToArray.AsImmutableOrNull()
+        Return (From sym In _children Where TypeOf sym Is NamedTypeSymbol AndAlso IdentifierComparison.Equals(sym.Name, name) Select DirectCast(sym, NamedTypeSymbol)).AsImmutableOrNull()
     End Function
 
     Public Overloads Overrides Function GetTypeMembers(name As String, arity As Integer) As ImmutableArray(Of NamedTypeSymbol)

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -9,6 +9,13 @@ Friend Class MockVbi
     Inherits VisualBasicCompiler
 
     Public Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing, New DesktopAnalyzerAssemblyLoader())
+        MyBase.New(VisualBasicCommandLineParser.ScriptRunner,
+                   responseFile,
+                   args,
+                   Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
+                   baseDirectory,
+                   RuntimeEnvironment.GetRuntimeDirectory(),
+                   Nothing,
+                   New DesktopAnalyzerAssemblyLoader())
     End Sub
 End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/ParserTestUtilities.vb
@@ -482,7 +482,7 @@ Public Module VerificationHelpers
 
         Public Overrides ReadOnly Property FilePath As String
             Get
-                Return ""
+                Return String.Empty
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -3557,7 +3557,7 @@ End Namespace
         ]]>
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[Testing with ternary test flag == True
+expectedOutput:="Testing with ternary test flag == True
 1
 TernaryAndVarianceConversion.Mammal
 TernaryAndVarianceConversion.Animal
@@ -3607,7 +3607,7 @@ TernaryAndVarianceConversion.Mammal
 TernaryAndVarianceConversion.Animal
 TernaryAndVarianceConversion.Mammal
 System.Collections.Generic.List`1[System.Int32]
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3632,7 +3632,7 @@ End Module
 </compilation>,
             expectedOutput:="30492").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       28 (0x1c)
   .maxstack  3
@@ -3644,17 +3644,17 @@ End Module
   IL_0005:  ldc.i4.s   31
   IL_0007:  and
   IL_0008:  shr
-  IL_0009:  call       "Sub System.Console.Write(Integer)"
+  IL_0009:  call       ""Sub System.Console.Write(Integer)""
   IL_000e:  ldc.i4.s   123
   IL_0010:  conv.i8
   IL_0011:  ldloc.0
   IL_0012:  ldc.i4.s   63
   IL_0014:  and
   IL_0015:  shl
-  IL_0016:  call       "Sub System.Console.Write(Long)"
+  IL_0016:  call       ""Sub System.Console.Write(Long)""
   IL_001b:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3677,7 +3677,7 @@ End Module
 </compilation>,
             expectedOutput:="Iterate").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       20 (0x14)
   .maxstack  1
@@ -3685,15 +3685,15 @@ End Module
   IL_0000:  ldc.i4.1  
   IL_0001:  stloc.0   
   IL_0002:  br.s       IL_0010
-  IL_0004:  ldstr      "Iterate"
-  IL_0009:  call       "Sub System.Console.WriteLine(String)"
+  IL_0004:  ldstr      ""Iterate""
+  IL_0009:  call       ""Sub System.Console.WriteLine(String)""
   IL_000e:  ldc.i4.0  
   IL_000f:  stloc.0   
   IL_0010:  ldloc.0   
   IL_0011:  brtrue.s   IL_0004
   IL_0013:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3716,7 +3716,7 @@ End Module
 </compilation>,
 expectedOutput:="").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       20 (0x14)
   .maxstack  1
@@ -3724,15 +3724,15 @@ expectedOutput:="").
   IL_0000:  ldc.i4.1  
   IL_0001:  stloc.0   
   IL_0002:  br.s       IL_0010
-  IL_0004:  ldstr      "Iterate"
-  IL_0009:  call       "Sub System.Console.WriteLine(String)"
+  IL_0004:  ldstr      ""Iterate""
+  IL_0009:  call       ""Sub System.Console.WriteLine(String)""
   IL_000e:  ldc.i4.0  
   IL_000f:  stloc.0   
   IL_0010:  ldloc.0   
   IL_0011:  brfalse.s  IL_0004
   IL_0013:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3753,26 +3753,26 @@ Module M1
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 Iterate
-]]>).
+").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       18 (0x12)
   .maxstack  1
   .locals init (Boolean V_0) //breakLoop
   IL_0000:  ldc.i4.1  
   IL_0001:  stloc.0   
-  IL_0002:  ldstr      "Iterate"
-  IL_0007:  call       "Sub System.Console.WriteLine(String)"
+  IL_0002:  ldstr      ""Iterate""
+  IL_0007:  call       ""Sub System.Console.WriteLine(String)""
   IL_000c:  ldc.i4.0  
   IL_000d:  stloc.0   
   IL_000e:  ldloc.0   
   IL_000f:  brtrue.s   IL_0002
   IL_0011:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3794,22 +3794,22 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       18 (0x12)
   .maxstack  1
   .locals init (Boolean V_0) //breakLoop
   IL_0000:  ldc.i4.1  
   IL_0001:  stloc.0   
-  IL_0002:  ldstr      "Iterate"
-  IL_0007:  call       "Sub System.Console.WriteLine(String)"
+  IL_0002:  ldstr      ""Iterate""
+  IL_0007:  call       ""Sub System.Console.WriteLine(String)""
   IL_000c:  ldc.i4.0  
   IL_000d:  stloc.0   
   IL_000e:  ldloc.0   
   IL_000f:  brfalse.s  IL_0002
   IL_0011:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3828,15 +3828,15 @@ End Class
     </file>
 </compilation>).
             VerifyIL("C.M",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  ldstr      "Iterate"
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
+  IL_0000:  ldstr      ""Iterate""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
   IL_000a:  br.s       IL_0000
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3866,15 +3866,15 @@ Module M1
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 Stmt1
 Continuing
 Stmt1
 Exiting
 After Loop
-]]>).
+").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       59 (0x3b)
   .maxstack  1
@@ -3885,25 +3885,25 @@ After Loop
   IL_0002:  ldc.i4.1  
   IL_0003:  stloc.1   
   IL_0004:  br.s       IL_002d
-  IL_0006:  ldstr      "Stmt1"
-  IL_000b:  call       "Sub System.Console.WriteLine(String)"
+  IL_0006:  ldstr      ""Stmt1""
+  IL_000b:  call       ""Sub System.Console.WriteLine(String)""
   IL_0010:  ldloc.1   
   IL_0011:  brfalse.s  IL_0021
-  IL_0013:  ldstr      "Continuing"
-  IL_0018:  call       "Sub System.Console.WriteLine(String)"
+  IL_0013:  ldstr      ""Continuing""
+  IL_0018:  call       ""Sub System.Console.WriteLine(String)""
   IL_001d:  ldc.i4.0  
   IL_001e:  stloc.1   
   IL_001f:  br.s       IL_002d
-  IL_0021:  ldstr      "Exiting"
-  IL_0026:  call       "Sub System.Console.WriteLine(String)"
+  IL_0021:  ldstr      ""Exiting""
+  IL_0026:  call       ""Sub System.Console.WriteLine(String)""
   IL_002b:  br.s       IL_0030
   IL_002d:  ldloc.0   
   IL_002e:  brtrue.s   IL_0006
-  IL_0030:  ldstr      "After Loop"
-  IL_0035:  call       "Sub System.Console.WriteLine(String)"
+  IL_0030:  ldstr      ""After Loop""
+  IL_0035:  call       ""Sub System.Console.WriteLine(String)""
   IL_003a:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3930,13 +3930,13 @@ End Class
     </file>
 </compilation>, expectedOutput:="Nothing").
             VerifyIL("CLS.TST",
-            <![CDATA[
+            "
 {
   // Code size        1 (0x1)
   .maxstack  0
   IL_0000:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4226,7 +4226,7 @@ End Module
         <Fact()>
         Public Sub PartialMethod_ComplexGenerics()
             Dim vbCompilation = CreateVisualBasicCompilation("PartialMethod_ComplexGenerics",
-            <![CDATA[Imports System
+            "Imports System
 Imports System.Collections.Generic
 Imports A = C1(Of Integer)
 
@@ -4274,15 +4274,15 @@ Partial Class C1(Of T)
                                                                       aa As K, bb As I(Of K),
                                                                       cc As U, dd As V, ee As IDictionary(Of C1(Of U), I(Of V)),
                                                                       ff As Exception, yy As C1(Of ArgumentException))
-            Console.WriteLine("Success")
+            Console.WriteLine(""Success"")
         End Sub
     End Class
-End Class]]>,
+End Class",
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
 
             Dim vbVerifier = CompileAndVerify(vbCompilation,
-                expectedOutput:=<![CDATA[Success
-]]>)
+                expectedOutput:="Success
+")
             vbVerifier.VerifyDiagnostics()
         End Sub
 
@@ -4290,12 +4290,12 @@ End Class]]>,
         <Fact()>
         Public Sub PartialMethod_InNestedStructsAndModules()
             Dim vbCompilation = CreateVisualBasicCompilation("PartialMethod_InNestedStructsAndModules",
-            <![CDATA[Imports System
+           "Imports System
 
 Public Module M
     Private Sub Foo(Of V)(ByRef x As V,
                           ParamArray y() As Integer)
-        Console.WriteLine("M.Foo - Integer")
+        Console.WriteLine(""M.Foo - Integer"")
     End Sub
     Partial Private Sub Foo(Of V)(ByRef x As V,
                                   ParamArray y() As Long)
@@ -4317,7 +4317,7 @@ Public Module M
     End Sub
     Private Sub Foo(Of V)(ByRef x As V,
                           ParamArray y() As Long)
-        Console.WriteLine("M.Foo - Long")
+        Console.WriteLine(""M.Foo - Long"")
     End Sub
 End Module
 
@@ -4328,7 +4328,7 @@ Interface I(Of T)
         End Sub
         Private Sub Foo(Of V As {T, U})(ByRef x As C(Of S(Of V)),
                                         ParamArray y() As Long)
-            Console.WriteLine("S.Foo - Long")
+            Console.WriteLine(""S.Foo - Long"")
         End Sub
     End Structure
     Class C(Of W As Structure)
@@ -4336,7 +4336,7 @@ Interface I(Of T)
     Partial Structure S(Of U As T)
         Private Sub Foo(Of V As {T, U})(ByRef x As C(Of S(Of V)),
                                         ParamArray y() As Integer)
-            Console.WriteLine("S.Foo - Integer")
+            Console.WriteLine(""S.Foo - Integer"")
         End Sub
         Partial Private Sub Foo(Of V As {T, U})(ByRef x As C(Of S(Of V)),
                                                 ParamArray y() As Long)
@@ -4350,14 +4350,14 @@ Interface I(Of T)
             s.Foo(c, x, x, y)
         End Sub
     End Structure
-End Interface]]>,
+End Interface",
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
             Dim vbVerifier = CompileAndVerify(vbCompilation,
-                expectedOutput:=<![CDATA[S.Foo - Integer
+                expectedOutput:="S.Foo - Integer
 S.Foo - Long
 M.Foo - Integer
 M.Foo - Long
-]]>)
+")
             vbVerifier.VerifyDiagnostics()
         End Sub
 
@@ -4383,19 +4383,19 @@ Module M1
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[Base.New(): 0]]>).
+expectedOutput:="Base.New(): 0").
             VerifyIL("M1.Derived..ctor",
-            <![CDATA[
+            "
 {
   // Code size       13 (0xd)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
-  IL_0002:  newarr     "Object"
-  IL_0007:  call       "Sub M1.Base..ctor(ParamArray Object())"
+  IL_0002:  newarr     ""Object""
+  IL_0007:  call       ""Sub M1.Base..ctor(ParamArray Object())""
   IL_000c:  ret
 }
-]]>)
+")
         End Sub
 
         ' Test access to a parameter (both simple and byref)
@@ -4428,24 +4428,24 @@ Module M1
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 x = 143
 y = 16442
 143
 16442
 x = 143
 y = 189
-]]>).
+").
             VerifyIL("M1.Foo",
-            <![CDATA[
+            "
 {
   // Code size       26 (0x1a)
   .maxstack  2
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0001:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0006:  ldarg.1   
   IL_0007:  ldind.i8  
-  IL_0008:  call       "Sub System.Console.WriteLine(Long)"
+  IL_0008:  call       ""Sub System.Console.WriteLine(Long)""
   IL_000d:  ldc.i4.s   17
   IL_000f:  starg.s    V_0
   IL_0011:  ldarg.1   
@@ -4454,7 +4454,7 @@ y = 189
   IL_0018:  stind.i8  
   IL_0019:  ret       
 }
-]]>)
+")
         End Sub
 
         ' Test that parameterless functions are invoked when in argument lists
@@ -4477,22 +4477,22 @@ Module M1
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 hi
 hi
-]]>).
+").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       21 (0x15)
   .maxstack  1
-  IL_0000:  call       "Function M1.SayHi() As String"
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  call       "Function M1.SayHi() As String"
-  IL_000f:  call       "Sub System.Console.WriteLine(String)"
+  IL_0000:  call       ""Function M1.SayHi() As String""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  call       ""Function M1.SayHi() As String""
+  IL_000f:  call       ""Sub System.Console.WriteLine(String)""
   IL_0014:  ret       
 }    
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4631,20 +4631,20 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.S1",
-            <![CDATA[
+            "
 {
   // Code size       25 (0x19)
   .maxstack  1
   IL_0000:  ldc.i4.1
   IL_0001:  brfalse.s  IL_000e
-  IL_0003:  ldstr      "true"
-  IL_0008:  call       "Sub System.Console.WriteLine(String)"
+  IL_0003:  ldstr      ""true""
+  IL_0008:  call       ""Sub System.Console.WriteLine(String)""
   IL_000d:  ret
-  IL_000e:  ldstr      "false"
-  IL_0013:  call       "Sub System.Console.WriteLine(String)"
+  IL_000e:  ldstr      ""false""
+  IL_0013:  call       ""Sub System.Console.WriteLine(String)""
   IL_0018:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4671,26 +4671,26 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.F1",
-            <![CDATA[
+            "
 {
   // Code size       31 (0x1f)
   .maxstack  1
   .locals init (Boolean V_0) //F1
   IL_0000:  ldc.i4.1
   IL_0001:  brfalse.s  IL_0011
-  IL_0003:  ldstr      "true"
-  IL_0008:  call       "Sub System.Console.WriteLine(String)"
+  IL_0003:  ldstr      ""true""
+  IL_0008:  call       ""Sub System.Console.WriteLine(String)""
   IL_000d:  ldc.i4.1
   IL_000e:  stloc.0
   IL_000f:  br.s       IL_001d
-  IL_0011:  ldstr      "false"
-  IL_0016:  call       "Sub System.Console.WriteLine(String)"
+  IL_0011:  ldstr      ""false""
+  IL_0016:  call       ""Sub System.Console.WriteLine(String)""
   IL_001b:  ldc.i4.0
   IL_001c:  stloc.0
   IL_001d:  ldloc.0
   IL_001e:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4709,7 +4709,7 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.F1",
-            <![CDATA[
+            "
 {
 // Code size        4 (0x4)
 .maxstack  1
@@ -4719,7 +4719,7 @@ IL_0001:  stloc.0
 IL_0002:  ldloc.0
 IL_0003:  ret
 }  
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4741,7 +4741,7 @@ End Class
     </file>
 </compilation>).
             VerifyIL("C.M",
-            <![CDATA[
+            "
 {
   // Code size       29 (0x1d)
   .maxstack  4
@@ -4753,16 +4753,16 @@ End Class
   IL_0002:  stloc.0
   IL_0003:  ldc.i4.0
   IL_0004:  ldloc.0
-  IL_0005:  call       "Sub System.Console.Write(Integer)"
+  IL_0005:  call       ""Sub System.Console.Write(Integer)""
   IL_000a:  ldloc.1
   IL_000b:  ldloc.2
   IL_000c:  ldloc.3
-  IL_000d:  call       "Function String.Concat(String, String, String) As String"
-  IL_0012:  call       "Sub System.Console.Write(String)"
-  IL_0017:  call       "Sub System.Console.Write(Boolean)"
+  IL_000d:  call       ""Function String.Concat(String, String, String) As String""
+  IL_0012:  call       ""Sub System.Console.Write(String)""
+  IL_0017:  call       ""Sub System.Console.Write(Boolean)""
   IL_001c:  ret
 }   
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4783,16 +4783,16 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldc.i4.3
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  pop
   IL_0007:  ret
 } 
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4809,16 +4809,16 @@ End Class
     </file>
 </compilation>).
             VerifyIL("C.M",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldc.i4.4
-  IL_0001:  newarr     "Integer(,)"
+  IL_0001:  newarr     ""Integer(,)""
   IL_0006:  pop
   IL_0007:  ret
 }    
-]]>)
+")
         End Sub
 
         <WorkItem(538660, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538660")>
@@ -4839,37 +4839,37 @@ End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseExe.WithModuleName("MODULE"),
 expectedOutput:="3b").VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       56 (0x38)
   .maxstack  4
   .locals init (Integer() V_0) //z1
   IL_0000:  ldc.i4.3
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E"
-  IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=12 <PrivateImplementationDetails>.E429CCA3F703A39CC5954A6572FEC9086135B34E""
+  IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  stloc.0
   IL_0012:  ldc.i4.2
-  IL_0013:  newarr     "String"
+  IL_0013:  newarr     ""String""
   IL_0018:  dup
   IL_0019:  ldc.i4.0
-  IL_001a:  ldstr      "a"
+  IL_001a:  ldstr      ""a""
   IL_001f:  stelem.ref
   IL_0020:  dup
   IL_0021:  ldc.i4.1
-  IL_0022:  ldstr      "b"
+  IL_0022:  ldstr      ""b""
   IL_0027:  stelem.ref
   IL_0028:  ldloc.0
   IL_0029:  ldc.i4.2
   IL_002a:  ldelem.i4
-  IL_002b:  call       "Sub System.Console.Write(Integer)"
+  IL_002b:  call       ""Sub System.Console.Write(Integer)""
   IL_0030:  ldc.i4.1
   IL_0031:  ldelem.ref
-  IL_0032:  call       "Sub System.Console.Write(String)"
+  IL_0032:  call       ""Sub System.Console.Write(String)""
   IL_0037:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4888,22 +4888,22 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       22 (0x16)
   .maxstack  4
   IL_0000:  ldc.i4.2
-  IL_0001:  newarr     "String"
+  IL_0001:  newarr     ""String""
   IL_0006:  dup
   IL_0007:  ldc.i4.0
-  IL_0008:  ldstr      "hello"
+  IL_0008:  ldstr      ""hello""
   IL_000d:  stelem.ref
   IL_000e:  ldc.i4.1
-  IL_000f:  ldstr      "world"
+  IL_000f:  ldstr      ""world""
   IL_0014:  stelem.ref
   IL_0015:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4932,11 +4932,11 @@ Class MyArray
 End Class
     </file>
 </compilation>,
-    expectedOutput:=<![CDATA[
+    expectedOutput:="
 1.234
 -12345
 -1
-]]>)
+")
         End Sub
 
         <WorkItem(529849, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529849")>
@@ -4968,12 +4968,12 @@ Class MyArray
 End Class
     </file>
 </compilation>,
-    expectedOutput:=<![CDATA[
+    expectedOutput:="
 1.1
 2.20000004768372
 0.123
 c c
-]]>)
+")
         End Sub
 
         <WorkItem(538660, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538660")>
@@ -5019,11 +5019,11 @@ Namespace N
 End Namespace
     </file>
 </compilation>,
-    expectedOutput:=<![CDATA[
+    expectedOutput:="
 123
 XXX
 1/1/0001 12:24:35 PM
-]]>)
+")
         End Sub
 
         <WorkItem(538660, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538660")>
@@ -5062,9 +5062,9 @@ Namespace N
 End Namespace
     </file>
 </compilation>,
-    expectedOutput:=<![CDATA[
+    expectedOutput:="
 12345
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -5166,7 +5166,7 @@ Module Module1
 End Module
     </file>
 </compilation>,
-    expectedOutput:=<![CDATA[
+    expectedOutput:="
 Boolean: False
 Boolean: True
 SByte: 1
@@ -5194,7 +5194,7 @@ Date: 1/1/0001 12:00:00 AM
 Date: 8/23/1970 3:45:39 AM
 Date: 1/1/0001 12:00:00 AM
 Char: v
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -5231,7 +5231,7 @@ Char: v
         <%= My.Resources.Resource.ConversionsILGenTestSource2 %>
     </file>
 </compilation>,
-            expectedOutput:=<![CDATA[
+            expectedOutput:="
 Conversions from Nothing literal:
 Boolean: False
 SByte: 0
@@ -5253,7 +5253,7 @@ IComparable: []
 ValueType: []
 String: []
 Guid: 00000000-0000-0000-0000-000000000000
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -5306,30 +5306,30 @@ End Class
 </compilation>,
     expectedOutput:="System.StringSystem.Int32123M1+Boo1").
             VerifyIL("M1.Boo(Of T).Moo",
-            <![CDATA[
+            "
 {
   // Code size       65 (0x41)
   .maxstack  1
   .locals init (Integer V_0) //iii
-  IL_0000:  ldstr      "hello"
-  IL_0005:  callvirt   "Function Object.GetType() As System.Type"
-  IL_000a:  call       "Sub System.Console.Write(Object)"
+  IL_0000:  ldstr      ""hello""
+  IL_0005:  callvirt   ""Function Object.GetType() As System.Type""
+  IL_000a:  call       ""Sub System.Console.Write(Object)""
   IL_000f:  ldc.i4.s   123
   IL_0011:  stloc.0
   IL_0012:  ldloc.0
-  IL_0013:  box        "Integer"
-  IL_0018:  call       "Function Object.GetType() As System.Type"
-  IL_001d:  call       "Sub System.Console.Write(Object)"
+  IL_0013:  box        ""Integer""
+  IL_0018:  call       ""Function Object.GetType() As System.Type""
+  IL_001d:  call       ""Sub System.Console.Write(Object)""
   IL_0022:  ldloca.s   V_0
-  IL_0024:  call       "Function Integer.ToString() As String"
-  IL_0029:  call       "Sub System.Console.Write(String)"
+  IL_0024:  call       ""Function Integer.ToString() As String""
+  IL_0029:  call       ""Sub System.Console.Write(String)""
   IL_002e:  ldarga.s   V_1
-  IL_0030:  constrained. "T"
-  IL_0036:  callvirt   "Function Object.ToString() As String"
-  IL_003b:  call       "Sub System.Console.WriteLine(String)"
+  IL_0030:  constrained. ""T""
+  IL_0036:  callvirt   ""Function Object.ToString() As String""
+  IL_003b:  call       ""Sub System.Console.WriteLine(String)""
   IL_0040:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -5946,343 +5946,343 @@ End Module
 </compilation>, additionalRefs:={TestReferences.SymbolsTests.PropertiesWithByRef})
 
             verifier.VerifyIL("Module1.M",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldnull
   IL_0001:  ldc.i4.1
   IL_0002:  ldelem.ref
-  IL_0003:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0003:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0008:  pop
   IL_0009:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test1",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  call       "Sub Module1.PassByRef(ByRef Object)"
+  IL_0002:  call       ""Sub Module1.PassByRef(ByRef Object)""
   IL_0007:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test2",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0006:  call       "Sub Module1.PassByVal(Object)"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0006:  call       ""Sub Module1.PassByVal(Object)""
   IL_000b:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test3",
-            <![CDATA[
+            "
 {
   // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0006:  newobj     "Sub TestClass1..ctor(Object)"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0006:  newobj     ""Sub TestClass1..ctor(Object)""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test4",
-            <![CDATA[
+            "
 {
   // Code size       15 (0xf)
   .maxstack  1
   .locals init (Object V_0)
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0006:  stloc.0   
   IL_0007:  ldloca.s   V_0
-  IL_0009:  call       "Sub Module1.PassByRef(ByRef Object)"
+  IL_0009:  call       ""Sub Module1.PassByRef(ByRef Object)""
   IL_000e:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test4_1",
-            <![CDATA[
+            "
 {
   // Code size       15 (0xf)
   .maxstack  1
   .locals init (Object V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
-  IL_0009:  call       "Function PropertiesWithByRef.get_P2(ByRef Object) As Object"
+  IL_0009:  call       ""Function PropertiesWithByRef.get_P2(ByRef Object) As Object""
   IL_000e:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test4_2",
-            <![CDATA[
+            "
 {
   // Code size       15 (0xf)
   .maxstack  1
   .locals init (Object V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
-  IL_0009:  call       "Function PropertiesWithByRef.get_P2(ByRef Object) As Object"
+  IL_0009:  call       ""Function PropertiesWithByRef.get_P2(ByRef Object) As Object""
   IL_000e:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test5",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ExponentObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.ExponentObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test6",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.NegateObject(Object) As Object"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.NegateObject(Object) As Object""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test7",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.PlusObject(Object) As Object"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.PlusObject(Object) As Object""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test8",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.DivideObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.DivideObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test9",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ModObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.ModObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test10",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.IntDivideObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.IntDivideObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test11",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.ConcatenateObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.ConcatenateObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test12",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.NotObject(Object) As Object"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.NotObject(Object) As Object""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test13",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AndObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.AndObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test14",
-            <![CDATA[
+            "
 {
   // Code size       25 (0x19)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean""
   IL_0006:  brfalse.s  IL_0010
   IL_0008:  ldarg.0   
-  IL_0009:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+  IL_0009:  call       ""Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean""
   IL_000e:  br.s       IL_0011
   IL_0010:  ldc.i4.0  
-  IL_0011:  box        "Boolean"
+  IL_0011:  box        ""Boolean""
   IL_0016:  starg.s    V_0
   IL_0018:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test15",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.OrObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.OrObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test16",
-            <![CDATA[
+            "
 {
   // Code size       25 (0x19)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean""
   IL_0006:  brtrue.s   IL_0010
   IL_0008:  ldarg.0   
-  IL_0009:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+  IL_0009:  call       ""Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean""
   IL_000e:  br.s       IL_0011
   IL_0010:  ldc.i4.1  
-  IL_0011:  box        "Boolean"
+  IL_0011:  box        ""Boolean""
   IL_0016:  starg.s    V_0
   IL_0018:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test17",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.XorObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.XorObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test18",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.MultiplyObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.MultiplyObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test19",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.AddObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test20",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.SubtractObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.SubtractObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test21",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.LeftShiftObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.LeftShiftObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test22",
-            <![CDATA[
+            "
 {
   // Code size       10 (0xa)
   .maxstack  2
   IL_0000:  ldarg.0   
   IL_0001:  ldarg.0
-  IL_0002:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.RightShiftObject(Object, Object) As Object"
+  IL_0002:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.RightShiftObject(Object, Object) As Object""
   IL_0007:  starg.s    V_0
   IL_0009:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test23",
-            <![CDATA[
+            "
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -6290,10 +6290,10 @@ End Module
   IL_0001:  starg.s    V_0
   IL_0003:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test23_1",
-            <![CDATA[
+            "
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -6301,10 +6301,10 @@ End Module
   IL_0001:  starg.s    V_0
   IL_0003:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test23_2",
-            <![CDATA[
+            "
 {
   // Code size        4 (0x4)
   .maxstack  1
@@ -6312,248 +6312,248 @@ End Module
   IL_0001:  starg.s    V_0
   IL_0003:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test24",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
-  IL_0000:  ldstr      "x"
+  IL_0000:  ldstr      ""x""
   IL_0005:  starg.s    V_0
   IL_0007:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test25",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
-  IL_0000:  ldstr      "x"
+  IL_0000:  ldstr      ""x""
   IL_0005:  starg.s    V_0
   IL_0007:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test26",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
-  IL_0000:  ldstr      "x"
+  IL_0000:  ldstr      ""x""
   IL_0005:  starg.s    V_0
   IL_0007:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test27",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.0   
-  IL_0001:  castclass  "System.ValueType"
+  IL_0001:  castclass  ""System.ValueType""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test28",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  1
   .locals init (System.Guid V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "System.Guid"
+  IL_0002:  initobj    ""System.Guid""
   IL_0008:  ldloc.0   
-  IL_0009:  box        "System.Guid"
+  IL_0009:  box        ""System.Guid""
   IL_000e:  starg.s    V_0
   IL_0010:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test29",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  1
   .locals init (System.Guid V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "System.Guid"
+  IL_0002:  initobj    ""System.Guid""
   IL_0008:  ldloc.0   
-  IL_0009:  box        "System.Guid"
+  IL_0009:  box        ""System.Guid""
   IL_000e:  starg.s    V_0
   IL_0010:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test30",
-            <![CDATA[
+           "
 {
   // Code size       17 (0x11)
   .maxstack  1
   .locals init (System.Guid V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "System.Guid"
+  IL_0002:  initobj    ""System.Guid""
   IL_0008:  ldloc.0   
-  IL_0009:  box        "System.Guid"
+  IL_0009:  box        ""System.Guid""
   IL_000e:  starg.s    V_0
   IL_0010:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test31",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.1   
-  IL_0001:  box        "T"
+  IL_0001:  box        ""T""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test32",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarg.1   
-  IL_0001:  box        "T"
+  IL_0001:  box        ""T""
   IL_0006:  starg.s    V_0
   IL_0008:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Test33",
-            <![CDATA[
+            "
 {
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarg.1   
-  IL_0001:  box        "T"
-  IL_0006:  isinst     "Object"
+  IL_0001:  box        ""T""
+  IL_0006:  isinst     ""Object""
   IL_000b:  starg.s    V_0
   IL_000d:  ret       
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test1",
-            <![CDATA[
+            "
 {
   // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldc.i4.1
-  IL_0001:  box        "Integer"
-  IL_0006:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0001:  box        ""Integer""
+  IL_0006:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test2",
-            <![CDATA[
+            "
 {
   // Code size       13 (0xd)
   .maxstack  1
   IL_0000:  ldc.i4.1
-  IL_0001:  box        "Integer"
-  IL_0006:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0001:  box        ""Integer""
+  IL_0006:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test3",
-            <![CDATA[
+            "
 {
   // Code size       35 (0x23)
   .maxstack  1
   .locals init (Object V_0) //x
   IL_0000:  ldc.i4.1
-  IL_0001:  box        "Integer"
+  IL_0001:  box        ""Integer""
   IL_0006:  stloc.0
-  IL_0007:  call       "Function Program1.fun1() As Object"
-  IL_000c:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean"
+  IL_0007:  call       ""Function Program1.fun1() As Object""
+  IL_000c:  call       ""Function Microsoft.VisualBasic.CompilerServices.Conversions.ToBoolean(Object) As Boolean""
   IL_0011:  brtrue.s   IL_001b
   IL_0013:  ldc.i4.2
-  IL_0014:  box        "Integer"
+  IL_0014:  box        ""Integer""
   IL_0019:  br.s       IL_001c
   IL_001b:  ldloc.0
-  IL_001c:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_001c:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0021:  pop
   IL_0022:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test4",
-            <![CDATA[
+            "
 {
   // Code size       23 (0x17)
   .maxstack  1
-  IL_0000:  newobj     "Sub Object..ctor()"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  newobj     ""Sub Object..ctor()""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  pop
-  IL_000b:  newobj     "Sub Object..ctor()"
-  IL_0010:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_000b:  newobj     ""Sub Object..ctor()""
+  IL_0010:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0015:  pop
   IL_0016:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test5",
-            <![CDATA[
+           "
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  newobj     "Sub Object..ctor()"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  newobj     ""Sub Object..ctor()""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  pop
   IL_000b:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test6",
-            <![CDATA[
+            "
 {
   // Code size       18 (0x12)
   .maxstack  1
   IL_0000:  ldc.i4.1
-  IL_0001:  box        "Integer"
-  IL_0006:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_000b:  call       "Function Program1.get_P2(Object) As Integer"
+  IL_0001:  box        ""Integer""
+  IL_0006:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_000b:  call       ""Function Program1.get_P2(Object) As Integer""
   IL_0010:  pop
   IL_0011:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.get_P1",
-            <![CDATA[
+            "
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  ldsfld     "Program1._P1 As Object"
+  IL_0000:  ldsfld     ""Program1._P1 As Object""
   IL_0005:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.set_P1",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0006:  stsfld     "Program1._P1 As Object"
+  IL_0001:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0006:  stsfld     ""Program1._P1 As Object""
   IL_000b:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test7",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  1
@@ -6561,61 +6561,61 @@ End Module
   IL_0000:  ldnull
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  call       "Sub Program1.PassByRef1(ByRef Object)"
+  IL_0004:  call       ""Sub Program1.PassByRef1(ByRef Object)""
   IL_0009:  ldloc.0
-  IL_000a:  castclass  "System.ValueType"
+  IL_000a:  castclass  ""System.ValueType""
   IL_000f:  pop
   IL_0010:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test8",
-            <![CDATA[
+            "
 {
   // Code size       45 (0x2d)
   .maxstack  2
   .locals init (System.Guid V_0,
   Object V_1)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "System.Guid"
+  IL_0002:  initobj    ""System.Guid""
   IL_0008:  ldloc.0
-  IL_0009:  box        "System.Guid"
+  IL_0009:  box        ""System.Guid""
   IL_000e:  stloc.1
   IL_000f:  ldloca.s   V_1
-  IL_0011:  call       "Sub Program1.PassByRef1(ByRef Object)"
+  IL_0011:  call       ""Sub Program1.PassByRef1(ByRef Object)""
   IL_0016:  ldloc.1
   IL_0017:  dup
   IL_0018:  brtrue.s   IL_0026
   IL_001a:  pop
   IL_001b:  ldloca.s   V_0
-  IL_001d:  initobj    "System.Guid"
+  IL_001d:  initobj    ""System.Guid""
   IL_0023:  ldloc.0
   IL_0024:  br.s       IL_002b
-  IL_0026:  unbox.any  "System.Guid"
+  IL_0026:  unbox.any  ""System.Guid""
   IL_002b:  pop
   IL_002c:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test9",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  1
   .locals init (System.ValueType V_0)
   IL_0000:  ldnull
-  IL_0001:  castclass  "System.ValueType"
+  IL_0001:  castclass  ""System.ValueType""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
-  IL_0009:  call       "Sub Program1.PassByRef2(ByRef System.ValueType)"
+  IL_0009:  call       ""Sub Program1.PassByRef2(ByRef System.ValueType)""
   IL_000e:  ldloc.0
   IL_000f:  pop
   IL_0010:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test10",
-            <![CDATA[
+            "
 {
   // Code size       37 (0x25)
   .maxstack  2
@@ -6626,37 +6626,37 @@ End Module
   IL_0002:  brtrue.s   IL_0010
   IL_0004:  pop
   IL_0005:  ldloca.s   V_1
-  IL_0007:  initobj    "System.Guid"
+  IL_0007:  initobj    ""System.Guid""
   IL_000d:  ldloc.1
   IL_000e:  br.s       IL_0015
-  IL_0010:  unbox.any  "System.Guid"
+  IL_0010:  unbox.any  ""System.Guid""
   IL_0015:  stloc.0
   IL_0016:  ldloca.s   V_0
-  IL_0018:  call       "Sub Program1.PassByRef3(ByRef System.Guid)"
+  IL_0018:  call       ""Sub Program1.PassByRef3(ByRef System.Guid)""
   IL_001d:  ldloc.0
-  IL_001e:  box        "System.Guid"
+  IL_001e:  box        ""System.Guid""
   IL_0023:  pop
   IL_0024:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Program1.Test11",
-            <![CDATA[
+            "
 {
   // Code size       30 (0x1e)
   .maxstack  1
   .locals init (Object V_0)
-  IL_0000:  call       "Function Program1.get_P1() As Object"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  call       ""Function Program1.get_P1() As Object""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  stloc.0
   IL_000b:  ldloca.s   V_0
-  IL_000d:  call       "Sub Program1.PassByRef1(ByRef Object)"
+  IL_000d:  call       ""Sub Program1.PassByRef1(ByRef Object)""
   IL_0012:  ldloc.0
-  IL_0013:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0018:  call       "Sub Program1.set_P1(Object)"
+  IL_0013:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0018:  call       ""Sub Program1.set_P1(Object)""
   IL_001d:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(540882, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540882")>
@@ -6684,48 +6684,48 @@ End Module
 </compilation>)
 
             verifier.VerifyIL("Module1.S",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  newobj     "Sub Object..ctor()"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  newobj     ""Sub Object..ctor()""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  pop
   IL_000b:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Func2",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  newobj     "Sub Object..ctor()"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  newobj     ""Sub Object..ctor()""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Func1",
-            <![CDATA[
+            "
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.Func2",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  newobj     "Sub Object..ctor()"
-  IL_0005:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0000:  newobj     ""Sub Object..ctor()""
+  IL_0005:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_000a:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(538853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538853")>
@@ -6749,24 +6749,24 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       32 (0x20)
   .maxstack  2
   IL_0000:  ldc.i4     0x80000000
-  IL_0005:  newarr     "Integer"
+  IL_0005:  newarr     ""Integer""
   IL_000a:  pop
-  IL_000b:  call       "Function M1.Count() As Integer"
+  IL_000b:  call       ""Function M1.Count() As Integer""
   IL_0010:  ldc.i4.1
   IL_0011:  add.ovf
-  IL_0012:  newarr     "Integer"
+  IL_0012:  newarr     ""Integer""
   IL_0017:  pop
   IL_0018:  ldc.i4.0
-  IL_0019:  newarr     "Integer"
+  IL_0019:  newarr     ""Integer""
   IL_001e:  pop
   IL_001f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(538852, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538852")>
@@ -6791,37 +6791,37 @@ End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseDll.WithModuleName("MODULE")).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       73 (0x49)
   .maxstack  3
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "Byte"
+  IL_0001:  newarr     ""Byte""
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB"
-  IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.9755240DD0C4C1AD226DEBD40C6D2EBD408250CB""
+  IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  pop
   IL_0012:  ldc.i4.5
-  IL_0013:  newarr     "Double"
+  IL_0013:  newarr     ""Double""
   IL_0018:  dup
-  IL_0019:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A"
-  IL_001e:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0019:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=40 <PrivateImplementationDetails>.11F3436B917FFBA0FAB0FAD5563AF18FA24AC16A""
+  IL_001e:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0023:  pop
   IL_0024:  ldc.i4.5
-  IL_0025:  newarr     "Boolean"
+  IL_0025:  newarr     ""Boolean""
   IL_002a:  dup
-  IL_002b:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.4E724558F6B816715597A51663AD8F05247E2C4A"
-  IL_0030:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_002b:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=5 <PrivateImplementationDetails>.4E724558F6B816715597A51663AD8F05247E2C4A""
+  IL_0030:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0035:  pop
   IL_0036:  ldc.i4.5
-  IL_0037:  newarr     "Char"
+  IL_0037:  newarr     ""Char""
   IL_003c:  dup
-  IL_003d:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails>.E313A2813013780396D58750DC5D62221C86F42F"
-  IL_0042:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_003d:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=10 <PrivateImplementationDetails>.E313A2813013780396D58750DC5D62221C86F42F""
+  IL_0042:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0047:  pop
   IL_0048:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -6842,12 +6842,12 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       29 (0x1d)
   .maxstack  4
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "System.TypeCode"
+  IL_0001:  newarr     ""System.TypeCode""
   IL_0006:  dup
   IL_0007:  ldc.i4.0
   IL_0008:  ldc.i4.3
@@ -6871,7 +6871,7 @@ End Module
   IL_001b:  pop
   IL_001c:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -6892,19 +6892,19 @@ Module M1
 End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseDll.WithModuleName("MODULE"))).VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       19 (0x13)
   .maxstack  3
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "System.TypeCode"
+  IL_0001:  newarr     ""System.TypeCode""
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.3191FF614021ADF3122AC274EA5B6097C21BEB81"
-  IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.3191FF614021ADF3122AC274EA5B6097C21BEB81""
+  IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  pop
   IL_0012:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -6925,16 +6925,16 @@ End Module
     </file>
 </compilation>).
             VerifyIL("M1.M",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  newobj     "Sub Clazz..ctor()"
-  IL_0005:  callvirt   "Function Clazz.get_Prop() As String"
+  IL_0000:  newobj     ""Sub Clazz..ctor()""
+  IL_0005:  callvirt   ""Function Clazz.get_Prop() As String""
   IL_000a:  pop
   IL_000b:  ret
 }
-]]>)
+")
         End Sub
 
         ''' <summary>
@@ -6976,74 +6976,74 @@ End Module
 ]]></file>
 </compilation>).
             VerifyIL("Program.Main",
-            <![CDATA[
+            "
 {
   // Code size      192 (0xc0)
   .maxstack  5
-  IL_0000:  ldsfld     "Decimal.Zero As Decimal"
-  IL_0005:  call       "Sub Program.Print(Decimal)"
-  IL_000a:  ldsfld     "Decimal.One As Decimal"
-  IL_000f:  call       "Sub Program.Print(Decimal)"
+  IL_0000:  ldsfld     ""Decimal.Zero As Decimal""
+  IL_0005:  call       ""Sub Program.Print(Decimal)""
+  IL_000a:  ldsfld     ""Decimal.One As Decimal""
+  IL_000f:  call       ""Sub Program.Print(Decimal)""
   IL_0014:  ldc.i4.8
   IL_0015:  conv.i8
-  IL_0016:  newobj     "Sub Decimal..ctor(Long)"
-  IL_001b:  call       "Sub Program.Print(Decimal)"
-  IL_0020:  ldsfld     "Decimal.MinusOne As Decimal"
-  IL_0025:  call       "Sub Program.Print(Decimal)"
+  IL_0016:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_001b:  call       ""Sub Program.Print(Decimal)""
+  IL_0020:  ldsfld     ""Decimal.MinusOne As Decimal""
+  IL_0025:  call       ""Sub Program.Print(Decimal)""
   IL_002a:  ldc.i4.s   -128
   IL_002c:  conv.i8
-  IL_002d:  newobj     "Sub Decimal..ctor(Long)"
-  IL_0032:  call       "Sub Program.Print(Decimal)"
+  IL_002d:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_0032:  call       ""Sub Program.Print(Decimal)""
   IL_0037:  ldc.i4     0x7fffffff
   IL_003c:  conv.i8
-  IL_003d:  newobj     "Sub Decimal..ctor(Long)"
-  IL_0042:  call       "Sub Program.Print(Decimal)"
+  IL_003d:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_0042:  call       ""Sub Program.Print(Decimal)""
   IL_0047:  ldc.i4     0x80000000
   IL_004c:  conv.i8
-  IL_004d:  newobj     "Sub Decimal..ctor(Long)"
-  IL_0052:  call       "Sub Program.Print(Decimal)"
+  IL_004d:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_0052:  call       ""Sub Program.Print(Decimal)""
   IL_0057:  ldc.i4.m1
   IL_0058:  conv.u8
-  IL_0059:  newobj     "Sub Decimal..ctor(Long)"
-  IL_005e:  call       "Sub Program.Print(Decimal)"
+  IL_0059:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_005e:  call       ""Sub Program.Print(Decimal)""
   IL_0063:  ldc.i4.m1
   IL_0064:  ldc.i4     0x7fffffff
   IL_0069:  ldc.i4.0
   IL_006a:  ldc.i4.0
   IL_006b:  ldc.i4.0
-  IL_006c:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_0071:  call       "Sub Program.Print(Decimal)"
+  IL_006c:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_0071:  call       ""Sub Program.Print(Decimal)""
   IL_0076:  ldc.i4.m1
   IL_0077:  ldc.i4     0x7fffffff
   IL_007c:  ldc.i4.0
   IL_007d:  ldc.i4.1
   IL_007e:  ldc.i4.0
-  IL_007f:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_0084:  call       "Sub Program.Print(Decimal)"
+  IL_007f:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_0084:  call       ""Sub Program.Print(Decimal)""
   IL_0089:  ldc.i4.m1
   IL_008a:  ldc.i4.m1
   IL_008b:  ldc.i4.0
   IL_008c:  ldc.i4.0
   IL_008d:  ldc.i4.0
-  IL_008e:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_0093:  call       "Sub Program.Print(Decimal)"
+  IL_008e:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_0093:  call       ""Sub Program.Print(Decimal)""
   IL_0098:  ldc.i4.m1
   IL_0099:  ldc.i4.m1
   IL_009a:  ldc.i4.m1
   IL_009b:  ldc.i4.1
   IL_009c:  ldc.i4.0
-  IL_009d:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_00a2:  call       "Sub Program.Print(Decimal)"
+  IL_009d:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_00a2:  call       ""Sub Program.Print(Decimal)""
   IL_00a7:  ldc.i4     0x85f0d5ff
   IL_00ac:  ldc.i4     0x7048
   IL_00b1:  ldc.i4.0
   IL_00b2:  ldc.i4.0
   IL_00b3:  ldc.i4.s   10
-  IL_00b5:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_00ba:  call       "Sub Program.Print(Decimal)"
+  IL_00b5:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_00ba:  call       ""Sub Program.Print(Decimal)""
   IL_00bf:  ret
 }
-]]>)
+")
         End Sub
 
 #End Region
@@ -7071,24 +7071,24 @@ End Module
 </compilation>,
             expectedOutput:="4243x").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       47 (0x2f)
   .maxstack  2
   IL_0000:  ldc.i4.s   42
-  IL_0002:  call       "Sub System.Console.Write(Integer)"
+  IL_0002:  call       ""Sub System.Console.Write(Integer)""
   IL_0007:  ldc.i4.s   43
-  IL_0009:  call       "Sub System.Console.Write(Integer)"
+  IL_0009:  call       ""Sub System.Console.Write(Integer)""
   IL_000e:  ldc.i4.s   43
-  IL_0010:  box        "E1"
-  IL_0015:  call       "Function Object.GetType() As System.Type"
-  IL_001a:  ldstr      "42"
-  IL_001f:  call       "Function System.Enum.Parse(System.Type, String) As Object"
-  IL_0024:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0029:  call       "Sub System.Console.Write(Object)"
+  IL_0010:  box        ""E1""
+  IL_0015:  call       ""Function Object.GetType() As System.Type""
+  IL_001a:  ldstr      ""42""
+  IL_001f:  call       ""Function System.Enum.Parse(System.Type, String) As Object""
+  IL_0024:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0029:  call       ""Sub System.Console.Write(Object)""
   IL_002e:  ret       
 }    
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7110,7 +7110,7 @@ End Module
 </compilation>,
             expectedOutput:=" 42System.Int322147483647System.Int32").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
 // Code size       71 (0x47)
 .maxstack  1
@@ -7118,24 +7118,24 @@ End Module
 IL_0000:  ldc.i4.s   42
 IL_0002:  stloc.0
 IL_0003:  ldloca.s   V_0
-IL_0005:  call       "Function Integer.ToString() As String"
-IL_000a:  call       "Sub System.Console.Write(String)"
+IL_0005:  call       ""Function Integer.ToString() As String""
+IL_000a:  call       ""Sub System.Console.Write(String)""
 IL_000f:  ldc.i4.s   42
-IL_0011:  box        "Integer"
-IL_0016:  call       "Function Object.GetType() As System.Type"
-IL_001b:  call       "Sub System.Console.Write(Object)"
+IL_0011:  box        ""Integer""
+IL_0016:  call       ""Function Object.GetType() As System.Type""
+IL_001b:  call       ""Sub System.Console.Write(Object)""
 IL_0020:  ldc.i4     0x7fffffff
 IL_0025:  stloc.0
 IL_0026:  ldloca.s   V_0
-IL_0028:  call       "Function Integer.ToString() As String"
-IL_002d:  call       "Sub System.Console.Write(String)"
+IL_0028:  call       ""Function Integer.ToString() As String""
+IL_002d:  call       ""Sub System.Console.Write(String)""
 IL_0032:  ldc.i4     0x7fffffff
-IL_0037:  box        "Integer"
-IL_003c:  call       "Function Object.GetType() As System.Type"
-IL_0041:  call       "Sub System.Console.Write(Object)"
+IL_0037:  box        ""Integer""
+IL_003c:  call       ""Function Object.GetType() As System.Type""
+IL_0041:  call       ""Sub System.Console.Write(Object)""
 IL_0046:  ret
 }   
-]]>)
+")
         End Sub
 
         <WorkItem(539920, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539920")>
@@ -7253,7 +7253,7 @@ End Module
 </compilation>,
             expectedOutput:="246810").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       22 (0x16)
   .maxstack  2
@@ -7265,7 +7265,7 @@ End Module
   IL_0004:  add.ovf
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  call       "Sub System.Console.Write(Integer)"
+  IL_0007:  call       ""Sub System.Console.Write(Integer)""
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
   IL_000e:  add.ovf
@@ -7275,7 +7275,7 @@ End Module
   IL_0013:  ble.s      IL_0002
   IL_0015:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7297,28 +7297,28 @@ End Module
 </compilation>,
             expectedOutput:="246810").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       50 (0x32)
   .maxstack  2
   IL_0000:  ldc.i4.1
-  IL_0001:  stsfld     "M1.i As Integer"
-  IL_0006:  ldsfld     "M1.i As Integer"
+  IL_0001:  stsfld     ""M1.i As Integer""
+  IL_0006:  ldsfld     ""M1.i As Integer""
   IL_000b:  ldc.i4.1
   IL_000c:  add.ovf
-  IL_000d:  stsfld     "M1.i As Integer"
-  IL_0012:  ldsfld     "M1.i As Integer"
-  IL_0017:  call       "Sub System.Console.Write(Integer)"
-  IL_001c:  ldsfld     "M1.i As Integer"
+  IL_000d:  stsfld     ""M1.i As Integer""
+  IL_0012:  ldsfld     ""M1.i As Integer""
+  IL_0017:  call       ""Sub System.Console.Write(Integer)""
+  IL_001c:  ldsfld     ""M1.i As Integer""
   IL_0021:  ldc.i4.1
   IL_0022:  add.ovf
-  IL_0023:  stsfld     "M1.i As Integer"
-  IL_0028:  ldsfld     "M1.i As Integer"
+  IL_0023:  stsfld     ""M1.i As Integer""
+  IL_0028:  ldsfld     ""M1.i As Integer""
   IL_002d:  ldc.i4.s   10
   IL_002f:  ble.s      IL_0006
   IL_0031:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7345,31 +7345,31 @@ End Module
 </compilation>,
             expectedOutput:="246810").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       56 (0x38)
   .maxstack  2
   IL_0000:  ldc.i4.1
-  IL_0001:  stsfld     "M1.i As Integer"
-  IL_0006:  ldsfld     "M1.i As Integer"
+  IL_0001:  stsfld     ""M1.i As Integer""
+  IL_0006:  ldsfld     ""M1.i As Integer""
   IL_000b:  ldc.i4.s   10
   IL_000d:  bgt.s      IL_0037
-  IL_000f:  ldsfld     "M1.i As Integer"
+  IL_000f:  ldsfld     ""M1.i As Integer""
   IL_0014:  ldc.i4.2
   IL_0015:  rem
   IL_0016:  brtrue.s   IL_0022
-  IL_0018:  ldsfld     "M1.i As Integer"
-  IL_001d:  call       "Sub System.Console.Write(Integer)"
-  IL_0022:  ldsfld     "M1.i As Integer"
+  IL_0018:  ldsfld     ""M1.i As Integer""
+  IL_001d:  call       ""Sub System.Console.Write(Integer)""
+  IL_0022:  ldsfld     ""M1.i As Integer""
   IL_0027:  ldc.i4.1
   IL_0028:  add.ovf
-  IL_0029:  stsfld     "M1.i As Integer"
-  IL_002e:  ldsfld     "M1.i As Integer"
+  IL_0029:  stsfld     ""M1.i As Integer""
+  IL_002e:  ldsfld     ""M1.i As Integer""
   IL_0033:  ldc.i4.s   20
   IL_0035:  ble.s      IL_0006
   IL_0037:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7395,35 +7395,35 @@ End Module
 </compilation>,
             expectedOutput:="6789101112 13").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       91 (0x5b)
   .maxstack  3
   .locals init (Integer V_0,
   Integer V_1)
   IL_0000:  ldc.i4.3
-  IL_0001:  stsfld     "M1.p1 As Integer"
-  IL_0006:  ldsfld     "M1.p1 As Integer"
+  IL_0001:  stsfld     ""M1.p1 As Integer""
+  IL_0006:  ldsfld     ""M1.p1 As Integer""
   IL_000b:  ldc.i4.4
   IL_000c:  mul.ovf
   IL_000d:  stloc.0
-  IL_000e:  ldsfld     "M1.p1 As Integer"
+  IL_000e:  ldsfld     ""M1.p1 As Integer""
   IL_0013:  ldc.i4.2
   IL_0014:  sub.ovf
   IL_0015:  stloc.1
   IL_0016:  ldc.i4.6
-  IL_0017:  stsfld     "M1.p1 As Integer"
+  IL_0017:  stsfld     ""M1.p1 As Integer""
   IL_001c:  br.s       IL_0034
-  IL_001e:  ldsfld     "M1.p1 As Integer"
-  IL_0023:  call       "Sub System.Console.Write(Integer)"
-  IL_0028:  ldsfld     "M1.p1 As Integer"
+  IL_001e:  ldsfld     ""M1.p1 As Integer""
+  IL_0023:  call       ""Sub System.Console.Write(Integer)""
+  IL_0028:  ldsfld     ""M1.p1 As Integer""
   IL_002d:  ldloc.1
   IL_002e:  add.ovf
-  IL_002f:  stsfld     "M1.p1 As Integer"
+  IL_002f:  stsfld     ""M1.p1 As Integer""
   IL_0034:  ldloc.1
   IL_0035:  ldc.i4.s   31
   IL_0037:  shr
-  IL_0038:  ldsfld     "M1.p1 As Integer"
+  IL_0038:  ldsfld     ""M1.p1 As Integer""
   IL_003d:  xor
   IL_003e:  ldloc.1
   IL_003f:  ldc.i4.s   31
@@ -7431,13 +7431,13 @@ End Module
   IL_0042:  ldloc.0
   IL_0043:  xor
   IL_0044:  ble.s      IL_001e
-  IL_0046:  ldstr      " "
-  IL_004b:  call       "Sub System.Console.Write(String)"
-  IL_0050:  ldsfld     "M1.p1 As Integer"
-  IL_0055:  call       "Sub System.Console.Write(Integer)"
+  IL_0046:  ldstr      "" ""
+  IL_004b:  call       ""Sub System.Console.Write(String)""
+  IL_0050:  ldsfld     ""M1.p1 As Integer""
+  IL_0055:  call       ""Sub System.Console.Write(Integer)""
   IL_005a:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(540443, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540443")>
@@ -7465,51 +7465,51 @@ End Class
     </file>
 </compilation>).
                 VerifyIL("A.ToString",
-            <![CDATA[
+            "
 {
   // Code size       15 (0xf)
   .maxstack  1
   .locals init (Integer V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      "A.Value As Integer"
+  IL_0001:  ldfld      ""A.Value As Integer""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
-  IL_0009:  call       "Function Integer.ToString() As String"
+  IL_0009:  call       ""Function Integer.ToString() As String""
   IL_000e:  ret
 }
-]]>).
+").
 VerifyIL("A..ctor",
-            <![CDATA[
+            "
 {
 // Code size       26 (0x1a)
 .maxstack  2
 IL_0000:  ldarg.0
-IL_0001:  call       "Sub Object..ctor()"
+IL_0001:  call       ""Sub Object..ctor()""
 IL_0006:  ldarg.0
 IL_0007:  ldarg.1
-IL_0008:  stfld      "A.Value As Integer"
+IL_0008:  stfld      ""A.Value As Integer""
 IL_000d:  ldarg.0
-IL_000e:  ldflda     "A.Value As Integer"
-IL_0013:  call       "Function Integer.ToString() As String"
+IL_000e:  ldflda     ""A.Value As Integer""
+IL_0013:  call       ""Function Integer.ToString() As String""
 IL_0018:  pop
 IL_0019:  ret
 }
-]]>).
+").
 VerifyIL("A.moo",
-            <![CDATA[
+            "
 {
 // Code size       16 (0x10)
 .maxstack  2
 .locals init (Integer V_0)
 IL_0000:  ldarg.0
 IL_0001:  ldarg.0
-IL_0002:  ldfld      "A.Value As Integer"
+IL_0002:  ldfld      ""A.Value As Integer""
 IL_0007:  stloc.0
 IL_0008:  ldloca.s   V_0
-IL_000a:  call       "Sub A.foo(ByRef Integer)"
+IL_000a:  call       ""Sub A.foo(ByRef Integer)""
 IL_000f:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7532,7 +7532,7 @@ End Module
 </compilation>,
             expectedOutput:="").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
 // Code size       14 (0xe)
 .maxstack  1
@@ -7540,10 +7540,10 @@ End Module
 IL_0000:  ldc.i4     0x7fffffff
 IL_0005:  stloc.0
 IL_0006:  ldloca.s   V_0
-IL_0008:  call       "Sub M1.Foo(ByRef Integer)"
+IL_0008:  call       ""Sub M1.Foo(ByRef Integer)""
 IL_000d:  ret
 }
-]]>)
+")
         End Sub
 
         ' Constructor initializers don't bind yet
@@ -7562,15 +7562,15 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("S..ctor(Integer)",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  initobj    "S"
+  IL_0001:  initobj    ""S""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -7609,26 +7609,26 @@ Structure S1
     End Sub
 End Structure
     </file>
-</compilation>, expectedOutput:=<![CDATA[
-C1.New("S1.FLD")
+</compilation>, expectedOutput:="
+C1.New(""S1.FLD"")
 C1.P.Get
 S1.New(x As String)
 C1.P.Set
 S1.New(x As C1)
-]]>).
+").
             VerifyIL("S1..cctor()",
-            <![CDATA[
+            "
 {
   // Code size       16 (0x10)
   .maxstack  1
-  IL_0000:  ldstr      "S1.FLD"
-  IL_0005:  newobj     "Sub C1..ctor(String)"
-  IL_000a:  stsfld     "S1.FLD As C1"
+  IL_0000:  ldstr      ""S1.FLD""
+  IL_0005:  newobj     ""Sub C1..ctor(String)""
+  IL_000a:  stsfld     ""S1.FLD As C1""
   IL_000f:  ret
 }
-]]>).
+").
             VerifyIL("S1..ctor(C1)",
-            <![CDATA[
+"
 {
   // Code size       35 (0x23)
   .maxstack  3
@@ -7638,30 +7638,30 @@ S1.New(x As C1)
   IL_0001:  ldarg.1
   IL_0002:  dup
   IL_0003:  stloc.0
-  IL_0004:  callvirt   "Function C1.get_P() As String"
+  IL_0004:  callvirt   ""Function C1.get_P() As String""
   IL_0009:  stloc.1
   IL_000a:  ldloca.s   V_1
-  IL_000c:  call       "Sub S1..ctor(ByRef String)"
+  IL_000c:  call       ""Sub S1..ctor(ByRef String)""
   IL_0011:  ldloc.0
   IL_0012:  ldloc.1
-  IL_0013:  callvirt   "Sub C1.set_P(String)"
-  IL_0018:  ldstr      "S1.New(x As C1)"
-  IL_001d:  call       "Sub System.Console.WriteLine(String)"
+  IL_0013:  callvirt   ""Sub C1.set_P(String)""
+  IL_0018:  ldstr      ""S1.New(x As C1)""
+  IL_001d:  call       ""Sub System.Console.WriteLine(String)""
   IL_0022:  ret
 }
-]]>).
+").
             VerifyIL("S1..ctor(ByRef String)",
-            <![CDATA[
+"
 {
   // Code size       18 (0x12)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
-  IL_0007:  ldstr      "S1.New(x As String)"
-  IL_000c:  call       "Sub System.Console.WriteLine(String)"
+  IL_0001:  initobj    ""S1""
+  IL_0007:  ldstr      ""S1.New(x As String)""
+  IL_000c:  call       ""Sub System.Console.WriteLine(String)""
   IL_0011:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(543751, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543751")>
@@ -7669,22 +7669,22 @@ S1.New(x As C1)
         Public Sub StructConstructorWithOptionalParametersCSVB()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",
-            <![CDATA[
+"
 using System;
 
 public struct SymbolModifiers
 {
     public SymbolModifiers(bool isStatic = true, bool isSupa = true)
     {
-        Console.Write("isStatic = " + isStatic.ToString() + ", isSupa = " + isSupa.ToString() + "; ");
+        Console.Write(""isStatic = "" + isStatic.ToString() + "", isSupa = "" + isSupa.ToString() + ""; "");
     }
 }
-]]>,
+",
                 compilationOptions:=New CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             csCompilation.VerifyDiagnostics()
 
             Dim vbCompilation = CreateVisualBasicCompilation("VBDll",
-            <![CDATA[
+"
 Class S
     Shared Sub Main(args() As String)
         Dim z1 = New SymbolModifiers(isSupa:=False)
@@ -7692,7 +7692,7 @@ Class S
         Dim z3 = New SymbolModifiers()
     End Sub
 End Class
-]]>,
+",
                             compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                             referencedCompilations:={csCompilation})
             Dim vbexeVerifier = CompileAndVerify(vbCompilation,
@@ -7706,26 +7706,26 @@ End Class
         Public Sub StructConstructorWithOptionalParametersVBVB()
 
             Dim vbCompilationA = CreateVisualBasicCompilation("VBDllA",
-            <![CDATA[
+"
 Imports System
 Public Structure STRUCT
     Public Sub New(Optional ByVal x As Integer = 0)
-        Console.WriteLine("Public Sub New(Optional ByVal x As Integer = 0)")
+        Console.WriteLine(""Public Sub New(Optional ByVal x As Integer = 0)"")
     End Sub
 End Structure
-]]>,
+",
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             vbCompilationA.VerifyDiagnostics()
 
             Dim vbCompilationB = CreateVisualBasicCompilation("VBExeB",
-            <![CDATA[
+"
 Class S
     Shared Sub Main(args() As String)
         Dim z1 = New STRUCT(1)
         Dim z2 = New STRUCT()
     End Sub
 End Class
-]]>,
+",
                             compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                             referencedCompilations:={vbCompilationA})
             Dim vbexeVerifier = CompileAndVerify(vbCompilationB,
@@ -7739,26 +7739,26 @@ End Class
         Public Sub StructConstructorWithOptionalParametersVBVB2()
 
             Dim vbCompilationA = CreateVisualBasicCompilation("VBDllA",
-            <![CDATA[
+"
 Imports System
 Public Structure STRUCT
     Public Sub New(ParamArray x() As Integer)
-        Console.WriteLine("ParamArray x() As Integer")
+        Console.WriteLine(""ParamArray x() As Integer"")
     End Sub
 End Structure
-]]>,
+",
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             vbCompilationA.VerifyDiagnostics()
 
             Dim vbCompilationB = CreateVisualBasicCompilation("VBExeB",
-            <![CDATA[
+"
 Class S
     Shared Sub Main(args() As String)
         Dim z1 = New STRUCT(1)
         Dim z2 = New STRUCT()
     End Sub
 End Class
-]]>,
+",
                             compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                             referencedCompilations:={vbCompilationA})
             Dim vbexeVerifier = CompileAndVerify(vbCompilationB,
@@ -7869,47 +7869,48 @@ Module Program
     End Sub
 End Module
     </file>
-</compilation>, expectedOutput:=<![CDATA[
+</compilation>,
+expectedOutput:="
 BASE2: f(x As Integer, Optional y As Integer = 0)
 BASE2: f(x As Integer, Optional y As Integer = 0)
-BASE1: f(x As Integer, Optional y As String = "")
+BASE1: f(x As Integer, Optional y As String = """")
 DERIVED: f(x As Integer, Optional y As Integer = 0)
 DERIVED: f(x As Integer, Optional y As Integer = 0)
-DERIVED: f(x As Integer, Optional y As String = "")
-]]>)
+DERIVED: f(x As Integer, Optional y As String = """")
+")
         End Sub
         <WorkItem(543751, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543751")>
         <Fact>
         Public Sub OverloadsWithOnlyOptionalParameters()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",
-            <![CDATA[
+"
 using System;
 
 public class OverloadsUsingOptional
 {
     public static void M(int k, int l = 0)
     {
-        Console.Write("M(int k, int l = 0);");
+        Console.Write(""M(int k, Int l = 0),"""");
     }
     public static void M(int k, int l = 0, int m = 0)
     {
-        Console.Write("M(int k, int l = 0, int m = 0);");
+        Console.Write(""M(int k, int l = 0, int m = 0),"""");
     }
 }
-]]>,
+",
                 compilationOptions:=New Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             csCompilation.VerifyDiagnostics()
 
             Dim vbCompilation = CreateVisualBasicCompilation("VBDll",
-            <![CDATA[
+"
 Class S
     Shared Sub Main(args() As String)
         OverloadsUsingOptional.M(1, 2)
         OverloadsUsingOptional.M(1, 2, 3)
     End Sub
 End Class
-]]>,
+",
                             compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                             referencedCompilations:={csCompilation})
             Dim vbexeVerifier = CompileAndVerify(vbCompilation,
@@ -7923,26 +7924,26 @@ End Class
         Public Sub OverloadsWithOnlyOptionalParameters2()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",
-            <![CDATA[
+"
 using System;
 
 public class OverloadsUsingOptional
 {
     public static void M(int k, int l = 0)
     {
-        Console.Write("M(int k, int l = 0);");
+        Console.Write(""M(int k, int l = 0),"");
     }
     public static void M(int k, int l = 0, int m = 0)
     {
-        Console.Write("M(int k, int l = 0, int m = 0);");
+        Console.Write(""M(int k, int l = 0, int m = 0),"");
     }
 }
-]]>,
+",
                 compilationOptions:=New Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             csCompilation.VerifyDiagnostics()
 
             Dim vbCompilation = CreateVisualBasicCompilation("VBDll",
-            <![CDATA[
+"
 Imports System
 Imports System.Collections.Generic
 Imports System.Linq
@@ -7952,7 +7953,7 @@ Class S
         OverloadsUsingOptional.M(1)
     End Sub
 End Class
-]]>,
+",
                             compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
                             referencedCompilations:={csCompilation})
 
@@ -8088,15 +8089,15 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("S1..ctor(Integer)",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
+  IL_0001:  initobj    ""S1""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8115,15 +8116,15 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("S1..ctor(Integer)",
-            <![CDATA[
+            "
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  initobj    "S1"
+  IL_0001:  initobj    ""S1""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(7926, "DevDiv_Projects/Roslyn")>
@@ -8144,16 +8145,16 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("S..ctor(Integer, String)",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldarg.1
-  IL_0002:  call       "Sub S..ctor(Integer)"
+  IL_0002:  call       ""Sub S..ctor(Integer)""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8188,46 +8189,46 @@ End Class
 
             CompileAndVerify(vbSource).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       77 (0x4d)
   .maxstack  3
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.1
-  IL_0002:  newobj     "Sub S..ctor(Integer)"
-  IL_0007:  stfld      "C.Fld As S"
+  IL_0002:  newobj     ""Sub S..ctor(Integer)""
+  IL_0007:  stfld      ""C.Fld As S""
   IL_000c:  ldarg.0
-  IL_000d:  ldfld      "C.FldArr As S()"
+  IL_000d:  ldfld      ""C.FldArr As S()""
   IL_0012:  ldc.i4.1
   IL_0013:  ldc.i4.1
-  IL_0014:  newobj     "Sub S..ctor(Integer)"
-  IL_0019:  stelem     "S"
+  IL_0014:  newobj     ""Sub S..ctor(Integer)""
+  IL_0019:  stelem     ""S""
   .try
 {
   IL_001e:  ldarg.0
   IL_001f:  ldc.i4.1
-  IL_0020:  newobj     "Sub S..ctor(Integer)"
-  IL_0025:  stfld      "C.Fld As S"
+  IL_0020:  newobj     ""Sub S..ctor(Integer)""
+  IL_0025:  stfld      ""C.Fld As S""
   IL_002a:  ldarg.0
-  IL_002b:  ldfld      "C.FldArr As S()"
+  IL_002b:  ldfld      ""C.FldArr As S()""
   IL_0030:  ldc.i4.1
   IL_0031:  ldc.i4.1
-  IL_0032:  newobj     "Sub S..ctor(Integer)"
-  IL_0037:  stelem     "S"
+  IL_0032:  newobj     ""Sub S..ctor(Integer)""
+  IL_0037:  stelem     ""S""
   IL_003c:  leave.s    IL_004c
 }
   catch System.Exception
 {
   IL_003e:  dup
-  IL_003f:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_003f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0044:  stloc.0
-  IL_0045:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0045:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_004a:  leave.s    IL_004c
 }
   IL_004c:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8262,46 +8263,46 @@ End Class
 
             CompileAndVerify(vbSource).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       64 (0x40)
   .maxstack  3
   .locals init (S() V_0, //locArr
   System.Exception V_1) //ex
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "S"
+  IL_0001:  newarr     ""S""
   IL_0006:  stloc.0
   IL_0007:  ldc.i4.1
-  IL_0008:  newobj     "Sub S..ctor(Integer)"
+  IL_0008:  newobj     ""Sub S..ctor(Integer)""
   IL_000d:  pop
   IL_000e:  ldloc.0
   IL_000f:  ldc.i4.1
   IL_0010:  ldc.i4.1
-  IL_0011:  newobj     "Sub S..ctor(Integer)"
-  IL_0016:  stelem     "S"
+  IL_0011:  newobj     ""Sub S..ctor(Integer)""
+  IL_0016:  stelem     ""S""
   .try
 {
   IL_001b:  ldc.i4.1
-  IL_001c:  newobj     "Sub S..ctor(Integer)"
+  IL_001c:  newobj     ""Sub S..ctor(Integer)""
   IL_0021:  pop
   IL_0022:  ldloc.0
   IL_0023:  ldc.i4.1
   IL_0024:  ldc.i4.1
-  IL_0025:  newobj     "Sub S..ctor(Integer)"
-  IL_002a:  stelem     "S"
+  IL_0025:  newobj     ""Sub S..ctor(Integer)""
+  IL_002a:  stelem     ""S""
   IL_002f:  leave.s    IL_003f
 }
   catch System.Exception
 {
   IL_0031:  dup
-  IL_0032:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_0032:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0037:  stloc.1
-  IL_0038:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0038:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_003d:  leave.s    IL_003f
 }
   IL_003f:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8345,7 +8346,7 @@ x=0, y=0
 x=1, y=2
 ]]>).
 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       80 (0x50)
   .maxstack  3
@@ -8358,31 +8359,31 @@ VerifyIL("C.Main",
   IL_0004:  nop
   .try
 {
-  IL_0005:  ldstr      "x={0}, y={1}"
+  IL_0005:  ldstr      ""x={0}, y={1}""
   IL_000a:  ldloc.1
-  IL_000b:  ldfld      "S.x As Integer"
-  IL_0010:  box        "Integer"
+  IL_000b:  ldfld      ""S.x As Integer""
+  IL_0010:  box        ""Integer""
   IL_0015:  ldloc.1
-  IL_0016:  ldfld      "S.y As Integer"
-  IL_001b:  box        "Integer"
-  IL_0020:  call       "Sub System.Console.WriteLine(String, Object, Object)"
+  IL_0016:  ldfld      ""S.y As Integer""
+  IL_001b:  box        ""Integer""
+  IL_0020:  call       ""Sub System.Console.WriteLine(String, Object, Object)""
   IL_0025:  ldloc.0
   IL_0026:  ldc.i4.1
   IL_0027:  add.ovf
   IL_0028:  ldc.i4.2
-  IL_0029:  newobj     "Sub S..ctor(Integer, Integer)"
+  IL_0029:  newobj     ""Sub S..ctor(Integer, Integer)""
   IL_002e:  stloc.1
   IL_002f:  ldc.i4.s   10
-  IL_0031:  newobj     "Sub S..ctor(Integer)"
+  IL_0031:  newobj     ""Sub S..ctor(Integer)""
   IL_0036:  stloc.1
   IL_0037:  leave.s    IL_0047
 }
   catch System.Exception
 {
   IL_0039:  dup
-  IL_003a:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_003a:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_003f:  stloc.2
-  IL_0040:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0040:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0045:  leave.s    IL_0047
 }
   IL_0047:  ldloc.0
@@ -8394,7 +8395,7 @@ VerifyIL("C.Main",
   IL_004d:  blt.s      IL_0004
   IL_004f:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8424,7 +8425,7 @@ End Class
 
             CompileAndVerify(vbSource).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       38 (0x26)
   .maxstack  2
@@ -8432,27 +8433,27 @@ End Class
   .try
   {
     IL_0000:  ldc.i4.1
-    IL_0001:  newobj     "Sub S..ctor(Integer)"
+    IL_0001:  newobj     ""Sub S..ctor(Integer)""
     IL_0006:  pop
     IL_0007:  ldc.i4.1
-    IL_0008:  newobj     "Sub S..ctor(Integer)"
+    IL_0008:  newobj     ""Sub S..ctor(Integer)""
     IL_000d:  pop
     IL_000e:  ldc.i4.1
-    IL_000f:  newobj     "Sub S..ctor(Integer)"
+    IL_000f:  newobj     ""Sub S..ctor(Integer)""
     IL_0014:  pop
     IL_0015:  leave.s    IL_0025
   }
   catch System.Exception
   {
     IL_0017:  dup
-    IL_0018:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0018:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
     IL_001d:  stloc.0
-    IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_001e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
     IL_0023:  leave.s    IL_0025
   }
   IL_0025:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8486,63 +8487,63 @@ End Class
             ' NOTE: Current implementation does not support optimization for constructor calls with side effects
             CompileAndVerify(vbSource).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size      105 (0x69)
   .maxstack  3
   .locals init (Integer V_0,
   System.Exception V_1) //ex
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function C.get_AutoProp() As Integer"
+  IL_0001:  call       ""Function C.get_AutoProp() As Integer""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
-  IL_0009:  newobj     "Sub S..ctor(ByRef Integer)"
+  IL_0009:  newobj     ""Sub S..ctor(ByRef Integer)""
   IL_000e:  ldarg.0
   IL_000f:  ldloc.0
-  IL_0010:  call       "Sub C.set_AutoProp(Integer)"
+  IL_0010:  call       ""Sub C.set_AutoProp(Integer)""
   IL_0015:  pop
   IL_0016:  ldarg.0
-  IL_0017:  call       "Function C.get_AutoProp() As Integer"
+  IL_0017:  call       ""Function C.get_AutoProp() As Integer""
   IL_001c:  stloc.0
   IL_001d:  ldloca.s   V_0
-  IL_001f:  newobj     "Sub S..ctor(ByRef Integer)"
+  IL_001f:  newobj     ""Sub S..ctor(ByRef Integer)""
   IL_0024:  ldarg.0
   IL_0025:  ldloc.0
-  IL_0026:  call       "Sub C.set_AutoProp(Integer)"
+  IL_0026:  call       ""Sub C.set_AutoProp(Integer)""
   IL_002b:  pop
   .try
 {
   IL_002c:  ldarg.0
-  IL_002d:  call       "Function C.get_AutoProp() As Integer"
+  IL_002d:  call       ""Function C.get_AutoProp() As Integer""
   IL_0032:  stloc.0
   IL_0033:  ldloca.s   V_0
-  IL_0035:  newobj     "Sub S..ctor(ByRef Integer)"
+  IL_0035:  newobj     ""Sub S..ctor(ByRef Integer)""
   IL_003a:  ldarg.0
   IL_003b:  ldloc.0
-  IL_003c:  call       "Sub C.set_AutoProp(Integer)"
+  IL_003c:  call       ""Sub C.set_AutoProp(Integer)""
   IL_0041:  pop
   IL_0042:  ldarg.0
-  IL_0043:  call       "Function C.get_AutoProp() As Integer"
+  IL_0043:  call       ""Function C.get_AutoProp() As Integer""
   IL_0048:  stloc.0
   IL_0049:  ldloca.s   V_0
-  IL_004b:  newobj     "Sub S..ctor(ByRef Integer)"
+  IL_004b:  newobj     ""Sub S..ctor(ByRef Integer)""
   IL_0050:  ldarg.0
   IL_0051:  ldloc.0
-  IL_0052:  call       "Sub C.set_AutoProp(Integer)"
+  IL_0052:  call       ""Sub C.set_AutoProp(Integer)""
   IL_0057:  pop
   IL_0058:  leave.s    IL_0068
 }
   catch System.Exception
 {
   IL_005a:  dup
-  IL_005b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_005b:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0060:  stloc.1
-  IL_0061:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0061:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0066:  leave.s    IL_0068
 }
   IL_0068:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -8573,45 +8574,45 @@ End Class
 
             CompileAndVerify(vbSource).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       57 (0x39)
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarga.s   V_1
   IL_0002:  ldc.i4.1
-  IL_0003:  call       "Sub S..ctor(Integer)"
+  IL_0003:  call       ""Sub S..ctor(Integer)""
   IL_0008:  ldarg.2
   IL_0009:  ldc.i4.1
-  IL_000a:  newobj     "Sub S..ctor(Integer)"
-  IL_000f:  stobj      "S"
+  IL_000a:  newobj     ""Sub S..ctor(Integer)""
+  IL_000f:  stobj      ""S""
   .try
 {
   IL_0014:  ldc.i4.1
-  IL_0015:  newobj     "Sub S..ctor(Integer)"
+  IL_0015:  newobj     ""Sub S..ctor(Integer)""
   IL_001a:  starg.s    V_1
   IL_001c:  ldarg.2
   IL_001d:  ldc.i4.1
-  IL_001e:  newobj     "Sub S..ctor(Integer)"
-  IL_0023:  stobj      "S"
+  IL_001e:  newobj     ""Sub S..ctor(Integer)""
+  IL_0023:  stobj      ""S""
   IL_0028:  leave.s    IL_0038
 }
   catch System.Exception
 {
   IL_002a:  dup
-  IL_002b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_002b:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0030:  stloc.0
-  IL_0031:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0031:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0036:  leave.s    IL_0038
 }
   IL_0038:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
         Public Sub PartiallyInitializedValue_PublicParameterlessConstructor_Fields()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -8624,7 +8625,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -8648,49 +8649,49 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       73 (0x49)
   .maxstack  3
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarg.0
-  IL_0001:  newobj     "Sub S..ctor()"
-  IL_0006:  stfld      "C.Fld As S"
+  IL_0001:  newobj     ""Sub S..ctor()""
+  IL_0006:  stfld      ""C.Fld As S""
   IL_000b:  ldarg.0
-  IL_000c:  ldfld      "C.FldArr As S()"
+  IL_000c:  ldfld      ""C.FldArr As S()""
   IL_0011:  ldc.i4.1
-  IL_0012:  newobj     "Sub S..ctor()"
-  IL_0017:  stelem     "S"
+  IL_0012:  newobj     ""Sub S..ctor()""
+  IL_0017:  stelem     ""S""
   .try
 {
   IL_001c:  ldarg.0
-  IL_001d:  newobj     "Sub S..ctor()"
-  IL_0022:  stfld      "C.Fld As S"
+  IL_001d:  newobj     ""Sub S..ctor()""
+  IL_0022:  stfld      ""C.Fld As S""
   IL_0027:  ldarg.0
-  IL_0028:  ldfld      "C.FldArr As S()"
+  IL_0028:  ldfld      ""C.FldArr As S()""
   IL_002d:  ldc.i4.1
-  IL_002e:  newobj     "Sub S..ctor()"
-  IL_0033:  stelem     "S"
+  IL_002e:  newobj     ""Sub S..ctor()""
+  IL_0033:  stelem     ""S""
   IL_0038:  leave.s    IL_0048
 }
   catch System.Exception
 {
   IL_003a:  dup
-  IL_003b:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_003b:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0040:  stloc.0
-  IL_0041:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0041:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0046:  leave.s    IL_0048
 }
   IL_0048:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
         Public Sub PartiallyInitializedValue_PublicParameterlessConstructor_Locals()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -8703,7 +8704,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -8727,49 +8728,49 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       60 (0x3c)
   .maxstack  3
   .locals init (S() V_0, //locArr
   System.Exception V_1) //ex
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "S"
+  IL_0001:  newarr     ""S""
   IL_0006:  stloc.0
-  IL_0007:  newobj     "Sub S..ctor()"
+  IL_0007:  newobj     ""Sub S..ctor()""
   IL_000c:  pop
   IL_000d:  ldloc.0
   IL_000e:  ldc.i4.1
-  IL_000f:  newobj     "Sub S..ctor()"
-  IL_0014:  stelem     "S"
+  IL_000f:  newobj     ""Sub S..ctor()""
+  IL_0014:  stelem     ""S""
   .try
 {
-  IL_0019:  newobj     "Sub S..ctor()"
+  IL_0019:  newobj     ""Sub S..ctor()""
   IL_001e:  pop
   IL_001f:  ldloc.0
   IL_0020:  ldc.i4.1
-  IL_0021:  newobj     "Sub S..ctor()"
-  IL_0026:  stelem     "S"
+  IL_0021:  newobj     ""Sub S..ctor()""
+  IL_0026:  stelem     ""S""
   IL_002b:  leave.s    IL_003b
 }
   catch System.Exception
 {
   IL_002d:  dup
-  IL_002e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_002e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0033:  stloc.1
-  IL_0034:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0034:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0039:  leave.s    IL_003b
 }
   IL_003b:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
         Public Sub PartiallyInitializedValue_PublicParameterlessConstructor_Params()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -8782,7 +8783,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -8803,38 +8804,38 @@ End Class
 </compilation>
 
             ' TODO (tomat): verification fails
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       53 (0x35)
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarga.s   V_1
-  IL_0002:  call       "Sub S..ctor()"
+  IL_0002:  call       ""Sub S..ctor()""
   IL_0007:  ldarg.2
-  IL_0008:  newobj     "Sub S..ctor()"
-  IL_000d:  stobj      "S"
+  IL_0008:  newobj     ""Sub S..ctor()""
+  IL_000d:  stobj      ""S""
   .try
 {
-  IL_0012:  newobj     "Sub S..ctor()"
+  IL_0012:  newobj     ""Sub S..ctor()""
   IL_0017:  starg.s    V_1
   IL_0019:  ldarg.2
-  IL_001a:  newobj     "Sub S..ctor()"
-  IL_001f:  stobj      "S"
+  IL_001a:  newobj     ""Sub S..ctor()""
+  IL_001f:  stobj      ""S""
   IL_0024:  leave.s    IL_0034
 }
   catch System.Exception
 {
   IL_0026:  dup
-  IL_0027:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_0027:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_002c:  stloc.0
-  IL_002d:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_002d:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0032:  leave.s    IL_0034
 }
   IL_0034:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -10847,15 +10847,15 @@ Class Test
 End Class]]>
     </file>
 </compilation>, expectedOutput:="PASS").
-                VerifyIL("Test.Main", <![CDATA[
+                VerifyIL("Test.Main", "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  ldstr      "PASS"
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
+  IL_0000:  ldstr      ""PASS""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
   IL_000a:  ret
 }
-]]>)
+")
         End Sub
 
 
@@ -10883,21 +10883,21 @@ End Module
 ]]>
     </file>
 </compilation>, expectedOutput:="FalseTrue").
-                VerifyIL("Program.Main", <![CDATA[
+                VerifyIL("Program.Main", "
 {
   // Code size       34 (0x22)
   .maxstack  2
-  IL_0000:  ldsfld     "Program.f As Boolean"
-  IL_0005:  ldsfld     "Program.t As Boolean"
+  IL_0000:  ldsfld     ""Program.f As Boolean""
+  IL_0005:  ldsfld     ""Program.t As Boolean""
   IL_000a:  ceq
-  IL_000c:  call       "Sub System.Console.Write(Boolean)"
-  IL_0011:  ldsfld     "Program.f As Boolean"
-  IL_0016:  ldsfld     "Program.t As Boolean"
+  IL_000c:  call       ""Sub System.Console.Write(Boolean)""
+  IL_0011:  ldsfld     ""Program.f As Boolean""
+  IL_0016:  ldsfld     ""Program.t As Boolean""
   IL_001b:  xor
-  IL_001c:  call       "Sub System.Console.Write(Boolean)"
+  IL_001c:  call       ""Sub System.Console.Write(Boolean)""
   IL_0021:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -10935,7 +10935,7 @@ End Class
 ]]>
     </file>
 </compilation>, expectedOutput:="notequal1notequal2").
-                VerifyIL("Class1.Main", <![CDATA[
+                VerifyIL("Class1.Main", "
 {
   // Code size       92 (0x5c)
   .maxstack  3
@@ -10944,13 +10944,13 @@ End Class
   IL_0002:  ldc.i4.0
   IL_0003:  cgt.un
   IL_0005:  brfalse.s  IL_0011
-  IL_0007:  ldstr      "notequal1"
-  IL_000c:  call       "Sub System.Console.Write(String)"
+  IL_0007:  ldstr      ""notequal1""
+  IL_000c:  call       ""Sub System.Console.Write(String)""
   IL_0011:  ldc.i4.0
   IL_0012:  ceq
   IL_0014:  brfalse.s  IL_0020
-  IL_0016:  ldstr      "equal1"
-  IL_001b:  call       "Sub System.Console.Write(String)"
+  IL_0016:  ldstr      ""equal1""
+  IL_001b:  call       ""Sub System.Console.Write(String)""
   IL_0020:  ldc.r8     -1
   IL_0029:  dup
   IL_002a:  ldc.r8     0
@@ -10958,16 +10958,16 @@ End Class
   IL_0035:  ldc.i4.0
   IL_0036:  ceq
   IL_0038:  brfalse.s  IL_0044
-  IL_003a:  ldstr      "notequal2"
-  IL_003f:  call       "Sub System.Console.Write(String)"
+  IL_003a:  ldstr      ""notequal2""
+  IL_003f:  call       ""Sub System.Console.Write(String)""
   IL_0044:  ldc.r8     0
   IL_004d:  ceq
   IL_004f:  brfalse.s  IL_005b
-  IL_0051:  ldstr      "equal2"
-  IL_0056:  call       "Sub System.Console.Write(String)"
+  IL_0051:  ldstr      ""equal2""
+  IL_0056:  call       ""Sub System.Console.Write(String)""
   IL_005b:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact(), WorkItem(544128, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544128")>
@@ -10986,7 +10986,7 @@ End Class
 
         <Fact(), WorkItem(544182, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544182")>
         Public Sub OverrideImplementMembersWithOptArguments()
-            Dim optParameterSource = <![CDATA[
+            Dim optParameterSource = "
 .class interface public abstract auto ansi IAnimal
 {
   .method public newslot abstract strict virtual 
@@ -11029,7 +11029,7 @@ End Class
     .get instance class AbstractAnimal AbstractAnimal::get_Descendants(int32)
   } // end of property AbstractAnimal::Descendants
 } // end of class AbstractAnimal
-]]>.Value
+"
             Dim vbSource =
 <compilation>
     <file name="a.vb">
@@ -11079,16 +11079,16 @@ End Structure
 </compilation>,
 expectedOutput:="").
             VerifyIL("S.M",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldnull
-  IL_0002:  stfld      "S.F As Object"
+  IL_0002:  stfld      ""S.F As Object""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -11116,7 +11116,7 @@ expectedOutput:="")
         <Fact()>
         Public Sub TestConversionMultiDimArrayToIList()
             Dim vbCompilation = CreateVisualBasicCompilation("TestConversionMultiDimArrayToIList",
-            <![CDATA[Imports System
+            "Imports System
 Imports System.Collections
 Module Program
     Sub Main(args As String())
@@ -11132,7 +11132,7 @@ Module Test
                 Dim a As T, b As T
                 'T(,,)->IList
                 Dim l4 As IList = {{{a, b}, {a, b}}}
-                Console.WriteLine("PASS")
+                Console.WriteLine(""PASS"")
             Catch ex As Exception
                 Console.WriteLine(ex.ToString())
             End Try
@@ -11142,26 +11142,26 @@ Module Test
             Try
                'U(,,)->IList
                 Dim l4 As IList = {{{d(0), d(1)}, {d(2), d(3)}}}
-                Console.WriteLine("{0}", l4.GetType())
+                Console.WriteLine(""{0}"", l4.GetType())
                 dim a4 as integer(,,) = l4
                 for i = 0 to a4.GetLength(0) - 1
                     for j = 0 to a4.GetLength(1) - 1
                         for k = 0 to a4.GetLength(2) - 1
-                            Console.WriteLine("{0}", a4(i, j, k))
+                            Console.WriteLine(""{0}"", a4(i, j, k))
                         next
                     next
                 next
-                Console.WriteLine("PASS")
+                Console.WriteLine(""PASS"")
             Catch ex As Exception
                 Console.WriteLine(ex.ToString())
             End Try
         End Sub
     End Class
-End Module]]>,
+End Module",
                 compilationOptions:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication))
 
             Dim vbVerifier = CompileAndVerify(vbCompilation,
-                expectedOutput:=<![CDATA[
+                expectedOutput:="
 PASS
 System.Int32[,,]
 1
@@ -11169,7 +11169,7 @@ System.Int32[,,]
 3
 4
 PASS
-]]>)
+")
             vbVerifier.VerifyDiagnostics()
         End Sub
 
@@ -11225,25 +11225,25 @@ End Structure
 </compilation>,
 expectedOutput:="2").
             VerifyIL("Test.TestINop(Of T)(T)",
-            <![CDATA[
+"
 {
   // Code size       36 (0x24)
   .maxstack  3
   .locals init (T V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function Test.Nop(Of T)(T) As T"
+  IL_0001:  call       ""Function Test.Nop(Of T)(T) As T""
   IL_0006:  stloc.0
   IL_0007:  ldloca.s   V_0
   IL_0009:  ldloca.s   V_0
-  IL_000b:  constrained. "T"
-  IL_0011:  callvirt   "Function I.get_IntPropI() As Integer"
+  IL_000b:  constrained. ""T""
+  IL_0011:  callvirt   ""Function I.get_IntPropI() As Integer""
   IL_0016:  ldc.i4.1
   IL_0017:  add.ovf
-  IL_0018:  constrained. "T"
-  IL_001e:  callvirt   "Sub I.set_IntPropI(Integer)"
+  IL_0018:  constrained. ""T""
+  IL_001e:  callvirt   ""Sub I.set_IntPropI(Integer)""
   IL_0023:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -11384,7 +11384,7 @@ End Class
                 Diagnostic(ERRID.WRN_DefAsgNoRetValPropVal1, "End Get").WithArguments("P"))
 
             Dim verifier = CompileAndVerify(compilation)
-            verifier.VerifyIL("Program.get_P", <![CDATA[
+            verifier.VerifyIL("Program.get_P", "
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -11392,14 +11392,14 @@ End Class
   IL_0000:  ldloc.0
   IL_0001:  ret
 }
-]]>)
-            verifier.VerifyIL("Program.set_P", <![CDATA[
+")
+            verifier.VerifyIL("Program.set_P", "
 {
   // Code size        1 (0x1)
   .maxstack  0
   IL_0000:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -11425,14 +11425,14 @@ End Class
             compilation.VerifyDiagnostics()
 
             Dim verifier = CompileAndVerify(compilation)
-            verifier.VerifyIL("Program.get_P", <![CDATA[
+            verifier.VerifyIL("Program.get_P", "
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldc.i4.1
   IL_0001:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -11467,16 +11467,16 @@ BC42026: Expression recursively calls the containing property 'Public Property P
 
             ' NOTE: call setter - doesn't set return value.
             Dim verifier = CompileAndVerify(compilation)
-            verifier.VerifyIL("Program.set_P", <![CDATA[
+            verifier.VerifyIL("Program.set_P", "
 {
   // Code size        8 (0x8)
   .maxstack  2
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.1
-  IL_0002:  call       "Sub Program.set_P(Integer)"
+  IL_0002:  call       ""Sub Program.set_P(Integer)""
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -11510,14 +11510,14 @@ Class Program
 End Class
     ]]></file>
 </compilation>, TestOptions.ReleaseExe)
-            Dim verifier = CompileAndVerify(compilation, expectedOutput:=<![CDATA[
+            Dim verifier = CompileAndVerify(compilation, expectedOutput:="
 In get
 1
 In get
 In set
 In get
 2
-]]>)
+")
         End Sub
 
         <WorkItem(545716, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545716")>
@@ -11534,7 +11534,7 @@ End Class
     </file>
 </compilation>).
             VerifyIL("EdmFunction.SetFunctionAttribute",
-            <![CDATA[
+"
 {
   // Code size       11 (0xb)
   .maxstack  4
@@ -11550,7 +11550,7 @@ End Class
   IL_0009:  stind.i1
   IL_000a:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(546189, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546189")>
@@ -11577,7 +11577,7 @@ End Module
     </file>
 </compilation>, expectedOutput:="pass").
             VerifyIL("Module1.Main",
-            <![CDATA[
+"
 {
   // Code size       38 (0x26)
   .maxstack  2
@@ -11590,22 +11590,22 @@ End Module
 {
   IL_0004:  ldloc.0
   IL_0005:  conv.ovf.u8
-  IL_0006:  call       "Sub System.Console.WriteLine(ULong)"
+  IL_0006:  call       ""Sub System.Console.WriteLine(ULong)""
   IL_000b:  leave.s    IL_0025
 }
   catch System.OverflowException
 {
   IL_000d:  dup
-  IL_000e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_000e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0013:  stloc.1
-  IL_0014:  ldstr      "pass"
-  IL_0019:  call       "Sub System.Console.WriteLine(String)"
-  IL_001e:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_0014:  ldstr      ""pass""
+  IL_0019:  call       ""Sub System.Console.WriteLine(String)""
+  IL_001e:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_0023:  leave.s    IL_0025
 }
   IL_0025:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(546422, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546422")>
@@ -11640,7 +11640,7 @@ End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseExe.WithModuleName("MODULE"), expectedOutput:="12").
             VerifyIL("Module1.getTypes",
-            <![CDATA[
+"
 {
   // Code size      116 (0x74)
   .maxstack  6
@@ -11649,29 +11649,29 @@ End Module
                 Integer V_2, //i
                 Integer V_3)
   IL_0000:  ldc.i4.4
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848"
-  IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848""
+  IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  stloc.0
   IL_0012:  ldloc.0
-  IL_0013:  callvirt   "Function System.Array.get_Length() As Integer"
+  IL_0013:  callvirt   ""Function System.Array.get_Length() As Integer""
   IL_0018:  ldc.i4.1
   IL_0019:  sub.ovf
   IL_001a:  ldc.i4.1
   IL_001b:  add.ovf
-  IL_001c:  newarr     "Object"
+  IL_001c:  newarr     ""Object""
   IL_0021:  pop
   IL_0022:  ldloca.s   V_3
-  IL_0024:  initobj    "Integer"
+  IL_0024:  initobj    ""Integer""
   IL_002a:  ldloc.3
-  IL_002b:  box        "Integer"
-  IL_0030:  call       "Function Object.GetType() As System.Type"
+  IL_002b:  box        ""Integer""
+  IL_0030:  call       ""Function Object.GetType() As System.Type""
   IL_0035:  ldc.i4.s   12
-  IL_0037:  call       "Function System.Array.CreateInstance(System.Type, Integer) As System.Array"
+  IL_0037:  call       ""Function System.Array.CreateInstance(System.Type, Integer) As System.Array""
   IL_003c:  stloc.1
   IL_003d:  ldloc.0
-  IL_003e:  callvirt   "Function System.Array.get_Length() As Integer"
+  IL_003e:  callvirt   ""Function System.Array.get_Length() As Integer""
   IL_0043:  ldc.i4.1
   IL_0044:  sub.ovf
   IL_0045:  stloc.3
@@ -11680,20 +11680,20 @@ End Module
   IL_0048:  br.s       IL_006e
   IL_004a:  ldloc.1
   IL_004b:  ldc.i4.2
-  IL_004c:  newarr     "Object"
+  IL_004c:  newarr     ""Object""
   IL_0051:  dup
   IL_0052:  ldc.i4.0
   IL_0053:  ldloc.2
-  IL_0054:  box        "Integer"
+  IL_0054:  box        ""Integer""
   IL_0059:  stelem.ref
   IL_005a:  dup
   IL_005b:  ldc.i4.1
   IL_005c:  ldloc.0
   IL_005d:  ldloc.2
-  IL_005e:  callvirt   "Function System.Array.GetValue(Integer) As Object"
+  IL_005e:  callvirt   ""Function System.Array.GetValue(Integer) As Object""
   IL_0063:  stelem.ref
   IL_0064:  ldnull
-  IL_0065:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
+  IL_0065:  call       ""Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())""
   IL_006a:  ldloc.2
   IL_006b:  ldc.i4.1
   IL_006c:  add.ovf
@@ -11704,7 +11704,7 @@ End Module
   IL_0072:  ldloc.1
   IL_0073:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(546422, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546422")>
@@ -11739,7 +11739,7 @@ End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseDebugExe.WithModuleName("MODULE"), expectedOutput:="12").
             VerifyIL("Module1.getTypes",
-            <![CDATA[
+"
 {
   // Code size      127 (0x7f)
   .maxstack  6
@@ -11751,29 +11751,29 @@ End Module
                 Integer V_5,
                 Integer V_6)
   IL_0000:  ldc.i4.4
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  dup
-  IL_0007:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848"
-  IL_000c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0007:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=16 <PrivateImplementationDetails>.1456763F890A84558F99AFA687C36B9037697848""
+  IL_000c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0011:  stloc.1
   IL_0012:  ldloc.1
-  IL_0013:  callvirt   "Function System.Array.get_Length() As Integer"
+  IL_0013:  callvirt   ""Function System.Array.get_Length() As Integer""
   IL_0018:  ldc.i4.1
   IL_0019:  sub.ovf
   IL_001a:  ldc.i4.1
   IL_001b:  add.ovf
-  IL_001c:  newarr     "Object"
+  IL_001c:  newarr     ""Object""
   IL_0021:  stloc.2
   IL_0022:  ldloca.s   V_5
-  IL_0024:  initobj    "Integer"
+  IL_0024:  initobj    ""Integer""
   IL_002a:  ldloc.s    V_5
-  IL_002c:  box        "Integer"
-  IL_0031:  call       "Function Object.GetType() As System.Type"
+  IL_002c:  box        ""Integer""
+  IL_0031:  call       ""Function Object.GetType() As System.Type""
   IL_0036:  ldc.i4.s   12
-  IL_0038:  call       "Function System.Array.CreateInstance(System.Type, Integer) As System.Array"
+  IL_0038:  call       ""Function System.Array.CreateInstance(System.Type, Integer) As System.Array""
   IL_003d:  stloc.3
   IL_003e:  ldloc.1
-  IL_003f:  callvirt   "Function System.Array.get_Length() As Integer"
+  IL_003f:  callvirt   ""Function System.Array.get_Length() As Integer""
   IL_0044:  ldc.i4.1
   IL_0045:  sub.ovf
   IL_0046:  stloc.s    V_6
@@ -11782,20 +11782,20 @@ End Module
   IL_004b:  br.s       IL_0075
   IL_004d:  ldloc.3
   IL_004e:  ldc.i4.2
-  IL_004f:  newarr     "Object"
+  IL_004f:  newarr     ""Object""
   IL_0054:  dup
   IL_0055:  ldc.i4.0
   IL_0056:  ldloc.s    V_4
-  IL_0058:  box        "Integer"
+  IL_0058:  box        ""Integer""
   IL_005d:  stelem.ref
   IL_005e:  dup
   IL_005f:  ldc.i4.1
   IL_0060:  ldloc.1
   IL_0061:  ldloc.s    V_4
-  IL_0063:  callvirt   "Function System.Array.GetValue(Integer) As Object"
+  IL_0063:  callvirt   ""Function System.Array.GetValue(Integer) As Object""
   IL_0068:  stelem.ref
   IL_0069:  ldnull
-  IL_006a:  call       "Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())"
+  IL_006a:  call       ""Sub Microsoft.VisualBasic.CompilerServices.NewLateBinding.LateIndexSet(Object, Object(), String())""
   IL_006f:  ldloc.s    V_4
   IL_0071:  ldc.i4.1
   IL_0072:  add.ovf
@@ -11808,7 +11808,7 @@ End Module
   IL_007d:  ldloc.0
   IL_007e:  ret
 }
-]]>)
+")
         End Sub
 
 
@@ -11890,9 +11890,9 @@ End Module
     </file>
 </compilation>, options:=TestOptions.ReleaseExe,
 expectedOutput:=
-            <![CDATA[
+"
 -100
-]]>)
+")
         End Sub
 
         <Fact>
@@ -12035,56 +12035,56 @@ BC40054: 'Public Sub New(c As Integer)' in designer-generated type 'FromDesigner
 
 
             compilationVerifier.VerifyIL("FromDesigner3..ctor",
-            <![CDATA[
+"
 {
   // Code size       20 (0x14)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       "Sub Object..ctor()"
+  IL_0001:  call       ""Sub Object..ctor()""
   IL_0006:  ldarg.0
   IL_0007:  ldc.i4.1
-  IL_0008:  stfld      "FromDesigner3.field As Integer"
+  IL_0008:  stfld      ""FromDesigner3.field As Integer""
   IL_000d:  ldarg.0
-  IL_000e:  call       "Sub FromDesigner3.InitializeComponent()"
+  IL_000e:  call       ""Sub FromDesigner3.InitializeComponent()""
   IL_0013:  ret
 }
-]]>)
+")
 
             compilationVerifier.VerifyIL("FromDesigner3..cctor",
-            <![CDATA[
+"
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldc.i4.2
-  IL_0001:  stsfld     "FromDesigner3.sharedField As Integer"
+  IL_0001:  stsfld     ""FromDesigner3.sharedField As Integer""
   IL_0006:  ret
 }
-]]>)
+")
 
             compilationVerifier.VerifyIL("FromDesigner4..ctor",
-            <![CDATA[
+"
 {
   // Code size       14 (0xe)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  call       "Sub Object..ctor()"
+  IL_0001:  call       ""Sub Object..ctor()""
   IL_0006:  ldarg.0
   IL_0007:  ldc.i4.1
-  IL_0008:  stfld      "FromDesigner4.field As Integer"
+  IL_0008:  stfld      ""FromDesigner4.field As Integer""
   IL_000d:  ret
 }
-]]>)
+")
 
             compilationVerifier.VerifyIL("FromDesigner5..ctor",
-            <![CDATA[
+"
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  call       "Sub Object..ctor()"
+  IL_0001:  call       ""Sub Object..ctor()""
   IL_0006:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(530067, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530067")>
@@ -12118,31 +12118,31 @@ End Module
 
             ' (2) is not met.
             CompileAndVerify(compRelease).VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  call       "Sub C.S()"
-  IL_0005:  call       "Function C.F() As Integer"
+  IL_0000:  call       ""Sub C.S()""
+  IL_0005:  call       ""Function C.F() As Integer""
   IL_000a:  pop
   IL_000b:  ret
 }
-]]>)
+")
 
             ' S meets (1), but F does not (it doesn't need a nop since it has a pop).
             CompileAndVerify(compDebug).VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  nop
-  IL_0001:  call       "Sub C.S()"
+  IL_0001:  call       ""Sub C.S()""
   IL_0006:  nop
-  IL_0007:  call       "Function C.F() As Integer"
+  IL_0007:  call       ""Function C.F() As Integer""
   IL_000c:  pop
   IL_000d:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(529162, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529162")>
@@ -12210,7 +12210,7 @@ Microsoft.VisualBasic.CompilerServices.Versioned - System.String VbTypeName(Syst
 ]]>)
 
             verifier.VerifyIL("Module1.TestCallByName",
-            <![CDATA[
+"
 {
   // Code size       16 (0x10)
   .maxstack  4
@@ -12218,60 +12218,60 @@ Microsoft.VisualBasic.CompilerServices.Versioned - System.String VbTypeName(Syst
   IL_0001:  ldnull
   IL_0002:  ldc.i4.0
   IL_0003:  ldc.i4.0
-  IL_0004:  newarr     "Object"
-  IL_0009:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.CallByName(Object, String, Microsoft.VisualBasic.CallType, ParamArray Object()) As Object"
+  IL_0004:  newarr     ""Object""
+  IL_0009:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.CallByName(Object, String, Microsoft.VisualBasic.CallType, ParamArray Object()) As Object""
   IL_000e:  pop
   IL_000f:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.TestIsNumeric",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldnull
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.IsNumeric(Object) As Boolean"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.IsNumeric(Object) As Boolean""
   IL_0006:  pop
   IL_0007:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.TestTypeName",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldnull
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.TypeName(Object) As String"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.TypeName(Object) As String""
   IL_0006:  pop
   IL_0007:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.TestSystemTypeName",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldnull
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.SystemTypeName(String) As String"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.SystemTypeName(String) As String""
   IL_0006:  pop
   IL_0007:  ret
 }
-]]>)
+")
 
             verifier.VerifyIL("Module1.TestVbTypeName",
-            <![CDATA[
+"
 {
   // Code size        8 (0x8)
   .maxstack  1
   IL_0000:  ldnull
-  IL_0001:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.VbTypeName(String) As String"
+  IL_0001:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.VbTypeName(String) As String""
   IL_0006:  pop
   IL_0007:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(653588, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/653588")>
@@ -12298,16 +12298,16 @@ End Class
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("A.Main",
-            <![CDATA[
+"
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldc.i4.s   42
-  IL_0002:  newobj     "Sub S1..ctor(Integer)"
+  IL_0002:  newobj     ""Sub S1..ctor(Integer)""
   IL_0007:  pop
   IL_0008:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(531166, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531166")>
@@ -12328,19 +12328,19 @@ End Module
     </file>
 </compilation>, expectedOutput:="32767").
             VerifyIL("Program.Main",
-            <![CDATA[
+"
 {
   // Code size       19 (0x13)
   .maxstack  1
   .locals init (System.AttributeTargets V_0)
-  IL_0000:  call       "Function Program.Foo() As System.AttributeTargets"
+  IL_0000:  call       ""Function Program.Foo() As System.AttributeTargets""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
-  IL_0008:  ldfld      "System.AttributeTargets.value__ As Integer"
-  IL_000d:  call       "Sub System.Console.Write(Integer)"
+  IL_0008:  ldfld      ""System.AttributeTargets.value__ As Integer""
+  IL_000d:  call       ""Sub System.Console.Write(Integer)""
   IL_0012:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(665317, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/665317")>
@@ -12383,7 +12383,7 @@ End Class
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("Program.Foo(Of T)(T())",
-            <![CDATA[
+"
 {
   // Code size       17 (0x11)
   .maxstack  3
@@ -12391,14 +12391,14 @@ End Class
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  initobj    "T"
+  IL_0004:  initobj    ""T""
   IL_000a:  ldloc.0
-  IL_000b:  stelem     "T"
+  IL_000b:  stelem     ""T""
   IL_0010:  ret
 }
-]]>).
+").
             VerifyIL("Program.Bar(Of T)(T())",
-            <![CDATA[
+"
 {
   // Code size       17 (0x11)
   .maxstack  3
@@ -12406,14 +12406,14 @@ End Class
   IL_0000:  ldarg.0
   IL_0001:  ldc.i4.0
   IL_0002:  ldloca.s   V_0
-  IL_0004:  initobj    "T"
+  IL_0004:  initobj    ""T""
   IL_000a:  ldloc.0
-  IL_000b:  stelem     "T"
+  IL_000b:  stelem     ""T""
   IL_0010:  ret
 }
-]]>).
+").
             VerifyIL("Program.Baz(Of T)(T()())",
-            <![CDATA[
+"
 {
   // Code size        5 (0x5)
   .maxstack  3
@@ -12423,7 +12423,7 @@ End Class
   IL_0003:  stelem.ref
   IL_0004:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(718502, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/718502")>
@@ -12456,37 +12456,37 @@ End Class
     </file>
 </compilation>, expectedOutput:="11").
             VerifyIL("A.Main",
-            <![CDATA[
+"
 {
   // Code size       61 (0x3d)
   .maxstack  3
   IL_0000:  ldc.i4.0
   IL_0001:  ldc.i4.0
-  IL_0002:  ldsfld     "A.x As Integer"
+  IL_0002:  ldsfld     ""A.x As Integer""
   IL_0007:  sub.ovf
   IL_0008:  sub.ovf
   IL_0009:  brtrue.s   IL_0011
   IL_000b:  ldc.i4.0
-  IL_000c:  call       "Sub System.Console.Write(Integer)"
-  IL_0011:  ldsfld     "A.x As Integer"
+  IL_000c:  call       ""Sub System.Console.Write(Integer)""
+  IL_0011:  ldsfld     ""A.x As Integer""
   IL_0016:  brtrue.s   IL_001e
   IL_0018:  ldc.i4.0
-  IL_0019:  call       "Sub System.Console.Write(Integer)"
+  IL_0019:  call       ""Sub System.Console.Write(Integer)""
   IL_001e:  ldc.i4.0
   IL_001f:  ldc.i4.0
-  IL_0020:  ldsfld     "A.x As Integer"
+  IL_0020:  ldsfld     ""A.x As Integer""
   IL_0025:  sub.ovf
   IL_0026:  sub.ovf
   IL_0027:  brfalse.s  IL_002f
   IL_0029:  ldc.i4.1
-  IL_002a:  call       "Sub System.Console.Write(Integer)"
-  IL_002f:  ldsfld     "A.x As Integer"
+  IL_002a:  call       ""Sub System.Console.Write(Integer)""
+  IL_002f:  ldsfld     ""A.x As Integer""
   IL_0034:  brfalse.s  IL_003c
   IL_0036:  ldc.i4.1
-  IL_0037:  call       "Sub System.Console.Write(Integer)"
+  IL_0037:  call       ""Sub System.Console.Write(Integer)""
   IL_003c:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(745103, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/745103")>
@@ -12552,14 +12552,14 @@ End class
     </file>
 </compilation>, expectedOutput:="31").
             VerifyIL("test(Of T).Repro1(T)",
-            <![CDATA[
+"
 {
   // Code size       77 (0x4d)
   .maxstack  4
   .locals init (Integer& V_0)
   IL_0000:  ldarg.0
-  IL_0001:  box        "T"
-  IL_0006:  ldflda     "c0.x As Integer"
+  IL_0001:  box        ""T""
+  IL_0006:  ldflda     ""c0.x As Integer""
   IL_000b:  dup
   IL_000c:  stloc.0
   IL_000d:  ldloc.0
@@ -12569,46 +12569,46 @@ End class
   IL_0011:  stind.i4
   IL_0012:  ldarga.s   V_0
   IL_0014:  ldarga.s   V_0
-  IL_0016:  constrained. "T"
-  IL_001c:  callvirt   "Function c0.get_P1() As Integer"
+  IL_0016:  constrained. ""T""
+  IL_001c:  callvirt   ""Function c0.get_P1() As Integer""
   IL_0021:  ldc.i4.1
   IL_0022:  add.ovf
-  IL_0023:  constrained. "T"
-  IL_0029:  callvirt   "Sub c0.set_P1(Integer)"
+  IL_0023:  constrained. ""T""
+  IL_0029:  callvirt   ""Sub c0.set_P1(Integer)""
   IL_002e:  ldarga.s   V_0
   IL_0030:  ldc.i4.1
   IL_0031:  ldarga.s   V_0
   IL_0033:  ldc.i4.1
-  IL_0034:  constrained. "T"
-  IL_003a:  callvirt   "Function c0.get_Item(Integer) As Integer"
+  IL_0034:  constrained. ""T""
+  IL_003a:  callvirt   ""Function c0.get_Item(Integer) As Integer""
   IL_003f:  ldc.i4.1
   IL_0040:  add.ovf
-  IL_0041:  constrained. "T"
-  IL_0047:  callvirt   "Sub c0.set_Item(Integer, Integer)"
+  IL_0041:  constrained. ""T""
+  IL_0047:  callvirt   ""Sub c0.set_Item(Integer, Integer)""
   IL_004c:  ret
 }
-]]>).
+").
             VerifyIL("test(Of T).Repro2(T)",
-            <![CDATA[
+"
 {
   // Code size       52 (0x34)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  box        "T"
+  IL_0001:  box        ""T""
   IL_0006:  ldarg.0
-  IL_0007:  box        "T"
-  IL_000c:  castclass  "c0"
-  IL_0011:  call       "Function c0.Foo(c0) As Integer"
-  IL_0016:  stfld      "c0.x As Integer"
+  IL_0007:  box        ""T""
+  IL_000c:  castclass  ""c0""
+  IL_0011:  call       ""Function c0.Foo(c0) As Integer""
+  IL_0016:  stfld      ""c0.x As Integer""
   IL_001b:  ldarg.0
-  IL_001c:  box        "T"
+  IL_001c:  box        ""T""
   IL_0021:  ldarga.s   V_0
-  IL_0023:  constrained. "T"
-  IL_0029:  callvirt   "Function c0.Foo() As Integer"
-  IL_002e:  stfld      "c0.x As Integer"
+  IL_0023:  constrained. ""T""
+  IL_0029:  callvirt   ""Function c0.Foo() As Integer""
+  IL_002e:  stfld      ""c0.x As Integer""
   IL_0033:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -12654,29 +12654,29 @@ End Class
     </file>
 </compilation>, expectedOutput:="FooFooFoo").
             VerifyIL("Module1.Test1(Of T)(T)",
-            <![CDATA[
+"
 {
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  constrained. "T"
-  IL_0008:  callvirt   "Sub cls1.Foo()"
+  IL_0002:  constrained. ""T""
+  IL_0008:  callvirt   ""Sub cls1.Foo()""
   IL_000d:  ret
 }
 
-]]>).
+").
             VerifyIL("Module1.Test2(Of T)(T)",
-            <![CDATA[
+"
 {
   // Code size       14 (0xe)
   .maxstack  1
   IL_0000:  ldarga.s   V_0
-  IL_0002:  constrained. "T"
-  IL_0008:  callvirt   "Sub cls1.Foo()"
+  IL_0002:  constrained. ""T""
+  IL_0008:  callvirt   ""Sub cls1.Foo()""
   IL_000d:  ret
 }
 
-]]>)
+")
         End Sub
 
         <WorkItem(770557, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770557")>
@@ -12718,36 +12718,36 @@ End Module
     </file>
 </compilation>, expectedOutput:="i=2 -> x.bool = True i=21474836472 -> x.bool = True").
             VerifyIL("Module1.Main",
-            <![CDATA[
+"
 {
   // Code size       80 (0x50)
   .maxstack  2
   .locals init (BoolBreaker V_0) //x
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldc.i4.2
-  IL_0003:  stfld      "BoolBreaker.i As Integer"
+  IL_0003:  stfld      ""BoolBreaker.i As Integer""
   IL_0008:  ldloc.0
-  IL_0009:  ldfld      "BoolBreaker.bool As Boolean"
+  IL_0009:  ldfld      ""BoolBreaker.bool As Boolean""
   IL_000e:  brtrue.s   IL_001c
-  IL_0010:  ldstr      "i=2 -> x.bool <> True "
-  IL_0015:  call       "Sub System.Console.Write(String)"
+  IL_0010:  ldstr      ""i=2 -> x.bool <> True ""
+  IL_0015:  call       ""Sub System.Console.Write(String)""
   IL_001a:  br.s       IL_0026
-  IL_001c:  ldstr      "i=2 -> x.bool = True "
-  IL_0021:  call       "Sub System.Console.Write(String)"
+  IL_001c:  ldstr      ""i=2 -> x.bool = True ""
+  IL_0021:  call       ""Sub System.Console.Write(String)""
   IL_0026:  ldloca.s   V_0
   IL_0028:  ldc.i4     0x7fffffff
-  IL_002d:  stfld      "BoolBreaker.i As Integer"
+  IL_002d:  stfld      ""BoolBreaker.i As Integer""
   IL_0032:  ldloc.0
-  IL_0033:  ldfld      "BoolBreaker.bool As Boolean"
+  IL_0033:  ldfld      ""BoolBreaker.bool As Boolean""
   IL_0038:  brtrue.s   IL_0045
-  IL_003a:  ldstr      "i=2147483647 -> x.bool <> True "
-  IL_003f:  call       "Sub System.Console.Write(String)"
+  IL_003a:  ldstr      ""i=2147483647 -> x.bool <> True ""
+  IL_003f:  call       ""Sub System.Console.Write(String)""
   IL_0044:  ret
-  IL_0045:  ldstr      "i=21474836472 -> x.bool = True "
-  IL_004a:  call       "Sub System.Console.Write(String)"
+  IL_0045:  ldstr      ""i=21474836472 -> x.bool = True ""
+  IL_004a:  call       ""Sub System.Console.Write(String)""
   IL_004f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(770557, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/770557")>
@@ -12791,7 +12791,7 @@ End Module
                 expectedOutput:="i=2 -> x.bool = True i=21474836472 -> x.bool = True")
 
             c.VerifyIL("Module1.Main",
-            <![CDATA[
+"
 {
   // Code size      102 (0x66)
   .maxstack  2
@@ -12801,47 +12801,47 @@ End Module
   IL_0000:  nop
   IL_0001:  ldloca.s   V_0
   IL_0003:  ldc.i4.2
-  IL_0004:  stfld      "BoolBreaker.i As Integer"
+  IL_0004:  stfld      ""BoolBreaker.i As Integer""
   IL_0009:  ldloc.0
-  IL_000a:  ldfld      "BoolBreaker.bool As Boolean"
+  IL_000a:  ldfld      ""BoolBreaker.bool As Boolean""
   IL_000f:  ldc.i4.0
   IL_0010:  ceq
   IL_0012:  stloc.1
   IL_0013:  ldloc.1
   IL_0014:  brfalse.s  IL_0024
-  IL_0016:  ldstr      "i=2 -> x.bool <> True "
-  IL_001b:  call       "Sub System.Console.Write(String)"
+  IL_0016:  ldstr      ""i=2 -> x.bool <> True ""
+  IL_001b:  call       ""Sub System.Console.Write(String)""
   IL_0020:  nop
   IL_0021:  nop
   IL_0022:  br.s       IL_0031
   IL_0024:  nop
-  IL_0025:  ldstr      "i=2 -> x.bool = True "
-  IL_002a:  call       "Sub System.Console.Write(String)"
+  IL_0025:  ldstr      ""i=2 -> x.bool = True ""
+  IL_002a:  call       ""Sub System.Console.Write(String)""
   IL_002f:  nop
   IL_0030:  nop
   IL_0031:  ldloca.s   V_0
   IL_0033:  ldc.i4     0x7fffffff
-  IL_0038:  stfld      "BoolBreaker.i As Integer"
+  IL_0038:  stfld      ""BoolBreaker.i As Integer""
   IL_003d:  ldloc.0
-  IL_003e:  ldfld      "BoolBreaker.bool As Boolean"
+  IL_003e:  ldfld      ""BoolBreaker.bool As Boolean""
   IL_0043:  ldc.i4.0
   IL_0044:  ceq
   IL_0046:  stloc.2
   IL_0047:  ldloc.2
   IL_0048:  brfalse.s  IL_0058
-  IL_004a:  ldstr      "i=2147483647 -> x.bool <> True "
-  IL_004f:  call       "Sub System.Console.Write(String)"
+  IL_004a:  ldstr      ""i=2147483647 -> x.bool <> True ""
+  IL_004f:  call       ""Sub System.Console.Write(String)""
   IL_0054:  nop
   IL_0055:  nop
   IL_0056:  br.s       IL_0065
   IL_0058:  nop
-  IL_0059:  ldstr      "i=21474836472 -> x.bool = True "
-  IL_005e:  call       "Sub System.Console.Write(String)"
+  IL_0059:  ldstr      ""i=21474836472 -> x.bool = True ""
+  IL_005e:  call       ""Sub System.Console.Write(String)""
   IL_0063:  nop
   IL_0064:  nop
   IL_0065:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(797996, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/797996")>
@@ -13030,15 +13030,15 @@ End CLass
     </file>
 </compilation>, expectedOutput:="0").
             VerifyIL("A.Main",
-            <![CDATA[
+"
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldc.i4.0
-  IL_0001:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0001:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0006:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(824308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/824308")>
@@ -13166,15 +13166,15 @@ End Module
             Dim testReference = AssemblyMetadata.CreateFromImage(TestResources.Repros.BadDefaultParameterValue).GetReference()
             Dim compilation = CompileAndVerify(source, additionalRefs:=New MetadataReference() {testReference})
             compilation.VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       12 (0xc)
   .maxstack  2
-  IL_0000:  ldstr      "test"
+  IL_0000:  ldstr      ""test""
   IL_0005:  ldnull
-  IL_0006:  call       "Sub BadDefaultParameterValue.Util.M(String, String)"
+  IL_0006:  call       ""Sub BadDefaultParameterValue.Util.M(String, String)""
   IL_000b:  ret
-}]]>)
+}")
         End Sub
 
         <Fact, WorkItem(5395, "https://github.com/dotnet/roslyn/issues/5395")>
@@ -13464,7 +13464,7 @@ End Module
                 expectedOutput:="2")
 
             c.VerifyIL("Module1.Main",
-            <![CDATA[
+"
 {
   // Code size       51 (0x33)
   .maxstack  3
@@ -13472,24 +13472,24 @@ End Module
                 Module1.S1 V_1) //val
   IL_0000:  ldc.i4.1
   IL_0001:  ldc.i4.2
-  IL_0002:  call       "Function System.Math.Max(Integer, Integer) As Integer"
+  IL_0002:  call       ""Function System.Math.Max(Integer, Integer) As Integer""
   IL_0007:  stloc.0
   IL_0008:  ldloca.s   V_1
   IL_000a:  ldloc.0
   IL_000b:  ldloc.0
-  IL_000c:  call       "Sub Module1.S1..ctor(Integer, Integer)"
-  IL_0011:  ldsfld     "Module1.arr As Module1.S1()"
+  IL_000c:  call       ""Sub Module1.S1..ctor(Integer, Integer)""
+  IL_0011:  ldsfld     ""Module1.arr As Module1.S1()""
   IL_0016:  ldc.i4.0
   IL_0017:  ldloc.1
-  IL_0018:  stelem     "Module1.S1"
-  IL_001d:  ldsfld     "Module1.arr As Module1.S1()"
+  IL_0018:  stelem     ""Module1.S1""
+  IL_001d:  ldsfld     ""Module1.arr As Module1.S1()""
   IL_0022:  ldc.i4.0
-  IL_0023:  ldelema    "Module1.S1"
-  IL_0028:  ldfld      "Module1.S1.a As Integer"
-  IL_002d:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0023:  ldelema    ""Module1.S1""
+  IL_0028:  ldfld      ""Module1.S1.a As Integer""
+  IL_002d:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0032:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact, WorkItem(7148, "https://github.com/dotnet/roslyn/issues/7148")>
@@ -13515,25 +13515,25 @@ End Class
                 expectedOutput:="57.2957795130823")
 
             c.VerifyIL("TestClass.CalculateDimensions",
-            <![CDATA[
+"
 {
   // Code size       40 (0x28)
   .maxstack  3
   .locals init (Decimal& V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldflda     "TestClass._rotation As Decimal"
+  IL_0001:  ldflda     ""TestClass._rotation As Decimal""
   IL_0006:  dup
   IL_0007:  stloc.0
   IL_0008:  ldloc.0
-  IL_0009:  ldobj      "Decimal"
-  IL_000e:  call       "Function System.Convert.ToDouble(Decimal) As Double"
+  IL_0009:  ldobj      ""Decimal""
+  IL_000e:  call       ""Function System.Convert.ToDouble(Decimal) As Double""
   IL_0013:  ldc.r8     57.2957795130823
   IL_001c:  mul
-  IL_001d:  newobj     "Sub Decimal..ctor(Double)"
-  IL_0022:  stobj      "Decimal"
+  IL_001d:  newobj     ""Sub Decimal..ctor(Double)""
+  IL_0022:  stobj      ""Decimal""
   IL_0027:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact, WorkItem(7148, "https://github.com/dotnet/roslyn/issues/7148")>
@@ -13562,26 +13562,26 @@ End Class
                 expectedOutput:="57.2957795130823")
 
             c.VerifyIL("TestClass.CalculateDimensions",
-            <![CDATA[
+"
 {
   // Code size       45 (0x2d)
   .maxstack  3
   .locals init (Decimal& V_0)
   IL_0000:  ldarg.0
-  IL_0001:  call       "Function TestClass.GetIndex() As Integer"
-  IL_0006:  ldelema    "Decimal"
+  IL_0001:  call       ""Function TestClass.GetIndex() As Integer""
+  IL_0006:  ldelema    ""Decimal""
   IL_000b:  dup
   IL_000c:  stloc.0
   IL_000d:  ldloc.0
-  IL_000e:  ldobj      "Decimal"
-  IL_0013:  call       "Function System.Convert.ToDouble(Decimal) As Double"
+  IL_000e:  ldobj      ""Decimal""
+  IL_0013:  call       ""Function System.Convert.ToDouble(Decimal) As Double""
   IL_0018:  ldc.r8     57.2957795130823
   IL_0021:  mul
-  IL_0022:  newobj     "Sub Decimal..ctor(Double)"
-  IL_0027:  stobj      "Decimal"
+  IL_0022:  newobj     ""Sub Decimal..ctor(Double)""
+  IL_0027:  stobj      ""Decimal""
   IL_002c:  ret
 }
-]]>)
+")
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -7885,21 +7885,21 @@ DERIVED: f(x As Integer, Optional y As String = """")
         Public Sub OverloadsWithOnlyOptionalParameters()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",
-            <![CDATA[
+"
 using System;
 
 public class OverloadsUsingOptional
 {
     public static void M(int k, int l = 0)
     {
-        Console.Write("M(int k, int l = 0);");
+        Console.Write(""M(int k, int l = 0);"");
     }
     public static void M(int k, int l = 0, int m = 0)
     {
-        Console.Write("M(int k, int l = 0, int m = 0);");
+        Console.Write(""M(int k, int l = 0, int m = 0);"");
     }
 }
-]]>,
+",
                 compilationOptions:=New Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             csCompilation.VerifyDiagnostics()
 
@@ -8342,10 +8342,10 @@ Class C
     End Sub
 End Class
     </file>
-</compilation>, expectedOutput:=<![CDATA[
+</compilation>, expectedOutput:="
 x=0, y=0
 x=1, y=2
-]]>).
+").
 VerifyIL("C.Main",
 "
 {
@@ -8914,14 +8914,14 @@ End Class
 
         <Fact>
         Public Sub PartiallyInitializedValue_NoParameterlessConstructor_Locals()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
   .pack 0
   .size 1
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -8945,52 +8945,52 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       50 (0x32)
   .maxstack  2
   .locals init (S() V_0, //locArr
   System.Exception V_1) //ex
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "S"
+  IL_0001:  newarr     ""S""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4.1
-  IL_0009:  ldelema    "S"
-  IL_000e:  initobj    "S"
+  IL_0009:  ldelema    ""S""
+  IL_000e:  initobj    ""S""
   .try
 {
   IL_0014:  ldloc.0
   IL_0015:  ldc.i4.1
-  IL_0016:  ldelema    "S"
-  IL_001b:  initobj    "S"
+  IL_0016:  ldelema    ""S""
+  IL_001b:  initobj    ""S""
   IL_0021:  leave.s    IL_0031
 }
   catch System.Exception
 {
   IL_0023:  dup
-  IL_0024:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+  IL_0024:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
   IL_0029:  stloc.1
-  IL_002a:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+  IL_002a:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
   IL_002f:  leave.s    IL_0031
 }
   IL_0031:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
         Public Sub PartiallyInitializedValue_NoParameterlessConstructor_Params()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
   .pack 0
   .size 1
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9010,43 +9010,43 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       47 (0x2f)
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarga.s   V_1
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldarg.2   
-  IL_0009:  initobj    "S"
+  IL_0009:  initobj    ""S""
   .try
   {
     IL_000f:  ldarga.s   V_1
-    IL_0011:  initobj    "S"
+    IL_0011:  initobj    ""S""
     IL_0017:  ldarg.2   
-    IL_0018:  initobj    "S"
+    IL_0018:  initobj    ""S""
     IL_001e:  leave.s    IL_002e
   }
   catch System.Exception
   {
     IL_0020:  dup       
-    IL_0021:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_0021:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
     IL_0026:  stloc.0   
-    IL_0027:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0027:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
     IL_002c:  leave.s    IL_002e
   }
   IL_002e:  ret       
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541123, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541123")>
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
         <Fact>
         Public Sub PublicParameterlessConstructorInMetadata_Public()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9059,7 +9059,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9081,41 +9081,41 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       64 (0x40)
   .maxstack  1
   .locals init (S V_0)
-  IL_0000:  newobj     "Sub S..ctor()"
+  IL_0000:  newobj     ""Sub S..ctor()""
   IL_0005:  pop
-  IL_0006:  newobj     "Sub S..ctor()"
+  IL_0006:  newobj     ""Sub S..ctor()""
   IL_000b:  pop
   IL_000c:  ldloca.s   V_0
-  IL_000e:  initobj    "S"
+  IL_000e:  initobj    ""S""
   IL_0014:  ldloc.0
-  IL_0015:  call       "Sub C.SS(S)"
-  IL_001a:  newobj     "Sub S..ctor()"
-  IL_001f:  call       "Sub C.SS(S)"
-  IL_0024:  newobj     "Sub S..ctor()"
+  IL_0015:  call       ""Sub C.SS(S)""
+  IL_001a:  newobj     ""Sub S..ctor()""
+  IL_001f:  call       ""Sub C.SS(S)""
+  IL_0024:  newobj     ""Sub S..ctor()""
   IL_0029:  stloc.0
   IL_002a:  ldloca.s   V_0
-  IL_002c:  constrained. "S"
-  IL_0032:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_002c:  constrained. ""S""
+  IL_0032:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0037:  pop
   IL_0038:  ldnull
-  IL_0039:  unbox.any  "S"
+  IL_0039:  unbox.any  ""S""
   IL_003e:  pop
   IL_003f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
         <Fact>
         Public Sub PublicParameterlessConstructorInMetadata_Protected()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9128,7 +9128,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9150,41 +9150,41 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       60 (0x3c)
   .maxstack  1
   .locals init (S V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldloc.0
-  IL_0009:  call       "Sub C.SS(S)"
+  IL_0009:  call       ""Sub C.SS(S)""
   IL_000e:  ldloca.s   V_0
-  IL_0010:  initobj    "S"
+  IL_0010:  initobj    ""S""
   IL_0016:  ldloc.0
-  IL_0017:  call       "Sub C.SS(S)"
+  IL_0017:  call       ""Sub C.SS(S)""
   IL_001c:  ldloca.s   V_0
-  IL_001e:  initobj    "S"
+  IL_001e:  initobj    ""S""
   IL_0024:  ldloc.0
   IL_0025:  stloc.0
   IL_0026:  ldloca.s   V_0
-  IL_0028:  constrained. "S"
-  IL_002e:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0033:  pop
   IL_0034:  ldnull
-  IL_0035:  unbox.any  "S"
+  IL_0035:  unbox.any  ""S""
   IL_003a:  pop
   IL_003b:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
         <Fact>
         Public Sub PublicParameterlessConstructorInMetadata_Private()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9197,7 +9197,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9219,40 +9219,40 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       60 (0x3c)
   .maxstack  1
   .locals init (S V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldloc.0
-  IL_0009:  call       "Sub C.SS(S)"
+  IL_0009:  call       ""Sub C.SS(S)""
   IL_000e:  ldloca.s   V_0
-  IL_0010:  initobj    "S"
+  IL_0010:  initobj    ""S""
   IL_0016:  ldloc.0
-  IL_0017:  call       "Sub C.SS(S)"
+  IL_0017:  call       ""Sub C.SS(S)""
   IL_001c:  ldloca.s   V_0
-  IL_001e:  initobj    "S"
+  IL_001e:  initobj    ""S""
   IL_0024:  ldloc.0
   IL_0025:  stloc.0
   IL_0026:  ldloca.s   V_0
-  IL_0028:  constrained. "S"
-  IL_002e:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0033:  pop
   IL_0034:  ldnull
-  IL_0035:  unbox.any  "S"
+  IL_0035:  unbox.any  ""S""
   IL_003a:  pop
   IL_003b:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
         Public Sub PublicParameterlessConstructorInMetadata_Private_D()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9265,7 +9265,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9287,9 +9287,9 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDebugDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDebugDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       84 (0x54)
   .maxstack  1
@@ -9297,40 +9297,40 @@ End Class
                 Object V_1, //a
                 S V_2)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldloca.s   V_0
-  IL_000a:  initobj    "S"
+  IL_000a:  initobj    ""S""
   IL_0010:  ldloca.s   V_0
-  IL_0012:  initobj    "S"
+  IL_0012:  initobj    ""S""
   IL_0018:  ldloca.s   V_2
-  IL_001a:  initobj    "S"
+  IL_001a:  initobj    ""S""
   IL_0020:  ldloc.2
-  IL_0021:  call       "Sub C.SS(S)"
+  IL_0021:  call       ""Sub C.SS(S)""
   IL_0026:  ldloca.s   V_2
-  IL_0028:  initobj    "S"
+  IL_0028:  initobj    ""S""
   IL_002e:  ldloc.2
-  IL_002f:  call       "Sub C.SS(S)"
+  IL_002f:  call       ""Sub C.SS(S)""
   IL_0034:  ldloca.s   V_2
-  IL_0036:  initobj    "S"
+  IL_0036:  initobj    ""S""
   IL_003c:  ldloc.2
   IL_003d:  stloc.2
   IL_003e:  ldloca.s   V_2
-  IL_0040:  constrained. "S"
-  IL_0046:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0040:  constrained. ""S""
+  IL_0046:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_004b:  stloc.1
   IL_004c:  ldnull
-  IL_004d:  unbox.any  "S"
+  IL_004d:  unbox.any  ""S""
   IL_0052:  stloc.0
   IL_0053:  ret
 }
-]]>)
+")
         End Sub
 
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
         <Fact>
         Public Sub PublicParameterlessConstructorInMetadata_OptionalParameter()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9344,7 +9344,7 @@ End Class
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9366,48 +9366,48 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       60 (0x3c)
   .maxstack  1
   .locals init (S V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldloc.0
-  IL_0009:  call       "Sub C.SS(S)"
+  IL_0009:  call       ""Sub C.SS(S)""
   IL_000e:  ldloca.s   V_0
-  IL_0010:  initobj    "S"
+  IL_0010:  initobj    ""S""
   IL_0016:  ldloc.0
-  IL_0017:  call       "Sub C.SS(S)"
+  IL_0017:  call       ""Sub C.SS(S)""
   IL_001c:  ldloca.s   V_0
-  IL_001e:  initobj    "S"
+  IL_001e:  initobj    ""S""
   IL_0024:  ldloc.0
   IL_0025:  stloc.0
   IL_0026:  ldloca.s   V_0
-  IL_0028:  constrained. "S"
-  IL_002e:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0033:  pop
   IL_0034:  ldnull
-  IL_0035:  unbox.any  "S"
+  IL_0035:  unbox.any  ""S""
   IL_003a:  pop
   IL_003b:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
         <Fact>
         Public Sub SimpleStructInstantiationAndAssigningNothing()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
   .pack 0
   .size 1
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9429,35 +9429,35 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size       60 (0x3c)
   .maxstack  1
   .locals init (S V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S"
+  IL_0002:  initobj    ""S""
   IL_0008:  ldloc.0
-  IL_0009:  call       "Sub C.SS(S)"
+  IL_0009:  call       ""Sub C.SS(S)""
   IL_000e:  ldloca.s   V_0
-  IL_0010:  initobj    "S"
+  IL_0010:  initobj    ""S""
   IL_0016:  ldloc.0
-  IL_0017:  call       "Sub C.SS(S)"
+  IL_0017:  call       ""Sub C.SS(S)""
   IL_001c:  ldloca.s   V_0
-  IL_001e:  initobj    "S"
+  IL_001e:  initobj    ""S""
   IL_0024:  ldloc.0
   IL_0025:  stloc.0
   IL_0026:  ldloca.s   V_0
-  IL_0028:  constrained. "S"
-  IL_002e:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0028:  constrained. ""S""
+  IL_002e:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0033:  pop
   IL_0034:  ldnull
-  IL_0035:  unbox.any  "S"
+  IL_0035:  unbox.any  ""S""
   IL_003a:  pop
   IL_003b:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
@@ -9479,13 +9479,13 @@ End Module
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("CT(Of X).T()",
-            <![CDATA[
+"
 {
   // Code size        1 (0x1)
   .maxstack  0
   IL_0000:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
@@ -9509,17 +9509,17 @@ End Module
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("CT(Of X).T()",
-            <![CDATA[
+"
 {
   // Code size       13 (0xd)
   .maxstack  1
-  IL_0000:  call       "Function System.Activator.CreateInstance(Of X)() As X"
+  IL_0000:  call       ""Function System.Activator.CreateInstance(Of X)() As X""
   IL_0005:  pop
-  IL_0006:  call       "Function System.Activator.CreateInstance(Of X)() As X"
+  IL_0006:  call       ""Function System.Activator.CreateInstance(Of X)() As X""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
@@ -9543,17 +9543,17 @@ End Module
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("CT(Of X).T()",
-            <![CDATA[
+"
 {
   // Code size       13 (0xd)
   .maxstack  1
-  IL_0000:  call       "Function System.Activator.CreateInstance(Of X)() As X"
+  IL_0000:  call       ""Function System.Activator.CreateInstance(Of X)() As X""
   IL_0005:  pop
-  IL_0006:  call       "Function System.Activator.CreateInstance(Of X)() As X"
+  IL_0006:  call       ""Function System.Activator.CreateInstance(Of X)() As X""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541308, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541308")>
@@ -9578,34 +9578,34 @@ End Module
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("EmitTest.Main",
-            <![CDATA[
+"
 {
   // Code size       36 (0x24)
   .maxstack  1
   .locals init (S V_0)
   IL_0000:  ldc.i4.1
-  IL_0001:  newobj     "Sub S..ctor(Integer)"
+  IL_0001:  newobj     ""Sub S..ctor(Integer)""
   IL_0006:  pop
   IL_0007:  ldc.i4.1
-  IL_0008:  newobj     "Sub S..ctor(Integer)"
+  IL_0008:  newobj     ""Sub S..ctor(Integer)""
   IL_000d:  pop
   IL_000e:  ldc.i4.1
-  IL_000f:  newobj     "Sub S..ctor(Integer)"
+  IL_000f:  newobj     ""Sub S..ctor(Integer)""
   IL_0014:  stloc.0
   IL_0015:  ldloca.s   V_0
-  IL_0017:  constrained. "S"
-  IL_001d:  callvirt   "Function System.ValueType.ToString() As String"
+  IL_0017:  constrained. ""S""
+  IL_001d:  callvirt   ""Function System.ValueType.ToString() As String""
   IL_0022:  pop
   IL_0023:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(541123, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541123")>
         <WorkItem(541309, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/541309")>
         <Fact>
         Public Sub PrivateParameterlessConstructorInMetadata()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
@@ -9618,7 +9618,7 @@ End Module
     ret
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -9635,15 +9635,15 @@ End Class
             ' CONSIDER: This is the dev10 behavior.
             ' Shouldn't there be an error for trying to call an inaccessible ctor?
             ' NOTE: Current behavior is to skip private constructor and use 'initobj'
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.Main",
-            <![CDATA[
+"
 {
   // Code size        1 (0x1)
   .maxstack  0
   IL_0000:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact>
@@ -9684,22 +9684,22 @@ expectedOutput:=<![CDATA[
 2
 ]]>).
             VerifyIL("EmitTest.Main",
-            <![CDATA[
+"
 {
   // Code size       33 (0x21)
   .maxstack  2
   .locals init (EmitTest.C V_0) //x
-  IL_0000:  newobj     "Sub EmitTest.C..ctor()"
+  IL_0000:  newobj     ""Sub EmitTest.C..ctor()""
   IL_0005:  stloc.0
-  IL_0006:  newobj     "Sub EmitTest.C..ctor()"
+  IL_0006:  newobj     ""Sub EmitTest.C..ctor()""
   IL_000b:  ldloc.0
-  IL_000c:  callvirt   "Function EmitTest.C.get_P() As Integer"
-  IL_0011:  call       "Sub System.Console.WriteLine(Integer)"
-  IL_0016:  callvirt   "Function EmitTest.C.get_P() As Integer"
-  IL_001b:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_000c:  callvirt   ""Function EmitTest.C.get_P() As Integer""
+  IL_0011:  call       ""Sub System.Console.WriteLine(Integer)""
+  IL_0016:  callvirt   ""Function EmitTest.C.get_P() As Integer""
+  IL_001b:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0020:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(540533, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540533")>
@@ -9726,7 +9726,7 @@ End Module
 </compilation>,
 expectedOutput:="").
             VerifyIL("M1.foo",
-            <![CDATA[
+"
 {
   // Code size       21 (0x15)
   .maxstack  2
@@ -9735,12 +9735,12 @@ expectedOutput:="").
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_0
   IL_0004:  ldc.i4.2
-  IL_0005:  call       "Function Integer.CompareTo(Integer) As Integer"
-  IL_000a:  box        "Integer"
-  IL_000f:  call       "Sub M2.apCompare(Object)"
+  IL_0005:  call       ""Function Integer.CompareTo(Integer) As Integer""
+  IL_000a:  box        ""Integer""
+  IL_000f:  call       ""Sub M2.apCompare(Object)""
   IL_0014:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(8597, "DevDiv_Projects/Roslyn")>
@@ -9783,21 +9783,21 @@ End Module
             </compilation>,
             expectedOutput:="6").
                         VerifyIL("A.Main",
-            <![CDATA[
+"
 {
   // Code size       17 (0x11)
   .maxstack  2
   IL_0000:  ldc.i4.5
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  ldlen
   IL_0007:  conv.i8
   IL_0008:  ldc.i4.1
   IL_0009:  conv.i8
   IL_000a:  add.ovf
-  IL_000b:  call       "Sub System.Console.Write(Long)"
+  IL_000b:  call       ""Sub System.Console.Write(Long)""
   IL_0010:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(528679, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/528679")>
@@ -9824,17 +9824,17 @@ End Class
             </compilation>,
             expectedOutput:="").
                         VerifyIL("MyClass1.foo1",
-            <![CDATA[
+"
 {
     // Code size       10 (0xa)
     .maxstack  2
     .locals init (Integer V_0) //global_y
     IL_0000:  ldarg.0
     IL_0001:  ldloca.s   V_0
-    IL_0003:  call       "Function MyClass1.foo(ByRef Integer) As Integer"
+    IL_0003:  call       ""Function MyClass1.foo(ByRef Integer) As Integer""
     IL_0008:  stloc.0
     IL_0009:  ret
-}]]>)
+}")
         End Sub
 
         ' Verify that the metadata for an attribute with a serialized an enum type with generics and nested class is correctly written by compiler and read by reflection.
@@ -9889,22 +9889,22 @@ Module m1
 End Module
 ]]></file>
             </compilation>,
-            expectedOutput:=<![CDATA[
+            expectedOutput:="
 AEB
 AED
 AEC
-]]>).
+").
                         VerifyIL("m1.Main",
-            <![CDATA[
+"
 {
   // Code size       55 (0x37)
   .maxstack  2
   .locals init (Object() V_0,
   Integer V_1)
-  IL_0000:  newobj     "Sub C..ctor()"
-  IL_0005:  callvirt   "Function Object.GetType() As System.Type"
+  IL_0000:  newobj     ""Sub C..ctor()""
+  IL_0005:  callvirt   ""Function Object.GetType() As System.Type""
   IL_000a:  ldc.i4.0
-  IL_000b:  callvirt   "Function System.Reflection.MemberInfo.GetCustomAttributes(Boolean) As Object()"
+  IL_000b:  callvirt   ""Function System.Reflection.MemberInfo.GetCustomAttributes(Boolean) As Object()""
   IL_0010:  stloc.0
   IL_0011:  ldc.i4.0
   IL_0012:  stloc.1
@@ -9912,10 +9912,10 @@ AEC
   IL_0015:  ldloc.0
   IL_0016:  ldloc.1
   IL_0017:  ldelem.ref
-  IL_0018:  castclass  "A"
-  IL_001d:  callvirt   "Function A.get_Y() As Object"
-  IL_0022:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_0027:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0018:  castclass  ""A""
+  IL_001d:  callvirt   ""Function A.get_Y() As Object""
+  IL_0022:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_0027:  call       ""Sub System.Console.WriteLine(Object)""
   IL_002c:  ldloc.1
   IL_002d:  ldc.i4.1
   IL_002e:  add.ovf
@@ -9927,7 +9927,7 @@ AEC
   IL_0034:  blt.s      IL_0015
   IL_0036:  ret
 }
-    ]]>)
+    ")
         End Sub
 
         <Fact>
@@ -9954,27 +9954,27 @@ End Class
             </compilation>,
             expectedOutput:="SundayAAA").
                         VerifyIL("A.Main",
-            <![CDATA[
+"
 {
   // Code size       53 (0x35)
   .maxstack  1
   .locals init (System.DayOfWeek V_0, //e
   A.E1 V_1) //e1
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "System.DayOfWeek"
+  IL_0002:  initobj    ""System.DayOfWeek""
   IL_0008:  ldloca.s   V_0
-  IL_000a:  constrained. "System.DayOfWeek"
-  IL_0010:  callvirt   "Function System.Enum.ToString() As String"
-  IL_0015:  call       "Sub System.Console.Write(String)"
+  IL_000a:  constrained. ""System.DayOfWeek""
+  IL_0010:  callvirt   ""Function System.Enum.ToString() As String""
+  IL_0015:  call       ""Sub System.Console.Write(String)""
   IL_001a:  ldloca.s   V_1
-  IL_001c:  initobj    "A.E1"
+  IL_001c:  initobj    ""A.E1""
   IL_0022:  ldloca.s   V_1
-  IL_0024:  constrained. "A.E1"
-  IL_002a:  callvirt   "Function System.Enum.ToString() As String"
-  IL_002f:  call       "Sub System.Console.WriteLine(String)"
+  IL_0024:  constrained. ""A.E1""
+  IL_002a:  callvirt   ""Function System.Enum.ToString() As String""
+  IL_002f:  call       ""Sub System.Console.WriteLine(String)""
   IL_0034:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(542593, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/542593")>
@@ -10214,7 +10214,7 @@ End Module
     </file>
 </compilation>, options:=TestOptions.DebugDll)
 
-            comp.VerifyIL("Module1.Main", <![CDATA[
+            comp.VerifyIL("Module1.Main", "
 {
   // Code size       77 (0x4d)
   .maxstack  3
@@ -10222,14 +10222,14 @@ End Module
                 Double V_1, //b
                 Boolean V_2)
   IL_0000:  nop
-  IL_0001:  ldstr      "1"
+  IL_0001:  ldstr      ""1""
   IL_0006:  stloc.0
   IL_0007:  ldc.r8     0
   IL_0010:  stloc.1
   IL_0011:  ldloc.0
-  IL_0012:  ldstr      "1"
+  IL_0012:  ldstr      ""1""
   IL_0017:  ldc.i4.0
-  IL_0018:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.CompareString(String, String, Boolean) As Integer"
+  IL_0018:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.CompareString(String, String, Boolean) As Integer""
   IL_001d:  ldc.i4.0
   IL_001e:  cgt.un
   IL_0020:  ldloc.1
@@ -10239,19 +10239,19 @@ End Module
   IL_002d:  stloc.2
   IL_002e:  ldloc.2
   IL_002f:  brfalse.s  IL_003f
-  IL_0031:  ldstr      "Fail"
-  IL_0036:  call       "Sub System.Console.WriteLine(String)"
+  IL_0031:  ldstr      ""Fail""
+  IL_0036:  call       ""Sub System.Console.WriteLine(String)""
   IL_003b:  nop
   IL_003c:  nop
   IL_003d:  br.s       IL_004c
   IL_003f:  nop
-  IL_0040:  ldstr      "Pass"
-  IL_0045:  call       "Sub System.Console.WriteLine(String)"
+  IL_0040:  ldstr      ""Pass""
+  IL_0045:  call       ""Sub System.Console.WriteLine(String)""
   IL_004a:  nop
   IL_004b:  nop
   IL_004c:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(543243, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543243")>
@@ -10296,7 +10296,7 @@ End Module
             options:=TestOptions.DebugExe,
             expectedOutput:="Pass")
 
-            c.VerifyIL("Module1.Main", <![CDATA[
+            c.VerifyIL("Module1.Main", "
 {
   // Code size       77 (0x4d)
   .maxstack  3
@@ -10304,14 +10304,14 @@ End Module
                 Double V_1, //b
                 Boolean V_2)
   IL_0000:  nop
-  IL_0001:  ldstr      "1"
+  IL_0001:  ldstr      ""1""
   IL_0006:  stloc.0
   IL_0007:  ldc.r8     0
   IL_0010:  stloc.1
   IL_0011:  ldloc.0
-  IL_0012:  ldstr      "1"
+  IL_0012:  ldstr      ""1""
   IL_0017:  ldc.i4.0
-  IL_0018:  call       "Function Microsoft.VisualBasic.CompilerServices.Operators.CompareString(String, String, Boolean) As Integer"
+  IL_0018:  call       ""Function Microsoft.VisualBasic.CompilerServices.Operators.CompareString(String, String, Boolean) As Integer""
   IL_001d:  ldc.i4.0
   IL_001e:  cgt.un
   IL_0020:  ldloc.1
@@ -10321,19 +10321,19 @@ End Module
   IL_002d:  stloc.2
   IL_002e:  ldloc.2
   IL_002f:  brfalse.s  IL_003f
-  IL_0031:  ldstr      "Fail"
-  IL_0036:  call       "Sub System.Console.WriteLine(String)"
+  IL_0031:  ldstr      ""Fail""
+  IL_0036:  call       ""Sub System.Console.WriteLine(String)""
   IL_003b:  nop
   IL_003c:  nop
   IL_003d:  br.s       IL_004c
   IL_003f:  nop
-  IL_0040:  ldstr      "Pass"
-  IL_0045:  call       "Sub System.Console.WriteLine(String)"
+  IL_0040:  ldstr      ""Pass""
+  IL_0045:  call       ""Sub System.Console.WriteLine(String)""
   IL_004a:  nop
   IL_004b:  nop
   IL_004c:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(539392, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539392")>
@@ -10351,7 +10351,7 @@ End Module
     </file>
 </compilation>, expectedOutput:="79228162514264337593543950335").
             VerifyIL("Program.Main",
-            <![CDATA[
+"
 {
   // Code size       16 (0x10)
   .maxstack  5
@@ -10360,11 +10360,11 @@ End Module
   IL_0002:  ldc.i4.m1
   IL_0003:  ldc.i4.0
   IL_0004:  ldc.i4.0
-  IL_0005:  newobj     "Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)"
-  IL_000a:  call       "Sub System.Console.WriteLine(Decimal)"
+  IL_0005:  newobj     ""Sub Decimal..ctor(Integer, Integer, Integer, Boolean, Byte)""
+  IL_000a:  call       ""Sub System.Console.WriteLine(Decimal)""
   IL_000f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(543611, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543611")>
@@ -10382,22 +10382,22 @@ End Module
     </file>
 </compilation>, expectedOutput:="-1").
             VerifyIL("Program.Main",
-            <![CDATA[
+"
 {
   // Code size       26 (0x1a)
   .maxstack  2
   .locals init (Decimal V_0)
-  IL_0000:  ldsfld     "Decimal.One As Decimal"
+  IL_0000:  ldsfld     ""Decimal.One As Decimal""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
   IL_0008:  ldc.i4.2
   IL_0009:  conv.i8
-  IL_000a:  newobj     "Sub Decimal..ctor(Long)"
-  IL_000f:  call       "Function Decimal.CompareTo(Decimal) As Integer"
-  IL_0014:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_000a:  newobj     ""Sub Decimal..ctor(Long)""
+  IL_000f:  call       ""Function Decimal.CompareTo(Decimal) As Integer""
+  IL_0014:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0019:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(543611, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543611")>
@@ -10427,21 +10427,21 @@ End Class
     </file>
 </compilation>, expectedOutput:="-1").
             VerifyIL("Test.Main",
-            <![CDATA[
+"
 {
   // Code size       29 (0x1d)
   .maxstack  2
   .locals init (Test.C1 V_0)
-  IL_0000:  call       "Function Test.Foo() As Test.C1"
+  IL_0000:  call       ""Function Test.Foo() As Test.C1""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
-  IL_0008:  ldflda     "Test.C1.x As Decimal"
-  IL_000d:  ldsfld     "Decimal.One As Decimal"
-  IL_0012:  call       "Function Decimal.CompareTo(Decimal) As Integer"
-  IL_0017:  call       "Sub System.Console.Write(Integer)"
+  IL_0008:  ldflda     ""Test.C1.x As Decimal""
+  IL_000d:  ldsfld     ""Decimal.One As Decimal""
+  IL_0012:  call       ""Function Decimal.CompareTo(Decimal) As Integer""
+  IL_0017:  call       ""Sub System.Console.Write(Integer)""
   IL_001c:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -10501,34 +10501,34 @@ End Structure
     </file>
 </compilation>, expectedOutput:="42").
             VerifyIL("Program.Main",
-            <![CDATA[
+"
 {
   // Code size       76 (0x4c)
   .maxstack  3
   .locals init (MyManagedStruct V_0)
-  IL_0000:  newobj     "Sub cls1..ctor()"
+  IL_0000:  newobj     ""Sub cls1..ctor()""
   IL_0005:  dup
-  IL_0006:  ldfld      "cls1.y As MyManagedStruct"
+  IL_0006:  ldfld      ""cls1.y As MyManagedStruct""
   IL_000b:  stloc.0
   IL_000c:  ldloca.s   V_0
   IL_000e:  ldc.i4.s   123
-  IL_0010:  call       "Sub MyManagedStruct.mutate(Integer)"
+  IL_0010:  call       ""Sub MyManagedStruct.mutate(Integer)""
   IL_0015:  dup
-  IL_0016:  ldfld      "cls1.y As MyManagedStruct"
+  IL_0016:  ldfld      ""cls1.y As MyManagedStruct""
   IL_001b:  stloc.0
   IL_001c:  ldloca.s   V_0
-  IL_001e:  ldflda     "MyManagedStruct.n As MyManagedStruct.Nested"
-  IL_0023:  ldflda     "MyManagedStruct.Nested.n As MyManagedStruct.Nested.Nested1"
+  IL_001e:  ldflda     ""MyManagedStruct.n As MyManagedStruct.Nested""
+  IL_0023:  ldflda     ""MyManagedStruct.Nested.n As MyManagedStruct.Nested.Nested1""
   IL_0028:  ldc.i4     0x1c8
-  IL_002d:  call       "Sub MyManagedStruct.Nested.Nested1.mutate(Integer)"
-  IL_0032:  ldfld      "cls1.y As MyManagedStruct"
-  IL_0037:  ldfld      "MyManagedStruct.n As MyManagedStruct.Nested"
-  IL_003c:  ldfld      "MyManagedStruct.Nested.n As MyManagedStruct.Nested.Nested1"
-  IL_0041:  ldfld      "MyManagedStruct.Nested.Nested1.num As Integer"
-  IL_0046:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_002d:  call       ""Sub MyManagedStruct.Nested.Nested1.mutate(Integer)""
+  IL_0032:  ldfld      ""cls1.y As MyManagedStruct""
+  IL_0037:  ldfld      ""MyManagedStruct.n As MyManagedStruct.Nested""
+  IL_003c:  ldfld      ""MyManagedStruct.Nested.n As MyManagedStruct.Nested.Nested1""
+  IL_0041:  ldfld      ""MyManagedStruct.Nested.Nested1.num As Integer""
+  IL_0046:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_004b:  ret
 }
-]]>)
+")
         End Sub
 
 
@@ -10557,46 +10557,46 @@ End Module
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("Program.Main",
-            <![CDATA[
+"
 {
   // Code size       88 (0x58)
   .maxstack  3
   .locals init (Decimal V_0,
   Decimal V_1,
   Decimal V_2)
-  IL_0000:  ldsfld     "Decimal.One As Decimal"
+  IL_0000:  ldsfld     ""Decimal.One As Decimal""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_0
-  IL_0008:  ldsfld     "Decimal.One As Decimal"
+  IL_0008:  ldsfld     ""Decimal.One As Decimal""
   IL_000d:  stloc.1
   IL_000e:  ldloca.s   V_1
-  IL_0010:  ldsfld     "Decimal.One As Decimal"
+  IL_0010:  ldsfld     ""Decimal.One As Decimal""
   IL_0015:  stloc.2
   IL_0016:  ldloca.s   V_2
-  IL_0018:  call       "Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)"
-  IL_001d:  ldsfld     "Decimal.One As Decimal"
+  IL_0018:  call       ""Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)""
+  IL_001d:  ldsfld     ""Decimal.One As Decimal""
   IL_0022:  stloc.2
   IL_0023:  ldloca.s   V_2
-  IL_0025:  ldsfld     "Decimal.One As Decimal"
+  IL_0025:  ldsfld     ""Decimal.One As Decimal""
   IL_002a:  stloc.1
   IL_002b:  ldloca.s   V_1
-  IL_002d:  ldsfld     "Decimal.One As Decimal"
+  IL_002d:  ldsfld     ""Decimal.One As Decimal""
   IL_0032:  stloc.0
   IL_0033:  ldloca.s   V_0
-  IL_0035:  call       "Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)"
-  IL_003a:  ldsfld     "Decimal.One As Decimal"
+  IL_0035:  call       ""Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)""
+  IL_003a:  ldsfld     ""Decimal.One As Decimal""
   IL_003f:  stloc.0
   IL_0040:  ldloca.s   V_0
-  IL_0042:  ldsfld     "Decimal.One As Decimal"
+  IL_0042:  ldsfld     ""Decimal.One As Decimal""
   IL_0047:  stloc.1
   IL_0048:  ldloca.s   V_1
-  IL_004a:  ldsfld     "Decimal.One As Decimal"
+  IL_004a:  ldsfld     ""Decimal.One As Decimal""
   IL_004f:  stloc.2
   IL_0050:  ldloca.s   V_2
-  IL_0052:  call       "Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)"
+  IL_0052:  call       ""Sub Program.moo(ByRef Decimal, ByRef Decimal, ByRef Decimal)""
   IL_0057:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(638119, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/638119")>
@@ -10648,49 +10648,49 @@ System.Exception: Exception of type 'System.Exception' was thrown.
 True
 ]]>).
             VerifyIL("Program.Test",
-            <![CDATA[
+"
 {
   // Code size       89 (0x59)
   .maxstack  4
   IL_0000:  ldc.i4.3
-  IL_0001:  newarr     "Boolean"
+  IL_0001:  newarr     ""Boolean""
   IL_0006:  ldc.i4.0
   IL_0007:  ldelem.u1
-  IL_0008:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0008:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_000d:  ldc.i4.3
-  IL_000e:  newarr     "System.Exception"
+  IL_000e:  newarr     ""System.Exception""
   IL_0013:  ldc.i4.0
   IL_0014:  ldelem.ref
-  IL_0015:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0015:  call       ""Sub System.Console.WriteLine(Object)""
   IL_001a:  ldc.i4.3
-  IL_001b:  newarr     "Boolean"
+  IL_001b:  newarr     ""Boolean""
   IL_0020:  dup
   IL_0021:  ldc.i4.1
   IL_0022:  ldc.i4.1
   IL_0023:  stelem.i1
   IL_0024:  ldc.i4.1
   IL_0025:  ldelem.u1
-  IL_0026:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0026:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_002b:  ldc.i4.7
-  IL_002c:  newarr     "System.Exception"
+  IL_002c:  newarr     ""System.Exception""
   IL_0031:  dup
   IL_0032:  ldc.i4.1
-  IL_0033:  newobj     "Sub System.Exception..ctor()"
+  IL_0033:  newobj     ""Sub System.Exception..ctor()""
   IL_0038:  stelem.ref
   IL_0039:  ldc.i4.1
   IL_003a:  ldelem.ref
-  IL_003b:  call       "Sub System.Console.WriteLine(Object)"
+  IL_003b:  call       ""Sub System.Console.WriteLine(Object)""
   IL_0040:  ldc.i4.4
-  IL_0041:  newarr     "Boolean"
+  IL_0041:  newarr     ""Boolean""
   IL_0046:  dup
-  IL_0047:  ldtoken    "Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108"
-  IL_004c:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0047:  ldtoken    ""Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108""
+  IL_004c:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0051:  ldc.i4.2
   IL_0052:  ldelem.u1
-  IL_0053:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0053:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_0058:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -10741,7 +10741,7 @@ System.Exception: Exception of type 'System.Exception' was thrown.
 True
 ]]>).
             VerifyIL("Program.Test",
-            <![CDATA[
+"
 {
   // Code size      101 (0x65)
   .maxstack  4
@@ -10751,21 +10751,21 @@ True
                 System.Exception() V_3, //arrE2
                 Boolean() V_4) //arrB3
   IL_0000:  ldc.i4.3
-  IL_0001:  newarr     "Boolean"
+  IL_0001:  newarr     ""Boolean""
   IL_0006:  stloc.0
   IL_0007:  ldloc.0
   IL_0008:  ldc.i4.0
   IL_0009:  ldelem.u1
-  IL_000a:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_000a:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_000f:  ldc.i4.3
-  IL_0010:  newarr     "System.Exception"
+  IL_0010:  newarr     ""System.Exception""
   IL_0015:  stloc.1
   IL_0016:  ldloc.1
   IL_0017:  ldc.i4.0
   IL_0018:  ldelem.ref
-  IL_0019:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0019:  call       ""Sub System.Console.WriteLine(Object)""
   IL_001e:  ldc.i4.3
-  IL_001f:  newarr     "Boolean"
+  IL_001f:  newarr     ""Boolean""
   IL_0024:  dup
   IL_0025:  ldc.i4.1
   IL_0026:  ldc.i4.1
@@ -10774,57 +10774,57 @@ True
   IL_0029:  ldloc.2
   IL_002a:  ldc.i4.1
   IL_002b:  ldelem.u1
-  IL_002c:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_002c:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_0031:  ldc.i4.7
-  IL_0032:  newarr     "System.Exception"
+  IL_0032:  newarr     ""System.Exception""
   IL_0037:  dup
   IL_0038:  ldc.i4.1
-  IL_0039:  newobj     "Sub System.Exception..ctor()"
+  IL_0039:  newobj     ""Sub System.Exception..ctor()""
   IL_003e:  stelem.ref
   IL_003f:  stloc.3
   IL_0040:  ldloc.3
   IL_0041:  ldc.i4.1
   IL_0042:  ldelem.ref
-  IL_0043:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0043:  call       ""Sub System.Console.WriteLine(Object)""
   IL_0048:  ldc.i4.4
-  IL_0049:  newarr     "Boolean"
+  IL_0049:  newarr     ""Boolean""
   IL_004e:  dup
-  IL_004f:  ldtoken    "Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108"
-  IL_0054:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_004f:  ldtoken    ""Integer <PrivateImplementationDetails>.35CCB1599F52363510686EF38B7DB5E7998DB108""
+  IL_0054:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_0059:  stloc.s    V_4
   IL_005b:  ldloc.s    V_4
   IL_005d:  ldc.i4.2
   IL_005e:  ldelem.u1
-  IL_005f:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_005f:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_0064:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact, WorkItem(529162, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529162")>
         Public Sub TestMSVBTypeNameAPI()
             Dim vbCompilation = CreateVisualBasicCompilation("TestMSVBTypeNameAPI",
-            <![CDATA[Public Module Program
+            "Public Module Program
     Sub Main()
         Dim x = 0UI
         System.Console.WriteLine(Microsoft.VisualBasic.Information.TypeName(x))
     End Sub
-End Module]]>,
+End Module",
                 compilationOptions:=TestOptions.ReleaseExe)
 
             Dim vbVerifier = CompileAndVerify(vbCompilation, expectedOutput:="UInteger")
 
             vbVerifier.VerifyDiagnostics()
-            vbVerifier.VerifyIL("Program.Main", <![CDATA[
+            vbVerifier.VerifyIL("Program.Main", "
 {
   // Code size       17 (0x11)
   .maxstack  1
   IL_0000:  ldc.i4.0
-  IL_0001:  box        "UInteger"
-  IL_0006:  call       "Function Microsoft.VisualBasic.CompilerServices.Versioned.TypeName(Object) As String"
-  IL_000b:  call       "Sub System.Console.WriteLine(String)"
+  IL_0001:  box        ""UInteger""
+  IL_0006:  call       ""Function Microsoft.VisualBasic.CompilerServices.Versioned.TypeName(Object) As String""
+  IL_000b:  call       ""Sub System.Console.WriteLine(String)""
   IL_0010:  ret
-}]]>)
+}")
         End Sub
 
         <WorkItem(11640, "DevDiv_Projects/Roslyn")>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -49,24 +49,24 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("Program.M",
-            <![CDATA[
+            "
 {
   // Code size       37 (0x25)
   .maxstack  2
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     "Object"
+  IL_0001:  newarr     ""Object""
   IL_0006:  starg.s    V_0
   IL_0008:  ldarg.0
   IL_0009:  ldc.i4.0
   IL_000a:  ldelem.ref
-  IL_000b:  unbox      "OuterStruct"
-  IL_0010:  ldflda     "OuterStruct.z As DoubleAndStruct"
-  IL_0015:  ldflda     "DoubleAndStruct.y As TwoInteger"
-  IL_001a:  ldfld      "TwoInteger.x As Integer"
-  IL_001f:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_000b:  unbox      ""OuterStruct""
+  IL_0010:  ldflda     ""OuterStruct.z As DoubleAndStruct""
+  IL_0015:  ldflda     ""DoubleAndStruct.y As TwoInteger""
+  IL_001a:  ldfld      ""TwoInteger.x As Integer""
+  IL_001f:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0024:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(776642, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/776642")>
@@ -104,24 +104,24 @@ End Class
     </file>
 </compilation>).
             VerifyIL("Program.M",
-            <![CDATA[
+            "
 {
   // Code size       37 (0x25)
   .maxstack  2
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     "Object"
+  IL_0001:  newarr     ""Object""
   IL_0006:  starg.s    V_0
   IL_0008:  ldarg.0
   IL_0009:  ldc.i4.0
   IL_000a:  ldelem.ref
-  IL_000b:  castclass  "OuterStruct"
-  IL_0010:  ldflda     "OuterStruct.z As DoubleAndStruct"
-  IL_0015:  ldflda     "DoubleAndStruct.y As TwoInteger"
-  IL_001a:  ldfld      "TwoInteger.x As Integer"
-  IL_001f:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_000b:  castclass  ""OuterStruct""
+  IL_0010:  ldflda     ""OuterStruct.z As DoubleAndStruct""
+  IL_0015:  ldflda     ""DoubleAndStruct.y As TwoInteger""
+  IL_001a:  ldfld      ""TwoInteger.x As Integer""
+  IL_001f:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0024:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -162,30 +162,30 @@ End Structure
     </file>
 </compilation>).
             VerifyIL("Program.M",
-            <![CDATA[
+            "
 {
   // Code size       51 (0x33)
   .maxstack  4
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     "Object"
+  IL_0001:  newarr     ""Object""
   IL_0006:  dup
   IL_0007:  ldc.i4.0
   IL_0008:  ldc.i4.1
-  IL_0009:  newobj     "Sub OuterStruct..ctor(Integer)"
-  IL_000e:  box        "OuterStruct"
+  IL_0009:  newobj     ""Sub OuterStruct..ctor(Integer)""
+  IL_000e:  box        ""OuterStruct""
   IL_0013:  stelem.ref
   IL_0014:  starg.s    V_0
   IL_0016:  ldarg.0
   IL_0017:  ldc.i4.0
   IL_0018:  ldelem.ref
-  IL_0019:  unbox      "OuterStruct"
-  IL_001e:  ldfld      "OuterStruct.z As DoubleAndStruct"
-  IL_0023:  ldflda     "DoubleAndStruct.y As TwoInteger"
-  IL_0028:  ldfld      "TwoInteger.x As Integer"
-  IL_002d:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0019:  unbox      ""OuterStruct""
+  IL_001e:  ldfld      ""OuterStruct.z As DoubleAndStruct""
+  IL_0023:  ldflda     ""DoubleAndStruct.y As TwoInteger""
+  IL_0028:  ldfld      ""TwoInteger.x As Integer""
+  IL_002d:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0032:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(776642, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/776642")>
@@ -222,17 +222,17 @@ End Class
     </file>
 </compilation>).
             VerifyIL("Program.M",
-            <![CDATA[
+           "
 {
   // Code size       21 (0x15)
   .maxstack  1
-  IL_0000:  ldsflda    "OuterStruct.z As DoubleAndStruct"
-  IL_0005:  ldflda     "DoubleAndStruct.y As TwoInteger"
-  IL_000a:  ldfld      "TwoInteger.x As Integer"
-  IL_000f:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0000:  ldsflda    ""OuterStruct.z As DoubleAndStruct""
+  IL_0005:  ldflda     ""DoubleAndStruct.y As TwoInteger""
+  IL_000a:  ldfld      ""TwoInteger.x As Integer""
+  IL_000f:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0014:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(545724, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545724")>
@@ -330,41 +330,41 @@ expectedOutput:=<![CDATA[
 0
 ]]>).
             VerifyIL("RedimTest.Main",
-            <![CDATA[
+            "
 {
   // Code size       73 (0x49)
   .maxstack  4
   IL_0000:  ldc.i4.4
-  IL_0001:  newarr     "Integer"
+  IL_0001:  newarr     ""Integer""
   IL_0006:  dup
   IL_0007:  ldc.i4.1
   IL_0008:  ldc.i4     0xea
   IL_000d:  stelem.i4
   IL_000e:  ldc.i4.6
-  IL_000f:  newarr     "Integer"
-  IL_0014:  call       "Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array"
-  IL_0019:  castclass  "Integer()"
+  IL_000f:  newarr     ""Integer""
+  IL_0014:  call       ""Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array""
+  IL_0019:  castclass  ""Integer()""
   IL_001e:  dup
   IL_001f:  ldc.i4.1
   IL_0020:  ldelem.i4
-  IL_0021:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0021:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0026:  ldc.i4.4
   IL_0027:  ldelem.i4
-  IL_0028:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0028:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_002d:  ldc.i4.3
-  IL_002e:  newarr     "Integer"
+  IL_002e:  newarr     ""Integer""
   IL_0033:  pop
   IL_0034:  ldc.i4.4
-  IL_0035:  newarr     "Integer"
+  IL_0035:  newarr     ""Integer""
   IL_003a:  pop
   IL_003b:  ldc.i4.5
-  IL_003c:  newarr     "Integer"
+  IL_003c:  newarr     ""Integer""
   IL_0041:  ldc.i4.1
   IL_0042:  ldelem.i4
-  IL_0043:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0043:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0048:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -393,23 +393,23 @@ End Module
 </compilation>,
 expectedOutput:=<![CDATA[False]]>).
             VerifyIL("RedimTest.Main",
-            <![CDATA[
+            "
 {
   // Code size       39 (0x27)
   .maxstack  3
   IL_0000:  ldc.i4.0
-  IL_0001:  newarr     "String"
+  IL_0001:  newarr     ""String""
   IL_0006:  ldc.i4.0
-  IL_0007:  newarr     "String"
-  IL_000c:  call       "Function RedimTest.get_X(ParamArray String()) As Integer()"
+  IL_0007:  newarr     ""String""
+  IL_000c:  call       ""Function RedimTest.get_X(ParamArray String()) As Integer()""
   IL_0011:  ldc.i4.1
-  IL_0012:  newarr     "Integer"
-  IL_0017:  call       "Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array"
-  IL_001c:  castclass  "Integer()"
-  IL_0021:  call       "Sub RedimTest.set_X(ParamArray String(), Integer())"
+  IL_0012:  newarr     ""Integer""
+  IL_0017:  call       ""Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array""
+  IL_001c:  castclass  ""Integer()""
+  IL_0021:  call       ""Sub RedimTest.set_X(ParamArray String(), Integer())""
   IL_0026:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(546809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546809")>
@@ -468,26 +468,26 @@ End Module
 </compilation>,
 expectedOutput:="").
             VerifyIL("Program.Main",
-            <![CDATA[
+            "
 {
   // Code size       31 (0x1f)
   .maxstack  2
   .locals init (Base V_0) //o
-  IL_0000:  newobj     "Sub DerivedA..ctor()"
+  IL_0000:  newobj     ""Sub DerivedA..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  callvirt   "Function Base.get_Kind() As E"
+  IL_0007:  callvirt   ""Function Base.get_Kind() As E""
   IL_000c:  ldc.i4.1
   IL_000d:  bne.un.s   IL_001c
   IL_000f:  ldloc.0
-  IL_0010:  castclass  "DerivedB"
-  IL_0015:  callvirt   "Function DerivedB.get_IsGood() As Boolean"
+  IL_0010:  castclass  ""DerivedB""
+  IL_0015:  callvirt   ""Function DerivedB.get_IsGood() As Boolean""
   IL_001a:  br.s       IL_001d
   IL_001c:  ldc.i4.0
   IL_001d:  pop
   IL_001e:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(529861, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529861")>
@@ -522,7 +522,7 @@ Module Program
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 0.0000000000000000000000000000
 0.0000000000000000000000000000
 0.0000000000000000000000000000
@@ -540,7 +540,7 @@ expectedOutput:=<![CDATA[
 0.0000000000000000000000000000
 0.0000000000000000000000000000
 0.0000000000000000000000000000
-]]>)
+")
 
         End Sub
 
@@ -609,12 +609,12 @@ Module Program
 End Module
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 10000000000000000000000
 100000000000000000000000
 1000000000000000000000000
 10000000000000000000000000000
-]]>)
+")
         End Sub
 
         ''' <summary>
@@ -645,7 +645,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, additionalRefs:=XmlReferences, expectedOutput:="
 0.0000000000000000000000000031
 0.0000000000000000000000000030
 
@@ -656,7 +656,7 @@ End Module
 0.0000000000000000000000000000
 
 0.1000000000000000000000000000
-]]>)
+")
 
         End Sub
 
@@ -703,7 +703,7 @@ Module M
     End Sub
 End Module
     ]]></file>
-</compilation>, additionalRefs:=XmlReferences, expectedOutput:=<![CDATA[
+</compilation>, additionalRefs:=XmlReferences, expectedOutput:="
 00000000000000000000000000000000
 00000000000000000000000000010000
 00000000000000000000000000020000
@@ -723,7 +723,7 @@ End Module
 000000000000000000000000000a0000
 000000000000000000000000800c0000
 000000000000000000000000801c0000
-]]>)
+")
         End Sub
 
         ''' <summary>
@@ -825,26 +825,26 @@ End Class
 </compilation>,
 expectedOutput:=<![CDATA[Done]]>).
             VerifyIL("Member.get_P",
-            <![CDATA[
+            "
 {
   // Code size       35 (0x23)
   .maxstack  2
   .locals init (Array(Of Field) V_0,
   Field V_1)
   IL_0000:  ldarg.0
-  IL_0001:  ldfld      "Member.C As Container"
-  IL_0006:  ldfld      "Container.D As Descr"
-  IL_000b:  ldfld      "Descr.Fields As Array(Of Field)"
+  IL_0001:  ldfld      ""Member.C As Container""
+  IL_0006:  ldfld      ""Container.D As Descr""
+  IL_000b:  ldfld      ""Descr.Fields As Array(Of Field)""
   IL_0010:  stloc.0
   IL_0011:  ldloca.s   V_0
   IL_0013:  ldc.i4.s   123
-  IL_0015:  call       "Function Array(Of Field).get_Item(Integer) As Field"
+  IL_0015:  call       ""Function Array(Of Field).get_Item(Integer) As Field""
   IL_001a:  stloc.1
   IL_001b:  ldloca.s   V_1
-  IL_001d:  call       "Function Field.get_Type() As String"
+  IL_001d:  call       ""Function Field.get_Type() As String""
   IL_0022:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(545120, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545120")>
@@ -945,34 +945,34 @@ End Module
 </compilation>,
 expectedOutput:=<![CDATA[False]]>).
             VerifyIL("RedimTest.Main",
-            <![CDATA[
+            "
 {
   // Code size       53 (0x35)
   .maxstack  5
   .locals init (String V_0)
   IL_0000:  ldc.i4.1
-  IL_0001:  newarr     "String"
+  IL_0001:  newarr     ""String""
   IL_0006:  dup
   IL_0007:  ldc.i4.0
-  IL_0008:  call       "Function RedimTest.get_Y() As String"
+  IL_0008:  call       ""Function RedimTest.get_Y() As String""
   IL_000d:  dup
   IL_000e:  stloc.0
   IL_000f:  stelem.ref
   IL_0010:  ldc.i4.1
-  IL_0011:  newarr     "String"
+  IL_0011:  newarr     ""String""
   IL_0016:  dup
   IL_0017:  ldc.i4.0
   IL_0018:  ldloc.0
   IL_0019:  stelem.ref
-  IL_001a:  call       "Function RedimTest.get_X(ParamArray String()) As Integer()"
+  IL_001a:  call       ""Function RedimTest.get_X(ParamArray String()) As Integer()""
   IL_001f:  ldc.i4.1
-  IL_0020:  newarr     "Integer"
-  IL_0025:  call       "Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array"
-  IL_002a:  castclass  "Integer()"
-  IL_002f:  call       "Sub RedimTest.set_X(ParamArray String(), Integer())"
+  IL_0020:  newarr     ""Integer""
+  IL_0025:  call       ""Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array""
+  IL_002a:  castclass  ""Integer()""
+  IL_002f:  call       ""Sub RedimTest.set_X(ParamArray String(), Integer())""
   IL_0034:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -1006,24 +1006,24 @@ End Module
 </compilation>,
 expectedOutput:=<![CDATA[False]]>).
             VerifyIL("M.Main",
-            <![CDATA[
+            "
 {
   // Code size       32 (0x20)
   .maxstack  2
   .locals init (Integer() V_0)
   IL_0000:  ldc.i4.0
-  IL_0001:  newarr     "String"
-  IL_0006:  call       "Function M.get_X(ParamArray String()) As Integer()"
+  IL_0001:  newarr     ""String""
+  IL_0006:  call       ""Function M.get_X(ParamArray String()) As Integer()""
   IL_000b:  stloc.0
   IL_000c:  ldloca.s   V_0
-  IL_000e:  call       "Sub M.M(ByRef Integer())"
+  IL_000e:  call       ""Sub M.M(ByRef Integer())""
   IL_0013:  ldc.i4.0
-  IL_0014:  newarr     "String"
+  IL_0014:  newarr     ""String""
   IL_0019:  ldloc.0
-  IL_001a:  call       "Sub M.set_X(ParamArray String(), Integer())"
+  IL_001a:  call       ""Sub M.set_X(ParamArray String(), Integer())""
   IL_001f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(545404, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545404")>
@@ -1052,15 +1052,15 @@ End Class
 </compilation>,
 expectedOutput:="").
             VerifyIL("CLS.Main",
-            <![CDATA[
+            "
 {
   // Code size        7 (0x7)
   .maxstack  1
-  IL_0000:  newobj     "Sub CLS..ctor()"
+  IL_0000:  newobj     ""Sub CLS..ctor()""
   IL_0005:  pop
   IL_0006:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -1125,68 +1125,68 @@ End Class
 
             CompileWithCustomILSource(vbSource, ClassesWithReadWriteProperties, TestOptions.ReleaseDll).
             VerifyIL("D3.Test",
-            <![CDATA[
+            "
 {
   // Code size      127 (0x7f)
   .maxstack  2
   .locals init (Integer V_0) //tmp
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function D1.get_P_rw_r_w() As Integer"
+  IL_0001:  callvirt   ""Function D1.get_P_rw_r_w() As Integer""
   IL_0006:  stloc.0
   IL_0007:  ldarg.0
-  IL_0008:  call       "Function D1.get_P_rw_r_w() As Integer"
+  IL_0008:  call       ""Function D1.get_P_rw_r_w() As Integer""
   IL_000d:  stloc.0
   IL_000e:  ldarg.0
-  IL_000f:  call       "Function D1.get_P_rw_r_w() As Integer"
+  IL_000f:  call       ""Function D1.get_P_rw_r_w() As Integer""
   IL_0014:  stloc.0
   IL_0015:  ldarg.0
   IL_0016:  ldloc.0
-  IL_0017:  callvirt   "Sub D3.set_P_rw_r_w(Integer)"
+  IL_0017:  callvirt   ""Sub D3.set_P_rw_r_w(Integer)""
   IL_001c:  ldarg.0
   IL_001d:  ldloc.0
-  IL_001e:  call       "Sub D3.set_P_rw_r_w(Integer)"
+  IL_001e:  call       ""Sub D3.set_P_rw_r_w(Integer)""
   IL_0023:  ldarg.0
   IL_0024:  ldloc.0
-  IL_0025:  call       "Sub D2.set_P_rw_r_w(Integer)"
+  IL_0025:  call       ""Sub D2.set_P_rw_r_w(Integer)""
   IL_002a:  ldarg.0
-  IL_002b:  callvirt   "Function D3.get_P_rw_rw_r() As Integer"
+  IL_002b:  callvirt   ""Function D3.get_P_rw_rw_r() As Integer""
   IL_0030:  stloc.0
   IL_0031:  ldarg.0
-  IL_0032:  call       "Function D3.get_P_rw_rw_r() As Integer"
+  IL_0032:  call       ""Function D3.get_P_rw_rw_r() As Integer""
   IL_0037:  stloc.0
   IL_0038:  ldarg.0
-  IL_0039:  call       "Function D2.get_P_rw_rw_r() As Integer"
+  IL_0039:  call       ""Function D2.get_P_rw_rw_r() As Integer""
   IL_003e:  stloc.0
   IL_003f:  ldarg.0
   IL_0040:  ldloc.0
-  IL_0041:  callvirt   "Sub D1.set_P_rw_rw_r(Integer)"
+  IL_0041:  callvirt   ""Sub D1.set_P_rw_rw_r(Integer)""
   IL_0046:  ldarg.0
   IL_0047:  ldloc.0
-  IL_0048:  call       "Sub D1.set_P_rw_rw_r(Integer)"
+  IL_0048:  call       ""Sub D1.set_P_rw_rw_r(Integer)""
   IL_004d:  ldarg.0
   IL_004e:  ldloc.0
-  IL_004f:  call       "Sub D1.set_P_rw_rw_r(Integer)"
+  IL_004f:  call       ""Sub D1.set_P_rw_rw_r(Integer)""
   IL_0054:  ldarg.0
-  IL_0055:  callvirt   "Function D1.get_P_rw_rw_w() As Integer"
+  IL_0055:  callvirt   ""Function D1.get_P_rw_rw_w() As Integer""
   IL_005a:  stloc.0
   IL_005b:  ldarg.0
-  IL_005c:  call       "Function D1.get_P_rw_rw_w() As Integer"
+  IL_005c:  call       ""Function D1.get_P_rw_rw_w() As Integer""
   IL_0061:  stloc.0
   IL_0062:  ldarg.0
-  IL_0063:  call       "Function D1.get_P_rw_rw_w() As Integer"
+  IL_0063:  call       ""Function D1.get_P_rw_rw_w() As Integer""
   IL_0068:  stloc.0
   IL_0069:  ldarg.0
   IL_006a:  ldloc.0
-  IL_006b:  callvirt   "Sub D3.set_P_rw_rw_w(Integer)"
+  IL_006b:  callvirt   ""Sub D3.set_P_rw_rw_w(Integer)""
   IL_0070:  ldarg.0
   IL_0071:  ldloc.0
-  IL_0072:  call       "Sub D3.set_P_rw_rw_w(Integer)"
+  IL_0072:  call       ""Sub D3.set_P_rw_rw_w(Integer)""
   IL_0077:  ldarg.0
   IL_0078:  ldloc.0
-  IL_0079:  call       "Sub D2.set_P_rw_rw_w(Integer)"
+  IL_0079:  call       ""Sub D2.set_P_rw_rw_w(Integer)""
   IL_007e:  ret
 }
-]]>)
+")
         End Sub
 
         Public Shared ReadOnly AttributesWithReadWriteProperties As XCData = <![CDATA[
@@ -1451,7 +1451,7 @@ End Module
 
             CompileWithCustomILSource(vbSource, AttributesWithReadWriteProperties.Value,
                                       options:=New VisualBasicCompilationOptions(OutputKind.ConsoleApplication),
-                                      expectedOutput:=<![CDATA[
+                                      expectedOutput:="
 Void .ctor()(..0..)
 Int32 P_rw_r_w:=(Int32)1
 Int32 P_rw_rw_w:=(Int32)2
@@ -1459,7 +1459,7 @@ Void .ctor()(..0..)
 Int32 P_rw_r_w:=(Int32)1
 Int32 P_rw_rw_w:=(Int32)2
 Int32 P_rw_rw_r:=(Int32)3
-]]>.Value.Replace(vbLf, Environment.NewLine))
+") '.Replace(vbLf, Environment.NewLine))
         End Sub
 
         <Fact()>
@@ -1493,28 +1493,28 @@ End Module
 </compilation>,
 expectedOutput:=<![CDATA[True]]>).
             VerifyIL("M.Main",
-            <![CDATA[
+            "
 {
   // Code size       27 (0x1b)
   .maxstack  2
   .locals init (Integer() V_0)
   IL_0000:  ldc.i4.2
-  IL_0001:  newarr     "String"
+  IL_0001:  newarr     ""String""
   IL_0006:  dup
-  IL_0007:  call       "Function M.get_X(ParamArray String()) As Integer()"
+  IL_0007:  call       ""Function M.get_X(ParamArray String()) As Integer()""
   IL_000c:  stloc.0
   IL_000d:  ldloca.s   V_0
-  IL_000f:  call       "Sub M.M(ByRef Integer())"
+  IL_000f:  call       ""Sub M.M(ByRef Integer())""
   IL_0014:  ldloc.0
-  IL_0015:  call       "Sub M.set_X(ParamArray String(), Integer())"
+  IL_0015:  call       ""Sub M.set_X(ParamArray String(), Integer())""
   IL_001a:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
         Public Sub TestByRefMethodWithByRefParamArrayProperty()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public auto ansi sealed TestModule
        extends [mscorlib]System.Object
 {
@@ -1565,7 +1565,7 @@ expectedOutput:=<![CDATA[True]]>).
     .get int32[] TestModule::get_X(string[]&)
   } // end of property RedimTest::X
 } // end of class ClassLibrary1.RedimTest
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -1583,37 +1583,37 @@ End Module
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("M.Main",
-            <![CDATA[
+            "
                                                {
                                                   // Code size       38 (0x26)
                                                   .maxstack  2
                                                   .locals init (Integer() V_0,
                                                   String() V_1)
                                                   IL_0000:  ldc.i4.0
-                                                  IL_0001:  newarr     "String"
+                                                  IL_0001:  newarr     ""String""
                                                   IL_0006:  stloc.1
                                                   IL_0007:  ldloca.s   V_1
-                                                  IL_0009:  call       "Function TestModule.get_X(ByRef ParamArray String()) As Integer()"
+                                                  IL_0009:  call       ""Function TestModule.get_X(ByRef ParamArray String()) As Integer()""
                                                   IL_000e:  stloc.0
                                                   IL_000f:  ldloca.s   V_0
-                                                  IL_0011:  call       "Sub M.M(ByRef Integer())"
+                                                  IL_0011:  call       ""Sub M.M(ByRef Integer())""
                                                   IL_0016:  ldc.i4.0
-                                                  IL_0017:  newarr     "String"
+                                                  IL_0017:  newarr     ""String""
                                                   IL_001c:  stloc.1
                                                   IL_001d:  ldloca.s   V_1
                                                   IL_001f:  ldloc.0
-                                                  IL_0020:  call       "Sub TestModule.set_X(ByRef ParamArray String(), Integer())"
+                                                  IL_0020:  call       ""Sub TestModule.set_X(ByRef ParamArray String(), Integer())""
                                                   IL_0025:  ret
                                                }
-                                               ]]>)
+                                               ")
         End Sub
 
         <WorkItem(546853, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546853")>
         <Fact()>
         Public Sub CallingVirtualFinalMethod()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public auto ansi beforefieldinit B
        extends [mscorlib]System.Object
 {
@@ -1650,7 +1650,7 @@ End Module
     .get instance bool B::get_M2()
   }
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -1664,28 +1664,28 @@ End Module
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.S",
-            <![CDATA[
+            "
 {
   // Code size       27 (0x1b)
   .maxstack  1
-  IL_0000:  newobj     "Sub B..ctor()"
-  IL_0005:  callvirt   "Function B.get_M1() As Boolean"
+  IL_0000:  newobj     ""Sub B..ctor()""
+  IL_0005:  callvirt   ""Function B.get_M1() As Boolean""
   IL_000a:  brfalse.s  IL_0018
-  IL_000c:  newobj     "Sub B..ctor()"
-  IL_0011:  call       "Function B.get_M2() As Boolean"
+  IL_000c:  newobj     ""Sub B..ctor()""
+  IL_0011:  call       ""Function B.get_M2() As Boolean""
   IL_0016:  br.s       IL_0019
   IL_0018:  ldc.i4.0
   IL_0019:  pop
   IL_001a:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
         Public Sub TestToStringOnStruct()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class sequential ansi sealed public Struct1
          extends [mscorlib]System.ValueType
 {
@@ -1696,7 +1696,7 @@ End Module
       .maxstack  1
       .locals init (string V_0)
       IL_0000:  nop
-      IL_0001:  ldstr      "Struct1 "
+      IL_0001:  ldstr      ""Struct1 ""
       IL_0006:  stloc.0
       IL_0007:  br.s       IL_0009
       IL_0009:  ldloc.0
@@ -1713,15 +1713,14 @@ End Module
       .maxstack  1
       .locals init (string V_0)
       IL_0000:  nop
-      IL_0001:  ldstr      "Struct2 "
+      IL_0001:  ldstr      ""Struct2 ""
       IL_0006:  stloc.0
       IL_0007:  br.s       IL_0009
       IL_0009:  ldloc.0
       IL_000a:  ret
     }
 }
-]]>
-
+"
             Dim vbSource =
 <compilation>
     <file name="a.vb">
@@ -1737,29 +1736,29 @@ End Module
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("M.Main",
-            <![CDATA[
+            "
 {
   // Code size       53 (0x35)
   .maxstack  1
   .locals init (Struct1 V_0, //s1
   Struct2 V_1) //s2
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "Struct1"
+  IL_0002:  initobj    ""Struct1""
   IL_0008:  ldloca.s   V_0
-  IL_000a:  constrained. "Struct1"
-  IL_0010:  callvirt   "Function Object.ToString() As String"
-  IL_0015:  call       "Sub System.Console.Write(String)"
+  IL_000a:  constrained. ""Struct1""
+  IL_0010:  callvirt   ""Function Object.ToString() As String""
+  IL_0015:  call       ""Sub System.Console.Write(String)""
   IL_001a:  ldloca.s   V_1
-  IL_001c:  initobj    "Struct2"
+  IL_001c:  initobj    ""Struct2""
   IL_0022:  ldloca.s   V_1
-  IL_0024:  constrained. "Struct2"
-  IL_002a:  callvirt   "Function Object.ToString() As String"
-  IL_002f:  call       "Sub System.Console.Write(String)"
+  IL_0024:  constrained. ""Struct2""
+  IL_002a:  callvirt   ""Function Object.ToString() As String""
+  IL_002f:  call       ""Sub System.Console.Write(String)""
   IL_0034:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -1795,50 +1794,50 @@ Class RedimTest
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 Writing
 Reading
 Reading
 Writing
 Reading
 stored value
-]]>).
+").
             VerifyIL("RedimTest.Main",
-            <![CDATA[
+            "
 {
 // Code size      100 (0x64)
 .maxstack  3
 .locals init (RedimTest V_0)
-IL_0000:  call       "Function RedimTest.Func() As RedimTest"
+IL_0000:  call       ""Function RedimTest.Func() As RedimTest""
 IL_0005:  ldc.i4.3
-IL_0006:  newarr     "Object"
-IL_000b:  callvirt   "Sub RedimTest.set_Prop(Object)"
-IL_0010:  call       "Function RedimTest.Func() As RedimTest"
-IL_0015:  callvirt   "Function RedimTest.get_Prop() As Object"
-IL_001a:  castclass  "Object()"
+IL_0006:  newarr     ""Object""
+IL_000b:  callvirt   ""Sub RedimTest.set_Prop(Object)""
+IL_0010:  call       ""Function RedimTest.Func() As RedimTest""
+IL_0015:  callvirt   ""Function RedimTest.get_Prop() As Object""
+IL_001a:  castclass  ""Object()""
 IL_001f:  ldc.i4.1
-IL_0020:  ldstr      "stored value"
+IL_0020:  ldstr      ""stored value""
 IL_0025:  stelem.ref
-IL_0026:  call       "Function RedimTest.Func() As RedimTest"
+IL_0026:  call       ""Function RedimTest.Func() As RedimTest""
 IL_002b:  dup
 IL_002c:  stloc.0
 IL_002d:  ldloc.0
-IL_002e:  callvirt   "Function RedimTest.get_Prop() As Object"
-IL_0033:  castclass  "System.Array"
+IL_002e:  callvirt   ""Function RedimTest.get_Prop() As Object""
+IL_0033:  castclass  ""System.Array""
 IL_0038:  ldc.i4.6
-IL_0039:  newarr     "Object"
-IL_003e:  call       "Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array"
-IL_0043:  callvirt   "Sub RedimTest.set_Prop(Object)"
-IL_0048:  call       "Function RedimTest.Func() As RedimTest"
-IL_004d:  callvirt   "Function RedimTest.get_Prop() As Object"
-IL_0052:  castclass  "Object()"
+IL_0039:  newarr     ""Object""
+IL_003e:  call       ""Function Microsoft.VisualBasic.CompilerServices.Utils.CopyArray(System.Array, System.Array) As System.Array""
+IL_0043:  callvirt   ""Sub RedimTest.set_Prop(Object)""
+IL_0048:  call       ""Function RedimTest.Func() As RedimTest""
+IL_004d:  callvirt   ""Function RedimTest.get_Prop() As Object""
+IL_0052:  castclass  ""Object()""
 IL_0057:  ldc.i4.1
 IL_0058:  ldelem.ref
-IL_0059:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-IL_005e:  call       "Sub System.Console.WriteLine(Object)"
+IL_0059:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+IL_005e:  call       ""Sub System.Console.WriteLine(Object)""
 IL_0063:  ret
 }
-]]>)
+")
 
         End Sub
 
@@ -1883,24 +1882,24 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 S1
-]]>).
+").
             VerifyIL("MainClass.Main",
-            <![CDATA[
+            "
 {
   // Code size       25 (0x19)
   .maxstack  1
   .locals init (S1 V_0)
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S1"
+  IL_0002:  initobj    ""S1""
   IL_0008:  ldloc.0
-  IL_0009:  box        "S1"
-  IL_000e:  call       "Function Object.GetType() As System.Type"
-  IL_0013:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0009:  box        ""S1""
+  IL_000e:  call       ""Function Object.GetType() As System.Type""
+  IL_0013:  call       ""Sub System.Console.WriteLine(Object)""
   IL_0018:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -1924,24 +1923,24 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 123
-]]>).
+").
             VerifyIL("MainClass.Main",
-            <![CDATA[
+            "
 {
   // Code size       27 (0x1b)
   .maxstack  1
   .locals init (S1 V_0) //s
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S1"
+  IL_0002:  initobj    ""S1""
   IL_0008:  ldloca.s   V_0
-  IL_000a:  constrained. "S1"
-  IL_0010:  callvirt   "Function Object.ToString() As String"
-  IL_0015:  call       "Sub System.Console.WriteLine(String)"
+  IL_000a:  constrained. ""S1""
+  IL_0010:  callvirt   ""Function Object.ToString() As String""
+  IL_0015:  call       ""Sub System.Console.WriteLine(String)""
   IL_001a:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -1977,22 +1976,22 @@ S1:M
 S1:M
 ]]>).
             VerifyIL("MainClass.Main",
-            <![CDATA[
+            "
 {
   // Code size       32 (0x20)
   .maxstack  1
   .locals init (S1 V_0) //s
   IL_0000:  ldloca.s   V_0
-  IL_0002:  initobj    "S1"
+  IL_0002:  initobj    ""S1""
   IL_0008:  ldloca.s   V_0
-  IL_000a:  call       "Sub S1.M()"
+  IL_000a:  call       ""Sub S1.M()""
   IL_000f:  ldloc.0
-  IL_0010:  box        "S1"
-  IL_0015:  castclass  "I"
-  IL_001a:  callvirt   "Sub I.M()"
+  IL_0010:  box        ""S1""
+  IL_0015:  castclass  ""I""
+  IL_001a:  callvirt   ""Sub I.M()""
   IL_001f:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(531085, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531085")>
@@ -2029,13 +2028,13 @@ End Module
 </compilation>,
 expectedOutput:="").
             VerifyIL("Derived.inc",
-            <![CDATA[
+            "
 {
   // Code size       44 (0x2c)
   .maxstack  4
   .locals init (Integer& V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldflda     "Base1.memberee As Integer"
+  IL_0001:  ldflda     ""Base1.memberee As Integer""
   IL_0006:  dup
   IL_0007:  stloc.0
   IL_0008:  ldloc.0
@@ -2045,21 +2044,21 @@ expectedOutput:="").
   IL_000c:  stind.i4
   IL_000d:  ldarg.0
   IL_000e:  ldarg.0
-  IL_000f:  call       "Function Base1.get_xyz() As Integer"
+  IL_000f:  call       ""Function Base1.get_xyz() As Integer""
   IL_0014:  ldc.i4.1
   IL_0015:  add.ovf
-  IL_0016:  call       "Sub Base1.set_xyz(Integer)"
+  IL_0016:  call       ""Sub Base1.set_xyz(Integer)""
   IL_001b:  ldarg.0
   IL_001c:  ldc.i4.0
   IL_001d:  ldarg.0
   IL_001e:  ldc.i4.0
-  IL_001f:  call       "Function Base1.get_this(Integer) As Integer"
+  IL_001f:  call       ""Function Base1.get_this(Integer) As Integer""
   IL_0024:  ldc.i4.1
   IL_0025:  add.ovf
-  IL_0026:  call       "Sub Base1.set_this(Integer, Integer)"
+  IL_0026:  call       ""Sub Base1.set_this(Integer, Integer)""
   IL_002b:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2077,9 +2076,9 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[123]]>).
+expectedOutput:="123").
             VerifyIL("MainClass.Main",
-            <![CDATA[
+            "
 {
   // Code size       16 (0x10)
   .maxstack  1
@@ -2087,11 +2086,11 @@ expectedOutput:=<![CDATA[123]]>).
   IL_0000:  ldc.i4.s   123
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_0
-  IL_0005:  call       "Function Integer.ToString() As String"
-  IL_000a:  call       "Sub System.Console.WriteLine(String)"
+  IL_0005:  call       ""Function Integer.ToString() As String""
+  IL_000a:  call       ""Sub System.Console.WriteLine(String)""
   IL_000f:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2111,16 +2110,16 @@ End Class
     </file>
 </compilation>).
             VerifyIL("MainClass.M",
-            <![CDATA[
+            "
 {
   // Code size        9 (0x9)
   .maxstack  1
   IL_0000:  ldarga.s   V_1
-  IL_0002:  call       "Function System.TypedReference.GetHashCode() As Integer"
+  IL_0002:  call       ""Function System.TypedReference.GetHashCode() As Integer""
   IL_0007:  pop
   IL_0008:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2146,13 +2145,13 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 Shade
 False
 Gray
-]]>).
+").
             VerifyIL("MainClass.Main",
-            <![CDATA[
+            "
 {
   // Code size       62 (0x3e)
   .maxstack  2
@@ -2160,23 +2159,23 @@ Gray
   IL_0000:  ldc.i4.1
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
-  IL_0003:  box        "Shade"
-  IL_0008:  call       "Function Object.GetType() As System.Type"
-  IL_000d:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0003:  box        ""Shade""
+  IL_0008:  call       ""Function Object.GetType() As System.Type""
+  IL_000d:  call       ""Sub System.Console.WriteLine(Object)""
   IL_0012:  ldloc.0
-  IL_0013:  box        "Shade"
+  IL_0013:  box        ""Shade""
   IL_0018:  ldc.i4.2
-  IL_0019:  box        "Shade"
-  IL_001e:  call       "Function System.Enum.HasFlag(System.Enum) As Boolean"
-  IL_0023:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0019:  box        ""Shade""
+  IL_001e:  call       ""Function System.Enum.HasFlag(System.Enum) As Boolean""
+  IL_0023:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_0028:  ldloc.0
-  IL_0029:  box        "Shade"
-  IL_002e:  ldstr      "G"
-  IL_0033:  call       "Function System.Enum.ToString(String) As String"
-  IL_0038:  call       "Sub System.Console.WriteLine(String)"
+  IL_0029:  box        ""Shade""
+  IL_002e:  ldstr      ""G""
+  IL_0033:  call       ""Function System.Enum.ToString(String) As String""
+  IL_0038:  call       ""Sub System.Console.WriteLine(String)""
   IL_003d:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2214,27 +2213,27 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 42
 1
-]]>).
+").
             VerifyIL("MainClass.g",
-            <![CDATA[
+            "
 {
   // Code size       23 (0x17)
   .maxstack  1
   .locals init (IB V_0)
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_000a
-  IL_0003:  newobj     "Sub AB2..ctor()"
+  IL_0003:  newobj     ""Sub AB2..ctor()""
   IL_0008:  br.s       IL_0011
-  IL_000a:  newobj     "Sub AB1..ctor()"
+  IL_000a:  newobj     ""Sub AB1..ctor()""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  callvirt   "Function IB.f() As Integer"
+  IL_0011:  callvirt   ""Function IB.f() As Integer""
   IL_0016:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(546809, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546809")>
@@ -2278,21 +2277,21 @@ End Module
 </compilation>,
 expectedOutput:="C1").
             VerifyIL("Program.F",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  2
   .locals init (I V_0)
-  IL_0000:  call       "Function Program.F1() As C1"
+  IL_0000:  call       ""Function Program.F1() As C1""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  dup
   IL_0008:  brtrue.s   IL_0010
   IL_000a:  pop
-  IL_000b:  call       "Function Program.F2() As C2"
+  IL_000b:  call       ""Function Program.F2() As C2""
   IL_0010:  ret
 }
-]]>)
+")
         End Sub
 
         <WorkItem(634407, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/634407")>
@@ -2328,28 +2327,28 @@ End Class
     </file>
 </compilation>, expectedOutput:="").
             VerifyIL("Program.Main",
-            <![CDATA[
+            "
 {
   // Code size       35 (0x23)
   .maxstack  1
   .locals init (System.Exception() V_0) //f1
   IL_0000:  ldnull
   IL_0001:  stloc.0
-  IL_0002:  call       "Function Program.C() As Boolean"
+  IL_0002:  call       ""Function Program.C() As Boolean""
   IL_0007:  brtrue.s   IL_000c
   IL_0009:  ldnull
   IL_000a:  br.s       IL_000d
   IL_000c:  ldloc.0
-  IL_000d:  call       "Sub System.Console.WriteLine(Object)"
-  IL_0012:  call       "Function Program.C() As Boolean"
+  IL_000d:  call       ""Sub System.Console.WriteLine(Object)""
+  IL_0012:  call       ""Function Program.C() As Boolean""
   IL_0017:  brtrue.s   IL_001c
   IL_0019:  ldloc.0
   IL_001a:  br.s       IL_001d
   IL_001c:  ldnull
-  IL_001d:  call       "Sub System.Console.WriteLine(Object)"
+  IL_001d:  call       ""Sub System.Console.WriteLine(Object)""
   IL_0022:  ret
 }
-]]>)
+")
         End Sub
 
 
@@ -2394,21 +2393,21 @@ End Module
 </compilation>,
 expectedOutput:="C1").
             VerifyIL("Program.F",
-            <![CDATA[
+            "
 {
   // Code size       17 (0x11)
   .maxstack  1
   .locals init (I V_0) //i
-  IL_0000:  call       "Function Program.F1() As C1"
+  IL_0000:  call       ""Function Program.F1() As C1""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  brfalse.s  IL_000b
   IL_0009:  ldloc.0
   IL_000a:  ret
-  IL_000b:  call       "Function Program.F2() As C2"
+  IL_000b:  call       ""Function Program.F2() As C2""
   IL_0010:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2445,26 +2444,26 @@ Class MainClass
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 42
-]]>).
+").
             VerifyIL("MainClass.g",
-            <![CDATA[
+            "
 {
   // Code size       22 (0x16)
   .maxstack  2
   .locals init (IB V_0)
-  IL_0000:  newobj     "Sub AB1..ctor()"
+  IL_0000:  newobj     ""Sub AB1..ctor()""
   IL_0005:  dup
   IL_0006:  brtrue.s   IL_0010
   IL_0008:  pop
-  IL_0009:  newobj     "Sub AB2..ctor()"
+  IL_0009:  newobj     ""Sub AB2..ctor()""
   IL_000e:  stloc.0
   IL_000f:  ldloc.0
-  IL_0010:  callvirt   "Function IB.f() As Integer"
+  IL_0010:  callvirt   ""Function IB.f() As Integer""
   IL_0015:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -2555,7 +2554,7 @@ Class EmitTest
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
     Test01:  <Nothing>
     Test02:  1/1/0001 12:00:00 AM||System.DateTime
     Test03:  if-false||System.String
@@ -2563,50 +2562,50 @@ expectedOutput:=<![CDATA[
     Test05:  0||System.Int32
     Test06:  Infinity||System.Double
     Test07:  str||System.String
-]]>).
+").
             VerifyIL("EmitTest.Test07",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  ldstr      "tr"
-  IL_0006:  call       "Function String.Concat(String, String) As String"
+  IL_0001:  ldstr      ""tr""
+  IL_0006:  call       ""Function String.Concat(String, String) As String""
   IL_000b:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test06",
-            <![CDATA[
+           "
 {
   // Code size       15 (0xf)
   .maxstack  1
   IL_0000:  ldc.r8     Infinity
-  IL_0009:  box        "Double"
+  IL_0009:  box        ""Double""
   IL_000e:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test05",
-            <![CDATA[
+            "
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldc.i4.0
-  IL_0001:  box        "Integer"
+  IL_0001:  box        ""Integer""
   IL_0006:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test04",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  ldsfld     "Date.MinValue As Date"
-  IL_0005:  box        "Date"
+  IL_0000:  ldsfld     ""Date.MinValue As Date""
+  IL_0005:  box        ""Date""
   IL_000a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test03",
-            <![CDATA[
+            "
 {
   // Code size       18 (0x12)
   .maxstack  1
@@ -2615,33 +2614,33 @@ expectedOutput:=<![CDATA[
   IL_0001:  stloc.0
   IL_0002:  ldarg.0
   IL_0003:  brtrue.s   IL_000b
-  IL_0005:  ldstr      "if-false"
+  IL_0005:  ldstr      ""if-false""
   IL_000a:  ret
   IL_000b:  ldloc.0
-  IL_000c:  newobj     "Sub String..ctor(Char())"
+  IL_000c:  newobj     ""Sub String..ctor(Char())""
   IL_0011:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test02",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  ldsfld     "Date.MinValue As Date"
-  IL_0005:  box        "Date"
+  IL_0000:  ldsfld     ""Date.MinValue As Date""
+  IL_0005:  box        ""Date""
   IL_000a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test01",
-            <![CDATA[
+            "
 {
   // Code size        7 (0x7)
   .maxstack  1
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function EmitTest.get_StrProp() As String"
+  IL_0001:  callvirt   ""Function EmitTest.get_StrProp() As String""
   IL_0006:  ret
 }
-]]>)
+")
 
         End Sub
 
@@ -2765,7 +2764,7 @@ Class EmitTest
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
     Test01:  1/1/0001 12:00:00 AM||System.DateTime
     Test02:  abc||System.String
     Test03:  cde||System.String
@@ -2782,18 +2781,18 @@ expectedOutput:=<![CDATA[
     Test14:  b||System.String
     Test15:  b||System.String
     Test16:  else-branch||System.String
-]]>).
+").
             VerifyIL("EmitTest.Test16",
-            <![CDATA[
+            "
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  ldstr      "else-branch"
+  IL_0000:  ldstr      ""else-branch""
   IL_0005:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test15",
-            <![CDATA[
+            "
 {
   // Code size       18 (0x12)
   .maxstack  1
@@ -2802,140 +2801,140 @@ expectedOutput:=<![CDATA[
   IL_0001:  stloc.0
   IL_0002:  ldloc.0
   IL_0003:  brtrue.s   IL_000b
-  IL_0005:  ldstr      "b"
+  IL_0005:  ldstr      ""b""
   IL_000a:  ret
   IL_000b:  ldloc.0
-  IL_000c:  newobj     "Sub String..ctor(Char())"
+  IL_000c:  newobj     ""Sub String..ctor(Char())""
   IL_0011:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test14",
-            <![CDATA[
+            "
 {
   // Code size       16 (0x10)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_0009
-  IL_0003:  ldstr      "b"
+  IL_0003:  ldstr      ""b""
   IL_0008:  ret
   IL_0009:  ldarg.0
-  IL_000a:  newobj     "Sub String..ctor(Char())"
+  IL_000a:  newobj     ""Sub String..ctor(Char())""
   IL_000f:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test13",
-            <![CDATA[
+            "
 {
   // Code size       27 (0x1b)
   .maxstack  2
   IL_0000:  ldarg.1
-  IL_0001:  ldstr      "b"
-  IL_0006:  call       "Function String.Concat(String, String) As String"
+  IL_0001:  ldstr      ""b""
+  IL_0006:  call       ""Function String.Concat(String, String) As String""
   IL_000b:  dup
   IL_000c:  brtrue.s   IL_001a
   IL_000e:  pop
   IL_000f:  ldarg.0
-  IL_0010:  callvirt   "Function EmitTest.get_CharArrProp() As Char()"
-  IL_0015:  newobj     "Sub String..ctor(Char())"
+  IL_0010:  callvirt   ""Function EmitTest.get_CharArrProp() As Char()""
+  IL_0015:  newobj     ""Sub String..ctor(Char())""
   IL_001a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test12",
-            <![CDATA[
+            "
 {
   // Code size       29 (0x1d)
   .maxstack  2
   .locals init (Char() V_0)
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function EmitTest.get_CharArrProp() As Char()"
+  IL_0001:  callvirt   ""Function EmitTest.get_CharArrProp() As Char()""
   IL_0006:  dup
   IL_0007:  stloc.0
   IL_0008:  brtrue.s   IL_0016
   IL_000a:  ldarg.1
-  IL_000b:  ldstr      "b"
-  IL_0010:  call       "Function String.Concat(String, String) As String"
+  IL_000b:  ldstr      ""b""
+  IL_0010:  call       ""Function String.Concat(String, String) As String""
   IL_0015:  ret
   IL_0016:  ldloc.0
-  IL_0017:  newobj     "Sub String..ctor(Char())"
+  IL_0017:  newobj     ""Sub String..ctor(Char())""
   IL_001c:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test11",
-            <![CDATA[
+            "
 {
   // Code size       13 (0xd)
   .maxstack  2
   .locals init (EmitTest.I1 V_0) //i
   IL_0000:  ldnull
   IL_0001:  stloc.0
-  IL_0002:  newobj     "Sub EmitTest.CLS..ctor()"
+  IL_0002:  newobj     ""Sub EmitTest.CLS..ctor()""
   IL_0007:  dup
   IL_0008:  brtrue.s   IL_000c
   IL_000a:  pop
   IL_000b:  ldloc.0
   IL_000c:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test10",
-            <![CDATA[
+            "
 {
   // Code size       15 (0xf)
   .maxstack  2
-  IL_0000:  ldstr      "abc"
+  IL_0000:  ldstr      ""abc""
   IL_0005:  dup
   IL_0006:  brtrue.s   IL_000e
   IL_0008:  pop
-  IL_0009:  ldstr      "No Value"
+  IL_0009:  ldstr      ""No Value""
   IL_000e:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test09",
-            <![CDATA[
+           "
 {
   // Code size       26 (0x1a)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function EmitTest.get_StrProp() As String"
-  IL_0006:  ldstr      "abc"
-  IL_000b:  call       "Function String.Concat(String, String) As String"
+  IL_0001:  callvirt   ""Function EmitTest.get_StrProp() As String""
+  IL_0006:  ldstr      ""abc""
+  IL_000b:  call       ""Function String.Concat(String, String) As String""
   IL_0010:  dup
   IL_0011:  brtrue.s   IL_0019
   IL_0013:  pop
-  IL_0014:  ldstr      "xyz"
+  IL_0014:  ldstr      ""xyz""
   IL_0019:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test08",
-            <![CDATA[
+            "
 {
   // Code size       21 (0x15)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function EmitTest.get_StrProp() As String"
+  IL_0001:  callvirt   ""Function EmitTest.get_StrProp() As String""
   IL_0006:  dup
   IL_0007:  brtrue.s   IL_0014
   IL_0009:  pop
-  IL_000a:  ldsfld     "Date.MinValue As Date"
-  IL_000f:  box        "Date"
+  IL_000a:  ldsfld     ""Date.MinValue As Date""
+  IL_000f:  box        ""Date""
   IL_0014:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test07",
-            <![CDATA[
+            "
 {
   // Code size       16 (0x10)
   .maxstack  2
   IL_0000:  ldarg.0
-  IL_0001:  callvirt   "Function EmitTest.get_ObjProp() As Object"
+  IL_0001:  callvirt   ""Function EmitTest.get_ObjProp() As Object""
   IL_0006:  dup
   IL_0007:  brtrue.s   IL_000f
   IL_0009:  pop
-  IL_000a:  newobj     "Sub Object..ctor()"
+  IL_000a:  newobj     ""Sub Object..ctor()""
   IL_000f:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test06",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  2
@@ -2943,57 +2942,57 @@ expectedOutput:=<![CDATA[
   IL_0001:  dup
   IL_0002:  brtrue.s   IL_000a
   IL_0004:  pop
-  IL_0005:  ldstr      "No Value"
+  IL_0005:  ldstr      ""No Value""
   IL_000a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test05",
-            <![CDATA[
+           "
 {
   // Code size        2 (0x2)
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test04",
-            <![CDATA[
+            "
 {
   // Code size       12 (0xc)
   .maxstack  2
-  IL_0000:  ldstr      "a"
+  IL_0000:  ldstr      ""a""
   IL_0005:  ldarg.0
-  IL_0006:  call       "Function String.Concat(String, String) As String"
+  IL_0006:  call       ""Function String.Concat(String, String) As String""
   IL_000b:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test03",
-            <![CDATA[
+            "
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  ldstr      "cde"
+  IL_0000:  ldstr      ""cde""
   IL_0005:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test02",
-            <![CDATA[
+            "
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  ldstr      "abc"
+  IL_0000:  ldstr      ""abc""
   IL_0005:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test01",
-            <![CDATA[
+            "
 {
   // Code size        6 (0x6)
   .maxstack  1
-  IL_0000:  ldsfld     "Date.MinValue As Date"
+  IL_0000:  ldsfld     ""Date.MinValue As Date""
   IL_0005:  ret
 }
-]]>)
+")
 
         End Sub
 
@@ -3056,75 +3055,75 @@ End Structure
 
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
     Test01:  +||SS
     Test02:  +||SS
     Test03:  +||SS
     Test04:  ++||SS
-]]>).
+").
             VerifyIL("EmitTest.Test01",
-            <![CDATA[
+            "
 {
   // Code size       11 (0xb)
   .maxstack  1
-  IL_0000:  ldstr      "+"
-  IL_0005:  call       "Function SS.op_Implicit(String) As SS"
+  IL_0000:  ldstr      ""+""
+  IL_0005:  call       ""Function SS.op_Implicit(String) As SS""
   IL_000a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test02",
-            <![CDATA[
+            "
 {
   // Code size       27 (0x1b)
   .maxstack  1
   .locals init (String V_0) //s
-  IL_0000:  ldstr      "+"
+  IL_0000:  ldstr      ""+""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
   IL_0007:  brtrue.s   IL_0014
-  IL_0009:  ldstr      "-"
-  IL_000e:  newobj     "Sub SS..ctor(String)"
+  IL_0009:  ldstr      ""-""
+  IL_000e:  newobj     ""Sub SS..ctor(String)""
   IL_0013:  ret
   IL_0014:  ldloc.0
-  IL_0015:  call       "Function SS.op_Implicit(String) As SS"
+  IL_0015:  call       ""Function SS.op_Implicit(String) As SS""
   IL_001a:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test03",
-            <![CDATA[
+            "
 {
   // Code size       21 (0x15)
   .maxstack  1
   IL_0000:  ldarg.0
   IL_0001:  brtrue.s   IL_000e
-  IL_0003:  ldstr      "-"
-  IL_0008:  newobj     "Sub SS..ctor(String)"
+  IL_0003:  ldstr      ""-""
+  IL_0008:  newobj     ""Sub SS..ctor(String)""
   IL_000d:  ret
   IL_000e:  ldarg.0
-  IL_000f:  call       "Function SS.op_Implicit(String) As SS"
+  IL_000f:  call       ""Function SS.op_Implicit(String) As SS""
   IL_0014:  ret
 }
-]]>).
+").
             VerifyIL("EmitTest.Test04",
-            <![CDATA[
+            "
 {
   // Code size       33 (0x21)
   .maxstack  2
   .locals init (String V_0)
   IL_0000:  ldarg.0
-  IL_0001:  ldstr      "+"
-  IL_0006:  call       "Function String.Concat(String, String) As String"
+  IL_0001:  ldstr      ""+""
+  IL_0006:  call       ""Function String.Concat(String, String) As String""
   IL_000b:  dup
   IL_000c:  stloc.0
   IL_000d:  brtrue.s   IL_001a
-  IL_000f:  ldstr      "-"
-  IL_0014:  newobj     "Sub SS..ctor(String)"
+  IL_000f:  ldstr      ""-""
+  IL_0014:  newobj     ""Sub SS..ctor(String)""
   IL_0019:  ret
   IL_001a:  ldloc.0
-  IL_001b:  call       "Function SS.op_Implicit(String) As SS"
+  IL_001b:  call       ""Function SS.op_Implicit(String) As SS""
   IL_0020:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3153,7 +3152,7 @@ End Module</file>
 </compilation>,
         expectedOutput:="Val ").
         VerifyIL("Program.Main",
-            <![CDATA[{
+            "{
   // Code size       41 (0x29)
   .maxstack  2
   .locals init (Program.IFoo(Of String) V_0, //i
@@ -3162,20 +3161,20 @@ End Module</file>
   IL_0001:  ldnull
   IL_0002:  stloc.0
   IL_0003:  ldloca.s   V_1
-  IL_0005:  initobj    "Program.FooVal"
+  IL_0005:  initobj    ""Program.FooVal""
   IL_000b:  ldc.i4.1
   IL_000c:  bgt.s      IL_001b
   IL_000e:  ldloc.1
-  IL_000f:  box        "Program.FooVal"
-  IL_0014:  castclass  "Program.IFoo(Of String)"
+  IL_000f:  box        ""Program.FooVal""
+  IL_0014:  castclass  ""Program.IFoo(Of String)""
   IL_0019:  br.s       IL_001c
   IL_001b:  ldloc.0
   IL_001c:  stloc.0
   IL_001d:  ldloc.0
-  IL_001e:  callvirt   "Function Program.IFoo(Of String).Foo() As String"
-  IL_0023:  call       "Sub System.Console.Write(String)"
+  IL_001e:  callvirt   ""Function Program.IFoo(Of String).Foo() As String""
+  IL_0023:  call       ""Sub System.Console.Write(String)""
   IL_0028:  ret
-}]]>)
+}")
         End Sub
 
         <Fact>
@@ -3208,7 +3207,7 @@ End Module</file>
 </compilation>,
         expectedOutput:="Val Val ").
         VerifyIL("Program.Main",
-            <![CDATA[
+            "
 {
   // Code size       90 (0x5a)
   .maxstack  2
@@ -3218,39 +3217,39 @@ End Module</file>
   IL_0000:  ldnull
   IL_0001:  stloc.0
   IL_0002:  ldloca.s   V_1
-  IL_0004:  initobj    "Program.FooVal"
+  IL_0004:  initobj    ""Program.FooVal""
   IL_000a:  ldloca.s   V_2
   IL_000c:  ldloc.1
-  IL_000d:  call       "Sub Program.FooVal?..ctor(Program.FooVal)"
+  IL_000d:  call       ""Sub Program.FooVal?..ctor(Program.FooVal)""
   IL_0012:  ldloc.0
   IL_0013:  dup
   IL_0014:  brtrue.s   IL_0022
   IL_0016:  pop
   IL_0017:  ldloc.1
-  IL_0018:  box        "Program.FooVal"
-  IL_001d:  castclass  "Program.IFoo(Of String)"
+  IL_0018:  box        ""Program.FooVal""
+  IL_001d:  castclass  ""Program.IFoo(Of String)""
   IL_0022:  stloc.0
   IL_0023:  ldloc.0
-  IL_0024:  callvirt   "Function Program.IFoo(Of String).Foo() As String"
-  IL_0029:  call       "Sub System.Console.Write(String)"
+  IL_0024:  callvirt   ""Function Program.IFoo(Of String).Foo() As String""
+  IL_0029:  call       ""Sub System.Console.Write(String)""
   IL_002e:  ldnull
   IL_002f:  stloc.0
   IL_0030:  ldloca.s   V_2
-  IL_0032:  call       "Function Program.FooVal?.get_HasValue() As Boolean"
+  IL_0032:  call       ""Function Program.FooVal?.get_HasValue() As Boolean""
   IL_0037:  brtrue.s   IL_003c
   IL_0039:  ldloc.0
   IL_003a:  br.s       IL_004d
   IL_003c:  ldloca.s   V_2
-  IL_003e:  call       "Function Program.FooVal?.GetValueOrDefault() As Program.FooVal"
-  IL_0043:  box        "Program.FooVal"
-  IL_0048:  castclass  "Program.IFoo(Of String)"
+  IL_003e:  call       ""Function Program.FooVal?.GetValueOrDefault() As Program.FooVal""
+  IL_0043:  box        ""Program.FooVal""
+  IL_0048:  castclass  ""Program.IFoo(Of String)""
   IL_004d:  stloc.0
   IL_004e:  ldloc.0
-  IL_004f:  callvirt   "Function Program.IFoo(Of String).Foo() As String"
-  IL_0054:  call       "Sub System.Console.Write(String)"
+  IL_004f:  callvirt   ""Function Program.IFoo(Of String).Foo() As String""
+  IL_0054:  call       ""Sub System.Console.Write(String)""
   IL_0059:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3276,9 +3275,9 @@ Class EmitTest
 End Class
     </file>
 </compilation>,
-expectedOutput:=<![CDATA[
+expectedOutput:="
 Test01:  123||System.Int32
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -3312,9 +3311,12 @@ Module M1
 End Module
     </file>
 </compilation>,
-            expectedOutput:="ThenPart" & vbCrLf & "After" & vbCrLf).
+            expectedOutput:=
+"ThenPart
+After
+").
             VerifyIL("M1.Main",
-            <![CDATA[
+            "
 {
   // Code size       70 (0x46)
   .maxstack  2
@@ -3326,26 +3328,26 @@ End Module
   IL_0003:  ldc.i4.1
   IL_0004:  stloc.1
   IL_0005:  brfalse.s  IL_0013
-  IL_0007:  ldstr      "ThenPart"
-  IL_000c:  call       "Sub System.Console.WriteLine(String)"
+  IL_0007:  ldstr      ""ThenPart""
+  IL_000c:  call       ""Sub System.Console.WriteLine(String)""
   IL_0011:  br.s       IL_003b
   IL_0013:  ldloc.0
   IL_0014:  brfalse.s  IL_0022
-  IL_0016:  ldstr      "ElseIf1Part"
-  IL_001b:  call       "Sub System.Console.WriteLine(String)"
+  IL_0016:  ldstr      ""ElseIf1Part""
+  IL_001b:  call       ""Sub System.Console.WriteLine(String)""
   IL_0020:  br.s       IL_003b
   IL_0022:  ldloc.1
   IL_0023:  brfalse.s  IL_0031
-  IL_0025:  ldstr      "ElseIf2Part"
-  IL_002a:  call       "Sub System.Console.WriteLine(String)"
+  IL_0025:  ldstr      ""ElseIf2Part""
+  IL_002a:  call       ""Sub System.Console.WriteLine(String)""
   IL_002f:  br.s       IL_003b
-  IL_0031:  ldstr      "ElsePart"
-  IL_0036:  call       "Sub System.Console.WriteLine(String)"
-  IL_003b:  ldstr      "After"
-  IL_0040:  call       "Sub System.Console.WriteLine(String)"
+  IL_0031:  ldstr      ""ElsePart""
+  IL_0036:  call       ""Sub System.Console.WriteLine(String)""
+  IL_003b:  ldstr      ""After""
+  IL_0040:  call       ""Sub System.Console.WriteLine(String)""
   IL_0045:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -1123,7 +1123,7 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ClassesWithReadWriteProperties.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ClassesWithReadWriteProperties, TestOptions.ReleaseDll).
             VerifyIL("D3.Test",
             <![CDATA[
 {

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTests.vb
@@ -7879,26 +7879,27 @@ DERIVED: f(x As Integer, Optional y As Integer = 0)
 DERIVED: f(x As Integer, Optional y As String = """")
 ")
         End Sub
+
         <WorkItem(543751, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543751")>
         <Fact>
         Public Sub OverloadsWithOnlyOptionalParameters()
 
             Dim csCompilation = CreateCSharpCompilation("CSDll",
-"
+            <![CDATA[
 using System;
 
 public class OverloadsUsingOptional
 {
     public static void M(int k, int l = 0)
     {
-        Console.Write(""M(int k, Int l = 0),"""");
+        Console.Write("M(int k, int l = 0);");
     }
     public static void M(int k, int l = 0, int m = 0)
     {
-        Console.Write(""M(int k, int l = 0, int m = 0),"""");
+        Console.Write("M(int k, int l = 0, int m = 0);");
     }
 }
-",
+]]>,
                 compilationOptions:=New Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
             csCompilation.VerifyDiagnostics()
 
@@ -8840,14 +8841,14 @@ End Class
 
         <Fact>
         Public Sub PartiallyInitializedValue_NoParameterlessConstructor_Fields()
-            Dim ilSource = <![CDATA[
+            Dim ilSource = "
 .class public sequential ansi sealed beforefieldinit S
        extends [mscorlib]System.ValueType
 {
   .pack 0
   .size 1
 }
-]]>
+"
 
             Dim vbSource =
 <compilation>
@@ -8871,44 +8872,44 @@ End Class
     </file>
 </compilation>
 
-            CompileWithCustomILSource(vbSource, ilSource.Value, TestOptions.ReleaseDll).
+            CompileWithCustomILSource(vbSource, ilSource, TestOptions.ReleaseDll).
                 VerifyIL("C.M",
-            <![CDATA[
+"
 {
   // Code size       77 (0x4d)
   .maxstack  2
   .locals init (System.Exception V_0) //ex
   IL_0000:  ldarg.0   
-  IL_0001:  ldflda     "C.Fld As S"
-  IL_0006:  initobj    "S"
+  IL_0001:  ldflda     ""C.Fld As S""
+  IL_0006:  initobj    ""S""
   IL_000c:  ldarg.0   
-  IL_000d:  ldfld      "C.FldArr As S()"
+  IL_000d:  ldfld      ""C.FldArr As S()""
   IL_0012:  ldc.i4.1  
-  IL_0013:  ldelema    "S"
-  IL_0018:  initobj    "S"
+  IL_0013:  ldelema    ""S""
+  IL_0018:  initobj    ""S""
   .try
   {
     IL_001e:  ldarg.0   
-    IL_001f:  ldflda     "C.Fld As S"
-    IL_0024:  initobj    "S"
+    IL_001f:  ldflda     ""C.Fld As S""
+    IL_0024:  initobj    ""S""
     IL_002a:  ldarg.0   
-    IL_002b:  ldfld      "C.FldArr As S()"
+    IL_002b:  ldfld      ""C.FldArr As S()""
     IL_0030:  ldc.i4.1  
-    IL_0031:  ldelema    "S"
-    IL_0036:  initobj    "S"
+    IL_0031:  ldelema    ""S""
+    IL_0036:  initobj    ""S""
     IL_003c:  leave.s    IL_004c
   }
   catch System.Exception
   {
     IL_003e:  dup       
-    IL_003f:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_003f:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
     IL_0044:  stloc.0   
-    IL_0045:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_0045:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
     IL_004a:  leave.s    IL_004c
   }
   IL_004c:  ret       
 }
-]]>)
+")
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/WinRTCollectionTests.vb
@@ -95,84 +95,84 @@ b
                 expectedOutput,
                 allReferences:=WinRtRefs)
 
-            verifier.VerifyIL("A.Main", <![CDATA[
+            verifier.VerifyIL("A.Main", "
 {
   // Code size      174 (0xae)
   .maxstack  3
   .locals init (Windows.Data.Json.JsonArray V_0, //jsonArray
-  Windows.Data.Json.JsonValue V_1, //a
-  Windows.Data.Json.JsonValue V_2, //b
-  System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue) V_3)
-  IL_0000:  newobj     "Sub Windows.Data.Json.JsonArray..ctor()"
+                Windows.Data.Json.JsonValue V_1, //a
+                Windows.Data.Json.JsonValue V_2, //b
+                System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue) V_3)
+  IL_0000:  newobj     ""Sub Windows.Data.Json.JsonArray..ctor()""
   IL_0005:  stloc.0
-  IL_0006:  ldstr      "a"
-  IL_000b:  call       "Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue"
+  IL_0006:  ldstr      ""a""
+  IL_000b:  call       ""Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue""
   IL_0010:  stloc.1
   IL_0011:  ldloc.0
   IL_0012:  ldloc.1
-  IL_0013:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)"
-  IL_0018:  ldstr      "b"
-  IL_001d:  call       "Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue"
+  IL_0013:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)""
+  IL_0018:  ldstr      ""b""
+  IL_001d:  call       ""Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue""
   IL_0022:  stloc.2
   IL_0023:  ldloc.0
   IL_0024:  ldc.i4.0
   IL_0025:  ldloc.2
-  IL_0026:  callvirt   "Sub System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).Insert(Integer, Windows.Data.Json.IJsonValue)"
+  IL_0026:  callvirt   ""Sub System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).Insert(Integer, Windows.Data.Json.IJsonValue)""
   IL_002b:  ldloc.0
   IL_002c:  ldloc.2
-  IL_002d:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Remove(Windows.Data.Json.IJsonValue) As Boolean"
+  IL_002d:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Remove(Windows.Data.Json.IJsonValue) As Boolean""
   IL_0032:  pop
   IL_0033:  ldloc.0
   IL_0034:  ldloc.2
-  IL_0035:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Contains(Windows.Data.Json.IJsonValue) As Boolean"
-  IL_003a:  call       "Sub System.Console.WriteLine(Boolean)"
+  IL_0035:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Contains(Windows.Data.Json.IJsonValue) As Boolean""
+  IL_003a:  call       ""Sub System.Console.WriteLine(Boolean)""
   IL_003f:  ldloc.0
   IL_0040:  ldloc.1
-  IL_0041:  callvirt   "Function System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).IndexOf(Windows.Data.Json.IJsonValue) As Integer"
-  IL_0046:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0041:  callvirt   ""Function System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).IndexOf(Windows.Data.Json.IJsonValue) As Integer""
+  IL_0046:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_004b:  ldloc.0
   IL_004c:  ldc.i4.0
-  IL_004d:  callvirt   "Sub System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).RemoveAt(Integer)"
+  IL_004d:  callvirt   ""Sub System.Collections.Generic.IList(Of Windows.Data.Json.IJsonValue).RemoveAt(Integer)""
   IL_0052:  ldloc.0
-  IL_0053:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer"
-  IL_0058:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0053:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer""
+  IL_0058:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_005d:  ldloc.0
   IL_005e:  ldloc.2
-  IL_005f:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)"
+  IL_005f:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)""
   .try
-{
-  IL_0064:  ldloc.0
-  IL_0065:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue)"
-  IL_006a:  stloc.3
-  IL_006b:  br.s       IL_007d
-  IL_006d:  ldloc.3
-  IL_006e:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue).get_Current() As Windows.Data.Json.IJsonValue"
-  IL_0073:  callvirt   "Function Windows.Data.Json.IJsonValue.GetString() As String"
-  IL_0078:  call       "Sub System.Console.WriteLine(String)"
-  IL_007d:  ldloc.3
-  IL_007e:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
-  IL_0083:  brtrue.s   IL_006d
-  IL_0085:  leave.s    IL_0091
-}
+  {
+    IL_0064:  ldloc.0
+    IL_0065:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue)""
+    IL_006a:  stloc.3
+    IL_006b:  br.s       IL_007d
+    IL_006d:  ldloc.3
+    IL_006e:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Windows.Data.Json.IJsonValue).get_Current() As Windows.Data.Json.IJsonValue""
+    IL_0073:  callvirt   ""Function Windows.Data.Json.IJsonValue.GetString() As String""
+    IL_0078:  call       ""Sub System.Console.WriteLine(String)""
+    IL_007d:  ldloc.3
+    IL_007e:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
+    IL_0083:  brtrue.s   IL_006d
+    IL_0085:  leave.s    IL_0091
+  }
   finally
-{
-  IL_0087:  ldloc.3
-  IL_0088:  brfalse.s  IL_0090
-  IL_008a:  ldloc.3
-  IL_008b:  callvirt   "Sub System.IDisposable.Dispose()"
-  IL_0090:  endfinally
-}
+  {
+    IL_0087:  ldloc.3
+    IL_0088:  brfalse.s  IL_0090
+    IL_008a:  ldloc.3
+    IL_008b:  callvirt   ""Sub System.IDisposable.Dispose()""
+    IL_0090:  endfinally
+  }
   IL_0091:  ldloc.0
-  IL_0092:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer"
-  IL_0097:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_0092:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer""
+  IL_0097:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_009c:  ldloc.0
-  IL_009d:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Clear()"
+  IL_009d:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Clear()""
   IL_00a2:  ldloc.0
-  IL_00a3:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer"
-  IL_00a8:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_00a3:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).get_Count() As Integer""
+  IL_00a8:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_00ad:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -200,26 +200,26 @@ End Class]]></file>
                 allReferences:=WinRtRefs)
 
             verifier.VerifyIL("A.Main",
-            <![CDATA[
+            "
 {
   // Code size       46 (0x2e)
   .maxstack  3
   .locals init (Windows.Foundation.WwwFormUrlDecoder V_0) //results
-  IL_0000:  ldstr      "?param1=test"
-  IL_0005:  newobj     "Sub Windows.Foundation.WwwFormUrlDecoder..ctor(String)"
+  IL_0000:  ldstr      ""?param1=test""
+  IL_0005:  newobj     ""Sub Windows.Foundation.WwwFormUrlDecoder..ctor(String)""
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
   IL_000c:  ldc.i4.0
-  IL_000d:  callvirt   "Function System.Collections.Generic.IReadOnlyList(Of Windows.Foundation.IWwwFormUrlDecoderEntry).get_Item(Integer) As Windows.Foundation.IWwwFormUrlDecoderEntry"
-  IL_0012:  callvirt   "Function Windows.Foundation.IWwwFormUrlDecoderEntry.get_Name() As String"
+  IL_000d:  callvirt   ""Function System.Collections.Generic.IReadOnlyList(Of Windows.Foundation.IWwwFormUrlDecoderEntry).get_Item(Integer) As Windows.Foundation.IWwwFormUrlDecoderEntry""
+  IL_0012:  callvirt   ""Function Windows.Foundation.IWwwFormUrlDecoderEntry.get_Name() As String""
   IL_0017:  ldloc.0
   IL_0018:  ldc.i4.0
-  IL_0019:  callvirt   "Function System.Collections.Generic.IReadOnlyList(Of Windows.Foundation.IWwwFormUrlDecoderEntry).get_Item(Integer) As Windows.Foundation.IWwwFormUrlDecoderEntry"
-  IL_001e:  callvirt   "Function Windows.Foundation.IWwwFormUrlDecoderEntry.get_Value() As String"
-  IL_0023:  call       "Function String.Concat(String, String) As String"
-  IL_0028:  call       "Sub System.Console.WriteLine(String)"
+  IL_0019:  callvirt   ""Function System.Collections.Generic.IReadOnlyList(Of Windows.Foundation.IWwwFormUrlDecoderEntry).get_Item(Integer) As Windows.Foundation.IWwwFormUrlDecoderEntry""
+  IL_001e:  callvirt   ""Function Windows.Foundation.IWwwFormUrlDecoderEntry.get_Value() As String""
+  IL_0023:  call       ""Function String.Concat(String, String) As String""
+  IL_0028:  call       ""Sub System.Console.WriteLine(String)""
   IL_002d:  ret
-}]]>.Value)
+}")
         End Sub
 
         <Fact>
@@ -248,40 +248,40 @@ End Class
             Dim comp = CompileAndVerifyOnWin8Only(source,
                                                   expectedOutput:=output,
                                                   additionalRefs:=LegacyRefs)
-            comp.VerifyIL("A.Main", <![CDATA[
+            comp.VerifyIL("A.Main", "
 {
   // Code size      114 (0x72)
   .maxstack  3
-  IL_0000:  newobj     "Sub Windows.Data.Json.JsonArray..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Data.Json.JsonArray..ctor()""
   IL_0005:  dup
-  IL_0006:  ldstr      "include"
-  IL_000b:  call       "Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue"
-  IL_0010:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)"
-  IL_0015:  ldsfld     "A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)"
+  IL_0006:  ldstr      ""include""
+  IL_000b:  call       ""Function Windows.Data.Json.JsonValue.CreateStringValue(String) As Windows.Data.Json.JsonValue""
+  IL_0010:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Data.Json.IJsonValue).Add(Windows.Data.Json.IJsonValue)""
+  IL_0015:  ldsfld     ""A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)""
   IL_001a:  brfalse.s  IL_0023
-  IL_001c:  ldsfld     "A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)"
+  IL_001c:  ldsfld     ""A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)""
   IL_0021:  br.s       IL_0039
-  IL_0023:  ldsfld     "A._Closure$__.$I As A._Closure$__"
-  IL_0028:  ldftn      "Function A._Closure$__._Lambda$__1-0(Windows.Data.Json.IJsonValue) As Boolean"
-  IL_002e:  newobj     "Sub System.Func(Of Windows.Data.Json.IJsonValue, Boolean)..ctor(Object, System.IntPtr)"
+  IL_0023:  ldsfld     ""A._Closure$__.$I As A._Closure$__""
+  IL_0028:  ldftn      ""Function A._Closure$__._Lambda$__1-0(Windows.Data.Json.IJsonValue) As Boolean""
+  IL_002e:  newobj     ""Sub System.Func(Of Windows.Data.Json.IJsonValue, Boolean)..ctor(Object, System.IntPtr)""
   IL_0033:  dup
-  IL_0034:  stsfld     "A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)"
-  IL_0039:  call       "Function System.Linq.Enumerable.Where(Of Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue), System.Func(Of Windows.Data.Json.IJsonValue, Boolean)) As System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)"
-  IL_003e:  ldsfld     "A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)"
+  IL_0034:  stsfld     ""A._Closure$__.$I1-0 As System.Func(Of Windows.Data.Json.IJsonValue, Boolean)""
+  IL_0039:  call       ""Function System.Linq.Enumerable.Where(Of Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue), System.Func(Of Windows.Data.Json.IJsonValue, Boolean)) As System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)""
+  IL_003e:  ldsfld     ""A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)""
   IL_0043:  brfalse.s  IL_004c
-  IL_0045:  ldsfld     "A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)"
+  IL_0045:  ldsfld     ""A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)""
   IL_004a:  br.s       IL_0062
-  IL_004c:  ldsfld     "A._Closure$__.$I As A._Closure$__"
-  IL_0051:  ldftn      "Function A._Closure$__._Lambda$__1-1(Windows.Data.Json.IJsonValue) As Windows.Data.Json.IJsonValue"
-  IL_0057:  newobj     "Sub System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)..ctor(Object, System.IntPtr)"
+  IL_004c:  ldsfld     ""A._Closure$__.$I As A._Closure$__""
+  IL_0051:  ldftn      ""Function A._Closure$__._Lambda$__1-1(Windows.Data.Json.IJsonValue) As Windows.Data.Json.IJsonValue""
+  IL_0057:  newobj     ""Sub System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)..ctor(Object, System.IntPtr)""
   IL_005c:  dup
-  IL_005d:  stsfld     "A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)"
-  IL_0062:  call       "Function System.Linq.Enumerable.Select(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue), System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)) As System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)"
-  IL_0067:  call       "Function System.Linq.Enumerable.Count(Of Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)) As Integer"
-  IL_006c:  call       "Sub System.Console.WriteLine(Integer)"
+  IL_005d:  stsfld     ""A._Closure$__.$I1-1 As System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)""
+  IL_0062:  call       ""Function System.Linq.Enumerable.Select(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue), System.Func(Of Windows.Data.Json.IJsonValue, Windows.Data.Json.IJsonValue)) As System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)""
+  IL_0067:  call       ""Function System.Linq.Enumerable.Count(Of Windows.Data.Json.IJsonValue)(System.Collections.Generic.IEnumerable(Of Windows.Data.Json.IJsonValue)) As Integer""
+  IL_006c:  call       ""Sub System.Console.WriteLine(Integer)""
   IL_0071:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -328,81 +328,81 @@ testKey2testValue3]]>
                 expectedOutput:=expectedOut,
                 allReferences:=WinRtRefs)
 
-            verifier.VerifyIL("A.Main", <![CDATA[
+            verifier.VerifyIL("A.Main", "
 {
   // Code size      229 (0xe5)
   .maxstack  3
   .locals init (Windows.ApplicationModel.DataTransfer.DataPackagePropertySet V_0, //dpps
-  Object V_1, //tv2
-  System.Collections.Generic.IEnumerator(Of Object) V_2, //valsEnumerator
-  System.Collections.Generic.IEnumerator(Of String) V_3) //keysEnumerator
-  IL_0000:  newobj     "Sub Windows.ApplicationModel.DataTransfer.DataPackage..ctor()"
-  IL_0005:  callvirt   "Function Windows.ApplicationModel.DataTransfer.DataPackage.get_Properties() As Windows.ApplicationModel.DataTransfer.DataPackagePropertySet"
+                Object V_1, //tv2
+                System.Collections.Generic.IEnumerator(Of Object) V_2, //valsEnumerator
+                System.Collections.Generic.IEnumerator(Of String) V_3) //keysEnumerator
+  IL_0000:  newobj     ""Sub Windows.ApplicationModel.DataTransfer.DataPackage..ctor()""
+  IL_0005:  callvirt   ""Function Windows.ApplicationModel.DataTransfer.DataPackage.get_Properties() As Windows.ApplicationModel.DataTransfer.DataPackagePropertySet""
   IL_000a:  stloc.0
   IL_000b:  ldloc.0
-  IL_000c:  ldstr      "testKey1"
-  IL_0011:  ldstr      "testValue1"
-  IL_0016:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of String, Object)..ctor(String, Object)"
-  IL_001b:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of String, Object)).Add(System.Collections.Generic.KeyValuePair(Of String, Object))"
-  IL_0020:  call       "Function System.Console.get_Out() As System.IO.TextWriter"
+  IL_000c:  ldstr      ""testKey1""
+  IL_0011:  ldstr      ""testValue1""
+  IL_0016:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of String, Object)..ctor(String, Object)""
+  IL_001b:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of String, Object)).Add(System.Collections.Generic.KeyValuePair(Of String, Object))""
+  IL_0020:  call       ""Function System.Console.get_Out() As System.IO.TextWriter""
   IL_0025:  ldloc.0
-  IL_0026:  ldstr      "testKey1"
-  IL_002b:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).ContainsKey(String) As Boolean"
-  IL_0030:  callvirt   "Sub System.IO.TextWriter.WriteLine(Boolean)"
-  IL_0035:  call       "Function System.Console.get_Out() As System.IO.TextWriter"
+  IL_0026:  ldstr      ""testKey1""
+  IL_002b:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).ContainsKey(String) As Boolean""
+  IL_0030:  callvirt   ""Sub System.IO.TextWriter.WriteLine(Boolean)""
+  IL_0035:  call       ""Function System.Console.get_Out() As System.IO.TextWriter""
   IL_003a:  ldloc.0
-  IL_003b:  ldstr      "testKey1"
-  IL_0040:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).get_Item(String) As Object"
-  IL_0045:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_004a:  callvirt   "Sub System.IO.TextWriter.WriteLine(Object)"
+  IL_003b:  ldstr      ""testKey1""
+  IL_0040:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).get_Item(String) As Object""
+  IL_0045:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_004a:  callvirt   ""Sub System.IO.TextWriter.WriteLine(Object)""
   IL_004f:  ldloc.0
-  IL_0050:  ldstr      "testKey2"
-  IL_0055:  ldstr      "testValue2"
-  IL_005a:  callvirt   "Sub System.Collections.Generic.IDictionary(Of String, Object).Add(String, Object)"
+  IL_0050:  ldstr      ""testKey2""
+  IL_0055:  ldstr      ""testValue2""
+  IL_005a:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of String, Object).Add(String, Object)""
   IL_005f:  ldnull
   IL_0060:  stloc.1
   IL_0061:  ldloc.0
-  IL_0062:  ldstr      "testKey2"
+  IL_0062:  ldstr      ""testKey2""
   IL_0067:  ldloca.s   V_1
-  IL_0069:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).TryGetValue(String, ByRef Object) As Boolean"
+  IL_0069:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).TryGetValue(String, ByRef Object) As Boolean""
   IL_006e:  pop
-  IL_006f:  call       "Function System.Console.get_Out() As System.IO.TextWriter"
+  IL_006f:  call       ""Function System.Console.get_Out() As System.IO.TextWriter""
   IL_0074:  ldloc.1
-  IL_0075:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
-  IL_007a:  callvirt   "Sub System.IO.TextWriter.WriteLine(Object)"
+  IL_0075:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
+  IL_007a:  callvirt   ""Sub System.IO.TextWriter.WriteLine(Object)""
   IL_007f:  ldloc.0
-  IL_0080:  ldstr      "testKey2"
-  IL_0085:  ldstr      "testValue3"
-  IL_008a:  callvirt   "Sub System.Collections.Generic.IDictionary(Of String, Object).set_Item(String, Object)"
+  IL_0080:  ldstr      ""testKey2""
+  IL_0085:  ldstr      ""testValue3""
+  IL_008a:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of String, Object).set_Item(String, Object)""
   IL_008f:  ldloc.0
-  IL_0090:  ldstr      "testKey1"
-  IL_0095:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).Remove(String) As Boolean"
+  IL_0090:  ldstr      ""testKey1""
+  IL_0095:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).Remove(String) As Boolean""
   IL_009a:  pop
   IL_009b:  ldloc.0
-  IL_009c:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).get_Values() As System.Collections.Generic.ICollection(Of Object)"
-  IL_00a1:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Object).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Object)"
+  IL_009c:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).get_Values() As System.Collections.Generic.ICollection(Of Object)""
+  IL_00a1:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Object).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Object)""
   IL_00a6:  stloc.2
   IL_00a7:  ldloc.0
-  IL_00a8:  callvirt   "Function System.Collections.Generic.IDictionary(Of String, Object).get_Keys() As System.Collections.Generic.ICollection(Of String)"
-  IL_00ad:  callvirt   "Function System.Collections.Generic.IEnumerable(Of String).GetEnumerator() As System.Collections.Generic.IEnumerator(Of String)"
+  IL_00a8:  callvirt   ""Function System.Collections.Generic.IDictionary(Of String, Object).get_Keys() As System.Collections.Generic.ICollection(Of String)""
+  IL_00ad:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of String).GetEnumerator() As System.Collections.Generic.IEnumerator(Of String)""
   IL_00b2:  stloc.3
   IL_00b3:  br.s       IL_00d5
-  IL_00b5:  call       "Function System.Console.get_Out() As System.IO.TextWriter"
+  IL_00b5:  call       ""Function System.Console.get_Out() As System.IO.TextWriter""
   IL_00ba:  ldloc.3
-  IL_00bb:  callvirt   "Function System.Collections.Generic.IEnumerator(Of String).get_Current() As String"
+  IL_00bb:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of String).get_Current() As String""
   IL_00c0:  ldloc.2
-  IL_00c1:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Object).get_Current() As Object"
-  IL_00c6:  callvirt   "Function Object.ToString() As String"
-  IL_00cb:  call       "Function String.Concat(String, String) As String"
-  IL_00d0:  callvirt   "Sub System.IO.TextWriter.WriteLine(String)"
+  IL_00c1:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Object).get_Current() As Object""
+  IL_00c6:  callvirt   ""Function Object.ToString() As String""
+  IL_00cb:  call       ""Function String.Concat(String, String) As String""
+  IL_00d0:  callvirt   ""Sub System.IO.TextWriter.WriteLine(String)""
   IL_00d5:  ldloc.3
-  IL_00d6:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+  IL_00d6:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
   IL_00db:  ldloc.2
-  IL_00dc:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+  IL_00dc:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
   IL_00e1:  and
   IL_00e2:  brtrue.s   IL_00b5
   IL_00e4:  ret
-}]]>.Value)
+}")
         End Sub
 
         <Fact()>
@@ -513,24 +513,24 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIIterableMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIIterableMembers", "
 {
   // Code size       41 (0x29)
   .maxstack  2
-  IL_0000:  ldstr      "===  IIterableFloat  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IIterableFloat..ctor()"
+  IL_0000:  ldstr      ""===  IIterableFloat  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IIterableFloat..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.IIterableFloat.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.IIterableFloat.ClearFlag()""
   IL_0015:  dup
-  IL_0016:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Single).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Single)"
+  IL_0016:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Single).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Single)""
   IL_001b:  pop
-  IL_001c:  callvirt   "Function Windows.Languages.WinRTTest.IIterableFloat.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_001c:  callvirt   ""Function Windows.Languages.WinRTTest.IIterableFloat.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0021:  ldc.i4.1
-  IL_0022:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0022:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0027:  pop
   IL_0028:  ret
-}]]>.Value)
+}")
         End Sub
 
         <Fact()>
@@ -1586,7 +1586,7 @@ End Class
             Dim verifier = CompileAndVerify(source,
                 additionalRefs:=LegacyRefs,
                 verify:=False)
-            verifier.VerifyIL("AllMembers.TestIMapIntIntMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIMapIntIntMembers", "
 {
   // Code size      756 (0x2f4)
   .maxstack  4
@@ -1598,295 +1598,295 @@ End Class
   Integer V_5, //count
   Boolean V_6, //isReadOnly
   Boolean V_7) //rez
-  IL_0000:  ldstr      "===  IMapIntInt  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()"
+  IL_0000:  ldstr      ""===  IMapIntInt  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0015:  dup
   IL_0016:  ldc.i4.1
   IL_0017:  ldc.i4.2
-  IL_0018:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_0018:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_001d:  dup
-  IL_001e:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_001e:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0023:  ldc.i4.s   21
-  IL_0025:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0025:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_002a:  pop
   IL_002b:  dup
-  IL_002c:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_0031:  box        "Integer"
+  IL_002c:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_0031:  box        ""Integer""
   IL_0036:  ldc.i4.1
-  IL_0037:  box        "Integer"
-  IL_003c:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0037:  box        ""Integer""
+  IL_003c:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0041:  pop
   IL_0042:  dup
-  IL_0043:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_0043:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0048:  dup
   IL_0049:  ldc.i4.1
-  IL_004a:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).ContainsKey(Integer) As Boolean"
+  IL_004a:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).ContainsKey(Integer) As Boolean""
   IL_004f:  pop
   IL_0050:  dup
-  IL_0051:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0051:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0056:  ldc.i4.s   19
-  IL_0058:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0058:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_005d:  pop
   IL_005e:  dup
-  IL_005f:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_005f:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0064:  dup
   IL_0065:  ldc.i4.1
-  IL_0066:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Item(Integer) As Integer"
+  IL_0066:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Item(Integer) As Integer""
   IL_006b:  stloc.0
   IL_006c:  dup
-  IL_006d:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_006d:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0072:  ldc.i4.s   17
-  IL_0074:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0074:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0079:  pop
   IL_007a:  ldloc.0
-  IL_007b:  box        "Integer"
+  IL_007b:  box        ""Integer""
   IL_0080:  ldc.i4.2
-  IL_0081:  box        "Integer"
-  IL_0086:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0081:  box        ""Integer""
+  IL_0086:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_008b:  pop
   IL_008c:  dup
-  IL_008d:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_008d:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0092:  dup
-  IL_0093:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Keys() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_0093:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Keys() As System.Collections.Generic.ICollection(Of Integer)""
   IL_0098:  pop
   IL_0099:  dup
-  IL_009a:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_009a:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_009f:  ldc.i4.0
-  IL_00a0:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00a0:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00a5:  pop
   IL_00a6:  dup
-  IL_00a7:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_00a7:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_00ac:  dup
-  IL_00ad:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Values() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_00ad:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Values() As System.Collections.Generic.ICollection(Of Integer)""
   IL_00b2:  pop
   IL_00b3:  dup
-  IL_00b4:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00b4:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00b9:  ldc.i4.0
-  IL_00ba:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00ba:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00bf:  pop
   IL_00c0:  dup
-  IL_00c1:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_00c1:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_00c6:  dup
   IL_00c7:  ldc.i4.1
   IL_00c8:  ldloca.s   V_1
-  IL_00ca:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).TryGetValue(Integer, ByRef Integer) As Boolean"
+  IL_00ca:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).TryGetValue(Integer, ByRef Integer) As Boolean""
   IL_00cf:  stloc.2
   IL_00d0:  dup
-  IL_00d1:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00d1:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00d6:  ldc.i4.s   17
-  IL_00d8:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00d8:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00dd:  pop
   IL_00de:  ldloc.1
-  IL_00df:  box        "Integer"
+  IL_00df:  box        ""Integer""
   IL_00e4:  ldc.i4.2
-  IL_00e5:  box        "Integer"
-  IL_00ea:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00e5:  box        ""Integer""
+  IL_00ea:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00ef:  pop
   IL_00f0:  ldloc.2
-  IL_00f1:  box        "Boolean"
+  IL_00f1:  box        ""Boolean""
   IL_00f6:  ldc.i4.1
-  IL_00f7:  box        "Boolean"
-  IL_00fc:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00f7:  box        ""Boolean""
+  IL_00fc:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0101:  pop
   IL_0102:  dup
-  IL_0103:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_0103:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0108:  dup
   IL_0109:  ldc.i4.3
   IL_010a:  ldc.i4.4
-  IL_010b:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0110:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Integer))"
+  IL_010b:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0110:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Integer))""
   IL_0115:  dup
-  IL_0116:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0116:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_011b:  ldc.i4.s   21
-  IL_011d:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_011d:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0122:  pop
   IL_0123:  dup
-  IL_0124:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_0129:  box        "Integer"
+  IL_0124:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_0129:  box        ""Integer""
   IL_012e:  ldc.i4.2
-  IL_012f:  box        "Integer"
-  IL_0134:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_012f:  box        ""Integer""
+  IL_0134:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0139:  pop
   IL_013a:  dup
-  IL_013b:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_013b:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0140:  dup
   IL_0141:  ldc.i4.3
   IL_0142:  ldc.i4.4
-  IL_0143:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0148:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0143:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0148:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_014d:  stloc.3
   IL_014e:  dup
-  IL_014f:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_014f:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0154:  ldc.i4.s   17
-  IL_0156:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0156:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_015b:  pop
   IL_015c:  ldloc.3
-  IL_015d:  box        "Boolean"
+  IL_015d:  box        ""Boolean""
   IL_0162:  ldc.i4.1
-  IL_0163:  box        "Boolean"
-  IL_0168:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0163:  box        ""Boolean""
+  IL_0168:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_016d:  pop
   IL_016e:  dup
-  IL_016f:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_016f:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0174:  dup
   IL_0175:  ldc.i4.8
   IL_0176:  ldc.i4.s   9
-  IL_0178:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_017d:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0178:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_017d:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_0182:  stloc.3
   IL_0183:  dup
-  IL_0184:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0184:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0189:  ldc.i4.s   19
-  IL_018b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_018b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0190:  pop
   IL_0191:  ldloc.3
-  IL_0192:  box        "Boolean"
+  IL_0192:  box        ""Boolean""
   IL_0197:  ldc.i4.0
-  IL_0198:  box        "Boolean"
-  IL_019d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0198:  box        ""Boolean""
+  IL_019d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01a2:  pop
   IL_01a3:  dup
-  IL_01a4:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_01a4:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_01a9:  dup
   IL_01aa:  ldc.i4.1
-  IL_01ab:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).Remove(Integer) As Boolean"
+  IL_01ab:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).Remove(Integer) As Boolean""
   IL_01b0:  stloc.s    V_4
   IL_01b2:  dup
-  IL_01b3:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01b3:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01b8:  ldc.i4.s   22
-  IL_01ba:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01ba:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01bf:  pop
   IL_01c0:  dup
-  IL_01c1:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_01c6:  box        "Integer"
+  IL_01c1:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_01c6:  box        ""Integer""
   IL_01cb:  ldc.i4.1
-  IL_01cc:  box        "Integer"
-  IL_01d1:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01cc:  box        ""Integer""
+  IL_01d1:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01d6:  pop
   IL_01d7:  ldloc.s    V_4
-  IL_01d9:  box        "Boolean"
+  IL_01d9:  box        ""Boolean""
   IL_01de:  ldc.i4.1
-  IL_01df:  box        "Boolean"
-  IL_01e4:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01df:  box        ""Boolean""
+  IL_01e4:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01e9:  pop
   IL_01ea:  dup
-  IL_01eb:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_01eb:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_01f0:  dup
-  IL_01f1:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
+  IL_01f1:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
   IL_01f6:  stloc.s    V_5
   IL_01f8:  dup
-  IL_01f9:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01f9:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01fe:  ldc.i4.s   18
-  IL_0200:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0200:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0205:  pop
   IL_0206:  ldloc.s    V_5
-  IL_0208:  box        "Integer"
+  IL_0208:  box        ""Integer""
   IL_020d:  ldc.i4.1
-  IL_020e:  box        "Integer"
-  IL_0213:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_020e:  box        ""Integer""
+  IL_0213:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0218:  pop
   IL_0219:  dup
-  IL_021a:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_021a:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_021f:  dup
-  IL_0220:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_IsReadOnly() As Boolean"
+  IL_0220:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_IsReadOnly() As Boolean""
   IL_0225:  stloc.s    V_6
   IL_0227:  dup
-  IL_0228:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0228:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_022d:  ldc.i4.0
-  IL_022e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_022e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0233:  pop
   IL_0234:  ldloc.s    V_6
-  IL_0236:  box        "Boolean"
+  IL_0236:  box        ""Boolean""
   IL_023b:  ldc.i4.0
-  IL_023c:  box        "Boolean"
-  IL_0241:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_023c:  box        ""Boolean""
+  IL_0241:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0246:  pop
   IL_0247:  dup
-  IL_0248:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_0248:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_024d:  dup
   IL_024e:  ldc.i4.3
   IL_024f:  ldc.i4.4
-  IL_0250:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0255:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0250:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0255:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_025a:  stloc.s    V_7
   IL_025c:  dup
-  IL_025d:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_025d:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0262:  ldc.i4.s   22
-  IL_0264:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0264:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0269:  pop
   IL_026a:  ldloc.s    V_7
-  IL_026c:  box        "Boolean"
+  IL_026c:  box        ""Boolean""
   IL_0271:  ldc.i4.1
-  IL_0272:  box        "Boolean"
-  IL_0277:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0272:  box        ""Boolean""
+  IL_0277:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_027c:  pop
   IL_027d:  dup
-  IL_027e:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_027e:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0283:  dup
   IL_0284:  ldc.i4.2
   IL_0285:  ldc.i4.3
-  IL_0286:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_028b:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0286:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_028b:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_0290:  stloc.s    V_7
   IL_0292:  dup
-  IL_0293:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0293:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0298:  ldc.i4.s   19
-  IL_029a:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_029a:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_029f:  pop
   IL_02a0:  ldloc.s    V_7
-  IL_02a2:  box        "Boolean"
+  IL_02a2:  box        ""Boolean""
   IL_02a7:  ldc.i4.0
-  IL_02a8:  box        "Boolean"
-  IL_02ad:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02a8:  box        ""Boolean""
+  IL_02ad:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02b2:  pop
   IL_02b3:  dup
   IL_02b4:  ldc.i4.1
   IL_02b5:  ldc.i4.2
-  IL_02b6:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_02b6:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_02bb:  dup
   IL_02bc:  ldc.i4.2
   IL_02bd:  ldc.i4.3
-  IL_02be:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_02be:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_02c3:  dup
-  IL_02c4:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_02c4:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_02c9:  dup
-  IL_02ca:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Clear()"
+  IL_02ca:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Clear()""
   IL_02cf:  dup
-  IL_02d0:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02d0:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02d5:  ldc.i4.s   23
-  IL_02d7:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02d7:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02dc:  pop
-  IL_02dd:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_02e2:  box        "Integer"
+  IL_02dd:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_02e2:  box        ""Integer""
   IL_02e7:  ldc.i4.0
-  IL_02e8:  box        "Integer"
-  IL_02ed:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02e8:  box        ""Integer""
+  IL_02ed:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02f2:  pop
   IL_02f3:  ret
 }
-]]>.Value)
+")
 
-            verifier.VerifyIL("AllMembers.TestIMapViewMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIMapViewMembers", "
 {
   // Code size       32 (0x20)
   .maxstack  2
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IMapViewIntInt..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IMapViewIntInt..ctor()""
   IL_0005:  dup
-  IL_0006:  callvirt   "Sub Windows.Languages.WinRTTest.IMapViewIntInt.ClearFlag()"
+  IL_0006:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapViewIntInt.ClearFlag()""
   IL_000b:  dup
-  IL_000c:  callvirt   "Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
+  IL_000c:  callvirt   ""Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
   IL_0011:  pop
-  IL_0012:  callvirt   "Function Windows.Languages.WinRTTest.IMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0012:  callvirt   ""Function Windows.Languages.WinRTTest.IMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0017:  ldc.i4.s   18
-  IL_0019:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0019:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_001e:  pop
   IL_001f:  ret
 }
-]]>.Value)
-            verifier.VerifyIL("AllMembers.TestIMapIntIMapViewIntStructMembers", <![CDATA[
+")
+            verifier.VerifyIL("AllMembers.TestIMapIntIMapViewIntStructMembers", "
 {
   // Code size      790 (0x316)
   .maxstack  5
@@ -1900,283 +1900,283 @@ End Class
   Boolean V_7, //isReadOnly
   Boolean V_8, //rez
   Windows.Languages.WinRTTest.UserDefinedStruct V_9)
-  IL_0000:  ldstr      "===  IMapIMapViewIntStruct  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct..ctor()"
+  IL_0000:  ldstr      ""===  IMapIMapViewIntStruct  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct..ctor()""
   IL_000f:  ldloca.s   V_9
-  IL_0011:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0011:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_0017:  ldloca.s   V_9
   IL_0019:  ldc.i4.s   10
-  IL_001b:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_001b:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_0020:  ldloc.s    V_9
   IL_0022:  stloc.0
   IL_0023:  dup
-  IL_0024:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_0024:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0029:  dup
   IL_002a:  ldc.i4.1
   IL_002b:  ldloc.0
-  IL_002c:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_002c:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_0031:  dup
-  IL_0032:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0032:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0037:  ldc.i4.s   21
-  IL_0039:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0039:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_003e:  pop
   IL_003f:  dup
-  IL_0040:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_0045:  box        "Integer"
+  IL_0040:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_0045:  box        ""Integer""
   IL_004a:  ldc.i4.1
-  IL_004b:  box        "Integer"
-  IL_0050:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_004b:  box        ""Integer""
+  IL_0050:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0055:  pop
   IL_0056:  dup
-  IL_0057:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_0057:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_005c:  dup
   IL_005d:  ldc.i4.1
-  IL_005e:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).ContainsKey(Integer) As Boolean"
+  IL_005e:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).ContainsKey(Integer) As Boolean""
   IL_0063:  pop
   IL_0064:  dup
-  IL_0065:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0065:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_006a:  ldc.i4.s   19
-  IL_006c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_006c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0071:  pop
   IL_0072:  dup
-  IL_0073:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_0073:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0078:  dup
   IL_0079:  ldc.i4.1
-  IL_007a:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_007a:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_007f:  stloc.1
   IL_0080:  dup
-  IL_0081:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0081:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0086:  ldc.i4.s   17
-  IL_0088:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0088:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_008d:  pop
   IL_008e:  ldloc.1
-  IL_008f:  ldfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
-  IL_0094:  box        "UInteger"
+  IL_008f:  ldfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
+  IL_0094:  box        ""UInteger""
   IL_0099:  ldc.i4.s   10
-  IL_009b:  box        "Integer"
-  IL_00a0:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_009b:  box        ""Integer""
+  IL_00a0:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00a5:  pop
   IL_00a6:  dup
-  IL_00a7:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_00a7:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_00ac:  dup
-  IL_00ad:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Keys() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_00ad:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Keys() As System.Collections.Generic.ICollection(Of Integer)""
   IL_00b2:  pop
   IL_00b3:  dup
-  IL_00b4:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00b4:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00b9:  ldc.i4.0
-  IL_00ba:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00ba:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00bf:  pop
   IL_00c0:  dup
-  IL_00c1:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_00c1:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_00c6:  dup
-  IL_00c7:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Values() As System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_00c7:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Values() As System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_00cc:  pop
   IL_00cd:  dup
-  IL_00ce:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00ce:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00d3:  ldc.i4.0
-  IL_00d4:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00d4:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00d9:  pop
   IL_00da:  dup
-  IL_00db:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_00db:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_00e0:  dup
   IL_00e1:  ldc.i4.1
   IL_00e2:  ldloca.s   V_2
-  IL_00e4:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).TryGetValue(Integer, ByRef Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean"
+  IL_00e4:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).TryGetValue(Integer, ByRef Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean""
   IL_00e9:  stloc.3
   IL_00ea:  dup
-  IL_00eb:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00eb:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00f0:  ldc.i4.s   17
-  IL_00f2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00f2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00f7:  pop
   IL_00f8:  ldloc.3
-  IL_00f9:  box        "Boolean"
+  IL_00f9:  box        ""Boolean""
   IL_00fe:  ldc.i4.1
-  IL_00ff:  box        "Boolean"
-  IL_0104:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00ff:  box        ""Boolean""
+  IL_0104:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0109:  pop
   IL_010a:  dup
-  IL_010b:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_010b:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0110:  dup
   IL_0111:  ldc.i4.3
   IL_0112:  ldloca.s   V_9
-  IL_0114:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0114:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_011a:  ldloca.s   V_9
   IL_011c:  ldc.i4.4
-  IL_011d:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_011d:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_0122:  ldloc.s    V_9
-  IL_0124:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_0129:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))"
+  IL_0124:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_0129:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))""
   IL_012e:  dup
-  IL_012f:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_012f:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0134:  ldc.i4.s   21
-  IL_0136:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0136:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_013b:  pop
   IL_013c:  dup
-  IL_013d:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_0142:  box        "Integer"
+  IL_013d:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_0142:  box        ""Integer""
   IL_0147:  ldc.i4.2
-  IL_0148:  box        "Integer"
-  IL_014d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0148:  box        ""Integer""
+  IL_014d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0152:  pop
   IL_0153:  dup
-  IL_0154:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_0154:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0159:  dup
   IL_015a:  ldc.i4.1
   IL_015b:  ldloc.0
-  IL_015c:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_0161:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_015c:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_0161:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_0166:  stloc.s    V_4
   IL_0168:  dup
-  IL_0169:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0169:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_016e:  ldc.i4.s   17
-  IL_0170:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0170:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0175:  pop
   IL_0176:  ldloc.s    V_4
-  IL_0178:  box        "Boolean"
+  IL_0178:  box        ""Boolean""
   IL_017d:  ldc.i4.1
-  IL_017e:  box        "Boolean"
-  IL_0183:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_017e:  box        ""Boolean""
+  IL_0183:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0188:  pop
   IL_0189:  dup
-  IL_018a:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_018a:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_018f:  dup
   IL_0190:  ldc.i4.8
   IL_0191:  ldloca.s   V_9
-  IL_0193:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0193:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_0199:  ldloc.s    V_9
-  IL_019b:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_01a0:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_019b:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_01a0:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_01a5:  stloc.s    V_4
   IL_01a7:  dup
-  IL_01a8:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01a8:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01ad:  ldc.i4.s   19
-  IL_01af:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01af:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01b4:  pop
   IL_01b5:  ldloc.s    V_4
-  IL_01b7:  box        "Boolean"
+  IL_01b7:  box        ""Boolean""
   IL_01bc:  ldc.i4.0
-  IL_01bd:  box        "Boolean"
-  IL_01c2:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01bd:  box        ""Boolean""
+  IL_01c2:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01c7:  pop
   IL_01c8:  dup
-  IL_01c9:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_01c9:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_01ce:  dup
   IL_01cf:  ldc.i4.3
-  IL_01d0:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Remove(Integer) As Boolean"
+  IL_01d0:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Remove(Integer) As Boolean""
   IL_01d5:  stloc.s    V_5
   IL_01d7:  dup
-  IL_01d8:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01d8:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01dd:  ldc.i4.s   22
-  IL_01df:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01df:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01e4:  pop
   IL_01e5:  dup
-  IL_01e6:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_01eb:  box        "Integer"
+  IL_01e6:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_01eb:  box        ""Integer""
   IL_01f0:  ldc.i4.1
-  IL_01f1:  box        "Integer"
-  IL_01f6:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01f1:  box        ""Integer""
+  IL_01f6:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01fb:  pop
   IL_01fc:  ldloc.s    V_5
-  IL_01fe:  box        "Boolean"
+  IL_01fe:  box        ""Boolean""
   IL_0203:  ldc.i4.1
-  IL_0204:  box        "Boolean"
-  IL_0209:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0204:  box        ""Boolean""
+  IL_0209:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_020e:  pop
   IL_020f:  dup
-  IL_0210:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_0210:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0215:  dup
-  IL_0216:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
+  IL_0216:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
   IL_021b:  stloc.s    V_6
   IL_021d:  dup
-  IL_021e:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_021e:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0223:  ldc.i4.s   18
-  IL_0225:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0225:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_022a:  pop
   IL_022b:  ldloc.s    V_6
-  IL_022d:  box        "Integer"
+  IL_022d:  box        ""Integer""
   IL_0232:  ldc.i4.1
-  IL_0233:  box        "Integer"
-  IL_0238:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0233:  box        ""Integer""
+  IL_0238:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_023d:  pop
   IL_023e:  dup
-  IL_023f:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_023f:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0244:  dup
-  IL_0245:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_IsReadOnly() As Boolean"
+  IL_0245:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_IsReadOnly() As Boolean""
   IL_024a:  stloc.s    V_7
   IL_024c:  dup
-  IL_024d:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_024d:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0252:  ldc.i4.0
-  IL_0253:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0253:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0258:  pop
   IL_0259:  ldloc.s    V_7
-  IL_025b:  box        "Boolean"
+  IL_025b:  box        ""Boolean""
   IL_0260:  ldc.i4.0
-  IL_0261:  box        "Boolean"
-  IL_0266:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0261:  box        ""Boolean""
+  IL_0266:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_026b:  pop
   IL_026c:  dup
-  IL_026d:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_026d:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0272:  dup
   IL_0273:  ldc.i4.1
   IL_0274:  ldloc.0
-  IL_0275:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_027a:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_0275:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_027a:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_027f:  stloc.s    V_8
   IL_0281:  dup
-  IL_0282:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0282:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0287:  ldc.i4.s   22
-  IL_0289:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0289:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_028e:  pop
   IL_028f:  ldloc.s    V_8
-  IL_0291:  box        "Boolean"
+  IL_0291:  box        ""Boolean""
   IL_0296:  ldc.i4.1
-  IL_0297:  box        "Boolean"
-  IL_029c:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0297:  box        ""Boolean""
+  IL_029c:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02a1:  pop
   IL_02a2:  dup
-  IL_02a3:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_02a8:  box        "Integer"
+  IL_02a3:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_02a8:  box        ""Integer""
   IL_02ad:  ldc.i4.0
-  IL_02ae:  box        "Integer"
-  IL_02b3:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02ae:  box        ""Integer""
+  IL_02b3:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02b8:  pop
   IL_02b9:  dup
   IL_02ba:  ldc.i4.1
   IL_02bb:  ldloc.0
-  IL_02bc:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_02bc:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_02c1:  dup
   IL_02c2:  ldc.i4.2
   IL_02c3:  ldloc.0
-  IL_02c4:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_02c4:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_02c9:  dup
-  IL_02ca:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_02ca:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_02cf:  dup
-  IL_02d0:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Clear()"
+  IL_02d0:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Clear()""
   IL_02d5:  dup
-  IL_02d6:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02d6:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02db:  ldc.i4.s   23
-  IL_02dd:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02dd:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02e2:  pop
   IL_02e3:  dup
-  IL_02e4:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_02e9:  box        "Integer"
+  IL_02e4:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_02e9:  box        ""Integer""
   IL_02ee:  ldc.i4.0
-  IL_02ef:  box        "Integer"
-  IL_02f4:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02ef:  box        ""Integer""
+  IL_02f4:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02f9:  pop
   IL_02fa:  dup
-  IL_02fb:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()"
+  IL_02fb:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct.ClearFlag()""
   IL_0300:  dup
-  IL_0301:  callvirt   "Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
+  IL_0301:  callvirt   ""Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
   IL_0306:  stloc.s    V_6
-  IL_0308:  callvirt   "Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0308:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_030d:  ldc.i4.s   18
-  IL_030f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_030f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0314:  pop
   IL_0315:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -2495,7 +2495,7 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIVectorIntIVectorViewIntIMapIntIntIMapViewIntIntMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIVectorIntIVectorViewIntIMapIntIntIMapViewIntIntMembers", "
 {
   // Code size     1496 (0x5d8)
   .maxstack  4
@@ -2511,105 +2511,105 @@ End Class
                 Boolean V_9, //remove
                 Boolean V_10, //rez2
                 System.Collections.Generic.IEnumerator(Of Integer) V_11)
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0007:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_000e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0013:  ldloc.0
-  IL_0014:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0014:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0019:  ldc.i4.s   9
-  IL_001b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_001b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0020:  pop
   IL_0021:  ldloc.0
   IL_0022:  ldc.i4.0
-  IL_0023:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_0028:  box        "Integer"
+  IL_0023:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_0028:  box        ""Integer""
   IL_002d:  ldc.i4.1
-  IL_002e:  box        "Integer"
-  IL_0033:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_002e:  box        ""Integer""
+  IL_0033:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0038:  pop
   IL_0039:  ldloc.0
-  IL_003a:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_003a:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_003f:  ldloc.0
   IL_0040:  ldc.i4.1
-  IL_0041:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean"
+  IL_0041:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean""
   IL_0046:  ldloc.0
-  IL_0047:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0047:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_004c:  ldc.i4.5
-  IL_004d:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004d:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0052:  pop
-  IL_0053:  box        "Boolean"
+  IL_0053:  box        ""Boolean""
   IL_0058:  ldc.i4.1
-  IL_0059:  box        "Boolean"
-  IL_005e:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0059:  box        ""Boolean""
+  IL_005e:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0063:  pop
   IL_0064:  ldloc.0
-  IL_0065:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0065:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_006a:  ldc.i4.0
-  IL_006b:  newarr     "Integer"
+  IL_006b:  newarr     ""Integer""
   IL_0070:  stloc.1
   IL_0071:  ldloc.0
   IL_0072:  ldloc.1
   IL_0073:  ldc.i4.0
-  IL_0074:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)"
+  IL_0074:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)""
   IL_0079:  ldloc.0
-  IL_007a:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_007a:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_007f:  ldc.i4.2
-  IL_0080:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0080:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0085:  pop
   IL_0086:  ldloc.1
   IL_0087:  ldc.i4.0
   IL_0088:  ldelem.i4
-  IL_0089:  box        "Integer"
+  IL_0089:  box        ""Integer""
   IL_008e:  ldc.i4.1
-  IL_008f:  box        "Integer"
-  IL_0094:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_008f:  box        ""Integer""
+  IL_0094:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0099:  pop
   IL_009a:  ldloc.1
   IL_009b:  ldc.i4.1
   IL_009c:  ldelem.i4
-  IL_009d:  box        "Integer"
+  IL_009d:  box        ""Integer""
   IL_00a2:  ldc.i4.0
-  IL_00a3:  box        "Integer"
-  IL_00a8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00a3:  box        ""Integer""
+  IL_00a8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00ad:  pop
   IL_00ae:  ldloc.0
-  IL_00af:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_00af:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_00b4:  ldloc.0
-  IL_00b5:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
+  IL_00b5:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
   IL_00ba:  stloc.2
   IL_00bb:  ldloc.0
-  IL_00bc:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+  IL_00bc:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)""
   IL_00c1:  pop
   IL_00c2:  ldloc.0
-  IL_00c3:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00c3:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00c8:  ldc.i4.1
-  IL_00c9:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00c9:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00ce:  pop
   IL_00cf:  ldc.i4.0
   IL_00d0:  stloc.3
   .try
   {
     IL_00d1:  ldloc.0
-    IL_00d2:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+    IL_00d2:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)""
     IL_00d7:  stloc.s    V_11
     IL_00d9:  br.s       IL_00f7
     IL_00db:  ldloc.s    V_11
-    IL_00dd:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer"
+    IL_00dd:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer""
     IL_00e2:  ldloc.3
     IL_00e3:  ldc.i4.1
     IL_00e4:  add.ovf
     IL_00e5:  stloc.3
-    IL_00e6:  box        "Integer"
+    IL_00e6:  box        ""Integer""
     IL_00eb:  ldloc.3
-    IL_00ec:  box        "Integer"
-    IL_00f1:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+    IL_00ec:  box        ""Integer""
+    IL_00f1:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
     IL_00f6:  pop
     IL_00f7:  ldloc.s    V_11
-    IL_00f9:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+    IL_00f9:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
     IL_00fe:  brtrue.s   IL_00db
     IL_0100:  leave.s    IL_010e
   }
@@ -2618,449 +2618,449 @@ End Class
     IL_0102:  ldloc.s    V_11
     IL_0104:  brfalse.s  IL_010d
     IL_0106:  ldloc.s    V_11
-    IL_0108:  callvirt   "Sub System.IDisposable.Dispose()"
+    IL_0108:  callvirt   ""Sub System.IDisposable.Dispose()""
     IL_010d:  endfinally
   }
   IL_010e:  ldloc.3
-  IL_010f:  box        "Integer"
+  IL_010f:  box        ""Integer""
   IL_0114:  ldc.i4.1
-  IL_0115:  box        "Integer"
-  IL_011a:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0115:  box        ""Integer""
+  IL_011a:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_011f:  pop
   IL_0120:  ldloc.0
-  IL_0121:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0121:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0126:  ldloc.0
   IL_0127:  ldc.i4.1
-  IL_0128:  callvirt   "Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer"
+  IL_0128:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer""
   IL_012d:  ldloc.0
-  IL_012e:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_012e:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0133:  ldc.i4.5
-  IL_0134:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0134:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0139:  pop
-  IL_013a:  box        "Integer"
+  IL_013a:  box        ""Integer""
   IL_013f:  ldc.i4.0
-  IL_0140:  box        "Integer"
-  IL_0145:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0140:  box        ""Integer""
+  IL_0145:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_014a:  pop
   IL_014b:  ldloc.0
-  IL_014c:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_014c:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0151:  ldloc.0
   IL_0152:  ldc.i4.1
   IL_0153:  ldc.i4.2
-  IL_0154:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)"
+  IL_0154:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)""
   IL_0159:  ldloc.0
-  IL_015a:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_015a:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_015f:  ldc.i4.7
-  IL_0160:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0160:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0165:  pop
   IL_0166:  ldloc.0
   IL_0167:  ldc.i4.1
-  IL_0168:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_016d:  box        "Integer"
+  IL_0168:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_016d:  box        ""Integer""
   IL_0172:  ldc.i4.2
-  IL_0173:  box        "Integer"
-  IL_0178:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0173:  box        ""Integer""
+  IL_0178:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_017d:  pop
   IL_017e:  ldloc.0
-  IL_017f:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_017f:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0184:  ldloc.0
-  IL_0185:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean"
+  IL_0185:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean""
   IL_018a:  stloc.s    V_4
   IL_018c:  ldloc.0
-  IL_018d:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_018d:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0192:  ldc.i4.0
-  IL_0193:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0193:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0198:  pop
   IL_0199:  ldloc.s    V_4
-  IL_019b:  box        "Boolean"
+  IL_019b:  box        ""Boolean""
   IL_01a0:  ldc.i4.0
-  IL_01a1:  box        "Boolean"
-  IL_01a6:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01a1:  box        ""Boolean""
+  IL_01a6:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01ab:  pop
   IL_01ac:  ldloc.0
-  IL_01ad:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_01ad:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_01b2:  ldloc.0
   IL_01b3:  ldc.i4.0
-  IL_01b4:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_01b9:  call       "Function System.Convert.ToUInt32(Integer) As UInteger"
+  IL_01b4:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_01b9:  call       ""Function System.Convert.ToUInt32(Integer) As UInteger""
   IL_01be:  conv.ovf.i4.un
   IL_01bf:  stloc.s    V_5
   IL_01c1:  ldloc.0
-  IL_01c2:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01c2:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01c7:  ldc.i4.2
-  IL_01c8:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01c8:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01cd:  pop
   IL_01ce:  ldloc.s    V_5
-  IL_01d0:  box        "Integer"
+  IL_01d0:  box        ""Integer""
   IL_01d5:  ldc.i4.1
-  IL_01d6:  box        "Integer"
-  IL_01db:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01d6:  box        ""Integer""
+  IL_01db:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01e0:  pop
   IL_01e1:  ldloc.0
-  IL_01e2:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_01e2:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_01e7:  ldloc.0
   IL_01e8:  ldc.i4.1
-  IL_01e9:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
+  IL_01e9:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
   IL_01ee:  stloc.s    V_5
   IL_01f0:  ldloc.0
-  IL_01f1:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01f1:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01f6:  ldc.i4.2
-  IL_01f7:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01f7:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01fc:  pop
   IL_01fd:  ldloc.s    V_5
-  IL_01ff:  box        "Integer"
+  IL_01ff:  box        ""Integer""
   IL_0204:  ldc.i4.2
-  IL_0205:  box        "Integer"
-  IL_020a:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0205:  box        ""Integer""
+  IL_020a:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_020f:  pop
   IL_0210:  ldloc.0
-  IL_0211:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0211:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0216:  ldloc.0
   IL_0217:  ldc.i4.1
-  IL_0218:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean"
+  IL_0218:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean""
   IL_021d:  pop
   IL_021e:  ldloc.0
-  IL_021f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_021f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0224:  ldc.i4.8
-  IL_0225:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0225:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_022a:  pop
   IL_022b:  ldloc.0
-  IL_022c:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_0231:  box        "Integer"
+  IL_022c:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_0231:  box        ""Integer""
   IL_0236:  ldc.i4.1
-  IL_0237:  box        "Integer"
-  IL_023c:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0237:  box        ""Integer""
+  IL_023c:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0241:  pop
   IL_0242:  ldloc.0
-  IL_0243:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0243:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0248:  ldloc.0
   IL_0249:  ldc.i4.0
-  IL_024a:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)"
+  IL_024a:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)""
   IL_024f:  ldloc.0
-  IL_0250:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0250:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0255:  ldc.i4.8
-  IL_0256:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0256:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_025b:  pop
   IL_025c:  ldloc.0
-  IL_025d:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_0262:  box        "Integer"
+  IL_025d:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_0262:  box        ""Integer""
   IL_0267:  ldc.i4.0
-  IL_0268:  box        "Integer"
-  IL_026d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0268:  box        ""Integer""
+  IL_026d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0272:  pop
   IL_0273:  ldloc.0
   IL_0274:  ldc.i4.1
-  IL_0275:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0275:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_027a:  ldloc.0
   IL_027b:  ldc.i4.2
-  IL_027c:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_027c:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0281:  ldloc.0
-  IL_0282:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0282:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0287:  ldloc.0
-  IL_0288:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Clear()"
+  IL_0288:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Clear()""
   IL_028d:  ldloc.0
-  IL_028e:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_028e:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0293:  ldc.i4.s   11
-  IL_0295:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0295:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_029a:  pop
   IL_029b:  ldloc.0
-  IL_029c:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_02a1:  box        "Integer"
+  IL_029c:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_02a1:  box        ""Integer""
   IL_02a6:  ldc.i4.0
-  IL_02a7:  box        "Integer"
-  IL_02ac:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02a7:  box        ""Integer""
+  IL_02ac:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02b1:  pop
   IL_02b2:  ldloc.0
-  IL_02b3:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_02b3:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_02b8:  ldloc.0
-  IL_02b9:  callvirt   "Function System.Collections.Generic.IReadOnlyCollection(Of Integer).get_Count() As Integer"
+  IL_02b9:  callvirt   ""Function System.Collections.Generic.IReadOnlyCollection(Of Integer).get_Count() As Integer""
   IL_02be:  stloc.2
   IL_02bf:  ldloc.0
-  IL_02c0:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02c0:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02c5:  ldc.i4.3
-  IL_02c6:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02c6:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02cb:  pop
   IL_02cc:  ldloc.0
   IL_02cd:  dup
-  IL_02ce:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_02ce:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_02d3:  dup
   IL_02d4:  ldc.i4.1
   IL_02d5:  ldc.i4.2
-  IL_02d6:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_02d6:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_02db:  dup
-  IL_02dc:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02dc:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02e1:  ldc.i4.s   21
-  IL_02e3:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02e3:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02e8:  pop
   IL_02e9:  dup
-  IL_02ea:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_02ef:  box        "Integer"
+  IL_02ea:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_02ef:  box        ""Integer""
   IL_02f4:  ldc.i4.1
-  IL_02f5:  box        "Integer"
-  IL_02fa:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02f5:  box        ""Integer""
+  IL_02fa:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02ff:  pop
   IL_0300:  dup
-  IL_0301:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0301:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0306:  dup
   IL_0307:  ldc.i4.1
-  IL_0308:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).ContainsKey(Integer) As Boolean"
+  IL_0308:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).ContainsKey(Integer) As Boolean""
   IL_030d:  pop
   IL_030e:  dup
-  IL_030f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_030f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0314:  ldc.i4.s   19
-  IL_0316:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0316:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_031b:  pop
   IL_031c:  dup
-  IL_031d:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_031d:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0322:  dup
   IL_0323:  ldc.i4.1
-  IL_0324:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Item(Integer) As Integer"
-  IL_0329:  call       "Function System.Convert.ToInt32(Integer) As Integer"
+  IL_0324:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Item(Integer) As Integer""
+  IL_0329:  call       ""Function System.Convert.ToInt32(Integer) As Integer""
   IL_032e:  stloc.s    V_5
   IL_0330:  dup
-  IL_0331:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0331:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0336:  ldc.i4.s   17
-  IL_0338:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0338:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_033d:  pop
   IL_033e:  ldloc.s    V_5
-  IL_0340:  box        "Integer"
+  IL_0340:  box        ""Integer""
   IL_0345:  ldc.i4.2
-  IL_0346:  box        "Integer"
-  IL_034b:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0346:  box        ""Integer""
+  IL_034b:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0350:  pop
   IL_0351:  dup
-  IL_0352:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0352:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0357:  dup
-  IL_0358:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Keys() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_0358:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Keys() As System.Collections.Generic.ICollection(Of Integer)""
   IL_035d:  pop
   IL_035e:  dup
-  IL_035f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_035f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0364:  ldc.i4.0
-  IL_0365:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0365:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_036a:  pop
   IL_036b:  dup
-  IL_036c:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_036c:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0371:  dup
-  IL_0372:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Values() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_0372:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).get_Values() As System.Collections.Generic.ICollection(Of Integer)""
   IL_0377:  pop
   IL_0378:  dup
-  IL_0379:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0379:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_037e:  ldc.i4.0
-  IL_037f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_037f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0384:  pop
   IL_0385:  dup
-  IL_0386:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0386:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_038b:  dup
   IL_038c:  ldc.i4.1
   IL_038d:  ldloca.s   V_6
-  IL_038f:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).TryGetValue(Integer, ByRef Integer) As Boolean"
+  IL_038f:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).TryGetValue(Integer, ByRef Integer) As Boolean""
   IL_0394:  stloc.s    V_7
   IL_0396:  dup
-  IL_0397:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0397:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_039c:  ldc.i4.s   17
-  IL_039e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_039e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_03a3:  pop
   IL_03a4:  ldloc.s    V_6
-  IL_03a6:  box        "Integer"
+  IL_03a6:  box        ""Integer""
   IL_03ab:  ldc.i4.2
-  IL_03ac:  box        "Integer"
-  IL_03b1:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_03ac:  box        ""Integer""
+  IL_03b1:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_03b6:  pop
   IL_03b7:  ldloc.s    V_7
-  IL_03b9:  box        "Boolean"
+  IL_03b9:  box        ""Boolean""
   IL_03be:  ldc.i4.1
-  IL_03bf:  box        "Boolean"
-  IL_03c4:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_03bf:  box        ""Boolean""
+  IL_03c4:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_03c9:  pop
   IL_03ca:  dup
-  IL_03cb:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_03cb:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_03d0:  dup
   IL_03d1:  ldc.i4.3
   IL_03d2:  ldc.i4.4
-  IL_03d3:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_03d8:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Integer))"
+  IL_03d3:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_03d8:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Integer))""
   IL_03dd:  dup
-  IL_03de:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_03de:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_03e3:  ldc.i4.s   21
-  IL_03e5:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_03e5:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_03ea:  pop
   IL_03eb:  dup
-  IL_03ec:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_03f1:  box        "Integer"
+  IL_03ec:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_03f1:  box        ""Integer""
   IL_03f6:  ldc.i4.2
-  IL_03f7:  box        "Integer"
-  IL_03fc:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_03f7:  box        ""Integer""
+  IL_03fc:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0401:  pop
   IL_0402:  dup
-  IL_0403:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0403:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0408:  dup
   IL_0409:  ldc.i4.3
   IL_040a:  ldc.i4.4
-  IL_040b:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0410:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_040b:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0410:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_0415:  stloc.s    V_8
   IL_0417:  dup
-  IL_0418:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0418:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_041d:  ldc.i4.s   17
-  IL_041f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_041f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0424:  pop
   IL_0425:  ldloc.s    V_8
-  IL_0427:  box        "Boolean"
+  IL_0427:  box        ""Boolean""
   IL_042c:  ldc.i4.1
-  IL_042d:  box        "Boolean"
-  IL_0432:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_042d:  box        ""Boolean""
+  IL_0432:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0437:  pop
   IL_0438:  dup
-  IL_0439:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0439:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_043e:  dup
   IL_043f:  ldc.i4.8
   IL_0440:  ldc.i4.s   9
-  IL_0442:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0447:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0442:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0447:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_044c:  stloc.s    V_8
   IL_044e:  dup
-  IL_044f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_044f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0454:  ldc.i4.s   19
-  IL_0456:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0456:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_045b:  pop
   IL_045c:  ldloc.s    V_8
-  IL_045e:  box        "Boolean"
+  IL_045e:  box        ""Boolean""
   IL_0463:  ldc.i4.0
-  IL_0464:  box        "Boolean"
-  IL_0469:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0464:  box        ""Boolean""
+  IL_0469:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_046e:  pop
   IL_046f:  dup
-  IL_0470:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0470:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0475:  dup
   IL_0476:  ldc.i4.1
-  IL_0477:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Integer).Remove(Integer) As Boolean"
+  IL_0477:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Integer).Remove(Integer) As Boolean""
   IL_047c:  stloc.s    V_9
   IL_047e:  dup
-  IL_047f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_047f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0484:  ldc.i4.s   22
-  IL_0486:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0486:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_048b:  pop
   IL_048c:  dup
-  IL_048d:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_0492:  box        "Integer"
+  IL_048d:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_0492:  box        ""Integer""
   IL_0497:  ldc.i4.1
-  IL_0498:  box        "Integer"
-  IL_049d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0498:  box        ""Integer""
+  IL_049d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_04a2:  pop
   IL_04a3:  ldloc.s    V_9
-  IL_04a5:  box        "Boolean"
+  IL_04a5:  box        ""Boolean""
   IL_04aa:  ldc.i4.1
-  IL_04ab:  box        "Boolean"
-  IL_04b0:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_04ab:  box        ""Boolean""
+  IL_04b0:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_04b5:  pop
   IL_04b6:  dup
-  IL_04b7:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_04b7:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_04bc:  dup
-  IL_04bd:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
+  IL_04bd:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
   IL_04c2:  stloc.2
   IL_04c3:  dup
-  IL_04c4:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_04c4:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_04c9:  ldc.i4.s   18
-  IL_04cb:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_04cb:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_04d0:  pop
   IL_04d1:  ldloc.2
-  IL_04d2:  box        "Integer"
+  IL_04d2:  box        ""Integer""
   IL_04d7:  ldc.i4.1
-  IL_04d8:  box        "Integer"
-  IL_04dd:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_04d8:  box        ""Integer""
+  IL_04dd:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_04e2:  pop
   IL_04e3:  dup
-  IL_04e4:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_04e4:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_04e9:  dup
-  IL_04ea:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_IsReadOnly() As Boolean"
+  IL_04ea:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_IsReadOnly() As Boolean""
   IL_04ef:  stloc.s    V_4
   IL_04f1:  dup
-  IL_04f2:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_04f2:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_04f7:  ldc.i4.0
-  IL_04f8:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_04f8:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_04fd:  pop
   IL_04fe:  ldloc.s    V_4
-  IL_0500:  box        "Boolean"
+  IL_0500:  box        ""Boolean""
   IL_0505:  ldc.i4.0
-  IL_0506:  box        "Boolean"
-  IL_050b:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0506:  box        ""Boolean""
+  IL_050b:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0510:  pop
   IL_0511:  dup
-  IL_0512:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0512:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0517:  dup
   IL_0518:  ldc.i4.3
   IL_0519:  ldc.i4.4
-  IL_051a:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_051f:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_051a:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_051f:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_0524:  stloc.s    V_10
   IL_0526:  dup
-  IL_0527:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0527:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_052c:  ldc.i4.s   22
-  IL_052e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_052e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0533:  pop
   IL_0534:  ldloc.s    V_10
-  IL_0536:  box        "Boolean"
+  IL_0536:  box        ""Boolean""
   IL_053b:  ldc.i4.1
-  IL_053c:  box        "Boolean"
-  IL_0541:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_053c:  box        ""Boolean""
+  IL_0541:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0546:  pop
   IL_0547:  dup
-  IL_0548:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_0548:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_054d:  dup
   IL_054e:  ldc.i4.2
   IL_054f:  ldc.i4.3
-  IL_0550:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)"
-  IL_0555:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean"
+  IL_0550:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0555:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Integer)) As Boolean""
   IL_055a:  stloc.s    V_10
   IL_055c:  dup
-  IL_055d:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_055d:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0562:  ldc.i4.s   19
-  IL_0564:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0564:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0569:  pop
   IL_056a:  ldloc.s    V_10
-  IL_056c:  box        "Boolean"
+  IL_056c:  box        ""Boolean""
   IL_0571:  ldc.i4.0
-  IL_0572:  box        "Boolean"
-  IL_0577:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0572:  box        ""Boolean""
+  IL_0577:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_057c:  pop
   IL_057d:  dup
   IL_057e:  ldc.i4.1
   IL_057f:  ldc.i4.2
-  IL_0580:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_0580:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_0585:  dup
   IL_0586:  ldc.i4.2
   IL_0587:  ldc.i4.3
-  IL_0588:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_0588:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_058d:  dup
-  IL_058e:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_058e:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_0593:  dup
-  IL_0594:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Clear()"
+  IL_0594:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).Clear()""
   IL_0599:  dup
-  IL_059a:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_059a:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_059f:  ldc.i4.s   23
-  IL_05a1:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_05a1:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_05a6:  pop
   IL_05a7:  dup
-  IL_05a8:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_05ad:  box        "Integer"
+  IL_05a8:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_05ad:  box        ""Integer""
   IL_05b2:  ldc.i4.0
-  IL_05b3:  box        "Integer"
-  IL_05b8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_05b3:  box        ""Integer""
+  IL_05b8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_05bd:  pop
   IL_05be:  dup
-  IL_05bf:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()"
+  IL_05bf:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.ClearFlag()""
   IL_05c4:  dup
-  IL_05c5:  callvirt   "Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
+  IL_05c5:  callvirt   ""Function System.Collections.Generic.IReadOnlyCollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
   IL_05ca:  stloc.2
-  IL_05cb:  callvirt   "Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_05cb:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorIntIVectorViewIntIMapIntIntIMapViewIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_05d0:  ldc.i4.3
-  IL_05d1:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_05d1:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_05d6:  pop
   IL_05d7:  ret
 }
-]]>.Value)
+")
 
-            verifier.VerifyIL("AllMembers.TestIVectorStructIVectorViewStructIMapIntStructIMapViewIntStructMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIVectorStructIVectorViewStructIMapIntStructIMapViewIntStructMembers", "
 {
   // Code size     1378 (0x562)
   .maxstack  5
@@ -3075,108 +3075,108 @@ End Class
                 Boolean V_8, //contains
                 Windows.Languages.WinRTTest.UserDefinedStruct V_9,
                 System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct) V_10)
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloca.s   V_9
-  IL_0008:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0008:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_000e:  ldloca.s   V_9
   IL_0010:  ldc.i4.1
-  IL_0011:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_0011:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_0016:  ldloc.s    V_9
   IL_0018:  stloc.1
   IL_0019:  ldloc.0
-  IL_001a:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_001a:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_001f:  ldloc.0
   IL_0020:  ldloc.1
-  IL_0021:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0021:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_0026:  ldloc.0
-  IL_0027:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0027:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_002c:  ldc.i4.s   9
-  IL_002e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_002e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0033:  pop
   IL_0034:  ldloc.0
-  IL_0035:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0035:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_003a:  ldloc.0
   IL_003b:  ldloc.1
-  IL_003c:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Contains(Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean"
+  IL_003c:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Contains(Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean""
   IL_0041:  ldloc.0
-  IL_0042:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0042:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0047:  ldc.i4.5
-  IL_0048:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0048:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_004d:  pop
-  IL_004e:  box        "Boolean"
+  IL_004e:  box        ""Boolean""
   IL_0053:  ldc.i4.1
-  IL_0054:  box        "Boolean"
-  IL_0059:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0054:  box        ""Boolean""
+  IL_0059:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_005e:  pop
   IL_005f:  ldloc.0
-  IL_0060:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0060:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0065:  ldc.i4.0
-  IL_0066:  newarr     "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0066:  newarr     ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_006b:  stloc.2
   IL_006c:  ldloc.0
   IL_006d:  ldloc.2
   IL_006e:  ldc.i4.0
-  IL_006f:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).CopyTo(Windows.Languages.WinRTTest.UserDefinedStruct(), Integer)"
+  IL_006f:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).CopyTo(Windows.Languages.WinRTTest.UserDefinedStruct(), Integer)""
   IL_0074:  ldloc.0
-  IL_0075:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0075:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_007a:  ldc.i4.2
-  IL_007b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_007b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0080:  pop
   IL_0081:  ldloc.2
   IL_0082:  ldc.i4.0
-  IL_0083:  ldelema    "Windows.Languages.WinRTTest.UserDefinedStruct"
-  IL_0088:  ldfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
-  IL_008d:  box        "UInteger"
+  IL_0083:  ldelema    ""Windows.Languages.WinRTTest.UserDefinedStruct""
+  IL_0088:  ldfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
+  IL_008d:  box        ""UInteger""
   IL_0092:  ldloc.1
-  IL_0093:  ldfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
-  IL_0098:  box        "UInteger"
-  IL_009d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0093:  ldfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
+  IL_0098:  box        ""UInteger""
+  IL_009d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00a2:  pop
   IL_00a3:  ldloc.0
-  IL_00a4:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_00a4:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_00a9:  ldloc.0
-  IL_00aa:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer"
+  IL_00aa:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer""
   IL_00af:  stloc.3
   IL_00b0:  ldloc.0
-  IL_00b1:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Windows.Languages.WinRTTest.UserDefinedStruct).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_00b1:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Windows.Languages.WinRTTest.UserDefinedStruct).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_00b6:  ldloc.0
-  IL_00b7:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00b7:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00bc:  ldc.i4.1
-  IL_00bd:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00bd:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00c2:  pop
   IL_00c3:  dup
-  IL_00c4:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+  IL_00c4:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
   IL_00c9:  pop
-  IL_00ca:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Current() As Windows.Languages.WinRTTest.UserDefinedStruct"
-  IL_00cf:  ldfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
-  IL_00d4:  box        "UInteger"
+  IL_00ca:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Current() As Windows.Languages.WinRTTest.UserDefinedStruct""
+  IL_00cf:  ldfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
+  IL_00d4:  box        ""UInteger""
   IL_00d9:  ldc.i4.1
-  IL_00da:  box        "Integer"
-  IL_00df:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00da:  box        ""Integer""
+  IL_00df:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00e4:  pop
   IL_00e5:  ldc.i4.0
   IL_00e6:  stloc.s    V_4
   .try
   {
     IL_00e8:  ldloc.0
-    IL_00e9:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Windows.Languages.WinRTTest.UserDefinedStruct).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct)"
+    IL_00e9:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Windows.Languages.WinRTTest.UserDefinedStruct).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct)""
     IL_00ee:  stloc.s    V_10
     IL_00f0:  br.s       IL_0116
     IL_00f2:  ldloc.s    V_10
-    IL_00f4:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Current() As Windows.Languages.WinRTTest.UserDefinedStruct"
+    IL_00f4:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Current() As Windows.Languages.WinRTTest.UserDefinedStruct""
     IL_00f9:  ldloc.s    V_4
     IL_00fb:  ldc.i4.1
     IL_00fc:  add.ovf
     IL_00fd:  stloc.s    V_4
-    IL_00ff:  ldfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
-    IL_0104:  box        "UInteger"
+    IL_00ff:  ldfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
+    IL_0104:  box        ""UInteger""
     IL_0109:  ldloc.s    V_4
-    IL_010b:  box        "Integer"
-    IL_0110:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+    IL_010b:  box        ""Integer""
+    IL_0110:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
     IL_0115:  pop
     IL_0116:  ldloc.s    V_10
-    IL_0118:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+    IL_0118:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
     IL_011d:  brtrue.s   IL_00f2
     IL_011f:  leave.s    IL_012d
   }
@@ -3185,396 +3185,396 @@ End Class
     IL_0121:  ldloc.s    V_10
     IL_0123:  brfalse.s  IL_012c
     IL_0125:  ldloc.s    V_10
-    IL_0127:  callvirt   "Sub System.IDisposable.Dispose()"
+    IL_0127:  callvirt   ""Sub System.IDisposable.Dispose()""
     IL_012c:  endfinally
   }
   IL_012d:  ldloc.s    V_4
-  IL_012f:  box        "Integer"
+  IL_012f:  box        ""Integer""
   IL_0134:  ldc.i4.1
-  IL_0135:  box        "Integer"
-  IL_013a:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0135:  box        ""Integer""
+  IL_013a:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_013f:  pop
   IL_0140:  ldloc.0
-  IL_0141:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0141:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0146:  ldloc.0
   IL_0147:  ldloc.1
-  IL_0148:  callvirt   "Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).IndexOf(Windows.Languages.WinRTTest.UserDefinedStruct) As Integer"
+  IL_0148:  callvirt   ""Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).IndexOf(Windows.Languages.WinRTTest.UserDefinedStruct) As Integer""
   IL_014d:  ldloc.0
-  IL_014e:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_014e:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0153:  ldc.i4.5
-  IL_0154:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0154:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0159:  pop
-  IL_015a:  box        "Integer"
+  IL_015a:  box        ""Integer""
   IL_015f:  ldc.i4.0
-  IL_0160:  box        "Integer"
-  IL_0165:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0160:  box        ""Integer""
+  IL_0165:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_016a:  pop
   IL_016b:  ldloc.0
-  IL_016c:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_016c:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0171:  ldloc.0
   IL_0172:  ldc.i4.1
   IL_0173:  ldloca.s   V_9
-  IL_0175:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0175:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_017b:  ldloca.s   V_9
   IL_017d:  ldc.i4.4
-  IL_017e:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_017e:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_0183:  ldloc.s    V_9
-  IL_0185:  callvirt   "Sub System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).Insert(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0185:  callvirt   ""Sub System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).Insert(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_018a:  ldloc.0
-  IL_018b:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_018b:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0190:  ldc.i4.7
-  IL_0191:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0191:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0196:  pop
   IL_0197:  ldloc.0
-  IL_0198:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0198:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_019d:  ldloc.0
-  IL_019e:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_IsReadOnly() As Boolean"
+  IL_019e:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_IsReadOnly() As Boolean""
   IL_01a3:  stloc.s    V_5
   IL_01a5:  ldloc.0
-  IL_01a6:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01a6:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01ab:  ldc.i4.0
-  IL_01ac:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01ac:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01b1:  pop
   IL_01b2:  ldloc.s    V_5
-  IL_01b4:  box        "Boolean"
+  IL_01b4:  box        ""Boolean""
   IL_01b9:  ldc.i4.0
-  IL_01ba:  box        "Boolean"
-  IL_01bf:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01ba:  box        ""Boolean""
+  IL_01bf:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01c4:  pop
   IL_01c5:  ldloc.0
-  IL_01c6:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_01c6:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_01cb:  ldloc.0
   IL_01cc:  ldc.i4.0
-  IL_01cd:  callvirt   "Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_01cd:  callvirt   ""Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_01d2:  pop
   IL_01d3:  ldloc.0
-  IL_01d4:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01d4:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01d9:  ldc.i4.2
-  IL_01da:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01da:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01df:  pop
   IL_01e0:  ldloc.0
-  IL_01e1:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_01e1:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_01e6:  ldloc.0
   IL_01e7:  ldc.i4.1
-  IL_01e8:  callvirt   "Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_01e8:  callvirt   ""Function System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_01ed:  pop
   IL_01ee:  ldloc.0
-  IL_01ef:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01ef:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01f4:  ldc.i4.2
-  IL_01f5:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01f5:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01fa:  pop
   IL_01fb:  ldloc.0
-  IL_01fc:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_01fc:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0201:  ldloc.0
   IL_0202:  ldloc.1
-  IL_0203:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Remove(Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean"
+  IL_0203:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Remove(Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean""
   IL_0208:  pop
   IL_0209:  ldloc.0
-  IL_020a:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_020a:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_020f:  ldc.i4.8
-  IL_0210:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0210:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0215:  pop
   IL_0216:  ldloc.0
-  IL_0217:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer"
-  IL_021c:  box        "Integer"
+  IL_0217:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer""
+  IL_021c:  box        ""Integer""
   IL_0221:  ldc.i4.1
-  IL_0222:  box        "Integer"
-  IL_0227:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0222:  box        ""Integer""
+  IL_0227:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_022c:  pop
   IL_022d:  ldloc.0
-  IL_022e:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_022e:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0233:  ldloc.0
   IL_0234:  ldc.i4.0
-  IL_0235:  callvirt   "Sub System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).RemoveAt(Integer)"
+  IL_0235:  callvirt   ""Sub System.Collections.Generic.IList(Of Windows.Languages.WinRTTest.UserDefinedStruct).RemoveAt(Integer)""
   IL_023a:  ldloc.0
-  IL_023b:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_023b:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0240:  ldc.i4.8
-  IL_0241:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0241:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0246:  pop
   IL_0247:  ldloc.0
-  IL_0248:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer"
-  IL_024d:  box        "Integer"
+  IL_0248:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer""
+  IL_024d:  box        ""Integer""
   IL_0252:  ldc.i4.0
-  IL_0253:  box        "Integer"
-  IL_0258:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0253:  box        ""Integer""
+  IL_0258:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_025d:  pop
   IL_025e:  ldloc.0
   IL_025f:  ldloc.1
-  IL_0260:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0260:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_0265:  ldloc.0
   IL_0266:  ldloca.s   V_9
-  IL_0268:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0268:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_026e:  ldloca.s   V_9
   IL_0270:  ldc.i4.4
-  IL_0271:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_0271:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_0276:  ldloc.s    V_9
-  IL_0278:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0278:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Add(Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_027d:  ldloc.0
-  IL_027e:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_027e:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0283:  ldloc.0
-  IL_0284:  callvirt   "Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Clear()"
+  IL_0284:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).Clear()""
   IL_0289:  ldloc.0
-  IL_028a:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_028a:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_028f:  ldc.i4.s   11
-  IL_0291:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0291:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0296:  pop
   IL_0297:  ldloc.0
-  IL_0298:  callvirt   "Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer"
-  IL_029d:  box        "Integer"
+  IL_0298:  callvirt   ""Function System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer""
+  IL_029d:  box        ""Integer""
   IL_02a2:  ldc.i4.0
-  IL_02a3:  box        "Integer"
-  IL_02a8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_02a3:  box        ""Integer""
+  IL_02a8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_02ad:  pop
   IL_02ae:  ldloc.0
-  IL_02af:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_02af:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_02b4:  ldloc.0
-  IL_02b5:  callvirt   "Function System.Collections.Generic.IReadOnlyCollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer"
+  IL_02b5:  callvirt   ""Function System.Collections.Generic.IReadOnlyCollection(Of Windows.Languages.WinRTTest.UserDefinedStruct).get_Count() As Integer""
   IL_02ba:  stloc.3
   IL_02bb:  ldloc.0
-  IL_02bc:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02bc:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02c1:  ldc.i4.3
-  IL_02c2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02c2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02c7:  pop
   IL_02c8:  ldloc.0
   IL_02c9:  ldloca.s   V_9
-  IL_02cb:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_02cb:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_02d1:  ldloca.s   V_9
   IL_02d3:  ldc.i4.s   10
-  IL_02d5:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_02d5:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_02da:  ldloc.s    V_9
   IL_02dc:  stloc.1
   IL_02dd:  dup
-  IL_02de:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_02de:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_02e3:  dup
   IL_02e4:  ldc.i4.1
   IL_02e5:  ldloc.1
-  IL_02e6:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_02e6:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_02eb:  dup
-  IL_02ec:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02ec:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02f1:  ldc.i4.s   21
-  IL_02f3:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02f3:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02f8:  pop
   IL_02f9:  dup
-  IL_02fa:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_02ff:  box        "Integer"
+  IL_02fa:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_02ff:  box        ""Integer""
   IL_0304:  ldc.i4.1
-  IL_0305:  box        "Integer"
-  IL_030a:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0305:  box        ""Integer""
+  IL_030a:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_030f:  pop
   IL_0310:  dup
-  IL_0311:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0311:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0316:  dup
   IL_0317:  ldc.i4.1
-  IL_0318:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).ContainsKey(Integer) As Boolean"
+  IL_0318:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).ContainsKey(Integer) As Boolean""
   IL_031d:  pop
   IL_031e:  dup
-  IL_031f:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_031f:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0324:  ldc.i4.s   19
-  IL_0326:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0326:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_032b:  pop
   IL_032c:  dup
-  IL_032d:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_032d:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0332:  dup
   IL_0333:  ldc.i4.1
-  IL_0334:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0334:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Item(Integer) As Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_0339:  pop
   IL_033a:  dup
-  IL_033b:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_033b:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0340:  ldc.i4.s   17
-  IL_0342:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0342:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0347:  pop
   IL_0348:  dup
-  IL_0349:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0349:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_034e:  dup
-  IL_034f:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Keys() As System.Collections.Generic.ICollection(Of Integer)"
+  IL_034f:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Keys() As System.Collections.Generic.ICollection(Of Integer)""
   IL_0354:  pop
   IL_0355:  dup
-  IL_0356:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0356:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_035b:  ldc.i4.0
-  IL_035c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_035c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0361:  pop
   IL_0362:  dup
-  IL_0363:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0363:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0368:  dup
-  IL_0369:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Values() As System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0369:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).get_Values() As System.Collections.Generic.ICollection(Of Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_036e:  pop
   IL_036f:  dup
-  IL_0370:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0370:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0375:  ldc.i4.0
-  IL_0376:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0376:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_037b:  pop
   IL_037c:  dup
-  IL_037d:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_037d:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0382:  dup
   IL_0383:  ldc.i4.1
   IL_0384:  ldloca.s   V_6
-  IL_0386:  callvirt   "Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).TryGetValue(Integer, ByRef Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean"
+  IL_0386:  callvirt   ""Function System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).TryGetValue(Integer, ByRef Windows.Languages.WinRTTest.UserDefinedStruct) As Boolean""
   IL_038b:  stloc.s    V_7
   IL_038d:  dup
-  IL_038e:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_038e:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0393:  ldc.i4.s   17
-  IL_0395:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0395:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_039a:  pop
   IL_039b:  ldloc.s    V_7
-  IL_039d:  box        "Boolean"
+  IL_039d:  box        ""Boolean""
   IL_03a2:  ldc.i4.1
-  IL_03a3:  box        "Boolean"
-  IL_03a8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_03a3:  box        ""Boolean""
+  IL_03a8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_03ad:  pop
   IL_03ae:  dup
-  IL_03af:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_03af:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_03b4:  dup
   IL_03b5:  ldc.i4.3
   IL_03b6:  ldloca.s   V_9
-  IL_03b8:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_03b8:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_03be:  ldloca.s   V_9
   IL_03c0:  ldc.i4.4
-  IL_03c1:  stfld      "Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger"
+  IL_03c1:  stfld      ""Windows.Languages.WinRTTest.UserDefinedStruct.Id As UInteger""
   IL_03c6:  ldloc.s    V_9
-  IL_03c8:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_03cd:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))"
+  IL_03c8:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_03cd:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Add(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))""
   IL_03d2:  dup
-  IL_03d3:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_03d3:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_03d8:  ldc.i4.s   21
-  IL_03da:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_03da:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_03df:  pop
   IL_03e0:  dup
-  IL_03e1:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_03e6:  box        "Integer"
+  IL_03e1:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_03e6:  box        ""Integer""
   IL_03eb:  ldc.i4.2
-  IL_03ec:  box        "Integer"
-  IL_03f1:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_03ec:  box        ""Integer""
+  IL_03f1:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_03f6:  pop
   IL_03f7:  dup
-  IL_03f8:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_03f8:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_03fd:  dup
   IL_03fe:  ldc.i4.1
   IL_03ff:  ldloc.1
-  IL_0400:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_0405:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_0400:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_0405:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_040a:  stloc.s    V_8
   IL_040c:  dup
-  IL_040d:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_040d:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0412:  ldc.i4.s   17
-  IL_0414:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0414:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0419:  pop
   IL_041a:  ldloc.s    V_8
-  IL_041c:  box        "Boolean"
+  IL_041c:  box        ""Boolean""
   IL_0421:  ldc.i4.1
-  IL_0422:  box        "Boolean"
-  IL_0427:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0422:  box        ""Boolean""
+  IL_0427:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_042c:  pop
   IL_042d:  dup
-  IL_042e:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_042e:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0433:  dup
   IL_0434:  ldc.i4.8
   IL_0435:  ldloca.s   V_9
-  IL_0437:  initobj    "Windows.Languages.WinRTTest.UserDefinedStruct"
+  IL_0437:  initobj    ""Windows.Languages.WinRTTest.UserDefinedStruct""
   IL_043d:  ldloc.s    V_9
-  IL_043f:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_0444:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_043f:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_0444:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Contains(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_0449:  stloc.s    V_8
   IL_044b:  dup
-  IL_044c:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_044c:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0451:  ldc.i4.s   19
-  IL_0453:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0453:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0458:  pop
   IL_0459:  ldloc.s    V_8
-  IL_045b:  box        "Boolean"
+  IL_045b:  box        ""Boolean""
   IL_0460:  ldc.i4.0
-  IL_0461:  box        "Boolean"
-  IL_0466:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0461:  box        ""Boolean""
+  IL_0466:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_046b:  pop
   IL_046c:  dup
-  IL_046d:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_046d:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0472:  dup
-  IL_0473:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0473:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_0478:  dup
-  IL_0479:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
+  IL_0479:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
   IL_047e:  stloc.3
   IL_047f:  dup
-  IL_0480:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0480:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0485:  ldc.i4.s   18
-  IL_0487:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0487:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_048c:  pop
   IL_048d:  ldloc.3
-  IL_048e:  box        "Integer"
+  IL_048e:  box        ""Integer""
   IL_0493:  ldc.i4.1
-  IL_0494:  box        "Integer"
-  IL_0499:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0494:  box        ""Integer""
+  IL_0499:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_049e:  pop
   IL_049f:  dup
-  IL_04a0:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_04a0:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_04a5:  dup
-  IL_04a6:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_IsReadOnly() As Boolean"
+  IL_04a6:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_IsReadOnly() As Boolean""
   IL_04ab:  stloc.s    V_5
   IL_04ad:  dup
-  IL_04ae:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_04ae:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_04b3:  ldc.i4.0
-  IL_04b4:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_04b4:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_04b9:  pop
   IL_04ba:  ldloc.s    V_5
-  IL_04bc:  box        "Boolean"
+  IL_04bc:  box        ""Boolean""
   IL_04c1:  ldc.i4.0
-  IL_04c2:  box        "Boolean"
-  IL_04c7:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_04c2:  box        ""Boolean""
+  IL_04c7:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_04cc:  pop
   IL_04cd:  dup
-  IL_04ce:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_04ce:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_04d3:  dup
   IL_04d4:  ldc.i4.1
   IL_04d5:  ldloc.1
-  IL_04d6:  newobj     "Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
-  IL_04db:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean"
+  IL_04d6:  newobj     ""Sub System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)..ctor(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
+  IL_04db:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Remove(System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)) As Boolean""
   IL_04e0:  pop
   IL_04e1:  dup
-  IL_04e2:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_04e2:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_04e7:  ldc.i4.s   22
-  IL_04e9:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_04e9:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_04ee:  pop
   IL_04ef:  dup
-  IL_04f0:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_04f5:  box        "Integer"
+  IL_04f0:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_04f5:  box        ""Integer""
   IL_04fa:  ldc.i4.0
-  IL_04fb:  box        "Integer"
-  IL_0500:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_04fb:  box        ""Integer""
+  IL_0500:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0505:  pop
   IL_0506:  dup
   IL_0507:  ldc.i4.1
   IL_0508:  ldloc.1
-  IL_0509:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0509:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_050e:  dup
   IL_050f:  ldc.i4.2
   IL_0510:  ldloc.1
-  IL_0511:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0511:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct).Add(Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_0516:  dup
-  IL_0517:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0517:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_051c:  dup
-  IL_051d:  callvirt   "Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Clear()"
+  IL_051d:  callvirt   ""Sub System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).Clear()""
   IL_0522:  dup
-  IL_0523:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0523:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0528:  ldc.i4.s   23
-  IL_052a:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_052a:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_052f:  pop
   IL_0530:  dup
-  IL_0531:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
-  IL_0536:  box        "Integer"
+  IL_0531:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
+  IL_0536:  box        ""Integer""
   IL_053b:  ldc.i4.0
-  IL_053c:  box        "Integer"
-  IL_0541:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_053c:  box        ""Integer""
+  IL_0541:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0546:  pop
   IL_0547:  dup
-  IL_0548:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()"
+  IL_0548:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.ClearFlag()""
   IL_054d:  dup
-  IL_054e:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer"
+  IL_054e:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)).get_Count() As Integer""
   IL_0553:  stloc.3
-  IL_0554:  callvirt   "Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0554:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorStructIVectorViewStructIMapIntStructIMapViewIntStruct.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0559:  ldc.i4.s   18
-  IL_055b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_055b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0560:  pop
   IL_0561:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -3702,113 +3702,113 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestISimpleInterfaceImplMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestISimpleInterfaceImplMembers", "
 {
   // Code size      662 (0x296)
   .maxstack  3
   .locals init (Windows.Languages.WinRTTest.ISimpleInterfaceImpl V_0, //v
-  Integer() V_1, //arr
-  Integer V_2, //index
-  System.Collections.Generic.IEnumerator(Of Integer) V_3)
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl..ctor()"
+                Integer() V_1, //arr
+                Integer V_2, //index
+                System.Collections.Generic.IEnumerator(Of Integer) V_3)
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_0007:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_000c:  ldloc.0
   IL_000d:  ldc.i4.1
-  IL_000e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_000e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0013:  ldloc.0
-  IL_0014:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0014:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0019:  ldc.i4.s   9
-  IL_001b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_001b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0020:  pop
   IL_0021:  ldloc.0
   IL_0022:  ldc.i4.0
-  IL_0023:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_0028:  box        "Integer"
+  IL_0023:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_0028:  box        ""Integer""
   IL_002d:  ldc.i4.1
-  IL_002e:  box        "Integer"
-  IL_0033:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_002e:  box        ""Integer""
+  IL_0033:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0038:  pop
   IL_0039:  ldloc.0
-  IL_003a:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_003a:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_003f:  ldloc.0
   IL_0040:  ldc.i4.1
-  IL_0041:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean"
+  IL_0041:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean""
   IL_0046:  ldloc.0
-  IL_0047:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0047:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_004c:  ldc.i4.5
-  IL_004d:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004d:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0052:  pop
-  IL_0053:  box        "Boolean"
+  IL_0053:  box        ""Boolean""
   IL_0058:  ldc.i4.1
-  IL_0059:  box        "Boolean"
-  IL_005e:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0059:  box        ""Boolean""
+  IL_005e:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0063:  pop
   IL_0064:  ldloc.0
-  IL_0065:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_0065:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_006a:  ldc.i4.0
-  IL_006b:  newarr     "Integer"
+  IL_006b:  newarr     ""Integer""
   IL_0070:  stloc.1
   IL_0071:  ldloc.0
   IL_0072:  ldloc.1
   IL_0073:  ldc.i4.0
-  IL_0074:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)"
+  IL_0074:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)""
   IL_0079:  ldloc.0
-  IL_007a:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_007a:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_007f:  ldc.i4.2
-  IL_0080:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0080:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0085:  pop
   IL_0086:  ldloc.1
   IL_0087:  ldc.i4.0
   IL_0088:  ldelem.i4
-  IL_0089:  box        "Integer"
+  IL_0089:  box        ""Integer""
   IL_008e:  ldc.i4.1
-  IL_008f:  box        "Integer"
-  IL_0094:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_008f:  box        ""Integer""
+  IL_0094:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0099:  pop
   IL_009a:  ldloc.1
   IL_009b:  ldc.i4.1
   IL_009c:  ldelem.i4
-  IL_009d:  box        "Integer"
+  IL_009d:  box        ""Integer""
   IL_00a2:  ldc.i4.0
-  IL_00a3:  box        "Integer"
-  IL_00a8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00a3:  box        ""Integer""
+  IL_00a8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00ad:  pop
   IL_00ae:  ldloc.0
-  IL_00af:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_00af:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_00b4:  ldloc.0
-  IL_00b5:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
+  IL_00b5:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
   IL_00ba:  pop
   IL_00bb:  ldloc.0
-  IL_00bc:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+  IL_00bc:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)""
   IL_00c1:  pop
   IL_00c2:  ldloc.0
-  IL_00c3:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00c3:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00c8:  ldc.i4.1
-  IL_00c9:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00c9:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00ce:  pop
   IL_00cf:  ldc.i4.0
   IL_00d0:  stloc.2
   .try
 {
   IL_00d1:  ldloc.0
-  IL_00d2:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+  IL_00d2:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)""
   IL_00d7:  stloc.3
   IL_00d8:  br.s       IL_00f5
   IL_00da:  ldloc.3
-  IL_00db:  callvirt   "Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer"
+  IL_00db:  callvirt   ""Function System.Collections.Generic.IEnumerator(Of Integer).get_Current() As Integer""
   IL_00e0:  ldloc.2
   IL_00e1:  ldc.i4.1
   IL_00e2:  add.ovf
   IL_00e3:  stloc.2
-  IL_00e4:  box        "Integer"
+  IL_00e4:  box        ""Integer""
   IL_00e9:  ldloc.2
-  IL_00ea:  box        "Integer"
-  IL_00ef:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00ea:  box        ""Integer""
+  IL_00ef:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00f4:  pop
   IL_00f5:  ldloc.3
-  IL_00f6:  callvirt   "Function System.Collections.IEnumerator.MoveNext() As Boolean"
+  IL_00f6:  callvirt   ""Function System.Collections.IEnumerator.MoveNext() As Boolean""
   IL_00fb:  brtrue.s   IL_00da
   IL_00fd:  leave.s    IL_0109
 }
@@ -3817,154 +3817,152 @@ End Class
   IL_00ff:  ldloc.3
   IL_0100:  brfalse.s  IL_0108
   IL_0102:  ldloc.3
-  IL_0103:  callvirt   "Sub System.IDisposable.Dispose()"
+  IL_0103:  callvirt   ""Sub System.IDisposable.Dispose()""
   IL_0108:  endfinally
 }
   IL_0109:  ldloc.2
-  IL_010a:  box        "Integer"
+  IL_010a:  box        ""Integer""
   IL_010f:  ldc.i4.1
-  IL_0110:  box        "Integer"
-  IL_0115:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0110:  box        ""Integer""
+  IL_0115:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_011a:  pop
   IL_011b:  ldloc.0
-  IL_011c:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_011c:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_0121:  ldloc.0
   IL_0122:  ldc.i4.1
-  IL_0123:  callvirt   "Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer"
+  IL_0123:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer""
   IL_0128:  ldloc.0
-  IL_0129:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0129:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_012e:  ldc.i4.5
-  IL_012f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_012f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0134:  pop
-  IL_0135:  box        "Integer"
+  IL_0135:  box        ""Integer""
   IL_013a:  ldc.i4.0
-  IL_013b:  box        "Integer"
-  IL_0140:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_013b:  box        ""Integer""
+  IL_0140:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0145:  pop
   IL_0146:  ldloc.0
-  IL_0147:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_0147:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_014c:  ldloc.0
   IL_014d:  ldc.i4.1
   IL_014e:  ldc.i4.2
-  IL_014f:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)"
+  IL_014f:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)""
   IL_0154:  ldloc.0
-  IL_0155:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0155:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_015a:  ldc.i4.7
-  IL_015b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_015b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0160:  pop
   IL_0161:  ldloc.0
   IL_0162:  ldc.i4.1
-  IL_0163:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_0168:  box        "Integer"
+  IL_0163:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_0168:  box        ""Integer""
   IL_016d:  ldc.i4.2
-  IL_016e:  box        "Integer"
-  IL_0173:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_016e:  box        ""Integer""
+  IL_0173:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0178:  pop
   IL_0179:  ldloc.0
-  IL_017a:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_017a:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_017f:  ldloc.0
-  IL_0180:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean"
+  IL_0180:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean""
   IL_0185:  ldloc.0
-  IL_0186:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0186:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_018b:  ldc.i4.0
-  IL_018c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_018c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0191:  pop
-  IL_0192:  box        "Boolean"
+  IL_0192:  box        ""Boolean""
   IL_0197:  ldc.i4.0
-  IL_0198:  box        "Boolean"
-  IL_019d:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0198:  box        ""Boolean""
+  IL_019d:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01a2:  pop
   IL_01a3:  ldloc.0
-  IL_01a4:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_01a4:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_01a9:  ldloc.0
   IL_01aa:  ldc.i4.0
-  IL_01ab:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
+  IL_01ab:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
   IL_01b0:  ldloc.0
-  IL_01b1:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01b1:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01b6:  ldc.i4.2
-  IL_01b7:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01b7:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01bc:  pop
-  IL_01bd:  box        "Integer"
+  IL_01bd:  box        ""Integer""
   IL_01c2:  ldc.i4.1
-  IL_01c3:  box        "Integer"
-  IL_01c8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01c3:  box        ""Integer""
+  IL_01c8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01cd:  pop
   IL_01ce:  ldloc.0
-  IL_01cf:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_01cf:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_01d4:  ldloc.0
   IL_01d5:  ldc.i4.1
-  IL_01d6:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
+  IL_01d6:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
   IL_01db:  ldloc.0
-  IL_01dc:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01dc:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01e1:  ldc.i4.2
-  IL_01e2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01e2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01e7:  pop
-  IL_01e8:  box        "Integer"
+  IL_01e8:  box        ""Integer""
   IL_01ed:  ldc.i4.2
-  IL_01ee:  box        "Integer"
-  IL_01f3:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_01ee:  box        ""Integer""
+  IL_01f3:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_01f8:  pop
   IL_01f9:  ldloc.0
-  IL_01fa:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_01fa:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_01ff:  ldloc.0
   IL_0200:  ldc.i4.1
-  IL_0201:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean"
+  IL_0201:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean""
   IL_0206:  pop
   IL_0207:  ldloc.0
-  IL_0208:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0208:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_020d:  ldc.i4.8
-  IL_020e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_020e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0213:  pop
   IL_0214:  ldloc.0
-  IL_0215:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_021a:  box        "Integer"
+  IL_0215:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_021a:  box        ""Integer""
   IL_021f:  ldc.i4.1
-  IL_0220:  box        "Integer"
-  IL_0225:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0220:  box        ""Integer""
+  IL_0225:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_022a:  pop
   IL_022b:  ldloc.0
-  IL_022c:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_022c:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_0231:  ldloc.0
   IL_0232:  ldc.i4.0
-  IL_0233:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)"
+  IL_0233:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)""
   IL_0238:  ldloc.0
-  IL_0239:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0239:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_023e:  ldc.i4.8
-  IL_023f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_023f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0244:  pop
   IL_0245:  ldloc.0
-  IL_0246:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_024b:  box        "Integer"
+  IL_0246:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_024b:  box        ""Integer""
   IL_0250:  ldc.i4.0
-  IL_0251:  box        "Integer"
-  IL_0256:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0251:  box        ""Integer""
+  IL_0256:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_025b:  pop
   IL_025c:  ldloc.0
   IL_025d:  ldc.i4.1
-  IL_025e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_025e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0263:  ldloc.0
   IL_0264:  ldc.i4.2
-  IL_0265:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0265:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_026a:  ldloc.0
-  IL_026b:  callvirt   "Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()"
+  IL_026b:  callvirt   ""Sub Windows.Languages.WinRTTest.ISimpleInterfaceImpl.ClearFlag()""
   IL_0270:  ldloc.0
-  IL_0271:  callvirt   "Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0271:  callvirt   ""Function Windows.Languages.WinRTTest.ISimpleInterfaceImpl.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0276:  ldc.i4.s   11
-  IL_0278:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0278:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_027d:  pop
   IL_027e:  ldloc.0
-  IL_027f:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_0284:  box        "Integer"
+  IL_027f:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_0284:  box        ""Integer""
   IL_0289:  ldc.i4.0
-  IL_028a:  box        "Integer"
-  IL_028f:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_028a:  box        ""Integer""
+  IL_028f:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0294:  pop
   IL_0295:  ret
 }
-]]>.Value)
+")
         End Sub
-
-
 
         <Fact()>
         Public Sub LegacyCollectionTest06()
@@ -4039,96 +4037,96 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestCollectionInitializers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestCollectionInitializers", "
 {
   // Code size      236 (0xec)
   .maxstack  6
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_0005:  dup
   IL_0006:  ldc.i4.1
-  IL_0007:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0007:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_000c:  dup
   IL_000d:  ldc.i4.2
-  IL_000e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_000e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0013:  dup
   IL_0014:  ldc.i4.3
-  IL_0015:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0015:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_001a:  dup
   IL_001b:  ldc.i4.4
-  IL_001c:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_001c:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0021:  dup
   IL_0022:  ldc.i4.5
-  IL_0023:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
-  IL_0028:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_002d:  box        "Integer"
+  IL_0023:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
+  IL_0028:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_002d:  box        ""Integer""
   IL_0032:  ldc.i4.5
-  IL_0033:  box        "Integer"
-  IL_0038:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0033:  box        ""Integer""
+  IL_0038:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_003d:  pop
-  IL_003e:  newobj     "Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()"
+  IL_003e:  newobj     ""Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()""
   IL_0043:  dup
   IL_0044:  ldc.i4.1
   IL_0045:  ldc.i4.2
-  IL_0046:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_0046:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_004b:  dup
   IL_004c:  ldc.i4.2
   IL_004d:  ldc.i4.3
-  IL_004e:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
-  IL_0053:  callvirt   "Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer"
-  IL_0058:  box        "Integer"
+  IL_004e:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
+  IL_0053:  callvirt   ""Function System.Collections.Generic.ICollection(Of System.Collections.Generic.KeyValuePair(Of Integer, Integer)).get_Count() As Integer""
+  IL_0058:  box        ""Integer""
   IL_005d:  ldc.i4.2
-  IL_005e:  box        "Integer"
-  IL_0063:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_005e:  box        ""Integer""
+  IL_0063:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0068:  pop
-  IL_0069:  newobj     "Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt)..ctor()"
+  IL_0069:  newobj     ""Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt)..ctor()""
   IL_006e:  dup
   IL_006f:  ldc.i4.1
-  IL_0070:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0070:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_0075:  dup
   IL_0076:  ldc.i4.1
-  IL_0077:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0077:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_007c:  dup
   IL_007d:  ldc.i4.2
-  IL_007e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_007e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0083:  dup
   IL_0084:  ldc.i4.3
-  IL_0085:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
-  IL_008a:  callvirt   "Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).Add(Integer, Windows.Languages.WinRTTest.IVectorInt)"
+  IL_0085:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
+  IL_008a:  callvirt   ""Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).Add(Integer, Windows.Languages.WinRTTest.IVectorInt)""
   IL_008f:  dup
   IL_0090:  ldc.i4.2
-  IL_0091:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0091:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_0096:  dup
   IL_0097:  ldc.i4.4
-  IL_0098:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0098:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_009d:  dup
   IL_009e:  ldc.i4.5
-  IL_009f:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_009f:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_00a4:  dup
   IL_00a5:  ldc.i4.6
-  IL_00a6:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
-  IL_00ab:  callvirt   "Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).Add(Integer, Windows.Languages.WinRTTest.IVectorInt)"
+  IL_00a6:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
+  IL_00ab:  callvirt   ""Sub System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).Add(Integer, Windows.Languages.WinRTTest.IVectorInt)""
   IL_00b0:  dup
   IL_00b1:  ldc.i4.1
-  IL_00b2:  callvirt   "Function System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).get_Item(Integer) As Windows.Languages.WinRTTest.IVectorInt"
+  IL_00b2:  callvirt   ""Function System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).get_Item(Integer) As Windows.Languages.WinRTTest.IVectorInt""
   IL_00b7:  ldc.i4.2
-  IL_00b8:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_00bd:  box        "Integer"
+  IL_00b8:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_00bd:  box        ""Integer""
   IL_00c2:  ldc.i4.3
-  IL_00c3:  box        "Integer"
-  IL_00c8:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00c3:  box        ""Integer""
+  IL_00c8:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00cd:  pop
   IL_00ce:  ldc.i4.2
-  IL_00cf:  callvirt   "Function System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).get_Item(Integer) As Windows.Languages.WinRTTest.IVectorInt"
+  IL_00cf:  callvirt   ""Function System.Collections.Generic.Dictionary(Of Integer, Windows.Languages.WinRTTest.IVectorInt).get_Item(Integer) As Windows.Languages.WinRTTest.IVectorInt""
   IL_00d4:  ldc.i4.2
-  IL_00d5:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_00da:  box        "Integer"
+  IL_00d5:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_00da:  box        ""Integer""
   IL_00df:  ldc.i4.6
-  IL_00e0:  box        "Integer"
-  IL_00e5:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00e0:  box        ""Integer""
+  IL_00e5:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00ea:  pop
   IL_00eb:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -4209,88 +4207,88 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestExpressionTreeCompiler", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestExpressionTreeCompiler", "
 {
   // Code size      226 (0xe2)
   .maxstack  6
   .locals init (AllMembers._Closure$__5-0 V_0, //$VB$Closure_0
                 System.Linq.Expressions.ParameterExpression V_1,
                 System.Exception V_2) //e
-  IL_0000:  newobj     "Sub AllMembers._Closure$__5-0..ctor()"
+  IL_0000:  newobj     ""Sub AllMembers._Closure$__5-0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
-  IL_000c:  stfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
+  IL_0007:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
+  IL_000c:  stfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
   .try
   {
-    IL_0011:  ldstr      "Dev11:205875"
-    IL_0016:  call       "Sub System.Console.WriteLine(String)"
+    IL_0011:  ldstr      ""Dev11:205875""
+    IL_0016:  call       ""Sub System.Console.WriteLine(String)""
     IL_001b:  ldc.i4.1
-    IL_001c:  box        "Boolean"
+    IL_001c:  box        ""Boolean""
     IL_0021:  ldc.i4.1
-    IL_0022:  box        "Boolean"
-    IL_0027:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+    IL_0022:  box        ""Boolean""
+    IL_0027:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
     IL_002c:  pop
-    IL_002d:  ldtoken    "Integer"
-    IL_0032:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-    IL_0037:  ldstr      "val"
-    IL_003c:  call       "Function System.Linq.Expressions.Expression.Parameter(System.Type, String) As System.Linq.Expressions.ParameterExpression"
+    IL_002d:  ldtoken    ""Integer""
+    IL_0032:  call       ""Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type""
+    IL_0037:  ldstr      ""val""
+    IL_003c:  call       ""Function System.Linq.Expressions.Expression.Parameter(System.Type, String) As System.Linq.Expressions.ParameterExpression""
     IL_0041:  stloc.1
     IL_0042:  ldloc.0
-    IL_0043:  ldtoken    "AllMembers._Closure$__5-0"
-    IL_0048:  call       "Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type"
-    IL_004d:  call       "Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression"
-    IL_0052:  ldtoken    "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-    IL_0057:  call       "Function System.Reflection.FieldInfo.GetFieldFromHandle(System.RuntimeFieldHandle) As System.Reflection.FieldInfo"
-    IL_005c:  call       "Function System.Linq.Expressions.Expression.Field(System.Linq.Expressions.Expression, System.Reflection.FieldInfo) As System.Linq.Expressions.MemberExpression"
-    IL_0061:  ldtoken    "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
-    IL_0066:  ldtoken    "System.Collections.Generic.ICollection(Of Integer)"
-    IL_006b:  call       "Function System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle) As System.Reflection.MethodBase"
-    IL_0070:  castclass  "System.Reflection.MethodInfo"
+    IL_0043:  ldtoken    ""AllMembers._Closure$__5-0""
+    IL_0048:  call       ""Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type""
+    IL_004d:  call       ""Function System.Linq.Expressions.Expression.Constant(Object, System.Type) As System.Linq.Expressions.ConstantExpression""
+    IL_0052:  ldtoken    ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+    IL_0057:  call       ""Function System.Reflection.FieldInfo.GetFieldFromHandle(System.RuntimeFieldHandle) As System.Reflection.FieldInfo""
+    IL_005c:  call       ""Function System.Linq.Expressions.Expression.Field(System.Linq.Expressions.Expression, System.Reflection.FieldInfo) As System.Linq.Expressions.MemberExpression""
+    IL_0061:  ldtoken    ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
+    IL_0066:  ldtoken    ""System.Collections.Generic.ICollection(Of Integer)""
+    IL_006b:  call       ""Function System.Reflection.MethodBase.GetMethodFromHandle(System.RuntimeMethodHandle, System.RuntimeTypeHandle) As System.Reflection.MethodBase""
+    IL_0070:  castclass  ""System.Reflection.MethodInfo""
     IL_0075:  ldc.i4.1
-    IL_0076:  newarr     "System.Linq.Expressions.Expression"
+    IL_0076:  newarr     ""System.Linq.Expressions.Expression""
     IL_007b:  dup
     IL_007c:  ldc.i4.0
     IL_007d:  ldloc.1
     IL_007e:  stelem.ref
-    IL_007f:  call       "Function System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression, System.Reflection.MethodInfo, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.MethodCallExpression"
+    IL_007f:  call       ""Function System.Linq.Expressions.Expression.Call(System.Linq.Expressions.Expression, System.Reflection.MethodInfo, ParamArray System.Linq.Expressions.Expression()) As System.Linq.Expressions.MethodCallExpression""
     IL_0084:  ldc.i4.1
-    IL_0085:  newarr     "System.Linq.Expressions.ParameterExpression"
+    IL_0085:  newarr     ""System.Linq.Expressions.ParameterExpression""
     IL_008a:  dup
     IL_008b:  ldc.i4.0
     IL_008c:  ldloc.1
     IL_008d:  stelem.ref
-    IL_008e:  call       "Function System.Linq.Expressions.Expression.Lambda(Of System.Action(Of Integer))(System.Linq.Expressions.Expression, ParamArray System.Linq.Expressions.ParameterExpression()) As System.Linq.Expressions.Expression(Of System.Action(Of Integer))"
+    IL_008e:  call       ""Function System.Linq.Expressions.Expression.Lambda(Of System.Action(Of Integer))(System.Linq.Expressions.Expression, ParamArray System.Linq.Expressions.ParameterExpression()) As System.Linq.Expressions.Expression(Of System.Action(Of Integer))""
     IL_0093:  ldloc.0
-    IL_0094:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-    IL_0099:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()"
-    IL_009e:  callvirt   "Function System.Linq.Expressions.Expression(Of System.Action(Of Integer)).Compile() As System.Action(Of Integer)"
+    IL_0094:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+    IL_0099:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()""
+    IL_009e:  callvirt   ""Function System.Linq.Expressions.Expression(Of System.Action(Of Integer)).Compile() As System.Action(Of Integer)""
     IL_00a3:  ldc.i4.1
-    IL_00a4:  callvirt   "Sub System.Action(Of Integer).Invoke(Integer)"
+    IL_00a4:  callvirt   ""Sub System.Action(Of Integer).Invoke(Integer)""
     IL_00a9:  ldloc.0
-    IL_00aa:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-    IL_00af:  callvirt   "Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+    IL_00aa:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+    IL_00af:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
     IL_00b4:  ldc.i4.s   9
-    IL_00b6:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+    IL_00b6:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
     IL_00bb:  pop
     IL_00bc:  leave.s    IL_00e1
   }
   catch System.Exception
   {
     IL_00be:  dup
-    IL_00bf:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_00bf:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
     IL_00c4:  stloc.2
-    IL_00c5:  ldstr      "ExprTree compiler"
-    IL_00ca:  call       "Sub System.Console.WriteLine(String)"
+    IL_00c5:  ldstr      ""ExprTree compiler""
+    IL_00ca:  call       ""Sub System.Console.WriteLine(String)""
     IL_00cf:  ldloc.2
-    IL_00d0:  callvirt   "Function System.Exception.get_Message() As String"
-    IL_00d5:  call       "Sub System.Console.WriteLine(String)"
-    IL_00da:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_00d0:  callvirt   ""Function System.Exception.get_Message() As String""
+    IL_00d5:  call       ""Sub System.Console.WriteLine(String)""
+    IL_00da:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
     IL_00df:  leave.s    IL_00e1
   }
   IL_00e1:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -4380,156 +4378,156 @@ End Class
                 options:=TestOptions.ReleaseExe.WithModuleName("MODULE"),
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestLINQ", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestLINQ", "
 {
   // Code size      460 (0x1cc)
   .maxstack  4
   .locals init (AllMembers._Closure$__5-0 V_0, //$VB$Closure_0
                 System.ArgumentException V_1) //e
-  IL_0000:  newobj     "Sub AllMembers._Closure$__5-0..ctor()"
+  IL_0000:  newobj     ""Sub AllMembers._Closure$__5-0..ctor()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
-  IL_0007:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0007:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_000c:  dup
   IL_000d:  ldc.i4.1
-  IL_000e:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_000e:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0013:  dup
   IL_0014:  ldc.i4.2
-  IL_0015:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0015:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_001a:  dup
   IL_001b:  ldc.i4.3
-  IL_001c:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_001c:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0021:  dup
   IL_0022:  ldc.i4.4
-  IL_0023:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0023:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0028:  dup
   IL_0029:  ldc.i4.5
-  IL_002a:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
-  IL_002f:  stfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
+  IL_002a:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
+  IL_002f:  stfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
   IL_0034:  ldloc.0
-  IL_0035:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-  IL_003a:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_003f:  box        "Integer"
+  IL_0035:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+  IL_003a:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_003f:  box        ""Integer""
   IL_0044:  ldc.i4.5
-  IL_0045:  box        "Integer"
-  IL_004a:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0045:  box        ""Integer""
+  IL_004a:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_004f:  pop
   IL_0050:  ldloc.0
-  IL_0051:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-  IL_0056:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()"
+  IL_0051:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+  IL_0056:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()""
   IL_005b:  ldc.i4.5
-  IL_005c:  newarr     "Integer"
+  IL_005c:  newarr     ""Integer""
   IL_0061:  dup
-  IL_0062:  ldtoken    "<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.864782BF337E3DBC1A27023D5C0C065C80F17087"
-  IL_0067:  call       "Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)"
+  IL_0062:  ldtoken    ""<PrivateImplementationDetails>.__StaticArrayInitTypeSize=20 <PrivateImplementationDetails>.864782BF337E3DBC1A27023D5C0C065C80F17087""
+  IL_0067:  call       ""Sub System.Runtime.CompilerServices.RuntimeHelpers.InitializeArray(System.Array, System.RuntimeFieldHandle)""
   IL_006c:  ldloc.0
-  IL_006d:  ldftn      "Function AllMembers._Closure$__5-0._Lambda$__0(Integer) As Boolean"
-  IL_0073:  newobj     "Sub System.Func(Of Integer, Boolean)..ctor(Object, System.IntPtr)"
-  IL_0078:  call       "Function System.Linq.Enumerable.Where(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Boolean)) As System.Collections.Generic.IEnumerable(Of Integer)"
-  IL_007d:  ldsfld     "AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)"
+  IL_006d:  ldftn      ""Function AllMembers._Closure$__5-0._Lambda$__0(Integer) As Boolean""
+  IL_0073:  newobj     ""Sub System.Func(Of Integer, Boolean)..ctor(Object, System.IntPtr)""
+  IL_0078:  call       ""Function System.Linq.Enumerable.Where(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Boolean)) As System.Collections.Generic.IEnumerable(Of Integer)""
+  IL_007d:  ldsfld     ""AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)""
   IL_0082:  brfalse.s  IL_008b
-  IL_0084:  ldsfld     "AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)"
+  IL_0084:  ldsfld     ""AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)""
   IL_0089:  br.s       IL_00a1
-  IL_008b:  ldsfld     "AllMembers._Closure$__.$I As AllMembers._Closure$__"
-  IL_0090:  ldftn      "Function AllMembers._Closure$__._Lambda$__5-1(Integer) As Integer"
-  IL_0096:  newobj     "Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)"
+  IL_008b:  ldsfld     ""AllMembers._Closure$__.$I As AllMembers._Closure$__""
+  IL_0090:  ldftn      ""Function AllMembers._Closure$__._Lambda$__5-1(Integer) As Integer""
+  IL_0096:  newobj     ""Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)""
   IL_009b:  dup
-  IL_009c:  stsfld     "AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)"
-  IL_00a1:  call       "Function System.Linq.Enumerable.Select(Of Integer, Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Integer)) As System.Collections.Generic.IEnumerable(Of Integer)"
-  IL_00a6:  call       "Function System.Linq.Enumerable.ToList(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As System.Collections.Generic.List(Of Integer)"
+  IL_009c:  stsfld     ""AllMembers._Closure$__.$I5-1 As System.Func(Of Integer, Integer)""
+  IL_00a1:  call       ""Function System.Linq.Enumerable.Select(Of Integer, Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Integer)) As System.Collections.Generic.IEnumerable(Of Integer)""
+  IL_00a6:  call       ""Function System.Linq.Enumerable.ToList(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As System.Collections.Generic.List(Of Integer)""
   IL_00ab:  ldloc.0
-  IL_00ac:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-  IL_00b1:  callvirt   "Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00ac:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+  IL_00b1:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00b6:  ldc.i4.5
-  IL_00b7:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00b7:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00bc:  pop
   IL_00bd:  dup
-  IL_00be:  call       "Function System.Linq.Enumerable.Count(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer"
-  IL_00c3:  box        "Integer"
+  IL_00be:  call       ""Function System.Linq.Enumerable.Count(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer""
+  IL_00c3:  box        ""Integer""
   IL_00c8:  ldc.i4.2
-  IL_00c9:  box        "Integer"
-  IL_00ce:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00c9:  box        ""Integer""
+  IL_00ce:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00d3:  pop
   IL_00d4:  dup
-  IL_00d5:  call       "Function System.Linq.Enumerable.ToArray(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer()"
+  IL_00d5:  call       ""Function System.Linq.Enumerable.ToArray(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer()""
   IL_00da:  ldc.i4.0
   IL_00db:  ldelem.i4
-  IL_00dc:  box        "Integer"
+  IL_00dc:  box        ""Integer""
   IL_00e1:  ldc.i4.2
-  IL_00e2:  box        "Integer"
-  IL_00e7:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00e2:  box        ""Integer""
+  IL_00e7:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_00ec:  pop
-  IL_00ed:  call       "Function System.Linq.Enumerable.ToArray(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer()"
+  IL_00ed:  call       ""Function System.Linq.Enumerable.ToArray(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer()""
   IL_00f2:  ldc.i4.1
   IL_00f3:  ldelem.i4
-  IL_00f4:  box        "Integer"
+  IL_00f4:  box        ""Integer""
   IL_00f9:  ldc.i4.4
-  IL_00fa:  box        "Integer"
-  IL_00ff:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_00fa:  box        ""Integer""
+  IL_00ff:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0104:  pop
   IL_0105:  ldloc.0
-  IL_0106:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-  IL_010b:  ldsfld     "AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)"
+  IL_0106:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+  IL_010b:  ldsfld     ""AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)""
   IL_0110:  brfalse.s  IL_0119
-  IL_0112:  ldsfld     "AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)"
+  IL_0112:  ldsfld     ""AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)""
   IL_0117:  br.s       IL_012f
-  IL_0119:  ldsfld     "AllMembers._Closure$__.$I As AllMembers._Closure$__"
-  IL_011e:  ldftn      "Function AllMembers._Closure$__._Lambda$__5-2(Integer) As Boolean"
-  IL_0124:  newobj     "Sub System.Func(Of Integer, Boolean)..ctor(Object, System.IntPtr)"
+  IL_0119:  ldsfld     ""AllMembers._Closure$__.$I As AllMembers._Closure$__""
+  IL_011e:  ldftn      ""Function AllMembers._Closure$__._Lambda$__5-2(Integer) As Boolean""
+  IL_0124:  newobj     ""Sub System.Func(Of Integer, Boolean)..ctor(Object, System.IntPtr)""
   IL_0129:  dup
-  IL_012a:  stsfld     "AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)"
-  IL_012f:  call       "Function System.Linq.Enumerable.Where(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Boolean)) As System.Collections.Generic.IEnumerable(Of Integer)"
-  IL_0134:  ldsfld     "AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)"
+  IL_012a:  stsfld     ""AllMembers._Closure$__.$I5-2 As System.Func(Of Integer, Boolean)""
+  IL_012f:  call       ""Function System.Linq.Enumerable.Where(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Boolean)) As System.Collections.Generic.IEnumerable(Of Integer)""
+  IL_0134:  ldsfld     ""AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)""
   IL_0139:  brfalse.s  IL_0142
-  IL_013b:  ldsfld     "AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)"
+  IL_013b:  ldsfld     ""AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)""
   IL_0140:  br.s       IL_0158
-  IL_0142:  ldsfld     "AllMembers._Closure$__.$I As AllMembers._Closure$__"
-  IL_0147:  ldftn      "Function AllMembers._Closure$__._Lambda$__5-3(Integer) As Integer"
-  IL_014d:  newobj     "Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)"
+  IL_0142:  ldsfld     ""AllMembers._Closure$__.$I As AllMembers._Closure$__""
+  IL_0147:  ldftn      ""Function AllMembers._Closure$__._Lambda$__5-3(Integer) As Integer""
+  IL_014d:  newobj     ""Sub System.Func(Of Integer, Integer)..ctor(Object, System.IntPtr)""
   IL_0152:  dup
-  IL_0153:  stsfld     "AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)"
-  IL_0158:  call       "Function System.Linq.Enumerable.Select(Of Integer, Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Integer)) As System.Collections.Generic.IEnumerable(Of Integer)"
-  IL_015d:  call       "Function System.Linq.Enumerable.ToList(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As System.Collections.Generic.List(Of Integer)"
+  IL_0153:  stsfld     ""AllMembers._Closure$__.$I5-3 As System.Func(Of Integer, Integer)""
+  IL_0158:  call       ""Function System.Linq.Enumerable.Select(Of Integer, Integer)(System.Collections.Generic.IEnumerable(Of Integer), System.Func(Of Integer, Integer)) As System.Collections.Generic.IEnumerable(Of Integer)""
+  IL_015d:  call       ""Function System.Linq.Enumerable.ToList(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As System.Collections.Generic.List(Of Integer)""
   IL_0162:  ldloc.0
-  IL_0163:  ldfld      "AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt"
-  IL_0168:  callvirt   "Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0163:  ldfld      ""AllMembers._Closure$__5-0.$VB$Local_v As Windows.Languages.WinRTTest.IVectorInt""
+  IL_0168:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_016d:  ldc.i4.1
-  IL_016e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_016e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0173:  pop
-  IL_0174:  call       "Function System.Linq.Enumerable.Count(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer"
-  IL_0179:  box        "Integer"
+  IL_0174:  call       ""Function System.Linq.Enumerable.Count(Of Integer)(System.Collections.Generic.IEnumerable(Of Integer)) As Integer""
+  IL_0179:  box        ""Integer""
   IL_017e:  ldc.i4.2
-  IL_017f:  box        "Integer"
-  IL_0184:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_017f:  box        ""Integer""
+  IL_0184:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0189:  pop
   .try
   {
-    IL_018a:  ldstr      "Dev11:205875"
-    IL_018f:  call       "Sub System.Console.WriteLine(String)"
+    IL_018a:  ldstr      ""Dev11:205875""
+    IL_018f:  call       ""Sub System.Console.WriteLine(String)""
     IL_0194:  ldc.i4.0
-    IL_0195:  box        "Boolean"
+    IL_0195:  box        ""Boolean""
     IL_019a:  ldc.i4.0
-    IL_019b:  box        "Boolean"
-    IL_01a0:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+    IL_019b:  box        ""Boolean""
+    IL_01a0:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
     IL_01a5:  pop
     IL_01a6:  leave.s    IL_01cb
   }
   catch System.ArgumentException
   {
     IL_01a8:  dup
-    IL_01a9:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)"
+    IL_01a9:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.SetProjectError(System.Exception)""
     IL_01ae:  stloc.1
-    IL_01af:  ldstr      "TestLINQ"
-    IL_01b4:  call       "Sub System.Console.WriteLine(String)"
+    IL_01af:  ldstr      ""TestLINQ""
+    IL_01b4:  call       ""Sub System.Console.WriteLine(String)""
     IL_01b9:  ldloc.1
-    IL_01ba:  callvirt   "Function System.ArgumentException.get_Message() As String"
-    IL_01bf:  call       "Sub System.Console.WriteLine(String)"
-    IL_01c4:  call       "Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()"
+    IL_01ba:  callvirt   ""Function System.ArgumentException.get_Message() As String""
+    IL_01bf:  call       ""Sub System.Console.WriteLine(String)""
+    IL_01c4:  call       ""Sub Microsoft.VisualBasic.CompilerServices.ProjectData.ClearProjectError()""
     IL_01c9:  leave.s    IL_01cb
   }
   IL_01cb:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -4610,52 +4608,52 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestNamedArguments", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestNamedArguments", "
 {
   // Code size      115 (0x73)
   .maxstack  4
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_0005:  dup
-  IL_0006:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()"
+  IL_0006:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()""
   IL_000b:  dup
   IL_000c:  ldc.i4.1
-  IL_000d:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_000d:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0012:  dup
-  IL_0013:  callvirt   "Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0013:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0018:  ldc.i4.s   9
-  IL_001a:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_001a:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_001f:  pop
-  IL_0020:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
-  IL_0025:  box        "Integer"
+  IL_0020:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
+  IL_0025:  box        ""Integer""
   IL_002a:  ldc.i4.1
-  IL_002b:  box        "Integer"
-  IL_0030:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_002b:  box        ""Integer""
+  IL_0030:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_0035:  pop
-  IL_0036:  newobj     "Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()"
+  IL_0036:  newobj     ""Sub Windows.Languages.WinRTTest.IMapIntInt..ctor()""
   IL_003b:  dup
-  IL_003c:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_003c:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_0041:  dup
   IL_0042:  ldc.i4.1
   IL_0043:  ldc.i4.1
-  IL_0044:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
+  IL_0044:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
   IL_0049:  dup
-  IL_004a:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_004a:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_004f:  ldc.i4.s   21
-  IL_0051:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0051:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0056:  pop
   IL_0057:  dup
-  IL_0058:  callvirt   "Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()"
+  IL_0058:  callvirt   ""Sub Windows.Languages.WinRTTest.IMapIntInt.ClearFlag()""
   IL_005d:  dup
   IL_005e:  ldc.i4.2
   IL_005f:  ldc.i4.2
-  IL_0060:  callvirt   "Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)"
-  IL_0065:  callvirt   "Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0060:  callvirt   ""Sub System.Collections.Generic.IDictionary(Of Integer, Integer).Add(Integer, Integer)""
+  IL_0065:  callvirt   ""Function Windows.Languages.WinRTTest.IMapIntInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_006a:  ldc.i4.s   21
-  IL_006c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_006c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0071:  pop
   IL_0072:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -4731,38 +4729,38 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestNullableArgs", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestNullableArgs", "
 {
   // Code size       80 (0x50)
   .maxstack  3
   .locals init (Integer? V_0) //x
-  IL_0000:  ldstr      "===  IVectorInt - nullable ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IVectorInt..ctor()"
+  IL_0000:  ldstr      ""===  IVectorInt - nullable ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IVectorInt..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.IVectorInt.ClearFlag()""
   IL_0015:  ldloca.s   V_0
   IL_0017:  ldc.i4.1
-  IL_0018:  call       "Sub Integer?..ctor(Integer)"
+  IL_0018:  call       ""Sub Integer?..ctor(Integer)""
   IL_001d:  dup
   IL_001e:  ldloca.s   V_0
-  IL_0020:  call       "Function Integer?.get_Value() As Integer"
-  IL_0025:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0020:  call       ""Function Integer?.get_Value() As Integer""
+  IL_0025:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_002a:  dup
-  IL_002b:  callvirt   "Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_002b:  callvirt   ""Function Windows.Languages.WinRTTest.IVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0030:  ldc.i4.s   9
-  IL_0032:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0032:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0037:  pop
   IL_0038:  ldc.i4.0
-  IL_0039:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_003e:  box        "Integer"
+  IL_0039:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_003e:  box        ""Integer""
   IL_0043:  ldc.i4.1
-  IL_0044:  box        "Integer"
-  IL_0049:  call       "Function AllMembers.ValidateValue(Object, Object) As Boolean"
+  IL_0044:  box        ""Integer""
+  IL_0049:  call       ""Function AllMembers.ValidateValue(Object, Object) As Boolean""
   IL_004e:  pop
   IL_004f:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -4966,168 +4964,168 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIBindableVectorMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIBindableVectorMembers", "
 {
   // Code size      421 (0x1a5)
   .maxstack  3
   .locals init (Windows.Languages.WinRTTest.IBindableVectorSimple V_0, //v
-  Integer() V_1) //arr
-  IL_0000:  ldstr      "===  IBindableVectorSimple  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IBindableVectorSimple..ctor()"
+                Integer() V_1) //arr
+  IL_0000:  ldstr      ""===  IBindableVectorSimple  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple..ctor()""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0011:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_0016:  ldloc.0
   IL_0017:  ldc.i4.1
-  IL_0018:  box        "Integer"
-  IL_001d:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_0018:  box        ""Integer""
+  IL_001d:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_0022:  pop
   IL_0023:  ldloc.0
-  IL_0024:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0024:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0029:  ldc.i4.s   28
-  IL_002b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_002b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0030:  pop
   IL_0031:  ldloc.0
-  IL_0032:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0032:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_0037:  ldloc.0
   IL_0038:  ldc.i4.1
-  IL_0039:  box        "Integer"
-  IL_003e:  callvirt   "Function System.Collections.IList.Contains(Object) As Boolean"
+  IL_0039:  box        ""Integer""
+  IL_003e:  callvirt   ""Function System.Collections.IList.Contains(Object) As Boolean""
   IL_0043:  pop
   IL_0044:  ldloc.0
-  IL_0045:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0045:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_004a:  ldc.i4.s   30
-  IL_004c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0051:  pop
   IL_0052:  ldloc.0
-  IL_0053:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0053:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_0058:  ldc.i4.0
-  IL_0059:  newarr     "Integer"
+  IL_0059:  newarr     ""Integer""
   IL_005e:  stloc.1
   IL_005f:  ldloc.0
   IL_0060:  ldloc.1
   IL_0061:  ldc.i4.0
-  IL_0062:  callvirt   "Sub System.Collections.ICollection.CopyTo(System.Array, Integer)"
+  IL_0062:  callvirt   ""Sub System.Collections.ICollection.CopyTo(System.Array, Integer)""
   IL_0067:  ldloc.0
-  IL_0068:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0068:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_006d:  ldc.i4.s   28
-  IL_006f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_006f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0074:  pop
   IL_0075:  ldloc.0
-  IL_0076:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0076:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_007b:  ldloc.0
-  IL_007c:  callvirt   "Function System.Collections.ICollection.get_Count() As Integer"
+  IL_007c:  callvirt   ""Function System.Collections.ICollection.get_Count() As Integer""
   IL_0081:  pop
   IL_0082:  ldloc.0
-  IL_0083:  callvirt   "Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0083:  callvirt   ""Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator""
   IL_0088:  pop
   IL_0089:  ldloc.0
-  IL_008a:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_008a:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_008f:  ldc.i4.s   26
-  IL_0091:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0091:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0096:  pop
   IL_0097:  ldloc.0
-  IL_0098:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0098:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_009d:  ldloc.0
   IL_009e:  ldc.i4.1
-  IL_009f:  box        "Integer"
-  IL_00a4:  callvirt   "Function System.Collections.IList.IndexOf(Object) As Integer"
+  IL_009f:  box        ""Integer""
+  IL_00a4:  callvirt   ""Function System.Collections.IList.IndexOf(Object) As Integer""
   IL_00a9:  pop
   IL_00aa:  ldloc.0
-  IL_00ab:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00ab:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00b0:  ldc.i4.s   30
-  IL_00b2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00b2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00b7:  pop
   IL_00b8:  ldloc.0
-  IL_00b9:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_00b9:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_00be:  ldloc.0
   IL_00bf:  ldc.i4.1
   IL_00c0:  ldc.i4.2
-  IL_00c1:  box        "Integer"
-  IL_00c6:  callvirt   "Sub System.Collections.IList.Insert(Integer, Object)"
+  IL_00c1:  box        ""Integer""
+  IL_00c6:  callvirt   ""Sub System.Collections.IList.Insert(Integer, Object)""
   IL_00cb:  ldloc.0
-  IL_00cc:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00cc:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00d1:  ldc.i4.s   32
-  IL_00d3:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00d3:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00d8:  pop
   IL_00d9:  ldloc.0
-  IL_00da:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_00da:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_00df:  ldloc.0
-  IL_00e0:  callvirt   "Function System.Collections.IList.get_IsReadOnly() As Boolean"
+  IL_00e0:  callvirt   ""Function System.Collections.IList.get_IsReadOnly() As Boolean""
   IL_00e5:  pop
   IL_00e6:  ldloc.0
-  IL_00e7:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00e7:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00ec:  ldc.i4.0
-  IL_00ed:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00ed:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00f2:  pop
   IL_00f3:  ldloc.0
-  IL_00f4:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_00f4:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_00f9:  ldloc.0
   IL_00fa:  ldc.i4.0
-  IL_00fb:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_0100:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_00fb:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_0100:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0105:  pop
   IL_0106:  ldloc.0
-  IL_0107:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0107:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_010c:  ldc.i4.s   27
-  IL_010e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_010e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0113:  pop
   IL_0114:  ldloc.0
-  IL_0115:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0115:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_011a:  ldloc.0
   IL_011b:  ldc.i4.1
-  IL_011c:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_0121:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_011c:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_0121:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0126:  pop
   IL_0127:  ldloc.0
-  IL_0128:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0128:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_012d:  ldc.i4.s   27
-  IL_012f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_012f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0134:  pop
   IL_0135:  ldloc.0
-  IL_0136:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0136:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_013b:  ldloc.0
   IL_013c:  ldc.i4.1
-  IL_013d:  box        "Integer"
-  IL_0142:  callvirt   "Sub System.Collections.IList.Remove(Object)"
+  IL_013d:  box        ""Integer""
+  IL_0142:  callvirt   ""Sub System.Collections.IList.Remove(Object)""
   IL_0147:  ldloc.0
-  IL_0148:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0148:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_014d:  ldc.i4.s   30
-  IL_014f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_014f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0154:  pop
   IL_0155:  ldloc.0
-  IL_0156:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_0156:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_015b:  ldloc.0
   IL_015c:  ldc.i4.0
-  IL_015d:  callvirt   "Sub System.Collections.IList.RemoveAt(Integer)"
+  IL_015d:  callvirt   ""Sub System.Collections.IList.RemoveAt(Integer)""
   IL_0162:  ldloc.0
-  IL_0163:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0163:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0168:  ldc.i4.s   33
-  IL_016a:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_016a:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_016f:  pop
   IL_0170:  ldloc.0
   IL_0171:  ldc.i4.1
-  IL_0172:  box        "Integer"
-  IL_0177:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_0172:  box        ""Integer""
+  IL_0177:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_017c:  pop
   IL_017d:  ldloc.0
   IL_017e:  ldc.i4.2
-  IL_017f:  box        "Integer"
-  IL_0184:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_017f:  box        ""Integer""
+  IL_0184:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_0189:  pop
   IL_018a:  ldloc.0
-  IL_018b:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()"
+  IL_018b:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorSimple.ClearFlag()""
   IL_0190:  ldloc.0
-  IL_0191:  callvirt   "Sub System.Collections.IList.Clear()"
+  IL_0191:  callvirt   ""Sub System.Collections.IList.Clear()""
   IL_0196:  ldloc.0
-  IL_0197:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0197:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_019c:  ldc.i4.s   36
-  IL_019e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_019e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01a3:  pop
   IL_01a4:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -5186,25 +5184,25 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIBindableIterableMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIBindableIterableMembers", "
 {
   // Code size       42 (0x2a)
   .maxstack  2
-  IL_0000:  ldstr      "===  IBindableIterableSimple  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IBindableIterableSimple..ctor()"
+  IL_0000:  ldstr      ""===  IBindableIterableSimple  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IBindableIterableSimple..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableIterableSimple.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableIterableSimple.ClearFlag()""
   IL_0015:  dup
-  IL_0016:  callvirt   "Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0016:  callvirt   ""Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator""
   IL_001b:  pop
-  IL_001c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableIterableSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_001c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableIterableSimple.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0021:  ldc.i4.s   26
-  IL_0023:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0023:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0028:  pop
   IL_0029:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -5340,299 +5338,299 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIBindableVectorIVectorIntMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIBindableVectorIVectorIntMembers", "
 {
   // Code size      743 (0x2e7)
   .maxstack  3
   .locals init (Windows.Languages.WinRTTest.IBindableVectorIVectorInt V_0, //v
-  Integer() V_1) //arr
-  IL_0000:  ldstr      "===  IBindableVectorIVectorIntSimple  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt..ctor()"
+                Integer() V_1) //arr
+  IL_0000:  ldstr      ""===  IBindableVectorIVectorIntSimple  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt..ctor()""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0011:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0016:  ldloc.0
   IL_0017:  ldc.i4.1
-  IL_0018:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0018:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_001d:  ldloc.0
-  IL_001e:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_001e:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0023:  ldc.i4.s   28
-  IL_0025:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0025:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_002a:  pop
   IL_002b:  ldloc.0
-  IL_002c:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_002c:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0031:  ldloc.0
   IL_0032:  ldc.i4.1
-  IL_0033:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean"
+  IL_0033:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean""
   IL_0038:  pop
   IL_0039:  ldloc.0
-  IL_003a:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_003a:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_003f:  ldc.i4.s   30
-  IL_0041:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0041:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0046:  pop
   IL_0047:  ldloc.0
-  IL_0048:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0048:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_004d:  ldc.i4.0
-  IL_004e:  newarr     "Integer"
+  IL_004e:  newarr     ""Integer""
   IL_0053:  stloc.1
   IL_0054:  ldloc.0
   IL_0055:  ldloc.1
   IL_0056:  ldc.i4.0
-  IL_0057:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)"
+  IL_0057:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)""
   IL_005c:  ldloc.0
-  IL_005d:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_005d:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0062:  ldc.i4.s   28
-  IL_0064:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0064:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0069:  pop
   IL_006a:  ldloc.0
-  IL_006b:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_006b:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0070:  ldloc.0
-  IL_0071:  callvirt   "Function System.Collections.ICollection.get_Count() As Integer"
+  IL_0071:  callvirt   ""Function System.Collections.ICollection.get_Count() As Integer""
   IL_0076:  pop
   IL_0077:  ldloc.0
-  IL_0078:  callvirt   "Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0078:  callvirt   ""Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator""
   IL_007d:  pop
   IL_007e:  ldloc.0
-  IL_007f:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_007f:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0084:  ldc.i4.1
-  IL_0085:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0085:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_008a:  pop
   IL_008b:  ldloc.0
-  IL_008c:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_008c:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0091:  ldloc.0
   IL_0092:  ldc.i4.1
-  IL_0093:  callvirt   "Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer"
+  IL_0093:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer""
   IL_0098:  pop
   IL_0099:  ldloc.0
-  IL_009a:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_009a:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_009f:  ldc.i4.s   30
-  IL_00a1:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00a1:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00a6:  pop
   IL_00a7:  ldloc.0
-  IL_00a8:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_00a8:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_00ad:  ldloc.0
   IL_00ae:  ldc.i4.1
   IL_00af:  ldc.i4.2
-  IL_00b0:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)"
+  IL_00b0:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)""
   IL_00b5:  ldloc.0
-  IL_00b6:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00b6:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00bb:  ldc.i4.s   32
-  IL_00bd:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00bd:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00c2:  pop
   IL_00c3:  ldloc.0
-  IL_00c4:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_00c4:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_00c9:  ldloc.0
-  IL_00ca:  callvirt   "Function System.Collections.IList.get_IsReadOnly() As Boolean"
+  IL_00ca:  callvirt   ""Function System.Collections.IList.get_IsReadOnly() As Boolean""
   IL_00cf:  pop
   IL_00d0:  ldloc.0
-  IL_00d1:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00d1:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00d6:  ldc.i4.0
-  IL_00d7:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00d7:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00dc:  pop
   IL_00dd:  ldloc.0
-  IL_00de:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_00de:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_00e3:  ldloc.0
   IL_00e4:  ldc.i4.0
-  IL_00e5:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_00ea:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_00e5:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_00ea:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_00ef:  pop
   IL_00f0:  ldloc.0
-  IL_00f1:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00f1:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00f6:  ldc.i4.s   27
-  IL_00f8:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00f8:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00fd:  pop
   IL_00fe:  ldloc.0
-  IL_00ff:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_00ff:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0104:  ldloc.0
   IL_0105:  ldc.i4.1
-  IL_0106:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_010b:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_0106:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_010b:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0110:  pop
   IL_0111:  ldloc.0
-  IL_0112:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0112:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0117:  ldc.i4.s   27
-  IL_0119:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0119:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_011e:  pop
   IL_011f:  ldloc.0
-  IL_0120:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0120:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0125:  ldloc.0
   IL_0126:  ldc.i4.1
-  IL_0127:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean"
+  IL_0127:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean""
   IL_012c:  pop
   IL_012d:  ldloc.0
-  IL_012e:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_012e:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0133:  ldc.i4.s   30
-  IL_0135:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0135:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_013a:  pop
   IL_013b:  ldloc.0
-  IL_013c:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_013c:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0141:  ldloc.0
   IL_0142:  ldc.i4.0
-  IL_0143:  callvirt   "Sub System.Collections.IList.RemoveAt(Integer)"
+  IL_0143:  callvirt   ""Sub System.Collections.IList.RemoveAt(Integer)""
   IL_0148:  ldloc.0
-  IL_0149:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0149:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_014e:  ldc.i4.s   33
-  IL_0150:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0150:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0155:  pop
   IL_0156:  ldloc.0
   IL_0157:  ldc.i4.1
-  IL_0158:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0158:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_015d:  ldloc.0
   IL_015e:  ldc.i4.2
-  IL_015f:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_015f:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_0164:  ldloc.0
-  IL_0165:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0165:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_016a:  ldloc.0
-  IL_016b:  callvirt   "Sub System.Collections.IList.Clear()"
+  IL_016b:  callvirt   ""Sub System.Collections.IList.Clear()""
   IL_0170:  ldloc.0
-  IL_0171:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0171:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0176:  ldc.i4.s   36
-  IL_0178:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0178:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_017d:  pop
   IL_017e:  ldloc.0
-  IL_017f:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_017f:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0184:  ldloc.0
   IL_0185:  ldc.i4.1
-  IL_0186:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_0186:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_018b:  ldloc.0
-  IL_018c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_018c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0191:  ldc.i4.s   9
-  IL_0193:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0193:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0198:  pop
   IL_0199:  ldloc.0
-  IL_019a:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_019a:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_019f:  ldloc.0
   IL_01a0:  ldc.i4.1
-  IL_01a1:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean"
+  IL_01a1:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Contains(Integer) As Boolean""
   IL_01a6:  pop
   IL_01a7:  ldloc.0
-  IL_01a8:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01a8:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01ad:  ldc.i4.5
-  IL_01ae:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01ae:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01b3:  pop
   IL_01b4:  ldloc.0
-  IL_01b5:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_01b5:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_01ba:  ldc.i4.0
-  IL_01bb:  newarr     "Integer"
+  IL_01bb:  newarr     ""Integer""
   IL_01c0:  stloc.1
   IL_01c1:  ldloc.0
   IL_01c2:  ldloc.1
   IL_01c3:  ldc.i4.0
-  IL_01c4:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)"
+  IL_01c4:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).CopyTo(Integer(), Integer)""
   IL_01c9:  ldloc.0
-  IL_01ca:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01ca:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01cf:  ldc.i4.s   28
-  IL_01d1:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01d1:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01d6:  pop
   IL_01d7:  ldloc.0
-  IL_01d8:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_01d8:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_01dd:  ldloc.0
-  IL_01de:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer"
+  IL_01de:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_Count() As Integer""
   IL_01e3:  pop
   IL_01e4:  ldloc.0
-  IL_01e5:  callvirt   "Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)"
+  IL_01e5:  callvirt   ""Function System.Collections.Generic.IEnumerable(Of Integer).GetEnumerator() As System.Collections.Generic.IEnumerator(Of Integer)""
   IL_01ea:  pop
   IL_01eb:  ldloc.0
-  IL_01ec:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01ec:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01f1:  ldc.i4.1
-  IL_01f2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01f2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01f7:  pop
   IL_01f8:  ldloc.0
-  IL_01f9:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_01f9:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_01fe:  ldloc.0
   IL_01ff:  ldc.i4.1
-  IL_0200:  callvirt   "Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer"
+  IL_0200:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).IndexOf(Integer) As Integer""
   IL_0205:  pop
   IL_0206:  ldloc.0
-  IL_0207:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0207:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_020c:  ldc.i4.5
-  IL_020d:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_020d:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0212:  pop
   IL_0213:  ldloc.0
-  IL_0214:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0214:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0219:  ldloc.0
   IL_021a:  ldc.i4.1
   IL_021b:  ldc.i4.2
-  IL_021c:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)"
+  IL_021c:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).Insert(Integer, Integer)""
   IL_0221:  ldloc.0
-  IL_0222:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0222:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0227:  ldc.i4.7
-  IL_0228:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0228:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_022d:  pop
   IL_022e:  ldloc.0
-  IL_022f:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_022f:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_0234:  ldloc.0
-  IL_0235:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean"
+  IL_0235:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).get_IsReadOnly() As Boolean""
   IL_023a:  pop
   IL_023b:  ldloc.0
-  IL_023c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_023c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0241:  ldc.i4.0
-  IL_0242:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0242:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0247:  pop
   IL_0248:  ldloc.0
-  IL_0249:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0249:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_024e:  ldloc.0
   IL_024f:  ldc.i4.0
-  IL_0250:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_0255:  box        "Integer"
+  IL_0250:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_0255:  box        ""Integer""
   IL_025a:  pop
   IL_025b:  ldloc.0
-  IL_025c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_025c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0261:  ldc.i4.2
-  IL_0262:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0262:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0267:  pop
   IL_0268:  ldloc.0
-  IL_0269:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0269:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_026e:  ldloc.0
   IL_026f:  ldc.i4.1
-  IL_0270:  callvirt   "Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer"
-  IL_0275:  box        "Integer"
+  IL_0270:  callvirt   ""Function System.Collections.Generic.IList(Of Integer).get_Item(Integer) As Integer""
+  IL_0275:  box        ""Integer""
   IL_027a:  pop
   IL_027b:  ldloc.0
-  IL_027c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_027c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0281:  ldc.i4.2
-  IL_0282:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0282:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0287:  pop
   IL_0288:  ldloc.0
-  IL_0289:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_0289:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_028e:  ldloc.0
   IL_028f:  ldc.i4.1
-  IL_0290:  callvirt   "Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean"
+  IL_0290:  callvirt   ""Function System.Collections.Generic.ICollection(Of Integer).Remove(Integer) As Boolean""
   IL_0295:  pop
   IL_0296:  ldloc.0
-  IL_0297:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0297:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_029c:  ldc.i4.5
-  IL_029d:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_029d:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02a2:  pop
   IL_02a3:  ldloc.0
-  IL_02a4:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_02a4:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_02a9:  ldloc.0
   IL_02aa:  ldc.i4.0
-  IL_02ab:  callvirt   "Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)"
+  IL_02ab:  callvirt   ""Sub System.Collections.Generic.IList(Of Integer).RemoveAt(Integer)""
   IL_02b0:  ldloc.0
-  IL_02b1:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02b1:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02b6:  ldc.i4.s   33
-  IL_02b8:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02b8:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02bd:  pop
   IL_02be:  ldloc.0
   IL_02bf:  ldc.i4.1
-  IL_02c0:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_02c0:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_02c5:  ldloc.0
   IL_02c6:  ldc.i4.2
-  IL_02c7:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)"
+  IL_02c7:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Add(Integer)""
   IL_02cc:  ldloc.0
-  IL_02cd:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()"
+  IL_02cd:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableVectorIVectorInt.ClearFlag()""
   IL_02d2:  ldloc.0
-  IL_02d3:  callvirt   "Sub System.Collections.Generic.ICollection(Of Integer).Clear()"
+  IL_02d3:  callvirt   ""Sub System.Collections.Generic.ICollection(Of Integer).Clear()""
   IL_02d8:  ldloc.0
-  IL_02d9:  callvirt   "Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_02d9:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableVectorIVectorInt.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_02de:  ldc.i4.s   36
-  IL_02e0:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_02e0:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_02e5:  pop
   IL_02e6:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -5691,25 +5689,25 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.TestIBindableIterableIIterableMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.TestIBindableIterableIIterableMembers", "
 {
   // Code size       41 (0x29)
   .maxstack  2
-  IL_0000:  ldstr      "===  IBindableIterableIIterable  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.IBindableIterableIIterable..ctor()"
+  IL_0000:  ldstr      ""===  IBindableIterableIIterable  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.IBindableIterableIIterable..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.IBindableIterableIIterable.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.IBindableIterableIIterable.ClearFlag()""
   IL_0015:  dup
-  IL_0016:  callvirt   "Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0016:  callvirt   ""Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator""
   IL_001b:  pop
-  IL_001c:  callvirt   "Function Windows.Languages.WinRTTest.IBindableIterableIIterable.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_001c:  callvirt   ""Function Windows.Languages.WinRTTest.IBindableIterableIIterable.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0021:  ldc.i4.1
-  IL_0022:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0022:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0027:  pop
   IL_0028:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -5822,193 +5820,193 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.INotifyCollectionAndBindableVectorMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.INotifyCollectionAndBindableVectorMembers", "
 {
   // Code size      488 (0x1e8)
   .maxstack  3
   .locals init (Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass V_0, //v
   Integer() V_1, //arr
   System.Collections.Specialized.NotifyCollectionChangedEventHandler V_2) //dele
-  IL_0000:  ldstr      "===  INotifyCollectionAndBindableVectorClass  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass..ctor()"
+  IL_0000:  ldstr      ""===  INotifyCollectionAndBindableVectorClass  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass..ctor()""
   IL_000f:  stloc.0
   IL_0010:  ldloc.0
-  IL_0011:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0011:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_0016:  ldloc.0
   IL_0017:  ldc.i4.1
-  IL_0018:  box        "Integer"
-  IL_001d:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_0018:  box        ""Integer""
+  IL_001d:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_0022:  pop
   IL_0023:  ldloc.0
-  IL_0024:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0024:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0029:  ldc.i4.s   28
-  IL_002b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_002b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0030:  pop
   IL_0031:  ldloc.0
-  IL_0032:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0032:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_0037:  ldloc.0
   IL_0038:  ldc.i4.1
-  IL_0039:  box        "Integer"
-  IL_003e:  callvirt   "Function System.Collections.IList.Contains(Object) As Boolean"
+  IL_0039:  box        ""Integer""
+  IL_003e:  callvirt   ""Function System.Collections.IList.Contains(Object) As Boolean""
   IL_0043:  pop
   IL_0044:  ldloc.0
-  IL_0045:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0045:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_004a:  ldc.i4.s   30
-  IL_004c:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004c:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0051:  pop
   IL_0052:  ldloc.0
-  IL_0053:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0053:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_0058:  ldc.i4.0
-  IL_0059:  newarr     "Integer"
+  IL_0059:  newarr     ""Integer""
   IL_005e:  stloc.1
   IL_005f:  ldloc.0
   IL_0060:  ldloc.1
   IL_0061:  ldc.i4.0
-  IL_0062:  callvirt   "Sub System.Collections.ICollection.CopyTo(System.Array, Integer)"
+  IL_0062:  callvirt   ""Sub System.Collections.ICollection.CopyTo(System.Array, Integer)""
   IL_0067:  ldloc.0
-  IL_0068:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0068:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_006d:  ldc.i4.s   28
-  IL_006f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_006f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0074:  pop
   IL_0075:  ldloc.0
-  IL_0076:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0076:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_007b:  ldloc.0
-  IL_007c:  callvirt   "Function System.Collections.ICollection.get_Count() As Integer"
+  IL_007c:  callvirt   ""Function System.Collections.ICollection.get_Count() As Integer""
   IL_0081:  pop
   IL_0082:  ldloc.0
-  IL_0083:  callvirt   "Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0083:  callvirt   ""Function System.Collections.IEnumerable.GetEnumerator() As System.Collections.IEnumerator""
   IL_0088:  pop
   IL_0089:  ldloc.0
-  IL_008a:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_008a:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_008f:  ldc.i4.s   26
-  IL_0091:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0091:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0096:  pop
   IL_0097:  ldloc.0
-  IL_0098:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0098:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_009d:  ldloc.0
   IL_009e:  ldc.i4.1
-  IL_009f:  box        "Integer"
-  IL_00a4:  callvirt   "Function System.Collections.IList.IndexOf(Object) As Integer"
+  IL_009f:  box        ""Integer""
+  IL_00a4:  callvirt   ""Function System.Collections.IList.IndexOf(Object) As Integer""
   IL_00a9:  pop
   IL_00aa:  ldloc.0
-  IL_00ab:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00ab:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00b0:  ldc.i4.s   30
-  IL_00b2:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00b2:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00b7:  pop
   IL_00b8:  ldloc.0
-  IL_00b9:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_00b9:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_00be:  ldloc.0
   IL_00bf:  ldc.i4.1
   IL_00c0:  ldc.i4.2
-  IL_00c1:  box        "Integer"
-  IL_00c6:  callvirt   "Sub System.Collections.IList.Insert(Integer, Object)"
+  IL_00c1:  box        ""Integer""
+  IL_00c6:  callvirt   ""Sub System.Collections.IList.Insert(Integer, Object)""
   IL_00cb:  ldloc.0
-  IL_00cc:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00cc:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00d1:  ldc.i4.s   32
-  IL_00d3:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00d3:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00d8:  pop
   IL_00d9:  ldloc.0
-  IL_00da:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_00da:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_00df:  ldloc.0
-  IL_00e0:  callvirt   "Function System.Collections.IList.get_IsReadOnly() As Boolean"
+  IL_00e0:  callvirt   ""Function System.Collections.IList.get_IsReadOnly() As Boolean""
   IL_00e5:  pop
   IL_00e6:  ldloc.0
-  IL_00e7:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_00e7:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_00ec:  ldc.i4.0
-  IL_00ed:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_00ed:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_00f2:  pop
   IL_00f3:  ldloc.0
-  IL_00f4:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_00f4:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_00f9:  ldloc.0
   IL_00fa:  ldc.i4.0
-  IL_00fb:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_0100:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_00fb:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_0100:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0105:  pop
   IL_0106:  ldloc.0
-  IL_0107:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0107:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_010c:  ldc.i4.s   27
-  IL_010e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_010e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0113:  pop
   IL_0114:  ldloc.0
-  IL_0115:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0115:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_011a:  ldloc.0
   IL_011b:  ldc.i4.1
-  IL_011c:  callvirt   "Function System.Collections.IList.get_Item(Integer) As Object"
-  IL_0121:  call       "Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object"
+  IL_011c:  callvirt   ""Function System.Collections.IList.get_Item(Integer) As Object""
+  IL_0121:  call       ""Function System.Runtime.CompilerServices.RuntimeHelpers.GetObjectValue(Object) As Object""
   IL_0126:  pop
   IL_0127:  ldloc.0
-  IL_0128:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0128:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_012d:  ldc.i4.s   27
-  IL_012f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_012f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0134:  pop
   IL_0135:  ldloc.0
-  IL_0136:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0136:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_013b:  ldloc.0
   IL_013c:  ldc.i4.1
-  IL_013d:  box        "Integer"
-  IL_0142:  callvirt   "Sub System.Collections.IList.Remove(Object)"
+  IL_013d:  box        ""Integer""
+  IL_0142:  callvirt   ""Sub System.Collections.IList.Remove(Object)""
   IL_0147:  ldloc.0
-  IL_0148:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0148:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_014d:  ldc.i4.s   30
-  IL_014f:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_014f:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0154:  pop
   IL_0155:  ldloc.0
-  IL_0156:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_0156:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_015b:  ldloc.0
   IL_015c:  ldc.i4.0
-  IL_015d:  callvirt   "Sub System.Collections.IList.RemoveAt(Integer)"
+  IL_015d:  callvirt   ""Sub System.Collections.IList.RemoveAt(Integer)""
   IL_0162:  ldloc.0
-  IL_0163:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0163:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0168:  ldc.i4.s   33
-  IL_016a:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_016a:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_016f:  pop
   IL_0170:  ldloc.0
   IL_0171:  ldc.i4.1
-  IL_0172:  box        "Integer"
-  IL_0177:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_0172:  box        ""Integer""
+  IL_0177:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_017c:  pop
   IL_017d:  ldloc.0
   IL_017e:  ldc.i4.2
-  IL_017f:  box        "Integer"
-  IL_0184:  callvirt   "Function System.Collections.IList.Add(Object) As Integer"
+  IL_017f:  box        ""Integer""
+  IL_0184:  callvirt   ""Function System.Collections.IList.Add(Object) As Integer""
   IL_0189:  pop
   IL_018a:  ldloc.0
-  IL_018b:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_018b:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_0190:  ldloc.0
-  IL_0191:  callvirt   "Sub System.Collections.IList.Clear()"
+  IL_0191:  callvirt   ""Sub System.Collections.IList.Clear()""
   IL_0196:  ldloc.0
-  IL_0197:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_0197:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_019c:  ldc.i4.s   36
-  IL_019e:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_019e:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01a3:  pop
   IL_01a4:  ldloc.0
-  IL_01a5:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_01a5:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_01aa:  ldnull
-  IL_01ab:  ldftn      "Sub AllMembers.v_CollectionChanged(Object, System.Collections.Specialized.NotifyCollectionChangedEventArgs)"
-  IL_01b1:  newobj     "Sub System.Collections.Specialized.NotifyCollectionChangedEventHandler..ctor(Object, System.IntPtr)"
+  IL_01ab:  ldftn      ""Sub AllMembers.v_CollectionChanged(Object, System.Collections.Specialized.NotifyCollectionChangedEventArgs)""
+  IL_01b1:  newobj     ""Sub System.Collections.Specialized.NotifyCollectionChangedEventHandler..ctor(Object, System.IntPtr)""
   IL_01b6:  stloc.2
   IL_01b7:  ldloc.0
   IL_01b8:  ldloc.2
-  IL_01b9:  callvirt   "Sub System.Collections.Specialized.INotifyCollectionChanged.add_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)"
+  IL_01b9:  callvirt   ""Sub System.Collections.Specialized.INotifyCollectionChanged.add_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)""
   IL_01be:  ldloc.0
-  IL_01bf:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01bf:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01c4:  ldc.i4.s   37
-  IL_01c6:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01c6:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01cb:  pop
   IL_01cc:  ldloc.0
-  IL_01cd:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()"
+  IL_01cd:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.ClearFlag()""
   IL_01d2:  ldloc.0
   IL_01d3:  ldloc.2
-  IL_01d4:  callvirt   "Sub System.Collections.Specialized.INotifyCollectionChanged.remove_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)"
+  IL_01d4:  callvirt   ""Sub System.Collections.Specialized.INotifyCollectionChanged.remove_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)""
   IL_01d9:  ldloc.0
-  IL_01da:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_01da:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionAndBindableVectorClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_01df:  ldc.i4.s   38
-  IL_01e1:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_01e1:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_01e6:  pop
   IL_01e7:  ret
 }
-]]>)
+")
         End Sub
 
         <Fact()>
@@ -6081,40 +6079,40 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.INotifyCollectionChangedMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.INotifyCollectionChangedMembers", "
 {
   // Code size       82 (0x52)
   .maxstack  3
   .locals init (System.Collections.Specialized.NotifyCollectionChangedEventHandler V_0) //dele
-  IL_0000:  ldstr      "===  INotifyCollectionChangedClass  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass..ctor()"
+  IL_0000:  ldstr      ""===  INotifyCollectionChangedClass  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass.ClearFlag()""
   IL_0015:  ldnull
-  IL_0016:  ldftn      "Sub AllMembers.v_CollectionChanged(Object, System.Collections.Specialized.NotifyCollectionChangedEventArgs)"
-  IL_001c:  newobj     "Sub System.Collections.Specialized.NotifyCollectionChangedEventHandler..ctor(Object, System.IntPtr)"
+  IL_0016:  ldftn      ""Sub AllMembers.v_CollectionChanged(Object, System.Collections.Specialized.NotifyCollectionChangedEventArgs)""
+  IL_001c:  newobj     ""Sub System.Collections.Specialized.NotifyCollectionChangedEventHandler..ctor(Object, System.IntPtr)""
   IL_0021:  stloc.0
   IL_0022:  dup
   IL_0023:  ldloc.0
-  IL_0024:  callvirt   "Sub System.Collections.Specialized.INotifyCollectionChanged.add_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)"
+  IL_0024:  callvirt   ""Sub System.Collections.Specialized.INotifyCollectionChanged.add_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)""
   IL_0029:  dup
-  IL_002a:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_002a:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_002f:  ldc.i4.s   37
-  IL_0031:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0031:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0036:  pop
   IL_0037:  dup
-  IL_0038:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass.ClearFlag()"
+  IL_0038:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyCollectionChangedClass.ClearFlag()""
   IL_003d:  dup
   IL_003e:  ldloc.0
-  IL_003f:  callvirt   "Sub System.Collections.Specialized.INotifyCollectionChanged.remove_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)"
-  IL_0044:  callvirt   "Function Windows.Languages.WinRTTest.INotifyCollectionChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_003f:  callvirt   ""Sub System.Collections.Specialized.INotifyCollectionChanged.remove_CollectionChanged(System.Collections.Specialized.NotifyCollectionChangedEventHandler)""
+  IL_0044:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyCollectionChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0049:  ldc.i4.s   38
-  IL_004b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0050:  pop
   IL_0051:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact>
@@ -6183,40 +6181,40 @@ End Class
                 additionalRefs:=LegacyRefs,
                 verify:=False)
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("AllMembers.IPropertyChangedMembers", <![CDATA[
+            verifier.VerifyIL("AllMembers.IPropertyChangedMembers", "
 {
   // Code size       82 (0x52)
   .maxstack  3
   .locals init (System.ComponentModel.PropertyChangedEventHandler V_0) //pdeleg
-  IL_0000:  ldstr      "===  INotifyCollectionChangedClass  ==="
-  IL_0005:  call       "Sub System.Console.WriteLine(String)"
-  IL_000a:  newobj     "Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass..ctor()"
+  IL_0000:  ldstr      ""===  INotifyCollectionChangedClass  ===""
+  IL_0005:  call       ""Sub System.Console.WriteLine(String)""
+  IL_000a:  newobj     ""Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass..ctor()""
   IL_000f:  dup
-  IL_0010:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass.ClearFlag()"
+  IL_0010:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass.ClearFlag()""
   IL_0015:  ldnull
-  IL_0016:  ldftn      "Sub AllMembers.v_PropertyChanged(Object, System.ComponentModel.PropertyChangedEventArgs)"
-  IL_001c:  newobj     "Sub System.ComponentModel.PropertyChangedEventHandler..ctor(Object, System.IntPtr)"
+  IL_0016:  ldftn      ""Sub AllMembers.v_PropertyChanged(Object, System.ComponentModel.PropertyChangedEventArgs)""
+  IL_001c:  newobj     ""Sub System.ComponentModel.PropertyChangedEventHandler..ctor(Object, System.IntPtr)""
   IL_0021:  stloc.0
   IL_0022:  dup
   IL_0023:  ldloc.0
-  IL_0024:  callvirt   "Sub System.ComponentModel.INotifyPropertyChanged.add_PropertyChanged(System.ComponentModel.PropertyChangedEventHandler)"
+  IL_0024:  callvirt   ""Sub System.ComponentModel.INotifyPropertyChanged.add_PropertyChanged(System.ComponentModel.PropertyChangedEventHandler)""
   IL_0029:  dup
-  IL_002a:  callvirt   "Function Windows.Languages.WinRTTest.INotifyPropertyChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_002a:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyPropertyChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_002f:  ldc.i4.s   39
-  IL_0031:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_0031:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0036:  pop
   IL_0037:  dup
-  IL_0038:  callvirt   "Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass.ClearFlag()"
+  IL_0038:  callvirt   ""Sub Windows.Languages.WinRTTest.INotifyPropertyChangedClass.ClearFlag()""
   IL_003d:  dup
   IL_003e:  ldloc.0
-  IL_003f:  callvirt   "Sub System.ComponentModel.INotifyPropertyChanged.remove_PropertyChanged(System.ComponentModel.PropertyChangedEventHandler)"
-  IL_0044:  callvirt   "Function Windows.Languages.WinRTTest.INotifyPropertyChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled"
+  IL_003f:  callvirt   ""Sub System.ComponentModel.INotifyPropertyChanged.remove_PropertyChanged(System.ComponentModel.PropertyChangedEventHandler)""
+  IL_0044:  callvirt   ""Function Windows.Languages.WinRTTest.INotifyPropertyChangedClass.GetFlagState() As Windows.Languages.WinRTTest.TestMethodCalled""
   IL_0049:  ldc.i4.s   40
-  IL_004b:  call       "Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean"
+  IL_004b:  call       ""Function AllMembers.ValidateMethod(Windows.Languages.WinRTTest.TestMethodCalled, Windows.Languages.WinRTTest.TestMethodCalled) As Boolean""
   IL_0050:  pop
   IL_0051:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact>
@@ -6242,17 +6240,17 @@ End Class
                                         verify:=False,
                                         options:=TestOptions.ReleaseExe)
 
-            comp.VerifyIL("A.Main", <![CDATA[
+            comp.VerifyIL("A.Main", "
 {
   // Code size       13 (0xd)
   .maxstack  2
-  IL_0000:  newobj     "Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct..ctor()"
+  IL_0000:  newobj     ""Sub Windows.Languages.WinRTTest.IMapIMapViewIntStruct..ctor()""
   IL_0005:  ldc.i4.1
-  IL_0006:  call       "Function System.Linq.Enumerable.ElementAtOrDefault(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))(System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)), Integer) As System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)"
+  IL_0006:  call       ""Function System.Linq.Enumerable.ElementAtOrDefault(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct))(System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)), Integer) As System.Collections.Generic.KeyValuePair(Of Integer, Windows.Languages.WinRTTest.UserDefinedStruct)""
   IL_000b:  pop
   IL_000c:  ret
 }
-]]>.Value)
+")
         End Sub
 
         <Fact()>
@@ -6289,7 +6287,7 @@ End Namespace
                 additionalRefs:=WinRtRefs)
 
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("Test.C.GetEnumerator()", <![CDATA[
+            verifier.VerifyIL("Test.C.GetEnumerator()", "
 {
   // Code size        2 (0x2)
   .maxstack  1
@@ -6297,7 +6295,7 @@ End Namespace
   IL_0001:  ret
 }
 
-]]>.Value)
+")
 
             Dim compRef = verifier.Compilation.EmitToImageReference(expectedWarnings:={Diagnostic(ERRID.HDN_UnusedImportStatement, "Imports System")})
             Dim allRefs = New List(Of MetadataReference)(WinRtRefs)
@@ -6326,16 +6324,16 @@ End Namespace
             verifier = CompileAndVerify(source,
                 additionalRefs:=allRefs.ToArray())
             AssertNoErrorsOrWarnings(verifier)
-            verifier.VerifyIL("Test2.D.Main", <![CDATA[
+            verifier.VerifyIL("Test2.D.Main", "
 {
   // Code size       12 (0xc)
   .maxstack  1
-  IL_0000:  newobj     "Sub Test.C..ctor()"
-  IL_0005:  callvirt   "Function Test.C.GetEnumerator() As System.Collections.IEnumerator"
+  IL_0000:  newobj     ""Sub Test.C..ctor()""
+  IL_0005:  callvirt   ""Function Test.C.GetEnumerator() As System.Collections.IEnumerator""
   IL_000a:  pop
   IL_000b:  ret
 }
-]]>.Value)
+")
         End Sub
 
         Private Shared Sub AssertNoErrorsOrWarnings(verifier As CompilationVerifier)

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -47,20 +47,35 @@ Namespace Global
     End Module
 
     Module ext
-        Const spc32 = "                              "
-        Const spc16 = "               "
+        '                       1         2         3
+        '              12345678901234567890123456789012
+        Const spc32 = "                                "
+        Const spc16 = "                "
+        Const spc14 = "              "
+        Const spc12 = "            "
+        Const spc10 = "          "
         Const spc08 = "        "
+        Const spc06 = "      "
         Const spc04 = "    "
         Const spc02 = "  "
         <System.Runtime.CompilerServices.Extension>
         Friend Function Indent(ByRef sb As StringBuilder, level As Integer) As StringBuilder
-            While level > 0
-                'If level >= 32 Then sb = sb.Append(spc32) : level -= 32
-                'If level >= 16 Then sb = sb.Append(spc16) : level -= 16
-                If level >= 8 Then sb = sb.Append(spc08) : level -= 8
-                If level >= 4 Then sb = sb.Append(spc04) : level -= 4
-                If level >= 2 Then sb = sb.Append(spc02) : level -= 2
-            End While
+simplecases:
+            Select Case level
+                Case 0 : Return sb
+                Case 2 : sb = sb.Append(spc02)
+                Case 4 : sb = sb.Append(spc04)
+                Case 6 : sb = sb.Append(spc06)
+                Case 8 : sb = sb.Append(spc08)
+                Case 10 : sb = sb.Append(spc10)
+                Case 12 : sb = sb.Append(spc12)
+                Case 14 : sb = sb.Append(spc14)
+                Case Else
+                    While level >= 16
+                        sb.Append(spc16) : level -= 16
+                    End While
+                    GoTo simplecases
+            End Select
             Return sb
         End Function
     End Module

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -46,18 +46,36 @@ Namespace Global
         End Function
     End Module
 
+    Module ext
+        Const spc32 = "                              "
+        Const spc16 = "               "
+        Const spc08 = "        "
+        Const spc04 = "    "
+        Const spc02 = "  "
+        <System.Runtime.CompilerServices.Extension>
+        Friend Function Indent(ByRef sb As StringBuilder, level As Integer) As StringBuilder
+            While level > 0
+                'If level >= 32 Then sb = sb.Append(spc32) : level -= 32
+                'If level >= 16 Then sb = sb.Append(spc16) : level -= 16
+                If level >= 8 Then sb = sb.Append(spc08) : level -= 8
+                If level >= 4 Then sb = sb.Append(spc04) : level -= 4
+                If level >= 2 Then sb = sb.Append(spc02) : level -= 2
+            End While
+            Return sb
+        End Function
+    End Module
+
     Friend Class ExpressionPrinter
         Inherits System.Linq.Expressions.ExpressionVisitor
 
-        Private ReadOnly _s As StringBuilder = New StringBuilder()
+        Private ReadOnly _s As StringBuilder = New StringBuilder(256)
 
-        Private _indent As String = ""
-        Private ReadOnly _indentStep As String = "  "
+        Private ReadOnly _IndentStep As Integer = 2
+        Private _indent As Integer = 0
 
         Public Shared Function GetCultureInvariantString(val As Object) As String
-            If val Is Nothing Then
-                Return Nothing
-            End If
+            If val Is Nothing Then Return Nothing
+
 
             Dim vType = val.GetType()
             Dim valStr = val.ToString()
@@ -80,124 +98,123 @@ Namespace Global
             Return p._s.ToString()
         End Function
 
+
+
         Public Overrides Function Visit(node As Expression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             If node Is Nothing Then
-                _s.AppendLine(Me._indent + "<NULL>")
+                _s.Indent(_indent).AppendLine("<NULL>")
                 Return Nothing
             End If
 
-            _s.AppendLine(indent + node.NodeType.ToString() + "(")
-            Me._indent = indent + _indentStep
+            _s.Indent(indent).Append(node.NodeType.ToString()).AppendLine("(")
+            _indent = indent + _IndentStep
             MyBase.Visit(node)
-            _s.AppendLine(indent + _indentStep + "type: " + node.Type.ToString())
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent + _IndentStep).Append("type: ").AppendLine(node.Type.ToString())
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberBinding(node As MemberBinding) As MemberBinding
-            If node Is Nothing Then
-                _s.AppendLine(Me._indent + "<NULL>")
-                Return Nothing
-            End If
-
-            Return MyBase.VisitMemberBinding(node)
+            If node IsNot Nothing Then Return MyBase.VisitMemberBinding(node)
+            _s.Indent(_indent).AppendLine("<NULL>")
+            Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberMemberBinding(node As MemberMemberBinding) As MemberMemberBinding
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberMemberBinding(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberMemberBinding(")
+            _s.Indent(indent + _IndentStep).Append("member: ").AppendLine(node.Member.ToString())
             For Each b In node.Bindings
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitMemberBinding(b)
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberListBinding(node As MemberListBinding) As MemberListBinding
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberListBinding(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberListBinding(")
+            _s.Indent(indent + _IndentStep).Append("member: ").AppendLine(node.Member.ToString())
             For Each i In node.Initializers
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitElementInit(i)
             Next
-
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberAssignment(node As MemberAssignment) As MemberAssignment
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberAssignment(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
-            _s.AppendLine(indent + _indentStep + "expression: {")
-            Me._indent = indent + _indentStep + _indentStep
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberAssignment(")
+            Dim nl = indent + _IndentStep
+            _s.Indent(nl).Append("member: ").AppendLine(node.Member.ToString())
+            _s.Indent(nl).AppendLine("expression: {")
+            _indent = nl + _IndentStep
             Visit(node.Expression)
-            _s.AppendLine(indent + _indentStep + "}")
-            _s.AppendLine(indent + ")")
+            _s.Indent(nl).AppendLine("}")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberInit(node As MemberInitExpression) As Expression
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "NewExpression(")
-            Me._indent = indent + _indentStep
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("NewExpression(")
+            _indent = indent + _IndentStep
             Visit(node.NewExpression)
-            _s.AppendLine(indent + ")")
-            _s.AppendLine(indent + "bindings:")
+            _s.Indent(indent).AppendLine(")")
+            _s.Indent(indent).AppendLine("bindings:")
             For Each b In node.Bindings
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitMemberBinding(b)
             Next
+
             Return Nothing
         End Function
 
         Protected Overrides Function VisitBinary(node As BinaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
 
-            Me._indent = indent
+            _indent = indent
             Visit(node.Left)
 
-            Me._indent = indent
+            _indent = indent
             Visit(node.Right)
 
             If node.Conversion IsNot Nothing Then
-                _s.AppendLine(indent + "conversion:")
-                Me._indent = indent + _indentStep
+                _s.Indent(indent).AppendLine("conversion:")
+                _indent = indent + _IndentStep
                 Visit(node.Conversion)
             End If
 
-            If node.IsLifted Then
-                _s.AppendLine(indent + "Lifted")
-            End If
+            If node.IsLifted Then _s.Indent(indent).AppendLine("Lifted")
 
-            If node.IsLiftedToNull Then
-                _s.AppendLine(indent + "LiftedToNull")
-            End If
+            If node.IsLiftedToNull Then _s.Indent(indent).
+                                             AppendLine("LiftedToNull")
 
-            If node.Method IsNot Nothing Then
-                _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString())
-            End If
+            If node.Method IsNot Nothing Then _s.Indent(indent).
+                                                   Append("method: ").
+                                                   Append(node.Method.ToString()).
+                                                   Append(" in ").
+                                                   AppendLine(node.Method.DeclaringType.ToString())
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitConditional(node As ConditionalExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Test)
-            Me._indent = indent
+            _indent = indent
             Visit(node.IfTrue)
-            Me._indent = indent
+            _indent = indent
             Visit(node.IfFalse)
             Return Nothing
         End Function
 
         Protected Overrides Function VisitConstant(node As ConstantExpression) As Expression
-            _s.AppendLine(_indent + If(node.Value Is Nothing, "null", GetCultureInvariantString(node.Value)))
+            _s.Indent(_indent).AppendLine(If(node.Value Is Nothing, "null", GetCultureInvariantString(node.Value)))
             Return Nothing
         End Function
 
@@ -206,89 +223,87 @@ Namespace Global
         End Function
 
         Protected Overrides Function VisitIndex(node As IndexExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.[Object])
 
-            Me._indent = indent
-            _s.AppendLine(indent + "indices(")
-            Dim n As Integer = node.Arguments.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _indent = indent
+            _s.Indent(indent).AppendLine("indices(")
+            Dim n As Integer = node.Arguments.Count - 1
+
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
 
-            If node.Indexer IsNot Nothing Then
-                _s.AppendLine(indent + "indexer: " + node.Indexer.ToString())
-            End If
+            If node.Indexer IsNot Nothing Then _s.Indent(indent).Append("indexer: ").AppendLine(node.Indexer.ToString())
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitInvocation(node As InvocationExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-            _s.AppendLine(indent + "(")
-            Dim n As Integer = node.Arguments.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("(")
+            Dim n As Integer = node.Arguments.Count - 1
+
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitLambda(Of T)(node As Expression(Of T)) As Expression
-            Dim indent = Me._indent
-            Dim n As Integer = node.Parameters.Count
-            For i = 0 To n - 1
-                Me._indent = indent
+            Dim indent = _indent
+            Dim n As Integer = node.Parameters.Count - 1
+
+            For i = 0 To n
+                _indent = indent
                 Visit(node.Parameters(i))
             Next
 
-            If node.Name IsNot Nothing Then
-                _s.AppendLine(indent + node.Name)
-            End If
+            If node.Name IsNot Nothing Then _s.Indent(indent).AppendLine(node.Name)
 
-            _s.AppendLine(indent + "body {")
-            Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("body {")
+            _indent = indent + _IndentStep
             Visit(node.Body)
-            _s.AppendLine(indent + "}")
 
-            If node.ReturnType IsNot Nothing Then
-                _s.AppendLine(indent + "return type: " + node.ReturnType.ToString())
-            End If
+            _s.Indent(indent).AppendLine("}")
 
-            If node.TailCall Then
-                _s.AppendLine(indent + "tail call")
-            End If
+            If node.ReturnType IsNot Nothing Then _s.Indent(indent).Append("return type: ").AppendLine(node.ReturnType.ToString())
+
+            If node.TailCall Then _s.Indent(indent).AppendLine("tail call")
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitParameter(node As ParameterExpression) As Expression
-            _s.Append(Me._indent + node.Name)
-            If node.IsByRef Then
-                _s.Append(" ByRef")
-            End If
+            _s.Indent(_indent).Append(node.Name)
+
+            If node.IsByRef Then _s.Append(" ByRef")
+
             _s.AppendLine()
+
             Return Nothing
         End Function
 
         Protected Overrides Function VisitListInit(node As ListInitExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
+
             Visit(node.NewExpression)
 
-            _s.AppendLine(indent + "{")
-            Dim n As Integer = node.Initializers.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("{")
+
+            Dim n As Integer = node.Initializers.Count - 1
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Initializers(i))
             Next
-
-            _s.AppendLine(indent + "}")
+            _s.Indent(indent).AppendLine("}")
             Return Nothing
         End Function
 
@@ -298,102 +313,88 @@ Namespace Global
         End Function
 
         Private Overloads Sub Visit(node As ElementInit)
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "ElementInit(")
-            _s.AppendLine(indent + _indentStep + node.AddMethod.ToString)
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("ElementInit(")
+            _s.Indent(indent + _IndentStep).AppendLine(node.AddMethod.ToString)
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
-
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
         End Sub
 
         Protected Overrides Function VisitUnary(node As UnaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Operand)
 
-            If node.IsLifted Then
-                _s.AppendLine(indent + "Lifted")
-            End If
+            If node.IsLifted Then _s.Indent(indent).AppendLine("Lifted")
 
-            If node.IsLiftedToNull Then
-                _s.AppendLine(indent + "LiftedToNull")
-            End If
+            If node.IsLiftedToNull Then _s.Indent(indent).AppendLine("LiftedToNull")
 
-            If node.Method IsNot Nothing Then
-                _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString())
-            End If
-
+            If node.Method IsNot Nothing Then _s.Indent(indent).Append("method: ").Append(node.Method.ToString()).Append(" in ").AppendLine(node.Method.DeclaringType.ToString())
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMember(node As MemberExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-            _s.AppendLine(indent + "-> " + node.Member.Name)
+            _s.Indent(indent).Append("-> ").AppendLine(node.Member.Name)
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMethodCall(node As MethodCallExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.[Object])
-
-            _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString() + " (")
+            _s.Indent(indent).Append("method: ").Append(node.Method.ToString()).Append(" in ").Append(node.Method.DeclaringType.ToString()).AppendLine(" (")
 
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitNew(node As NewExpression) As Expression
-            Dim indent = Me._indent
-
-            _s.AppendLine(indent + If((node.Constructor IsNot Nothing), node.Constructor.ToString(), "<.ctor>") + "(")
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine(If((node.Constructor IsNot Nothing), node.Constructor.ToString(), "<.ctor>") + "(")
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
+            If node.Members Is Nothing Then Return Nothing
+            n = node.Members.Count
+            If n = 0 Then Return Nothing
+            _s.Indent(indent).AppendLine("members: {")
 
-            If node.Members IsNot Nothing Then
-                n = node.Members.Count
-                If n <> 0 Then
-                    _s.AppendLine(indent + "members: {")
-                    For i = 0 To n - 1
-                        Dim info = node.Members(i)
-                        _s.AppendLine(indent + _indentStep + info.ToString())
-                    Next
-
-                    _s.AppendLine(indent + "}")
-                End If
-            End If
+            For i = 0 To n - 1
+                Dim info = node.Members(i)
+                _s.Indent(indent + _IndentStep).AppendLine(info.ToString())
+            Next
+            _s.Indent(indent).AppendLine("}")
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitNewArray(node As NewArrayExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Dim n As Integer = node.Expressions.Count
             For i = 0 To n - 1
-                Me._indent = indent
+                _indent = indent
                 Visit(node.Expressions(i))
             Next
             Return Nothing
         End Function
 
         Protected Overrides Function VisitTypeBinary(node As TypeBinaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-
-            _s.AppendLine(indent + "Type Operand: " + node.TypeOperand.ToString())
+            _s.Indent(indent).Append("Type Operand: ").AppendLine(node.TypeOperand.ToString())
             Return Nothing
         End Function
     End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IPEndBlockStatements.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IPEndBlockStatements.vb
@@ -23,8 +23,10 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Public Sub Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf
+        Dim code As String =
+"Public Sub Foo()
+Dim i = 1
+"
         Dim change As String = "End Function"
 
         IncParseAndVerify(New IncParseNode With {
@@ -39,13 +41,17 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
-        Dim change = "End Function" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = 1
+End Module
+End Namespace
+"
+        Dim change =
+"End Function
+"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -60,14 +66,18 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = Sub()" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
-        Dim change = "End Function" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = Sub()
+End Sub
+End Module
+End Namespace
+"
+        Dim change =
+"End Function
+"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -86,9 +96,11 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Public Sub Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Function" & vbCrLf
+        Dim code As String =
+"Public Sub Foo()
+Dim i = 1
+End Function
+"
         Dim change As String = "End Function"
 
         IncParseAndVerify(New IncParseNode With {
@@ -104,13 +116,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = 1
+End Function
+End Module
+End Namespace
+"
         Dim change = "End Function" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -126,14 +140,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = Sub()" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = Sub()
+End Function
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End Function" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -153,8 +169,10 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Public Function Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf
+        Dim code As String =
+"Public Function Foo()
+Dim i = 1
+"
         Dim change As String = "End Sub"
 
         IncParseAndVerify(New IncParseNode With {
@@ -170,12 +188,14 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = 1
+End Module
+End Namespace
+"
         Dim change = "End Sub" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -192,13 +212,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = Function()" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = Function() 
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End Sub" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -217,9 +239,11 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Public Function Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Sub" & vbCrLf
+        Dim code As String =
+"Public Function Foo()
+Dim i = 1
+End Sub
+"
         Dim change As String = "End Sub"
 
         IncParseAndVerify(New IncParseNode With {
@@ -238,13 +262,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = 1" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = 1
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End Sub" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -263,14 +289,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "Dim i = Function()" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+Dim i = Function()
+End Sub
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End Sub" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -289,10 +317,12 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "While True" & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+While True
+"
         Dim change = "End If" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -310,13 +340,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "While True" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+While True
+End Function
+End Module
+End Namespace
+"
         Dim change = "End If" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -334,13 +366,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "If True Then" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+If True Then
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End Sub" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -359,11 +393,13 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "While True" & vbCrLf &
-            "End If" & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+While True
+End If
+"
         Dim change = "End If" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -382,14 +418,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "While True" & vbCrLf &
-            "End If" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+While True
+End If
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End If" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -408,14 +446,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: For a statement lambda
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Sub Foo()" & vbCrLf &
-            "If True Then" & vbCrLf &
-            "End If" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Sub Foo()
+If True Then
+End If
+End Sub
+End Module
+End Namespace
+"
         Dim change = "End If" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -434,11 +474,13 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = From el in {1,2} " & vbCrLf &
-            "Select el " & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = From el In {1, 2} 
+Select el 
+"
         Dim change = "End Select" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -457,14 +499,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = From el in {1,2} " & vbCrLf &
-            "Select el " & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = From el in {1,2} 
+Select el 
+End Function
+End Module
+End Namespace
+"
         Dim change = "End Select" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -484,12 +528,14 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = From el in {1,2} " & vbCrLf &
-            "Select el " & vbCrLf &
-            "End Select" & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = From el in {1,2} 
+Select el 
+End Select
+"
         Dim change = "End Select" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -509,15 +555,17 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = From el in {1,2} " & vbCrLf &
-            "Select el " & vbCrLf &
-            "End Select" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = From el In {1, 2} 
+Select el 
+End Select
+End Function
+End Module
+End Namespace
+"
         Dim change = "End Select" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -537,10 +585,12 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "With New Integer " & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+With New Integer 
+"
         Dim change = "End Using" & vbCrLf
 
 
@@ -561,13 +611,15 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "With New Integer " & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+With New Integer 
+End Function
+End Module
+End Namespace
+"
         Dim change = "End Using" & vbCrLf
 
 
@@ -588,14 +640,16 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario3: Replacing In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "With New Integer " & vbCrLf &
-            "End With" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+With New Integer 
+End With
+End Function
+End Module
+End Namespace
+"
         Dim change = "Using" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -615,10 +669,12 @@ Public Class IPEndBlockStatements
         'Scenario1: At the end of file
         '===================================================================================================================
 
-        Dim code As String = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "With New Integer " & vbCrLf
+        Dim code As String =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+With New Integer 
+"
         Dim change = "End Using" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {
@@ -638,15 +694,17 @@ Public Class IPEndBlockStatements
         '===================================================================================================================
         'Scenario2: In the middle of the file
         '===================================================================================================================
-        Dim code = "Namespace n1" & vbCrLf &
-            "Public Module m1" & vbCrLf &
-            "Public Function Foo()" & vbCrLf &
-            "Dim i = From el in {1,2} " & vbCrLf &
-            "Select el " & vbCrLf &
-            "End Select" & vbCrLf &
-            "End Function" & vbCrLf &
-            "End Module" & vbCrLf &
-            "End Namespace" & vbCrLf
+        Dim code =
+"Namespace n1
+Public Module m1
+Public Function Foo()
+Dim i = From el In {1, 2} 
+Select el 
+End Select
+End Function
+End Module
+End Namespace
+"
         Dim change = "End Select" & vbCrLf
 
         IncParseAndVerify(New IncParseNode With {

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -338,7 +338,7 @@ End Sub"
 
     <Fact>
     Public Sub IncParsePPElse()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
 Function foo() As Boolean
 
 #Else
@@ -349,7 +349,7 @@ Function foo() As Boolean
 
 
 End Function
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "#End If",
@@ -851,11 +851,10 @@ End Module
     <WorkItem(545667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545667")>
     <Fact>
     Public Sub Bug14266()
-        Dim source = "
-Enum E
+        Dim source =
+"Enum E
     A
-End Enum
-".Trim()
+End Enum"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -868,13 +867,12 @@ End Enum
     <WorkItem(546680, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546680")>
     <Fact>
     Public Sub Bug16533()
-        Dim source = "
-Module M
+        Dim source =
+"Module M
     Sub M()
         If True Then M() Else : 
     End Sub
-End Module
-"
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Replace "True" with "True".
@@ -888,14 +886,13 @@ End Module
     <WorkItem(546685, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546685")>
     <Fact>
     Public Sub MultiLineIf()
-        Dim source = "
-Module M
+        Dim source =
+"Module M
     Sub M(b As Boolean)
         If b Then
         End If
     End Sub
-End Module
-".Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -915,16 +912,15 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_2()
-        Dim source = "
-Module M
+        Dim source =
+"Module M
     Sub M()
         Dim b = False
         b = True
         If b Then
         End If
     End Sub
-End Module
-".Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -944,16 +940,15 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_3()
-        Dim source = "
-Module M
+        Dim source =
+"Module M
     Sub M(b As Boolean)
         If b Then
         End If
         While b
         End While
     End Sub
-End Module
-".Trim()
+End Module"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1557,7 +1552,7 @@ End Class
     <WorkItem(604044, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/604044")>
     <Fact>
     Public Sub BunchALabels()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Sub Main()
 &HF:
@@ -1573,7 +1568,7 @@ Module Program
     End Sub
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Add enter after &HFFFFFFFFFF:.
@@ -1587,7 +1582,7 @@ End Module
     <Fact()>
     Public Sub LabelAfterColon()
         ' Label following another label on separate lines.
-        LabelAfterColonCore(True, <![CDATA[Module M
+        LabelAfterColonCore(True, "Module M
             Sub M()
         10:
         20:
@@ -1598,9 +1593,9 @@ End Module
         70:
             End Sub
         End Module
-        ]]>.Value)
+        ")
         ' Label following another label on separate lines.
-        LabelAfterColonCore(True, <![CDATA[Module M
+        LabelAfterColonCore(True, "Module M
             Sub M()
         10: : 
         20:
@@ -1611,9 +1606,9 @@ End Module
         70:
             End Sub
         End Module
-        ]]>.Value)
+        ")
         ' Label following on the same line as another label.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 10: 20:
 30:
@@ -1623,9 +1618,9 @@ End Module
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following on the same line as another label.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 10: : 20:
 30:
@@ -1635,9 +1630,9 @@ End Module
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following on the same line as another statement.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 M() : 20:
 30:
@@ -1647,9 +1642,9 @@ M() : 20:
 70:
     End Sub
 End Module
-]]>.Value)
+")
         ' Label following a colon within a single-line statement.
-        LabelAfterColonCore(False, <![CDATA[Module M
+        LabelAfterColonCore(False, "Module M
     Sub M()
 If True Then M() : 20:
 30:
@@ -1659,7 +1654,7 @@ If True Then M() : 20:
 70:
     End Sub
 End Module
-]]>.Value)
+")
     End Sub
 
     Private Sub LabelAfterColonCore(valid As Boolean, code As String)
@@ -1675,15 +1670,15 @@ End Module
         VerifyEquivalent(newTree, VisualBasicSyntaxTree.ParseText(newText))
     End Sub
 
-    <WorkItem(529260, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529260")>
+    <WorkItem(529260, "http:   //vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529260")>
     <Fact()>
     Public Sub DoNotReuseAnnotatedNodes()
-        Dim text As String = <![CDATA[
+        Dim text As String = "
 Class C
 End Class
 Class D
 End Class
-]]>.Value.Replace(vbCr, vbCrLf)
+".Replace(vbCr, vbCrLf)
 
         ' NOTE: We're using the class statement, rather than the block, because the
         ' change region is expanded enough to impinge on the block.
@@ -1744,7 +1739,7 @@ End Class
         'Sub Block
         'Function Block
         'Property Block
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Namespace N
     Module M
         Function F() as Boolean
@@ -1759,7 +1754,7 @@ Namespace N
     End Module
 End Namespace
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1774,7 +1769,7 @@ End Namespace
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxClass()
         'Class Block         
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M        
     Sub M()
     End Sub
@@ -1786,7 +1781,7 @@ Module M
     Class C2        
     End Class
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1801,7 +1796,7 @@ End Module
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxStructure()
         'Structure Block
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M        
     Sub M()
     End Sub
@@ -1815,7 +1810,7 @@ Module M
         Dim i as integer
     End Structure
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1830,12 +1825,12 @@ End Module
     <Fact()>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxOptionStatement()
         'Option Statement
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Option Strict Off
 Option Infer On
 Option Explicit On
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1850,11 +1845,11 @@ Option Explicit On
     <Fact()>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxImports()
         'Imports Statement
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Imports System
 Imports System.Collections
 Imports Microsoft.Visualbasic
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1870,7 +1865,7 @@ Imports Microsoft.Visualbasic
     <Fact>
     Public Sub IncrementalParsing_ExecutableStatementBlock_TryLinkSyntaxDelegateSub()
         'ExecutableStatementBlock -> DelegateSub
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
 
@@ -1880,7 +1875,7 @@ Module Module1
     Public Delegate Sub FooWithModifier()
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1894,7 +1889,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxOperatorBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
         Dim x As New SomeClass
@@ -1912,7 +1907,7 @@ Module Module1
     End Class
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1927,7 +1922,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxEventBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
         
@@ -1946,7 +1941,7 @@ Module Module1
     End Class
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1961,7 +1956,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxPropertyBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()        
     End Sub
@@ -1977,7 +1972,7 @@ Module Module1
         End Property
     End Class
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "Class SomeClass"
@@ -1991,7 +1986,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxNamespaceModuleBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Namespace NS1
     Module Module1
@@ -2008,7 +2003,7 @@ Namespace NS1
         Dim x
     End Module
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "End Module 'Remove"
@@ -2022,7 +2017,7 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxNamespaceNamespaceBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Namespace NS1
     Module Module1
@@ -2040,7 +2035,7 @@ Namespace NS1
 
     End Namespace
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "End Module 'Remove"
@@ -2054,12 +2049,12 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_DeclarationContextBlock_TryLinkSyntaxItems()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
     Class SomeClass
         Dim member As Long = 2
         Sub abc() 'Remove
             Dim xyz as integer = 2
-            IF member = 1 then Console.writeline("TEST");
+            IF member = 1 then Console.writeline(""TEST"");
             Dim SingleLineDeclare as integer = 2
         End Sub
 
@@ -2070,7 +2065,7 @@ End Namespace
                 Item1
         End Enum
     End Class
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim TextToRemove As String = "Sub abc() 'Remove"
@@ -2085,7 +2080,7 @@ End Namespace
     <Fact>
     Public Sub IncrementalParsing_PropertyContextBlock_TryLinkSyntaxSetAccessor()
         'PropertyContextBlock -> SetAccessor 
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Private _p As Integer = 0
 
@@ -2101,7 +2096,7 @@ Class C
     Private _d As Integer = 1
 End Class
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2116,7 +2111,7 @@ End Class
 
     <Fact>
     Public Sub IncrementalParsing_BlockContext_TryLinkSyntaxSelectBlock()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Private _p As Integer = 0
     Sub Bar()
@@ -2137,7 +2132,7 @@ Module Module1
         Catch ex As exception
         End Try
 
-        If y = 1 Then Console.WriteLine("Test")
+        If y = 1 Then Console.WriteLine(""Test"")
         Y = 1
 
         While y <= 10
@@ -2182,7 +2177,7 @@ End Module
 Class Foo
     Implements IDisposable
 
-#Region "IDisposable Support"
+#Region ""IDisposable Support""
     Private disposedValue As Boolean ' To detect redundant calls
     ' IDisposable
     Protected Overridable Sub Dispose(disposing As Boolean)
@@ -2203,7 +2198,7 @@ End Class
 Class OtherClass
 
 End Class
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2218,7 +2213,7 @@ End Class
 
     <Fact>
     Public Sub IncrementalParsing_EventBlockContext_TryLinkSyntax1()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Public Custom Event AnyName As EventHandler
         AddHandler(ByVal value As EventHandler)
@@ -2235,7 +2230,7 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2250,7 +2245,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_EventBlockContext_TryLinkSyntax2()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Public Custom Event AnyName As EventHandler
         AddHandler(ByVal value As EventHandler)
@@ -2269,7 +2264,7 @@ Module Module1
     End Sub
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2284,7 +2279,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_InterfaceBlockContext_TryLinkSyntaxClass()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
     End Sub
@@ -2295,7 +2290,7 @@ Module Module1
     End Class
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2310,7 +2305,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_InterfaceBlockContext_TryLinkSyntaxEnum()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Main()
 
@@ -2326,7 +2321,7 @@ Module Module1
     End Enum
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2341,7 +2336,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_CaseBlockContext_TryLinkSyntaxCase()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Foo()
         Dim i As Integer
@@ -2360,7 +2355,7 @@ Module Module1
 
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2374,7 +2369,7 @@ End Module
 
     <Fact>
     Public Sub IncrementalParsing_CatchContext_TryLinkSyntaxCatch()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Module1
     Sub Foo()
         Dim x1 As Integer = 1
@@ -2396,7 +2391,7 @@ Module Module1
     End Function
 End Module
 
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2411,7 +2406,7 @@ End Module
 
     <Fact()>
     Public Sub IncrementalParsing_NamespaceBlockContext_TryLinkSyntaxModule()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Namespace NS1
 Module ModuleTemp 'Remove
 End Module
@@ -2424,7 +2419,7 @@ Module Module1 'Remove
     End Function
 End Module
 End Namespace
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2439,7 +2434,7 @@ End Namespace
 
     <Fact>
     Public Sub IncrementalParsing_IfBlockContext_TryLinkSyntax()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 
 Module Module1
     Private _p As Integer = 0
@@ -2458,7 +2453,7 @@ Module Module1
         End If 
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -2474,16 +2469,15 @@ End Module
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact()>
     Public Sub Bug719787_EOF()
-        Dim source = <![CDATA[
-Namespace N
+        Dim source =
+"Namespace N
     Class C
         Property P As Integer
     End Class
     Structure S
         Private F As Object
     End Structure
-End Namespace
-]]>.Value.Trim()
+End Namespace"
         ' Add two line breaks at end.
         source += vbCrLf
         Dim position = source.Length
@@ -2502,8 +2496,8 @@ End Namespace
     <WorkItem(719787, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/719787")>
     <Fact>
     Public Sub Bug719787_MultiLineIf()
-        Dim source = <![CDATA[
-Class C
+        Dim source =
+"Class C
     Sub M()
         If e1 Then
             If e2 Then
@@ -2538,8 +2532,7 @@ Class C
         End If
     End Sub
     ' Comment
-End Class
-]]>.Value.Trim()
+End Class"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim toReplace = "' Comment"
@@ -2589,21 +2582,21 @@ End Class
         Next
     End Sub
 
-    Private Shared Function ToText(code As XCData) As String
-        Dim str = code.Value.Trim()
-        ' Normalize line terminators.
-        Dim builder = ArrayBuilder(Of Char).GetInstance()
-        For i = 0 To str.Length - 1
-            Dim c = str(i)
-            If (c = vbLf(0)) AndAlso
-                ((i = str.Length - 1) OrElse (str(i + 1) <> vbCr(0))) Then
-                builder.AddRange(vbCrLf)
-            Else
-                builder.Add(c)
-            End If
-        Next
-        Return New String(builder.ToArrayAndFree())
-    End Function
+    'Private Shared Function ToText(code As XCData) As String
+    '    Dim str = code.Value.Trim()
+    '    ' Normalize line terminators.
+    '    Dim builder = ArrayBuilder(Of Char).GetInstance()
+    '    For i = 0 To str.Length - 1
+    '        Dim c = str(i)
+    '        If (c = vbLf(0)) AndAlso
+    '            ((i = str.Length - 1) OrElse (str(i + 1) <> vbCr(0))) Then
+    '            builder.AddRange(vbCrLf)
+    '        Else
+    '            builder.Add(c)
+    '        End If
+    '    Next
+    '    Return New String(builder.ToArrayAndFree())
+    'End Function
 #End Region
 
 End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/IncrementalParser/IncrementalParser.vb
@@ -14,7 +14,7 @@ Imports Roslyn.Test.Utilities
 
 Public Class IncrementalParser
 
-    Private ReadOnly _s As String = <![CDATA[
+    Private ReadOnly _s As String = "
 '-----------------------
 '
 '  Copyright (c)
@@ -28,24 +28,24 @@ Imports Roslyn.Compilers.Common
 Imports Roslyn.Compilers.VisualBasic
 
 Public Module ParseExprSemantics
-    Dim text = SourceText.From("")
+    Dim text = SourceText.From("""")
     Dim tree As SyntaxTree = Nothing
 
     #const x = 1
     ''' <summary>
     ''' This is just gibberish to test parser
     ''' </summary>
-    ''' <param name="ITERS"> haha </param>
+    ''' <param name=""ITERS""> haha </param>
     ''' <remarks></remarks>
     Public Sub Run(ByVal ITERS As Long)
         Console.WriteLine()
 
 #if BLAH       
-        Console.WriteLine("==== Parsing file: " & "Sample_ExpressionSemantics.vb")
-        Console.WriteLine("Iterations:" & ITERS)
+        Console.WriteLine(""==== Parsing file: "" & ""Sample_ExpressionSemantics.vb"")
+        Console.WriteLine(""Iterations:"" & ITERS)
 #end if
 
-        Dim str = IO.File.ReadAllText("Sample_ExpressionSemantics.vb")
+        Dim str = IO.File.ReadAllText(""Sample_ExpressionSemantics.vb"")
         Dim lineNumber = 28335
         Dim root As SyntaxNode = Nothing
 
@@ -57,7 +57,7 @@ Public Module ParseExprSemantics
         For i As Integer = 0 To ITERS - 1
             tree = SyntaxTree.Parse(text, Nothing)
             root = tree.Root
-            Console.Write(".")
+            Console.Write(""."")
             Dim highWater As Integer = Math.Max(highWater, System.GC.GetTotalMemory(False))
         Next
 
@@ -68,10 +68,10 @@ In root.GetNodesWhile(root.FullSpan, Function() True)
                         Order By Count Descending
                         Take 30
 
-        Console.WriteLine("Quick token cache-hits: {0} ({1:G2}%)", Stats.quickReturnedToken, 100.0 * Stats.quickReturnedToken / Stats.quickAttempts)
+        Console.WriteLine(""Quick token cache-hits: {0} ({1:G2}%)"", Stats.quickReturnedToken, 100.0 * Stats.quickReturnedToken / Stats.quickAttempts)
 
     End Sub
-End Module]]>.Value
+End Module"
 
     <Fact>
     Public Sub FakeEdits()
@@ -145,17 +145,18 @@ End Module]]>.Value
     Public Sub IncParseWithEventsFollowingProperty()
         'Unable to verify this using CDATA, since CDATA value only has Cr appended at end of each line, 
         'where as this bug is reproducible only with CrLf at the end of each line
-        Dim code As String = "Public Class HasPublicMembersToConflictWith" & vbCrLf &
-    "Public ConflictWithProp" & vbCrLf &
-    "" & vbCrLf &
-    "Public Property _ConflictWithBF() As String" & vbCrLf &
-    "    Get" & vbCrLf &
-    "    End Get" & vbCrLf &
-    "    Set(value As String)" & vbCrLf &
-    "    End Set" & vbCrLf &
-    "End Property" & vbCrLf &
-    "" & vbCrLf &
-    "Public WithEvents ConflictWithBoth As Ob"
+        Dim code As String =
+"Public Class HasPublicMembersToConflictWith
+Public ConflictWithProp
+
+Public Property _ConflictWithBF() As String
+    Get
+    End Get
+    Set(value As String)
+    End Set
+End Property
+
+Public WithEvents ConflictWithBoth As Ob"
 
         ParseAndVerify(code,
         <errors>
@@ -172,12 +173,12 @@ End Module]]>.Value
     <WorkItem(899596, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseClassFollowingDocComments()
-        Dim code As String = <![CDATA[Class VBQATestcase
-    '''-----------------------------------------------------------------------------
-    ''' <summary>
-    '''Text
-    ''' </summary>
-    '''-----------------------------------------------------------------------------]]>.Value
+        Dim code As String = "Class VBQATestcase
+'''-----------------------------------------------------------------------------
+''' <summary>
+'''Text
+''' </summary>
+'''-----------------------------------------------------------------------------"
 
         ParseAndVerify(code,
                        <errors>
@@ -194,11 +195,14 @@ End Module]]>.Value
     <WorkItem(899918, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDirInElse()
-        Dim code As String = "Sub Sub1()" & vbCr &
-"If true Then" & vbCr &
-"foo("""")" & vbCr &
-"Else" & vbCr & vbCr &
-"#If Not ULTRAVIOLET Then" & vbCr
+        Dim code As String =
+"Sub Sub1()
+If True Then
+foo("""")
+Else
+
+#If Not ULTRAVIOLET Then
+"
 
         ParseAndVerify(code,
                        <errors>
@@ -217,11 +221,12 @@ End Module]]>.Value
     <WorkItem(899938, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseNamespaceFollowingEvent()
-        Dim code As String = "Class cls1" & vbCrLf &
-"Custom Event myevent As del" & vbCrLf &
-"End Event" & vbCrLf &
-"End Class" & vbCrLf &
-"Namespace r"
+        Dim code As String =
+"Class cls1
+Custom Event myevent As del
+End Event
+End Class
+Namespace r"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -233,14 +238,14 @@ End Module]]>.Value
     <WorkItem(900209, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseCaseElse()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
       Sub main()
          Select Case 5
             Case Else
                vvv = 6
             Case Else
                vvv = 7
-]]>).Value
+"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -252,10 +257,10 @@ End Module]]>.Value
     <WorkItem(901386, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExplicitOnGroupBy()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "[
 Option Explicit On
 Sub foo()
-Dim q2 = From x In col let y = x Group x, y By]]>).Value
+Dim q2 = From x In col let y = x Group x, y By"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -267,14 +272,15 @@ Dim q2 = From x In col let y = x Group x, y By]]>).Value
     <WorkItem(901639, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExprLambdaInSubContext()
-        Dim code As String = (<![CDATA[Function() NewTextPI.UnwrapObject().FileCodeModel)
+        Dim code As String =
+"Function() NewTextPI.UnwrapObject().FileCodeModel)
 If True Then
 End If
 End Sub
 Class WillHaveAnError
 End class
 Class willBeReused
-End class]]>).Value
+End class"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "(",
@@ -285,7 +291,8 @@ End class]]>).Value
 
     <Fact>
     Public Sub IncParseExprLambdaInSubContext2()
-        Dim code As String = (<![CDATA[Function() NewTextPI.UnwrapObject().FileCodeModel)
+        Dim code As String =
+"Function() NewTextPI.UnwrapObject().FileCodeModel)
 If True Then
 Else
 End If
@@ -293,7 +300,7 @@ End Sub
 Class WillHaveAnError
 End class
 Class willBeReused
-End class]]>).Value
+End class"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "(",
@@ -305,9 +312,10 @@ End class]]>).Value
     <WorkItem(901645, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseExitFunction()
-        Dim code As String = (<![CDATA[Function
-If strSwitches <> "" Then strCLine = strCLine & " " & strSwitches
-End Sub]]>).Value
+        Dim code As String =
+"Function
+If strSwitches <> """" Then strCLine = strCLine & "" "" & strSwitches
+End Sub"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "Exit ",
@@ -351,7 +359,7 @@ End Function
 
     <Fact>
     Public Sub IncParsePPElse1()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
 Function foo() As Boolean
 
 #Else
@@ -363,10 +371,10 @@ Function foo() As Boolean
 #End IF
 
 End Function
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
-        .changeText = "#If true " & vbCrLf,
+        .changeText = "#If True " & vbCrLf,
         .changeSpan = New TextSpan(code.IndexOf("#Else", StringComparison.Ordinal), 0),
         .changeType = ChangeType.Replace})
     End Sub
@@ -374,7 +382,7 @@ End Function
     <WorkItem(901669, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseXmlTagWithExprHole()
-        Dim code As String = (<![CDATA[e a=<%= b %>>]]>).Value
+        Dim code As String = "e a=<%= b %>"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "<",
@@ -385,9 +393,9 @@ End Function
     <WorkItem(901671, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseEndBeforeSubWithX()
-        Dim code As String = (<![CDATA[Sub
-        End Class
-    X]]>).Value
+        Dim code As String = "Sub
+    End Class
+X"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "End ",
@@ -398,16 +406,16 @@ End Function
     <WorkItem(901676, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseInterfaceFollByConstructs()
-        Dim code As String = (<![CDATA[
-        Public Interface I2
-        End Interface
-        Sub SEHIllegal501()
-            Try
-            Catch
-            End Try
-            Exit Sub
-        End Sub
-    X]]>).Value
+        Dim code As String = "
+    Public Interface I2
+    End Interface
+    Sub SEHIllegal501()
+        Try
+        Catch
+        End Try
+        Exit Sub
+    End Sub
+X"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "Interface",
@@ -418,11 +426,12 @@ End Function
     <WorkItem(901680, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseLCFunctionCompoundAsn()
-        Dim code As String = (<![CDATA[Public Function foo() As String
-            For i As Integer = 0 To  1
-                total += y(i)
-            Next
-End Function]]>).Value
+        Dim code As String =
+"Public Function foo() As String
+    For i As Integer = 0 To  1
+        total += y(i)
+    Next
+End Function"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "> _" & vbCrLf,
@@ -433,9 +442,10 @@ End Function]]>).Value
     <WorkItem(902710, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseInsertFunctionBeforeEndClass()
-        Dim code As String = (<![CDATA[End Class
+        Dim code As String =
+"End Class
 MustInherit Class C10
-End Class]]>).Value
+End Class"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "Function" & vbCrLf,
@@ -446,10 +456,11 @@ End Class]]>).Value
     <WorkItem(903134, "DevDiv/Personal")>
     <Fact>
     Public Sub InsertSubBeforeCustomEvent()
-        Dim code As String = (<![CDATA[            Custom Event e As del
-                AddHandler(ByVal value As del)
-                End AddHandler
-            End Event]]>).Value
+        Dim code As String = 
+"            Custom Event e As del
+    AddHandler(ByVal value As del)
+    End AddHandler
+End Event"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "Sub" & vbCrLf,
@@ -460,13 +471,14 @@ End Class]]>).Value
     <WorkItem(903555, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseMergedForEachAndDecl()
-        Dim code As String = (<![CDATA[#Region "abc"
+        Dim code As String =
+"#Region ""abc""
 Function foo() As Boolean
 Dim roleName As Object
 For Each roleName In wbirFields
 Next roleName
 End Function
-#End Region]]>).Value
+#End Region"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = vbCrLf,
@@ -477,14 +489,15 @@ End Function
     <WorkItem(903805, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseEnumWithoutEnd()
-        Dim code As String = (<![CDATA[Public Class Class2
+        Dim code As String =
+"Public Class Class2
     Protected Enum e
         e1
         e2
 	End Enum
     Public Function Foo(ByVal arg1 As e) As e
     End Function
-End Class]]>).Value
+End Class"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = vbCrLf,
@@ -495,14 +508,15 @@ End Class]]>).Value
     <WorkItem(903826, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseWrongSelectFollByIf()
-        Dim code As String = (<![CDATA[        Sub foo()
-                Select Case lng
-                    Case 44
-                        int1 = 4
-                End Select
-                If true Then
-                End If
-        End Sub]]>).Value
+        Dim code As String =
+"        Sub foo()
+        Select Case lng
+            Case 44
+                int1 = 4
+        End Select
+        If true Then
+        End If
+End Sub"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "End ",
@@ -513,12 +527,13 @@ End Class]]>).Value
     <WorkItem(904768, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseDoLoop()
-        Dim code As String = (<![CDATA[        Sub AnonTConStmnt()
+        Dim code As String =
+"        Sub AnonTConStmnt()
                 Do
                     i += 1
                 Loop Until true
         End Sub
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = vbCrLf,
@@ -529,14 +544,14 @@ End Class]]>).Value
     <WorkItem(904771, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseClassWithOpDecl()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
 Friend Module m1
 Class Class1
 Shared Operator -(ByVal x As Class1) As Boolean
 End Operator
 End Class
 End Module
-]]>).Value
+"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = "Class ",
@@ -547,19 +562,20 @@ End Module
     <WorkItem(904782, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParsePropFollIncompleteLambda()
-        Dim code As String = (<![CDATA[        Class c1
+        Dim code As String =
+"        Class c1
 
-            Public Function foo() As Object
-                Dim res = Function(x As Integer) c1.Foo(x)
-            End Function
+    Public Function foo() As Object
+        Dim res = Function(x As Integer) c1.Foo(x)
+    End Function
 
-            Default Public Property Prop(ByVal y As String) As Integer
-                Get
-                End Get
-                Set(ByVal value As Integer)
-                End Set
-            End Property
-        End Class]]>).Value
+    Default Public Property Prop(ByVal y As String) As Integer
+        Get
+        End Get
+        Set(ByVal value As Integer)
+        End Set
+    End Property
+End Class"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = ")",
@@ -570,10 +586,11 @@ End Module
     <WorkItem(904792, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseErroneousGroupByQuery()
-        Dim code As String = (<![CDATA[        Sub foo() 
-                Dim q2 = From i In str Group i By key1 = x
-                Dim q3 =From j In str Group By key = i 
-        End Sub]]>).Value
+        Dim code As String =
+"        Sub foo() 
+        Dim q2 = From i In str Group i By key1 = x
+        Dim q3 =From j In str Group By key = i 
+End Sub"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = " By",
@@ -584,12 +601,13 @@ End Module
     <WorkItem(904804, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseSetAfterIncompleteSub()
-        Dim code As String = (<![CDATA[Sub foo()
+        Dim code As String =
+"Sub foo()
 End Sub
 Public WriteOnly Property bar() as short
 Set
 End Set
-End Property]]>).Value
+End Property"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = vbCrLf,
@@ -600,10 +618,12 @@ End Property]]>).Value
     <WorkItem(911100, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseEmbeddedIfsInsideCondCompile()
-        Dim code As String = "Sub bar() " & vbCrLf &
-"#If true Then" & vbCrLf &
-    "if true Then foo()" & vbCrLf &
- "If Command() <" & vbCrLf
+        Dim code As String =
+"Sub bar() 
+#If True Then
+If True Then foo()
+If Command() <
+"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
         .changeText = ">",
@@ -614,9 +634,10 @@ End Property]]>).Value
     <WorkItem(911103, "DevDiv/Personal")>
     <Fact>
     Public Sub IncParseErrorIfStatement()
-        Dim code As String = "Public Sub Run() " & vbCrLf &
-"If NewTextPI.DTE Is Nothing Then End" & vbCrLf &
- "End Sub"
+        Dim code As String =
+"Public Sub Run() 
+If NewTextPI.DTE Is Nothing Then End
+End Sub"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -628,9 +649,10 @@ End Property]]>).Value
     <WorkItem(537168, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537168")>
     <Fact>
     Public Sub IncParseSubBeforePartialClass()
-        Dim code As String = (<![CDATA[End Class
+        Dim code As String =
+"End Class
 Partial Class class3
-End Class]]>).Value
+End Class"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -642,7 +664,7 @@ End Class]]>).Value
     <WorkItem(537172, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537172")>
     <Fact>
     Public Sub IncParseInterfaceDeleteWithColon()
-        Dim code As String = (<![CDATA[Interface I : Sub Foo() : End Interface]]>).Value
+        Dim code As String = "Interface I : Sub Foo() : End Interface"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -654,18 +676,18 @@ End Class]]>).Value
     <WorkItem(537174, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/537174")>
     <Fact>
     Public Sub IncParseMissingEndAddHandler()
-        Dim code As String = (<![CDATA[
-                Class C
-                    Custom Event e As del
-                        AddHandler(ByVal value As del)
-                        End AddHandler
-                        RemoveHandler(ByVal value As del)
-                        End RemoveHandler
-                        RaiseEvent()
-                        End RaiseEvent
-                    End Event
-                End Class
-]]>).Value
+        Dim code As String = "
+Class C
+    Custom Event e As del
+        AddHandler(ByVal value As del)
+        End AddHandler
+        RemoveHandler(ByVal value As del)
+        End RemoveHandler
+        RaiseEvent()
+        End RaiseEvent
+    End Event
+End Class
+"
         Dim change = "End AddHandler"
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -677,8 +699,9 @@ End Class]]>).Value
     <WorkItem(539038, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539038")>
     <Fact>
     Public Sub IncParseInvalidText()
-        Dim code As String = (<![CDATA[1. Verify that INT accepts an constant of each type as the
-        '                  argument.]]>).Value
+        Dim code As String =
+"1. Verify that INT accepts an constant of each type as the
+'                  argument."
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -690,11 +713,12 @@ End Class]]>).Value
     <WorkItem(539053, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539053")>
     <Fact>
     Public Sub IncParseAddSubValid()
-        Dim code As String = (<![CDATA[Class CFoo
+        Dim code As String =
+"Class CFoo
     Public S()
         Dim x As Integer = 0
     End Sub
-End Class]]>).Value
+End Class"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -725,7 +749,7 @@ End Class]]>).Value
     <WorkItem(538577, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538577")>
     <Fact>
     Public Sub IncParseAddSpaceAfterForNext()
-        Dim code As String = (<![CDATA[Module M
+        Dim code As String = "Module M
   Sub Main()
    Dim i(1) As Integer
    For i(0) = 1 To 10
@@ -733,7 +757,7 @@ End Class]]>).Value
    Next j, i(0) 
   End Sub
 End Module 
-]]>).Value
+"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -752,13 +776,13 @@ End Module
     <WorkItem(540667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540667")>
     Public Sub IncrementalParseAddSpaceInSingleLineIf()
         ' The code below intentionally is missing a space between the "Then" and "Console"
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
 Module M
   Sub Main()
-    If False ThenConsole.WriteLine("FIRST") : Console.WriteLine("TEST") Else Console.WriteLine("TRUE!") : 'comment
+    If False ThenConsole.WriteLine(""FIRST"") : Console.WriteLine(""TEST"") Else Console.WriteLine(""TRUE!"") : 'comment
   End Sub
 End Module 
-]]>).Value
+"
 
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -777,8 +801,7 @@ End Module
     <WorkItem(543489, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543489")>
     <Fact>
     Public Sub Bug11296()
-
-        Dim source As String = <![CDATA[    
+        Dim source As String = "
 Module M
     Sub Main()
         GoTo 100
@@ -789,13 +812,13 @@ Module M
         End If
     End Sub
 End Module
-]]>.Value
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Assert.Equal(1, oldTree.GetDiagnostics().Count)
         Assert.Equal("Syntax error.", oldTree.GetDiagnostics()(0).GetMessage(EnsureEnglishUICulture.PreferredOrNull))
-        Assert.Equal("[131..134)", oldTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
+        Assert.Equal("[134..137)", oldTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
 
         ' commenting out the goto
         Dim pos = source.IndexOf("GoTo 100", StringComparison.Ordinal)
@@ -806,17 +829,17 @@ End Module
         Dim tmpTree = VisualBasicSyntaxTree.ParseText(newText)
         Assert.Equal(1, tmpTree.GetDiagnostics().Count)
         Assert.Equal("Syntax error.", tmpTree.GetDiagnostics()(0).GetMessage(EnsureEnglishUICulture.PreferredOrNull))
-        Assert.Equal("[132..135)", tmpTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
+        Assert.Equal("[135..138)", tmpTree.GetDiagnostics()(0).Location.SourceSpan.ToString)
     End Sub
 
     <Fact>
     Public Sub IncParseTypeNewLine()
-        Dim code As String = (<![CDATA[
+        Dim code As String = "
 Module m
 Sub s
 End Sub
 End Module     
-]]>).Value
+"
 
         IncParseAndVerify(New IncParseNode With {
         .oldText = code,
@@ -828,11 +851,11 @@ End Module
     <WorkItem(545667, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545667")>
     <Fact>
     Public Sub Bug14266()
-        Dim source = <![CDATA[
+        Dim source = "
 Enum E
     A
 End Enum
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -845,13 +868,13 @@ End Enum
     <WorkItem(546680, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546680")>
     <Fact>
     Public Sub Bug16533()
-        Dim source = <![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then M() Else : 
     End Sub
 End Module
-]]>.Value
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Replace "True" with "True".
@@ -865,14 +888,14 @@ End Module
     <WorkItem(546685, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546685")>
     <Fact>
     Public Sub MultiLineIf()
-        Dim source = <![CDATA[
+        Dim source = "
 Module M
     Sub M(b As Boolean)
         If b Then
         End If
     End Sub
 End Module
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -892,7 +915,7 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_2()
-        Dim source = <![CDATA[
+        Dim source = "
 Module M
     Sub M()
         Dim b = False
@@ -901,7 +924,7 @@ Module M
         End If
     End Sub
 End Module
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -921,7 +944,7 @@ End Module
     ''' </summary>
     <Fact>
     Public Sub MultiLineIf_3()
-        Dim source = <![CDATA[
+        Dim source = "
 Module M
     Sub M(b As Boolean)
         If b Then
@@ -930,7 +953,7 @@ Module M
         End While
     End Sub
 End Module
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -947,14 +970,14 @@ End Module
     <WorkItem(546692, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546692")>
     <Fact>
     Public Sub Bug16575()
-        Dim source = <![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then Else Dim x = 1 : Dim y = x
         If True Then Else Dim x = 1 : Dim y = x
     End Sub
 End Module
-]]>.Value
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Add newline after first single line If
@@ -968,7 +991,7 @@ End Module
     <WorkItem(546698, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546698")>
     <Fact>
     Public Sub Bug16596()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then
@@ -976,7 +999,7 @@ Module M
         End If
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Uncomment "Else".
@@ -989,14 +1012,14 @@ End Module
     <WorkItem(530662, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530662")>
     <Fact>
     Public Sub Bug16662()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         ''' <[
         1: X
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Remove "X".
@@ -1009,7 +1032,7 @@ End Module
     <WorkItem(546774, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/546774")>
     <Fact>
     Public Sub Bug16786()
-        Dim source = <![CDATA[
+        Dim source = "
 Namespace N
     ''' <summary/>
     Class A
@@ -1019,7 +1042,7 @@ Class B
 End Class
 Class C
 End Class
-]]>.Value.Trim()
+".Trim()
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
 
@@ -1036,7 +1059,7 @@ End Class
     <WorkItem(530841, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530841")>
     <Fact>
     Public Sub Bug17031()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         If True Then
@@ -1045,7 +1068,7 @@ Module M
         End If
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Insert blank line at start of method.
@@ -1059,19 +1082,19 @@ End Module
     <WorkItem(531017, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/531017")>
     <Fact>
     Public Sub Bug17409()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Sub M()
         Dim ch As Char
         Dim ch As Char
         Select Case ch
-            Case "~"c
+            Case ""~""c
 
             Case Else
         End Select
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Remove second instance of "Dim ch As Char".
@@ -1084,10 +1107,10 @@ End Module
 
     <Fact, WorkItem(547242, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547242")>
     Public Sub IncParseAddRemoveStopAtAofAs()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Public obj0 As Object
-    Public obj1 A]]>.Value
+    Public obj1 A"
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
         Dim oldIText = tree.GetText()
@@ -1105,11 +1128,11 @@ Module M
 
     <Fact, WorkItem(547242, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547242")>
     Public Sub IncParseAddRemoveStopAtAofAs02()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub M()
         Try
-        Catch ex A]]>.Value
+        Catch ex A"
 
         Dim fullTree = VisualBasicSyntaxTree.ParseText(code)
         Dim fullText = fullTree.GetText()
@@ -1121,9 +1144,9 @@ Module M
     <Fact, WorkItem(547251, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547251")>
     Public Sub IncParseAddRemoveStopAtAofPropAs()
         Dim code As String =
-        <![CDATA[Class C
+"Class C
     Inherits Attribute
-]]>.Value
+"
         Dim code1 As String = <![CDATA[    Property foo() A]]>.Value
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
@@ -1148,11 +1171,11 @@ Module M
 
     <Fact, WorkItem(547303, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/547303")>
     Public Sub IncParseAddRemoveStopAtTofThen()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub M()
         If True Then
-        ElseIf False T]]>.Value
+        ElseIf False T"
 
         Dim fullTree = VisualBasicSyntaxTree.ParseText(code)
         Dim fullText = fullTree.GetText()
@@ -1164,13 +1187,13 @@ Module M
     <WorkItem(571105, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/571105")>
     <Fact()>
     Public Sub IncParseInsertLineBreakBeforeLambda()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Sub F()
         Dim a1 = If(Sub()
                     End Sub, Nothing)
     End Sub
-End Module]]>.Value
+End Module"
 
         Dim tree = VisualBasicSyntaxTree.ParseText(code)
         Dim oldText = tree.GetText()
@@ -1185,11 +1208,11 @@ End Module]]>.Value
     <WorkItem(578279, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/578279")>
     <Fact()>
     Public Sub IncParseInsertLineBreakBetweenEndSub()
-        Dim code As String = <![CDATA[Class C
+        Dim code As String = "Class C
     Sub M()
     En Sub
     Private F = 1
-End Class]]>.Value
+End Class"
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' insert line break
@@ -1202,12 +1225,12 @@ End Class]]>.Value
 
     <Fact()>
     Public Sub InsertWithinLookAhead()
-        Dim code As String = <![CDATA[
+        Dim code As String = "
 Module M
     Function F(s As String)
         Return From c In s
     End Function
-End Module]]>.Value
+End Module"
         Dim oldText = SourceText.From(code)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Insert "Select c" at end of method.
@@ -1221,7 +1244,7 @@ End Module]]>.Value
 #Region "Async & Iterator"
     <Fact>
     Public Sub AsyncToSyncMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Async Function M(t As Task) As Task
         Await (t)
@@ -1231,7 +1254,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1245,7 +1268,7 @@ End Class
 
     <Fact>
     Public Sub AsyncToSyncLambda()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task)
         Dim lambda = Async Function() Await(t)
@@ -1255,7 +1278,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1269,7 +1292,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task) As Task
         Await (t)
@@ -1279,7 +1302,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1293,7 +1316,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncLambda()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(t As Task)
         Dim lambda = Function() Await(t)
@@ -1303,7 +1326,7 @@ Class C
         Return Nothing
     End Function
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1317,7 +1340,7 @@ End Class
 
     <Fact>
     Public Sub AsyncToSyncMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Async Function M(a As Await, t As Task) As Task
         Await t
@@ -1326,7 +1349,7 @@ End Class
 
 Class Await
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1340,7 +1363,7 @@ End Class
 
     <Fact>
     Public Sub SyncToAsyncMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Class C
     Function M(a As Await, t As Task) As Task
         Await t
@@ -1349,7 +1372,7 @@ End Class
 
 Class Await
 End Class
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1363,13 +1386,13 @@ End Class
 
     <Fact>
     Public Sub IteratorToNonIteratorMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Iterator Function Foo() As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1383,13 +1406,13 @@ End Module
 
     <Fact>
     Public Sub NonIteratorToIteratorMethod()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Function Foo() As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1403,13 +1426,13 @@ End Module
 
     <Fact>
     Public Sub IteratorToNonIteratorMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Iterator Function Foo(Yield As Integer) As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1423,13 +1446,13 @@ End Module
 
     <Fact>
     Public Sub NonIteratorToIteratorMethodDecl()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module Program
     Function Foo(Yield As Integer) As IEnumerable
         Yield (1)
     End Function
 End Module
-]]>)
+"
 
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
@@ -1446,7 +1469,7 @@ End Module
     <WorkItem(554442, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/554442")>
     <Fact>
     Public Sub SplitCommentAtPreprocessorSymbol()
-        Dim source = ToText(<![CDATA[
+        Dim source = "
 Module M
     Function F()
         ' comment # 1 and # 2
@@ -1455,7 +1478,7 @@ Module M
         Return Nothing
     End Function
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(source)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Split comment at "#".
@@ -1468,7 +1491,7 @@ End Module
     <WorkItem(586698, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/586698")>
     <Fact>
     Public Sub SortUsings()
-        Dim oldSource = ToText(<![CDATA[
+        Dim oldSource = "
 Imports System.Linq
 Imports System
 Imports Microsoft.VisualBasic
@@ -1476,8 +1499,8 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
-        Dim newSource = ToText(<![CDATA[
+"
+        Dim newSource = "
 Imports System
 Imports System.Linq
 Imports Microsoft.VisualBasic
@@ -1485,7 +1508,7 @@ Module Module1
     Sub Main()
     End Sub
 End Module
-]]>)
+"
         Dim oldText = SourceText.From(oldSource)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         ' Changes:
@@ -1500,7 +1523,7 @@ End Module
 
     <Fact>
     Public Sub Reformat()
-        Dim oldSource = ToText(<![CDATA[
+        Dim oldSource = "
 Class C
     Sub Method()
                                 Dim i = 1
@@ -1509,8 +1532,8 @@ Select          Case            i
                                                     End             Select              
     End Sub
 End Class
-]]>)
-        Dim newSource = ToText(<![CDATA[
+"
+        Dim newSource = "
 Class C
     Sub Method()
         Dim i = 1
@@ -1519,7 +1542,7 @@ Class C
         End Select
     End Sub
 End Class
-]]>)
+"
         Dim oldText = SourceText.From(oldSource)
         Dim oldTree = VisualBasicSyntaxTree.ParseText(oldText)
         Dim startOfNew = newSource.IndexOf("Dim", StringComparison.Ordinal)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/DeclarationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/DeclarationTests.vb
@@ -17,7 +17,7 @@ Public Class DeclarationTests
 
     <Fact>
     Public Sub TestSimpleDeclarations()
-        Dim text1 = <literal>
+        Dim text1 = "
 namespace NA.NB
   partial class C(Of T)
     partial class D
@@ -27,9 +27,9 @@ namespace NA.NB
   class C 
   end class
 end namespace
-</literal>.Value
+"
 
-        Dim text2 = <literal>
+        Dim text2 = "
 namespace Na
   namespace nB
     partial class C(Of T)
@@ -40,7 +40,7 @@ namespace Na
     end class
   end namespace
 end namespace
-</literal>.Value
+"
 
         Dim rootNamespace = ImmutableArray.Create(Of String)()
         Dim tree1 = ParseFile(text1)

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAsyncTests.vb
@@ -11,7 +11,7 @@ Public Class ParseAsyncTests
 
     <Fact>
     Public Sub ParseAsyncModifier()
-        Dim tree = ParseAndVerify(<![CDATA[
+        Dim tree = ParseAndVerify("
 Imports Async = System.Threading.Tasks.Task
 
 Module Program
@@ -39,7 +39,7 @@ Class AsyncAttribute
     Sub New(p)
 
     End Sub
-End Class]]>)
+End Class")
 
         Assert.Equal(2, Aggregate t In tree.GetRoot().DescendantTokens Where t.Kind = SyntaxKind.AsyncKeyword Into Count())
 
@@ -50,7 +50,7 @@ End Class]]>)
 
     <Fact>
     Public Sub ParseAwaitExpressions()
-        Dim tree = ParseAndVerify(<![CDATA[
+        Dim tree = ParseAndVerify("
 Imports System.Console
 
 Module Program
@@ -89,9 +89,9 @@ Module Program
 
     End Function
 
-End Module]]>,
+End Module",
 <errors>
-    <error id="30800" message="Method arguments must be enclosed in parentheses." start="206" end="208"/>
+    <error id="30800" message="Method arguments must be enclosed In parentheses." start="206" end="208"/>
     <error id="32017" message="Comma, ')', or a valid expression continuation expected." start="234" end="236"/>
     <error id="30800" message="Method arguments must be enclosed in parentheses." start="398" end="400"/>
     <error id="30198" message="')' expected." start="424" end="424"/>
@@ -125,14 +125,14 @@ End Module]]>,
 
     <Fact>
     Public Sub ParseAwaitExpressionsWithPrecedence()
-        Dim tree = ParseAndVerify(<![CDATA[
+        Dim tree = ParseAndVerify("
 Module Program
     Async Function M(a As Task(Of Integer), x As Task(Of Integer), y As Task(Of Integer), b As Task(Of Integer)) As Task(Of Integer)
 
         Return Await a * Await x ^ Await y + Await b
         
     End Function
-End Module]]>)
+End Module")
 
         Dim returnStatement = tree.GetRoot().DescendantNodes.OfType(Of ReturnStatementSyntax).Single()
 
@@ -156,7 +156,7 @@ End Module]]>)
 
     <Fact>
     Public Sub ParseAwaitStatements()
-        Dim tree = ParseAndVerify(<![CDATA[
+        Dim tree = ParseAndVerify("
 Imports System.Console
 
 Module Program
@@ -200,7 +200,7 @@ Module Program
 
     End Function    
 
-End Module]]>,
+End Module",
 <errors>
     <error id="30800" message="Method arguments must be enclosed in parentheses." start="177" end="179"/>
     <error id="30800" message="Method arguments must be enclosed in parentheses." start="407" end="409"/>
@@ -236,7 +236,7 @@ End Module]]>,
 
     <Fact>
     Public Sub ParseAsyncLambdas()
-        Dim tree = ParseAndVerify(<![CDATA[
+        Dim tree = ParseAndVerify("
 Module Program
 
     Private t1 As Task
@@ -272,7 +272,7 @@ Module Program
                                End Function
 
     End Sub
-End Module]]>)
+End Module")
 
         Dim lambdas = tree.GetRoot().DescendantNodes.OfType(Of LambdaExpressionSyntax)().ToArray()
 
@@ -297,7 +297,7 @@ End Module]]>)
 
     <Fact>
     Public Sub ParseAsyncWithNesting()
-        Dim tree = VisualBasicSyntaxTree.ParseText(<![CDATA[
+        Dim tree = VisualBasicSyntaxTree.ParseText("
 Imports Async = System.Threading.Tasks.Task
 
 Class C
@@ -361,7 +361,7 @@ Class AsyncAttribute
     Sub New(p)
 
     End Sub
-End Class]]>.Value)
+End Class")
 
         ' Error BC30800: Method arguments must be enclosed in parentheses.
         Assert.True(Aggregate d In tree.GetDiagnostics() Into All(d.Code = ERRID.ERR_ObsoleteArgumentsNeedParens))

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAttributes.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseAttributes.vb
@@ -13,23 +13,23 @@ Public Class Attributes
 
     <Fact>
     Public Sub ParseAssemblyAttribute()
-        ParseModuleOrAssemblyAttribute(<![CDATA[
+        ParseModuleOrAssemblyAttribute("
             <Assembly:clscompliant(true)>
             Module Module1
             End Module
-        ]]>.Value, isFullWidth:=False)
+        ", isFullWidth:=False)
     End Sub
 
     <Fact>
     Public Sub ParseModuleAttribute()
-        ParseModuleOrAssemblyAttribute(<![CDATA[
+        ParseModuleOrAssemblyAttribute("
             <Module:clscompliant(true)>
             Module Module1
             End Module
-        ]]>.Value, isFullWidth:=False)
+        ", isFullWidth:=False)
     End Sub
 
-    <WorkItem(570756, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/570756")>
+    <WorkItem(570756, "http: //vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/570756")>
     <Fact()>
     Public Sub ParseFullWidthModuleAndAssemblyAttributes()
         ParseModuleOrAssemblyAttribute("<Assembly:A>".ToFullWidth(), isFullWidth:=True)
@@ -48,26 +48,26 @@ Public Class Attributes
 
     <Fact>
     Public Sub ParseModuleAndAssemblyAttributesWithTrivia()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 <Assembly : A>
-]]>)
-        ParseAndVerify(<![CDATA[
+")
+        ParseAndVerify("
 <Module _
 : _
 A>
-]]>)
-        ParseAndVerify(<![CDATA[
+")
+        ParseAndVerify("
 <Assembly : A>
-]]>.Value.Replace(":"c, FULLWIDTH_COLON))
+".Replace(":"c, FULLWIDTH_COLON))
     End Sub
 
     <Fact>
     Public Sub BC30183ERR_InvalidUseOfKeyword_FileNotAssemblyOrModuleAttribute()
-        Dim tree = ParseAndVerify(<![CDATA[
-            <Dim:clscompliant(true)>
-            Module Module1
-            End Module
-        ]]>,
+        Dim tree = ParseAndVerify("
+<Dim:clscompliant(true)>
+Module Module1
+End Module
+",
             Diagnostic(ERRID.ERR_InvalidUseOfKeyword, "Dim"),
             Diagnostic(ERRID.ERR_ExpectedGreater, ""),
             Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "clscompliant(true)"),
@@ -82,52 +82,52 @@ A>
 
     <Fact>
     Public Sub Bug862162()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Imports System.Runtime.InteropServices
             Structure Struct1
               <MarshalAs(UnmanagedType.ByValArray, sizeconst:=4)> Public A() As Integer
             End Structure
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub Bug862165()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Public Class Attr
                 Inherits Attribute
             End Class
             <Attr(CByte(2))> Class Class1
             End Class
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub Bug862181()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             <AttributeUsageAttribute(System.AttributeTargets.Class), Obsolete()> Public Class Attr
                                           Inherits Attribute
                   End Class
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub Bug862462()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             <Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
             Partial Class UserControl2
             End Class
-        ]]>)
+        ")
     End Sub
 
     <WorkItem(863443, "DevDiv/Personal")>
     <Fact>
     Public Sub BC32017ERR_ArgumentSyntax()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             <attr(i+=1)> Class c9
             <attr(l-=1)> Sub test()
                          End Sub
             End Class
-        ]]>,
+        ",
         <errors>
             <error id="32017"/>
             <error id="32017"/>
@@ -154,7 +154,7 @@ A>
             Class Class1
             End Class
         ]]>, <errors>
-                 <error id="32035" message="Attribute specifier is not a complete statement. Use a line continuation to apply the attribute to the following statement." start="13" end="33"/>
+                 <error id="32035" message="Attribute specifier Is Not a complete statement. Use a line continuation To apply the attribute To the following statement." start="13" end="33"/>
              </errors>)
     End Sub
 

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseDeclarationTests.vb
@@ -12,15 +12,15 @@ Public Class ParseDeclarations
     <WorkItem(927366, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseModuleDeclaration()
-        ParseAndVerify(<![CDATA[
-            Module Module1
-            End Module
-        ]]>).
+        ParseAndVerify("
+ Module Module1
+ End Module
+").
         VerifyOccurrenceCount(SyntaxKind.EndOfFileToken, 1)
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Module Module1 : End Module
-        ]]>).
+        ").
         VerifyOccurrenceCount(SyntaxKind.EndOfFileToken, 1)
 
         ParseAndVerify(<![CDATA[Module Module1
@@ -31,75 +31,75 @@ Public Class ParseDeclarations
 
     <Fact>
     Public Sub ParseNamespaceDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
              Namespace N1
              End Namespace
-        ]]>)
+        ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Namespace N1 : End Namespace
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseNamespaceDeclarationWithGlobal()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
              Namespace Global.N1
              End Namespace
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseClassDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Class C1
             End Class
-        ]]>)
+        ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Class C1 : End Class
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseStructureDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Structure S1
             End Structure
-        ]]>)
+        ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Structure S1 : End Structure
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseInterfaceDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Interface I1
             End Interface
-        ]]>)
+        ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Interface I1 :  End Interface
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseClassInheritsDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class C1
                 End Class
                 Class C2
                     Inherits C1
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(927384, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseClassInheritsStatementWithSeparator()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class C1
                 End Class
                 Class C2 : Inherits C1
@@ -131,67 +131,67 @@ Public Class ParseDeclarations
                 Structure S2:
                        Implements I1
                 End Structure
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub ParseClassImplementsDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                Interface I1
                 End Interface
                 Class C2
                     Implements I1
                 End Class
-           ]]>)
+           ")
     End Sub
 
     <Fact>
     Public Sub ParseGenericClassDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class C1(of T1, T2)
                 End Class
-             ]]>)
+             ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class C1(
                             of 
                                 T1, 
                                 T2
                         )
                 End Class
-             ]]>)
+             ")
     End Sub
 
     <Fact>
     Public Sub ParseGenericClassAsNewDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Base
                 End Class
                 Class C1(of T1 as new)
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub ParseGenericClassAsTypeDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Base
                 End Class
                 Class C1(of T1 as Base)
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub ParseGenericClassAsMultipleDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Base
                 End Class
                 Class C1(of T1 as {new, Base})
                 End Class
-            ]]>)
+            ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Base  
                 End Class
                 Class C1(of 
@@ -200,12 +200,12 @@ Public Class ParseDeclarations
                                     Base
                                   })
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub ParseEnum()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Module Module1
                     enum e1
                         member1
@@ -214,145 +214,145 @@ Public Class ParseDeclarations
                         member4
                    end enum
                 End Module
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub Bug8037()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Enum Y
     ::A ::B
 End Enum
-            ]]>)
+            ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Enum Y::
     ::A::B:::
 End Enum
-            ]]>)
+            ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Enum Y
     A::B:::  ' A: is parsed as a label
 End Enum
-            ]]>,
+            ",
                 Diagnostic(ERRID.ERR_InvInsideEnum, "A:"))
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Enum Y:::::
     A::B ' A: is parsed as a label
 End Enum
-            ]]>,
+            ",
                 Diagnostic(ERRID.ERR_InvInsideEnum, "A:"))
     End Sub
 
     <Fact>
     Public Sub Bug862490()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface I1 
                 End Interface
                 Interface I2
                     Inherits I1
                 End Interface
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub Bug863541()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Class1(Of Type)
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub Bug866559()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface IVariance1(Of Out)
                 End Interface
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub Bug866616()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Module Module1
-            Dim x = from i in ""
+            Dim x = from i in """"
 
 
             End Module
-        ]]>).
+        ").
         VerifyOccurrenceCount(SyntaxKind.EmptyStatement, 0)
     End Sub
 
     <Fact>
     Public Sub Bug867063()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface IVariance(Of In T, Out R) : : End Interface
-            ]]>)
+            ")
     End Sub
 
     <Fact>
     Public Sub Bug868402()
         'Tree does not round-trip for generic type parameter list with newlines
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface IVariance1(Of Out
                 )
                 End Interface
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(873467, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseInterfaceBasesDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface I1 : End Interface
                 Interface I2 : End Interface
                 Interface I3
                     Inherits I1, I2
                 End Interface
-            ]]>)
+            ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface I1 : End Interface
                 Interface I2 : End Interface
                 Class C1
                     Implements I1, I2
                 End Class
-            ]]>)
+            ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Interface I1 : End Interface
                 Interface I2 : End Interface
                 Structure S1
                     Implements I1, I2
                 End Structure
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(882976, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseLambdaInFieldInitializer()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Class Class1
                     Dim x = Sub() Console.WriteLine()
                     Dim y As Integer = 3
                 End Class
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(869140, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseInterfaceSingleLine()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Interface IVariance(Of Out T) : Function Foo() As T : End Interface
-        ]]>)
+        ")
     End Sub
 
     <WorkItem(889005, "DevDiv/Personal")>
     <Fact>
     Public Sub ParseErrorsInvalidEndFunctionAndExecutableAsDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                      Class Class1
                         Dim x32 As Object = Sub() Call Function()
                                      Return New Exception
@@ -362,53 +362,52 @@ End Enum
                                   Return Nothing
                                End Function, Action(Of Long))
                      End Class
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(917197, "DevDiv/Personal")>
     <Fact>
     Public Sub TraverseEmptyBlocks()
         ParseAndVerify(
-            "Module M1" & vbCrLf &
-            "Sub Foo" & vbCrLf &
-            "Try" & vbCrLf &
-            "Catch" & vbCrLf &
-            "Finally" & vbCrLf &
-            "End Try" & vbCrLf &
-            "End Sub" & vbCrLf &
-            "End Module"
-        ).
+"Module M1
+Sub Foo
+Try
+Catch
+Finally
+End Try
+End Sub
+End Module").
         TraverseAllNodes()
     End Sub
 
-    <WorkItem(527076, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527076")>
+    <WorkItem(527076, "http:  //vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527076")>
     <Fact>
     Public Sub ParseMustOverrideInsideModule()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Module M1
 Mustoverride Sub Foo()
 End Sub
 End Module
-        ]]>, <errors>
-                 <error id="30429" message="'End Sub' must be preceded by a matching 'Sub'." start="34" end="41"/>
-             </errors>)
+        ", <errors>
+               <error id="30429" message="'End Sub' must be preceded by a matching 'Sub'." start="34" end="41"/>
+           </errors>)
     End Sub
 
     <Fact>
     Public Sub ParseVariousOrderingOfDeclModifiers()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Public MustInherit Class A
     MustInherit Private Class B
         Public MustOverride Function Func() As Integer
         MustOverride Protected Property Prop As String
     End Class
 End Class
-        ]]>)
+        ")
     End Sub
 
     <Fact>
     Public Sub ParseIncompleteMemberBecauseOfAttributeAndOrModifiers()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Public Class C1
     <Obsolete1()> 
     foo
@@ -430,29 +429,29 @@ Public Class C1
     Public Shared Sub Main() 
     End Sub
 End Class
-        ]]>, <errors>
-                 <error id="32035"/>
-                 <error id="32035"/>
-                 <error id="30203"/>
-                 <error id="30203"/>
-                 <error id="32035"/>
-                 <error id="30183"/>
-                 <error id="30183"/>
-             </errors>)
+        ", <errors>
+               <error id="32035"/>
+               <error id="32035"/>
+               <error id="30203"/>
+               <error id="30203"/>
+               <error id="32035"/>
+               <error id="30183"/>
+               <error id="30183"/>
+           </errors>)
     End Sub
 
     <WorkItem(543607, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543607")>
     <Fact()>
     Public Sub ParseInheritsAtInvalidLocation()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Class Scen24
     Dim i = Sub(a as Integer, b as Long)
 Inherits Scen23
     End Sub
 End Class
-        ]]>, <errors>
-                 <error id="30024"/>
-             </errors>)
+        ", <errors>
+               <error id="30024"/>
+           </errors>)
     End Sub
 
 #Region "Parser Error Tests"
@@ -460,23 +459,23 @@ End Class
     <WorkItem(866455, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30001ERR_NoParseError()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Property Foo As Integer
              
                 Namespace Namespace1
                 End Namespace
-            ]]>)
+            ")
     End Sub
 
     <WorkItem(863086, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30025ERR_EndProp()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Structure Struct1
                     Default Public Property Foo(ByVal x) As Integer
                     End Function
                 End Structure
-            ]]>,
+            ",
              <errors>
                  <error id="30430"/>
                  <error id="30634"/>
@@ -484,13 +483,13 @@ End Class
              </errors>)
     End Sub
 
-    <WorkItem(527022, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527022")>
+    <WorkItem(527022, "http: //vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/527022")>
     <Fact()>
     Public Sub BC30037ERR_IllegalChar_TypeParamMissingAsCommaOrRParen()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                      Class Class1(of ])
                      End Class
-            ]]>,
+            ",
             Diagnostic(ERRID.ERR_ExpectedIdentifier, ""),
             Diagnostic(ERRID.ERR_TypeParamMissingAsCommaOrRParen, ""),
             Diagnostic(ERRID.ERR_IllegalChar, "]"))
@@ -499,14 +498,14 @@ End Class
     <WorkItem(888046, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30184ERR_InvalidEndEnum()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                         Enum myenum
                          x
                          Shared Narrowing Operator CType(ByVal x As Integer) As c2
                             Return New c2
                          End Operator
                         End Enum
-            ]]>,
+            ",
                 Diagnostic(ERRID.ERR_MissingEndEnum, "Enum myenum"),
                 Diagnostic(ERRID.ERR_InvInsideEndsEnum, "Shared Narrowing Operator CType(ByVal x As Integer) As c2"),
                 Diagnostic(ERRID.ERR_InvalidEndEnum, "End Enum"))
@@ -516,12 +515,12 @@ End Class
     <Fact>
     Public Sub BC30185ERR_MissingEndEnum()
         ' Tree loses text when access modifier used on Enum member
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Enum Access1
                     Orange
                     Public Red = 2
                 End Enum
-            ]]>,
+            ",
             <errors>
                 <error id="30185"/>
                 <error id="30619"/>
@@ -532,60 +531,60 @@ End Class
     <WorkItem(863528, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30188ERR_ExpectedDeclaration()
-        ParseAndVerify(<![CDATA[
-             VERSION 1.0 CLASS
-                BEGIN
-                    MultiUse = -1 'True
-                    Persistable = 0 'NotPersistable
-                    DataBindingBehavior = 0 'vbNone
-                    DataSourceBehavior = 0 'vbNone
-                    MTSTransactionMode = 0 'NotAnMTSObject
-                END
-                Attribute VB_Name = "Class1"
-                Attribute VB_GlobalNameSpace = False
-                Attribute VB_Creatable = True
-                Attribute VB_PredeclaredId = False
-                Attribute VB_Exposed = True
-                Public v As Variant
-            ]]>,
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "VERSION 1.0 CLASS"),
-                Diagnostic(ERRID.ERR_ObsoleteArgumentsNeedParens, "1.0 CLASS"),
-                Diagnostic(ERRID.ERR_ArgumentSyntax, "CLASS"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "BEGIN"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "MultiUse = -1"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "Persistable = 0"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "DataBindingBehavior = 0"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "DataSourceBehavior = 0"),
-                Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "MTSTransactionMode = 0"),
-                Diagnostic(ERRID.ERR_UnrecognizedEnd, "END"),
-                Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Name = ""Class1"""),
-                Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute"),
-                Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_GlobalNameSpace = False"),
-                Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute"),
-                Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Creatable = True"),
-                Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute"),
-                Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_PredeclaredId = False"),
-                Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute"),
-                Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Exposed = True"),
-                Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute"),
-                Diagnostic(ERRID.ERR_ObsoleteObjectNotVariant, "Variant"))
+        ParseAndVerify("
+         VERSION 1.0 CLASS
+            BEGIN
+                MultiUse = -1 'True
+                Persistable = 0 'NotPersistable
+                DataBindingBehavior = 0 'vbNone
+                DataSourceBehavior = 0 'vbNone
+                MTSTransactionMode = 0 'NotAnMTSObject
+            END
+            Attribute VB_Name = ""Class1""
+            Attribute VB_GlobalNameSpace = False
+            Attribute VB_Creatable = True
+            Attribute VB_PredeclaredId = False
+            Attribute VB_Exposed = True
+            Public v As Variant
+        ",
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "VERSION 1.0 CLASS").WithLocation(2, 10),
+    Diagnostic(ERRID.ERR_ObsoleteArgumentsNeedParens, "1.0 CLASS").WithLocation(2, 18),
+    Diagnostic(ERRID.ERR_ArgumentSyntax, "CLASS").WithLocation(2, 22),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "BEGIN").WithLocation(3, 13),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "MultiUse = -1").WithLocation(4, 17),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "Persistable = 0").WithLocation(5, 17),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "DataBindingBehavior = 0").WithLocation(6, 17),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "DataSourceBehavior = 0").WithLocation(7, 17),
+    Diagnostic(ERRID.ERR_ExecutableAsDeclaration, "MTSTransactionMode = 0").WithLocation(8, 17),
+    Diagnostic(ERRID.ERR_UnrecognizedEnd, "END").WithLocation(9, 13),
+    Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Name = ""Class1""").WithLocation(10, 23),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute").WithLocation(10, 13),
+    Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_GlobalNameSpace = False").WithLocation(11, 23),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute").WithLocation(11, 13),
+    Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Creatable = True").WithLocation(12, 23),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute").WithLocation(12, 13),
+    Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_PredeclaredId = False").WithLocation(13, 23),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute").WithLocation(13, 13),
+    Diagnostic(ERRID.ERR_ExpectedSpecifier, "VB_Exposed = True").WithLocation(14, 23),
+    Diagnostic(ERRID.ERR_ExpectedDeclaration, "Attribute").WithLocation(14, 13),
+    Diagnostic(ERRID.ERR_ObsoleteObjectNotVariant, "Variant").WithLocation(15, 25))
     End Sub
 
     <Fact>
     Public Sub BC30193ERR_SpecifiersInvalidOnInheritsImplOpt()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Class C
     <A> Inherits B
 End Class
-]]>,
+",
             <errors>
                 <error id="30193"/>
             </errors>)
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Class C
     <A> Implements I
 End Class
-]]>,
+",
             <errors>
                 <error id="30193"/>
             </errors>)
@@ -594,10 +593,10 @@ End Class
     <WorkItem(863112, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30193ERR_SpecifiersInvalidOnInheritsImplOpt_2()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             <System.Runtime.CompilerServices.Extension()> Namespace ExtensionAttributeNamespace01
             End Namespace
-        ]]>,
+        ",
         <errors>
             <error id="30193"/>
         </errors>)
@@ -606,11 +605,11 @@ End Class
     <WorkItem(887502, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30193_MismatchEndNoNamespace()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                          <System.Runtime.CompilerServices.CompilationRelaxations(Runtime.CompilerServices.CompilationRelaxations.NoStringInterning)> _
                          Namespace CompilerRelaxations02
                          End Namespace
-            ]]>,
+            ",
             <errors>
                 <error id="30193"/>
             </errors>)
@@ -618,11 +617,11 @@ End Class
 
     <Fact>
     Public Sub BC30193_ParseInterfaceInherits()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 interface i
                 public inherits i2
                 end interface
-            ]]>,
+            ",
             <errors>
                 <error id="30193"/>
             </errors>)
@@ -631,7 +630,7 @@ End Class
     <WorkItem(889075, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30201ERR_ExpectedExpression_InvInsideEndsEnumAndMissingEndEnum()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                      Module Module1
                       Enum byteenum As Byte
                         a = 200
@@ -642,7 +641,7 @@ End Class
                         d
                      End Enum
                      End Module
-            ]]>,
+            ",
             <errors>
                 <error id="30201"/>
             </errors>)
@@ -653,12 +652,12 @@ End Class
     Public Sub BC30203ERR_ExpectedIdentifier_ParasExtraError30213()
         ' Expected error 30203: Identifier expected.
         ' Was also reporting 30213.
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Friend Class cTest
                Sub Sub1 (0 To 10)
                End Sub
             End Class
-        ]]>,
+        ",
         <errors>
             <error id="30203"/>
         </errors>)
@@ -666,10 +665,10 @@ End Class
 
     <Fact>
     Public Sub BC30205ERR_ExpectedEOS_NamespaceDeclarationWithGeneric()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
              Namespace N1.N2(of T)
              End Namespace
-        ]]>,
+        ",
         <errors>
             <error id="30205"/>
         </errors>)
@@ -679,25 +678,25 @@ End Class
     <WorkItem(894067, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30213ERR_InvalidParameterSyntax_DollarAutoProp()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
 Property Scen4(
 p1 as vb$anonymous1
 ) a
-]]>,
+",
             Diagnostic(ERRID.ERR_InvalidParameterSyntax, "anonymous1"),
-            Diagnostic(ERRID.ERR_AutoPropertyCantHaveParams, <![CDATA[(
+            Diagnostic(ERRID.ERR_AutoPropertyCantHaveParams, "(
 p1 as vb$anonymous1
-)]]>.Value))
+)"))
     End Sub
 
     <Fact>
     Public Sub BC30363ERR_NewInInterface_InterfaceWithSubNew()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
         Interface i
             Sub new ()
 
         End Interface
-        ]]>,
+        ",
         <errors>
             <error id="30363"/>
         </errors>)
@@ -705,10 +704,10 @@ p1 as vb$anonymous1
 
     <WorkItem(887748, "DevDiv/Personal")>
     <WorkItem(889062, "DevDiv/Personal")>
-    <WorkItem(538919, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538919")>
+    <WorkItem(538919, "http:         //vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538919")>
     <Fact>
     Public Sub BC30602ERR_InterfaceMemberSyntax_TypeStatement()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             interface i1
                 dim i as integer
             End interface
@@ -721,7 +720,7 @@ p1 as vb$anonymous1
                _loc as object
             End Interface
 
-]]>,
+",
     <errors>
         <error id="30188"/>
         <error id="30602"/>
@@ -732,12 +731,12 @@ p1 as vb$anonymous1
     <WorkItem(887508, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30603ERR_InvInsideInterface_ParseInterfaceWithSubWithEndSub()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Interface i1
               Sub foo()
               end sub
             End Interface
-]]>,
+",
         <errors>
             <error id="30603"/>
         </errors>)
@@ -745,23 +744,23 @@ p1 as vb$anonymous1
 
     <Fact>
     Public Sub BC30618ERR_NamespaceNotAtNamespace_ModuleNamespaceClassDeclaration()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Namespace N1
                 Module M1
                     Class A
                     End Class
                End Module
             End Namespace
-        ]]>)
+        ")
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             Module Module1
                 Namespace N1
                     Class A
                     End Class
                 End Namespace
             End Module
-        ]]>,
+        ",
         <errors>
             <error id=<%= CInt(ERRID.ERR_ExpectedEndModule) %>/>
             <error id=<%= CInt(ERRID.ERR_NamespaceNotAtNamespace) %>/>
@@ -772,9 +771,9 @@ p1 as vb$anonymous1
     <WorkItem(862508, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30624ERR_ExpectedEndStructure()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Structure Struct1
-            ]]>,
+            ",
             <errors>
                 <error id="30624"/>
             </errors>)
@@ -792,12 +791,12 @@ p1 as vb$anonymous1
 
     <Fact>
     Public Sub BC30626ERR_ExpectedEndNamespace_ModuleNamespaceClassMissingEnd1()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Module Module1
                     Namespace N1
                         Class A
                 End Module
-            ]]>,
+            ",
             <errors>
                 <error id=<%= CInt(ERRID.ERR_ExpectedEndModule) %>/>
                 <error id=<%= CInt(ERRID.ERR_NamespaceNotAtNamespace) %>/>
@@ -809,11 +808,11 @@ p1 as vb$anonymous1
 
     <Fact>
     Public Sub NamespaceOutOfPlace()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Module Module1
                     Class C1
                         Namespace N1
-            ]]>,
+            ",
             <errors>
                 <error id="30625" message="'Module' statement must end with a matching 'End Module'." start="17" end="31"/>
                 <error id="30481" message="'Class' statement must end with a matching 'End Class'." start="52" end="60"/>
@@ -821,11 +820,11 @@ p1 as vb$anonymous1
                 <error id="30626" message="'Namespace' statement must end with a matching 'End Namespace'." start="85" end="97"/>
             </errors>)
 
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Module Module1
                     Sub S1()
                         Namespace N1
-            ]]>,
+            ",
             <errors>
                 <error id="30625" message="'Module' statement must end with a matching 'End Module'." start="17" end="31"/>
                 <error id="30026" message="'End Sub' expected." start="52" end="60"/>
@@ -837,14 +836,14 @@ p1 as vb$anonymous1
     <WorkItem(888556, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30984ERR_ExpectedAssignmentOperatorInInit_AndExpectedRbrace()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                         Module Module1
                          Sub Foo()
                             Dim scen2b = New With {.prop = 10, .321prop = 9, .567abc = -10}
                             Dim scen3 = New With {.$123prop=1}
                          End Sub
                         End Module
-            ]]>,
+            ",
             <errors>
                 <error id="36576"/>
                 <error id="36576"/>
@@ -858,7 +857,7 @@ p1 as vb$anonymous1
     <WorkItem(888560, "DevDiv/Personal")>
     <Fact>
     Public Sub BC30987ERR_ExpectedLbrace_EndNoModuleAndModuleNotAtNamespaceAndExpectedEndClass()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                            Namespace scen8
                               Class customer
                               End Class
@@ -870,7 +869,7 @@ p1 as vb$anonymous1
                                 End Sub
                               End Module
                            End Namespace
-            ]]>,
+            ",
             <errors>
                 <error id="30987"/>
             </errors>)
@@ -879,7 +878,7 @@ p1 as vb$anonymous1
     <WorkItem(889038, "DevDiv/Personal")>
     <Fact>
     Public Sub BC31111ERR_ExitEventMemberNotInvalid_ExpectedExitKindAndSubOfFuncAndExpectedExitKind()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                      Friend Class cTest
                        Friend Delegate Sub fir()
                         Friend Custom Event e As fir
@@ -894,7 +893,7 @@ p1 as vb$anonymous1
                        End RaiseEvent
                        End Event
                      End Class
-            ]]>,
+            ",
             <errors>
                 <error id="31111"/>
                 <error id="31111"/>
@@ -905,13 +904,13 @@ p1 as vb$anonymous1
     <WorkItem(536278, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/536278")>
     <Fact>
     Public Sub BC31140ERR_InvalidUseOfCustomModifier_ExpectedSpecifierAndInvalidEndSub()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                       Module Module1
                        Custom sub foo()
                        End Sub
                       End Module
 
-            ]]>,
+            ",
             <errors>
                 <error id="30195"/>
                 <error id="31140"/>
@@ -921,10 +920,10 @@ p1 as vb$anonymous1
 
     <Fact>
     Public Sub BC32100ERR_TypeParamMissingAsCommaOrRParen_GenericClassMissingComma()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
             class B(of a b)
             end class
-        ]]>,
+        ",
         <errors>
             <error id="32100"/>
         </errors>)
@@ -932,12 +931,12 @@ p1 as vb$anonymous1
 
     <Fact>
     Public Sub Bug863497()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 Namespace $safeitemname$
                     Public Module $safeitemname$
                     End Module
                 End Namespace
-            ]]>,
+            ",
             <errors>
                 <error id="30203"/>
                 <error id="30037"/>
@@ -950,13 +949,13 @@ p1 as vb$anonymous1
     <WorkItem(538990, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/538990")>
     <Fact>
     Public Sub Bug4770()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
          interface i1
             dim i as integer
          End interface
-            ]]>, <errors>
-                     <error id="30602"/>
-                 </errors>)
+            ", <errors>
+                   <error id="30602"/>
+               </errors>)
     End Sub
 
     <WorkItem(539509, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/539509")>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseSpecifiers.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseSpecifiers.vb
@@ -5,7 +5,7 @@ Public Class ParseSpecifiers
 
     <Fact>
     Public Sub ParseSpecifiersOnClass()
-        ParseAndVerify(<![CDATA[
+        ParseAndVerify("
                 public class c1
                 End class
 
@@ -29,7 +29,7 @@ Public Class ParseSpecifiers
 
                 public notinheritable class c8
                 end class
-            ]]>)
+            ")
     End Sub
 
 End Class

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/ManualTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/ManualTests.vb
@@ -27,11 +27,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
             Dim c = SyntaxFactory.ClassBlock(SyntaxFactory.ClassStatement("C").AddTypeParameterListParameters(SyntaxFactory.TypeParameter("T"))) _
                           .AddImplements(SyntaxFactory.ImplementsStatement(SyntaxFactory.ParseTypeName("X"), SyntaxFactory.ParseTypeName("Y")))
 
-            Dim expectedText As String = _
-                "Class C(Of T)" + vbCrLf + _
-                "    Implements X, Y" + vbCrLf + _
-                vbCrLf + _
-                "End Class"
+            Dim expectedText As String =
+"Class C(Of T)
+    Implements X, Y
+
+End Class"
 
             Dim actualText = c.NormalizeWhitespace().ToFullString()
             Assert.Equal(expectedText, actualText)
@@ -69,13 +69,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         <Fact()>
         Public Sub TestParsedSyntaxTreeToString()
 
-            Dim input = "    Module m1" + vbCrLf + _
-                        "Sub      Main(args As String())" + vbCrLf + _
-                        "Sub1  (   Function(p   As   Integer   )" + vbCrLf + _
-                        "Sub2(    )" + vbCrLf + _
-                        "End FUNCTION)" + vbCrLf + _
-                        "End              Sub" + vbCrLf + _
-                        "End       Module                     "
+            Dim input =
+"    Module m1
+Sub      Main(args As String())
+Sub1  (   Function(p   As   Integer   )
+Sub2(    )
+End FUNCTION)
+End              Sub
+End       Module                     "
 
             Dim node = VisualBasicSyntaxTree.ParseText(input)
             Assert.Equal(input, node.ToString())
@@ -120,7 +121,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests
         <WorkItem(529624, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/529624")>
         <Fact()>
         Public Sub SyntaxTreeIsHidden_Bug13776()
-            Dim source = <![CDATA[
+            Dim source = "
 Module Program
 Sub Main()
 If a Then
@@ -134,7 +135,7 @@ c()
 End If
 End Sub
 End Module
-]]>.Value
+"
 
             Dim tree = VisualBasicSyntaxTree.ParseText(source)
 
@@ -213,13 +214,13 @@ End Module
         <Fact(), WorkItem(701158, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/701158")>
         Public Sub FindTokenOnStartOfContinuedLine()
             Dim code =
-                <code>
-                Namespace a
-                    &lt;TestClass&gt; _
-                    Public Class UnitTest1
-                   End Class
-                End Namespace
-            </code>.Value
+"
+Namespace a
+    <TestClass> _
+    Public Class UnitTest1
+   End Class
+End Namespace
+"
             Dim text = SourceText.From(code)
             Dim tree = VisualBasicSyntaxTree.ParseText(text)
             Dim token = tree.GetRoot().FindToken(text.Lines.Item(3).Start)


### PR DESCRIPTION
The PR is tracking the progress of converting the Visual Basic Unit Test from XML Literals to Multi-Line String Literals. To see if the change is worth pursuing. The semantic meaning of the source used in each of the tests will be kept the same. Some minor changes in the expected positions are to be expected do realign the source to left margin edge. Do the change from in signification whitespace in XML to significant whitespace in the strings. Indention within the source code will be preserved. 

The results are being tested locally to check for changes. Updates to the code in this pr will pass local on a push. (Unless indicated in commit). 
The PR build system is also being used for ballpark benchmark ("standard") figures for the times.