### PR TITLE
Object creation providers don't need to compute insertion text.

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/VisualBasicCompletionCommandHandlerTests.vb
@@ -2432,5 +2432,28 @@ End Class]]></Document>)
                 Await state.AssertSelectedCompletionItem("value", isHardSelected:=False, isSoftSelected:=True).ConfigureAwait(True)
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(11812, "https://github.com/dotnet/roslyn/issues/11812")>
+        Public Async Function TestObjectCreationQualifiedName() As Task
+            Using state = TestState.CreateVisualBasicTestState(
+                            <Document><![CDATA[
+ Class A
+     Sub Test()
+         Dim b As B.C(Of Integer) = New$$
+     End Sub
+ End Class
+ 
+ Namespace B
+     Class C(Of T)
+     End Class
+ End Namespace]]></Document>)
+
+                state.SendTypeChars(" ")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("(")
+                state.AssertMatchesTextStartingAtLine(3, "Dim b As B.C(Of Integer) = New B.C(Of Integer)(")
+            End Using
+        End Function
     End Class
 End Namespace

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.cs
@@ -21,17 +21,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 {
     internal partial class ObjectCreationCompletionProvider : AbstractObjectCreationCompletionProvider
     {
-        protected override string GetInsertionText(ISymbol symbol, AbstractSyntaxContext context, char ch)
-        {
-            if (symbol is IAliasSymbol)
-            {
-                return ((IAliasSymbol)symbol).Name;
-            }
-
-            var displayService = context.GetLanguageService<ISymbolDisplayService>();
-            return displayService.ToMinimalDisplayString(context.SemanticModel, context.Position, symbol);
-        }
-
         internal override bool IsInsertionTrigger(SourceText text, int characterPosition, OptionSet options)
         {
             return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options);

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,9 +77,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return declarationSyntax != null && declarationSyntax.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.PartialKeyword));
         }
 
-        protected override CompletionItem AddAdditionalProperties(CompletionItem item, INamedTypeSymbol symbol, AbstractSyntaxContext context)
+        protected override ImmutableDictionary<string, string> GetProperties(
+            INamedTypeSymbol symbol, AbstractSyntaxContext context)
         {
-            return item.AddProperty(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier());
+            return ImmutableDictionary<string, string>.Empty.Add(InsertionTextOnLessThan, symbol.Name.EscapeIdentifier());
         }
 
         public async override Task<TextChange?> GetTextChangeAsync(

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SymbolCompletionProvider.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
             return ts != null && ts.IsIntrinsicType();
         }
 
-        protected override string GetInsertionText(ISymbol symbol, AbstractSyntaxContext context, char ch)
+        protected override string GetInsertionText(
+            CompletionItem item, ISymbol symbol, AbstractSyntaxContext context, char ch)
         {
             return GetInsertionText(symbol, context);
         }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractObjectCreationCompletionProvider.cs
@@ -10,9 +10,9 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Recommendations;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery;
-using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using Microsoft.CodeAnalysis.Shared.Utilities;
+using System;
 
 namespace Microsoft.CodeAnalysis.Completion.Providers
 {
@@ -122,11 +122,20 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return Task.FromResult(SpecializedCollections.SingletonEnumerable((ISymbol)type));
         }
 
-        protected override ValueTuple<string, string> GetDisplayAndInsertionText(ISymbol symbol, AbstractSyntaxContext context)
+        protected override ValueTuple<string, string> GetDisplayAndInsertionText(
+            ISymbol symbol, AbstractSyntaxContext context)
         {
             var displayService = context.GetLanguageService<ISymbolDisplayService>();
             var displayString = displayService.ToMinimalDisplayString(context.SemanticModel, context.Position, symbol);
             return ValueTuple.Create(displayString, displayString);
+        }
+
+        protected override string GetInsertionText(
+            CompletionItem item, ISymbol symbol, AbstractSyntaxContext context, char ch)
+        {
+            // The insertion text we put in the completion item is already the right text
+            // to insert.
+            return SymbolCompletionItem.GetInsertionText(item);
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractPartialTypeCompletionProvider.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,19 +53,18 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
         {
             var displayAndInsertionText = GetDisplayAndInsertionText(symbol, context);
 
-            var item = SymbolCompletionItem.Create(
+            return SymbolCompletionItem.Create(
                 displayText: displayAndInsertionText.Item1,
                 insertionText: displayAndInsertionText.Item2,
                 symbol: symbol,
                 contextPosition: context.Position,
+                properties: GetProperties(symbol, context),
                 rules: CompletionItemRules.Default);
-
-            item = AddAdditionalProperties(item, symbol, context);
-            return item;
         }
 
-        protected abstract CompletionItem AddAdditionalProperties(
-            CompletionItem item, INamedTypeSymbol symbol, AbstractSyntaxContext context);
+        protected abstract ImmutableDictionary<string, string> GetProperties(
+            INamedTypeSymbol symbol, AbstractSyntaxContext context);
+
         protected abstract Task<AbstractSyntaxContext> CreateSyntaxContextAsync(
             Document document,
             SemanticModel semanticModel,

--- a/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
+++ b/src/Features/Core/Portable/Completion/Providers/AbstractSymbolCompletionProvider.cs
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
                 var symbols = await SymbolCompletionItem.GetSymbolsAsync(selectedItem, document, cancellationToken).ConfigureAwait(false);
                 if (symbols.Length > 0)
                 {
-                    insertionText = GetInsertionText(symbols[0], context, ch.Value);
+                    insertionText = GetInsertionText(selectedItem, symbols[0], context, ch.Value);
                 }
                 else
                 {
@@ -355,6 +355,6 @@ namespace Microsoft.CodeAnalysis.Completion.Providers
             return new TextChange(selectedItem.Span, insertionText);
         }
 
-        protected abstract string GetInsertionText(ISymbol symbol, AbstractSyntaxContext context, char ch);
+        protected abstract string GetInsertionText(CompletionItem item, ISymbol symbol, AbstractSyntaxContext context, char ch);
     }
 }

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
@@ -136,9 +135,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return Task.FromResult(Of TextChange?)(New TextChange(selectedItem.Span, insertionText))
         End Function
 
-        Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
+        Protected Overrides Function GetInsertionText(
+                item As CompletionItem, symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
             Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
         End Function
-
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/HandlesClauseCompletionProvider.vb
@@ -9,7 +9,6 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.CodeAnalysis.VisualBasic.Extensions.ContextQuery
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Shared.Extensions.ContextQuery
-Imports System.Collections.Immutable
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class HandlesClauseCompletionProvider
@@ -148,9 +147,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return CompletionItemRules.Default
         End Function
 
-        Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
+        Protected Overrides Function GetInsertionText(
+                item As CompletionItem, symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
             Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
         End Function
-
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ImplementsClauseCompletionProvider.vb
@@ -295,9 +295,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return Await MyBase.GetTextChangeAsync(document, selectedItem, ch, cancellationToken).ConfigureAwait(False)
         End Function
 
-        Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
+        Protected Overrides Function GetInsertionText(
+                item As CompletionItem, symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
             Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
         End Function
-
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/ObjectCreationCompletionProvider.vb
@@ -14,10 +14,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class ObjectCreationCompletionProvider
         Inherits AbstractObjectCreationCompletionProvider
 
-        Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
-            Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
-        End Function
-
         Friend Overrides Function IsInsertionTrigger(text As SourceText, characterPosition As Integer, options As OptionSet) As Boolean
             Return CompletionUtilities.IsTriggerAfterSpaceOrStartOfWordCharacter(text, characterPosition, options)
         End Function

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/PartialTypeCompletionProvider.vb
@@ -1,5 +1,6 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Completion
 Imports Microsoft.CodeAnalysis.Completion.Providers
@@ -49,8 +50,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
             Return ValueTuple.Create(displayText, insertionText)
         End Function
 
-        Protected Overrides Function AddAdditionalProperties(item As CompletionItem, symbol As INamedTypeSymbol, context As AbstractSyntaxContext) As CompletionItem
-            Return item.AddProperty(InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier())
+        Protected Overrides Function GetProperties(symbol As INamedTypeSymbol,
+                                                   context As AbstractSyntaxContext) As ImmutableDictionary(Of String, String)
+            Return ImmutableDictionary(Of String, String).Empty.Add(
+                InsertionTextOnOpenParen, symbol.Name.EscapeIdentifier())
         End Function
 
         Public Overrides Async Function GetTextChangeAsync(document As Document, selectedItem As CompletionItem, ch As Char?, cancellationToken As CancellationToken) As Task(Of TextChange?)

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/SymbolCompletionProvider.vb
@@ -15,7 +15,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
     Partial Friend Class SymbolCompletionProvider
         Inherits AbstractRecommendationServiceBasedCompletionProvider
 
-        Protected Overrides Function GetInsertionText(symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
+        Protected Overrides Function GetInsertionText(item As CompletionItem, symbol As ISymbol, context As AbstractSyntaxContext, ch As Char) As String
             Return CompletionUtilities.GetInsertionTextAtInsertionTime(symbol, context, ch)
         End Function
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11812