### PR TITLE
ExpressionPrinter reduced the string concatenation usage.

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -55,8 +55,8 @@ Namespace Global
         <System.Runtime.CompilerServices.Extension>
         Friend Function Indent(ByRef sb As StringBuilder, level As Integer) As StringBuilder
             While level > 0
-                'If level >= 32 Then sb = sb.Append(spc32) : level -= 32
-                'If level >= 16 Then sb = sb.Append(spc16) : level -= 16
+                If level >= 32 Then sb = sb.Append(spc32) : level -= 32
+                If level >= 16 Then sb = sb.Append(spc16) : level -= 16
                 If level >= 8 Then sb = sb.Append(spc08) : level -= 8
                 If level >= 4 Then sb = sb.Append(spc04) : level -= 4
                 If level >= 2 Then sb = sb.Append(spc02) : level -= 2

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -72,7 +72,7 @@ simplecases:
                 Case 14 : sb = sb.Append(spc14)
                 Case Else
                     While level >= 16
-                        sb.Append(spc16)
+                        sb.Append(spc16) : level -= 16
                     End While
                     GoTo simplecases
             End Select

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -47,20 +47,35 @@ Namespace Global
     End Module
 
     Module ext
-        Const spc32 = "                              "
-        Const spc16 = "               "
+        '                       1         2         3
+        '              12345678901234567890123456789012
+        Const spc32 = "                                "
+        Const spc16 = "                "
+        Const spc14 = "              "
+        Const spc12 = "            "
+        Const spc10 = "          "
         Const spc08 = "        "
+        Const spc06 = "      "
         Const spc04 = "    "
         Const spc02 = "  "
         <System.Runtime.CompilerServices.Extension>
         Friend Function Indent(ByRef sb As StringBuilder, level As Integer) As StringBuilder
-            While level > 0
-                If level >= 32 Then sb = sb.Append(spc32) : level -= 32
-                If level >= 16 Then sb = sb.Append(spc16) : level -= 16
-                If level >= 8 Then sb = sb.Append(spc08) : level -= 8
-                If level >= 4 Then sb = sb.Append(spc04) : level -= 4
-                If level >= 2 Then sb = sb.Append(spc02) : level -= 2
-            End While
+simplecases:
+            Select Case level
+                Case 0 : Return sb
+                Case 2 : sb = sb.Append(spc02)
+                Case 4 : sb = sb.Append(spc04)
+                Case 6 : sb = sb.Append(spc06)
+                Case 8 : sb = sb.Append(spc08)
+                Case 10 : sb = sb.Append(spc10)
+                Case 12 : sb = sb.Append(spc12)
+                Case 14 : sb = sb.Append(spc14)
+                Case Else
+                    While level >= 16
+                        sb.Append(spc16)
+                    End While
+                    GoTo simplecases
+            End Select
             Return sb
         End Function
     End Module
@@ -68,7 +83,7 @@ Namespace Global
     Friend Class ExpressionPrinter
         Inherits System.Linq.Expressions.ExpressionVisitor
 
-        Private ReadOnly _s As StringBuilder = New StringBuilder(256)
+        Private ReadOnly _s As New StringBuilder(256)
 
         Private ReadOnly _IndentStep As Integer = 2
         Private _indent As Integer = 0

--- a/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/ExpressionTrees/Sources/ExprLambdaUtils.vb
@@ -46,18 +46,36 @@ Namespace Global
         End Function
     End Module
 
+    Module ext
+        Const spc32 = "                              "
+        Const spc16 = "               "
+        Const spc08 = "        "
+        Const spc04 = "    "
+        Const spc02 = "  "
+        <System.Runtime.CompilerServices.Extension>
+        Friend Function Indent(ByRef sb As StringBuilder, level As Integer) As StringBuilder
+            While level > 0
+                'If level >= 32 Then sb = sb.Append(spc32) : level -= 32
+                'If level >= 16 Then sb = sb.Append(spc16) : level -= 16
+                If level >= 8 Then sb = sb.Append(spc08) : level -= 8
+                If level >= 4 Then sb = sb.Append(spc04) : level -= 4
+                If level >= 2 Then sb = sb.Append(spc02) : level -= 2
+            End While
+            Return sb
+        End Function
+    End Module
+
     Friend Class ExpressionPrinter
         Inherits System.Linq.Expressions.ExpressionVisitor
 
-        Private ReadOnly _s As StringBuilder = New StringBuilder()
+        Private ReadOnly _s As StringBuilder = New StringBuilder(256)
 
-        Private _indent As String = ""
-        Private ReadOnly _indentStep As String = "  "
+        Private ReadOnly _IndentStep As Integer = 2
+        Private _indent As Integer = 0
 
         Public Shared Function GetCultureInvariantString(val As Object) As String
-            If val Is Nothing Then
-                Return Nothing
-            End If
+            If val Is Nothing Then Return Nothing
+
 
             Dim vType = val.GetType()
             Dim valStr = val.ToString()
@@ -80,124 +98,123 @@ Namespace Global
             Return p._s.ToString()
         End Function
 
+
+
         Public Overrides Function Visit(node As Expression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             If node Is Nothing Then
-                _s.AppendLine(Me._indent + "<NULL>")
+                _s.Indent(_indent).AppendLine("<NULL>")
                 Return Nothing
             End If
 
-            _s.AppendLine(indent + node.NodeType.ToString() + "(")
-            Me._indent = indent + _indentStep
+            _s.Indent(indent).Append(node.NodeType.ToString()).AppendLine("(")
+            _indent = indent + _IndentStep
             MyBase.Visit(node)
-            _s.AppendLine(indent + _indentStep + "type: " + node.Type.ToString())
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent + _IndentStep).Append("type: ").AppendLine(node.Type.ToString())
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberBinding(node As MemberBinding) As MemberBinding
-            If node Is Nothing Then
-                _s.AppendLine(Me._indent + "<NULL>")
-                Return Nothing
-            End If
-
-            Return MyBase.VisitMemberBinding(node)
+            If node IsNot Nothing Then Return MyBase.VisitMemberBinding(node)
+            _s.Indent(_indent).AppendLine("<NULL>")
+            Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberMemberBinding(node As MemberMemberBinding) As MemberMemberBinding
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberMemberBinding(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberMemberBinding(")
+            _s.Indent(indent + _IndentStep).Append("member: ").AppendLine(node.Member.ToString())
             For Each b In node.Bindings
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitMemberBinding(b)
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberListBinding(node As MemberListBinding) As MemberListBinding
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberListBinding(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberListBinding(")
+            _s.Indent(indent + _IndentStep).Append("member: ").AppendLine(node.Member.ToString())
             For Each i In node.Initializers
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitElementInit(i)
             Next
-
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberAssignment(node As MemberAssignment) As MemberAssignment
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "MemberAssignment(")
-            _s.AppendLine(indent + _indentStep + "member: " + node.Member.ToString())
-            _s.AppendLine(indent + _indentStep + "expression: {")
-            Me._indent = indent + _indentStep + _indentStep
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("MemberAssignment(")
+            Dim nl = indent + _IndentStep
+            _s.Indent(nl).Append("member: ").AppendLine(node.Member.ToString())
+            _s.Indent(nl).AppendLine("expression: {")
+            _indent = nl + _IndentStep
             Visit(node.Expression)
-            _s.AppendLine(indent + _indentStep + "}")
-            _s.AppendLine(indent + ")")
+            _s.Indent(nl).AppendLine("}")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMemberInit(node As MemberInitExpression) As Expression
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "NewExpression(")
-            Me._indent = indent + _indentStep
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("NewExpression(")
+            _indent = indent + _IndentStep
             Visit(node.NewExpression)
-            _s.AppendLine(indent + ")")
-            _s.AppendLine(indent + "bindings:")
+            _s.Indent(indent).AppendLine(")")
+            _s.Indent(indent).AppendLine("bindings:")
             For Each b In node.Bindings
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 VisitMemberBinding(b)
             Next
+
             Return Nothing
         End Function
 
         Protected Overrides Function VisitBinary(node As BinaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
 
-            Me._indent = indent
+            _indent = indent
             Visit(node.Left)
 
-            Me._indent = indent
+            _indent = indent
             Visit(node.Right)
 
             If node.Conversion IsNot Nothing Then
-                _s.AppendLine(indent + "conversion:")
-                Me._indent = indent + _indentStep
+                _s.Indent(indent).AppendLine("conversion:")
+                _indent = indent + _IndentStep
                 Visit(node.Conversion)
             End If
 
-            If node.IsLifted Then
-                _s.AppendLine(indent + "Lifted")
-            End If
+            If node.IsLifted Then _s.Indent(indent).AppendLine("Lifted")
 
-            If node.IsLiftedToNull Then
-                _s.AppendLine(indent + "LiftedToNull")
-            End If
+            If node.IsLiftedToNull Then _s.Indent(indent).
+                                             AppendLine("LiftedToNull")
 
-            If node.Method IsNot Nothing Then
-                _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString())
-            End If
+            If node.Method IsNot Nothing Then _s.Indent(indent).
+                                                   Append("method: ").
+                                                   Append(node.Method.ToString()).
+                                                   Append(" in ").
+                                                   AppendLine(node.Method.DeclaringType.ToString())
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitConditional(node As ConditionalExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Test)
-            Me._indent = indent
+            _indent = indent
             Visit(node.IfTrue)
-            Me._indent = indent
+            _indent = indent
             Visit(node.IfFalse)
             Return Nothing
         End Function
 
         Protected Overrides Function VisitConstant(node As ConstantExpression) As Expression
-            _s.AppendLine(_indent + If(node.Value Is Nothing, "null", GetCultureInvariantString(node.Value)))
+            _s.Indent(_indent).AppendLine(If(node.Value Is Nothing, "null", GetCultureInvariantString(node.Value)))
             Return Nothing
         End Function
 
@@ -206,89 +223,87 @@ Namespace Global
         End Function
 
         Protected Overrides Function VisitIndex(node As IndexExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.[Object])
 
-            Me._indent = indent
-            _s.AppendLine(indent + "indices(")
-            Dim n As Integer = node.Arguments.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _indent = indent
+            _s.Indent(indent).AppendLine("indices(")
+            Dim n As Integer = node.Arguments.Count - 1
+
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
 
-            If node.Indexer IsNot Nothing Then
-                _s.AppendLine(indent + "indexer: " + node.Indexer.ToString())
-            End If
+            If node.Indexer IsNot Nothing Then _s.Indent(indent).Append("indexer: ").AppendLine(node.Indexer.ToString())
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitInvocation(node As InvocationExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-            _s.AppendLine(indent + "(")
-            Dim n As Integer = node.Arguments.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("(")
+            Dim n As Integer = node.Arguments.Count - 1
+
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitLambda(Of T)(node As Expression(Of T)) As Expression
-            Dim indent = Me._indent
-            Dim n As Integer = node.Parameters.Count
-            For i = 0 To n - 1
-                Me._indent = indent
+            Dim indent = _indent
+            Dim n As Integer = node.Parameters.Count - 1
+
+            For i = 0 To n
+                _indent = indent
                 Visit(node.Parameters(i))
             Next
 
-            If node.Name IsNot Nothing Then
-                _s.AppendLine(indent + node.Name)
-            End If
+            If node.Name IsNot Nothing Then _s.Indent(indent).AppendLine(node.Name)
 
-            _s.AppendLine(indent + "body {")
-            Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("body {")
+            _indent = indent + _IndentStep
             Visit(node.Body)
-            _s.AppendLine(indent + "}")
 
-            If node.ReturnType IsNot Nothing Then
-                _s.AppendLine(indent + "return type: " + node.ReturnType.ToString())
-            End If
+            _s.Indent(indent).AppendLine("}")
 
-            If node.TailCall Then
-                _s.AppendLine(indent + "tail call")
-            End If
+            If node.ReturnType IsNot Nothing Then _s.Indent(indent).Append("return type: ").AppendLine(node.ReturnType.ToString())
+
+            If node.TailCall Then _s.Indent(indent).AppendLine("tail call")
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitParameter(node As ParameterExpression) As Expression
-            _s.Append(Me._indent + node.Name)
-            If node.IsByRef Then
-                _s.Append(" ByRef")
-            End If
+            _s.Indent(_indent).Append(node.Name)
+
+            If node.IsByRef Then _s.Append(" ByRef")
+
             _s.AppendLine()
+
             Return Nothing
         End Function
 
         Protected Overrides Function VisitListInit(node As ListInitExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
+
             Visit(node.NewExpression)
 
-            _s.AppendLine(indent + "{")
-            Dim n As Integer = node.Initializers.Count
-            For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+            _s.Indent(indent).AppendLine("{")
+
+            Dim n As Integer = node.Initializers.Count - 1
+            For i = 0 To n
+                _indent = indent + _IndentStep
                 Visit(node.Initializers(i))
             Next
-
-            _s.AppendLine(indent + "}")
+            _s.Indent(indent).AppendLine("}")
             Return Nothing
         End Function
 
@@ -298,102 +313,88 @@ Namespace Global
         End Function
 
         Private Overloads Sub Visit(node As ElementInit)
-            Dim indent = Me._indent
-            _s.AppendLine(indent + "ElementInit(")
-            _s.AppendLine(indent + _indentStep + node.AddMethod.ToString)
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine("ElementInit(")
+            _s.Indent(indent + _IndentStep).AppendLine(node.AddMethod.ToString)
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
-
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
         End Sub
 
         Protected Overrides Function VisitUnary(node As UnaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Operand)
 
-            If node.IsLifted Then
-                _s.AppendLine(indent + "Lifted")
-            End If
+            If node.IsLifted Then _s.Indent(indent).AppendLine("Lifted")
 
-            If node.IsLiftedToNull Then
-                _s.AppendLine(indent + "LiftedToNull")
-            End If
+            If node.IsLiftedToNull Then _s.Indent(indent).AppendLine("LiftedToNull")
 
-            If node.Method IsNot Nothing Then
-                _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString())
-            End If
-
+            If node.Method IsNot Nothing Then _s.Indent(indent).Append("method: ").Append(node.Method.ToString()).Append(" in ").AppendLine(node.Method.DeclaringType.ToString())
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMember(node As MemberExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-            _s.AppendLine(indent + "-> " + node.Member.Name)
+            _s.Indent(indent).Append("-> ").AppendLine(node.Member.Name)
             Return Nothing
         End Function
 
         Protected Overrides Function VisitMethodCall(node As MethodCallExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.[Object])
-
-            _s.AppendLine(indent + "method: " + node.Method.ToString() + " in " + node.Method.DeclaringType.ToString() + " (")
+            _s.Indent(indent).Append("method: ").Append(node.Method.ToString()).Append(" in ").Append(node.Method.DeclaringType.ToString()).AppendLine(" (")
 
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
 
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
             Return Nothing
         End Function
 
         Protected Overrides Function VisitNew(node As NewExpression) As Expression
-            Dim indent = Me._indent
-
-            _s.AppendLine(indent + If((node.Constructor IsNot Nothing), node.Constructor.ToString(), "<.ctor>") + "(")
+            Dim indent = _indent
+            _s.Indent(indent).AppendLine(If((node.Constructor IsNot Nothing), node.Constructor.ToString(), "<.ctor>") + "(")
             Dim n As Integer = node.Arguments.Count
             For i = 0 To n - 1
-                Me._indent = indent + _indentStep
+                _indent = indent + _IndentStep
                 Visit(node.Arguments(i))
             Next
-            _s.AppendLine(indent + ")")
+            _s.Indent(indent).AppendLine(")")
+            If node.Members Is Nothing Then Return Nothing
+            n = node.Members.Count
+            If n = 0 Then Return Nothing
+            _s.Indent(indent).AppendLine("members: {")
 
-            If node.Members IsNot Nothing Then
-                n = node.Members.Count
-                If n <> 0 Then
-                    _s.AppendLine(indent + "members: {")
-                    For i = 0 To n - 1
-                        Dim info = node.Members(i)
-                        _s.AppendLine(indent + _indentStep + info.ToString())
-                    Next
-
-                    _s.AppendLine(indent + "}")
-                End If
-            End If
+            For i = 0 To n - 1
+                Dim info = node.Members(i)
+                _s.Indent(indent + _IndentStep).AppendLine(info.ToString())
+            Next
+            _s.Indent(indent).AppendLine("}")
 
             Return Nothing
         End Function
 
         Protected Overrides Function VisitNewArray(node As NewArrayExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Dim n As Integer = node.Expressions.Count
             For i = 0 To n - 1
-                Me._indent = indent
+                _indent = indent
                 Visit(node.Expressions(i))
             Next
             Return Nothing
         End Function
 
         Protected Overrides Function VisitTypeBinary(node As TypeBinaryExpression) As Expression
-            Dim indent = Me._indent
+            Dim indent = _indent
             Visit(node.Expression)
-
-            _s.AppendLine(indent + "Type Operand: " + node.TypeOperand.ToString())
+            _s.Indent(indent).Append("Type Operand: ").AppendLine(node.TypeOperand.ToString())
             Return Nothing
         End Function
     End Class


### PR DESCRIPTION
Rewriten prefer using the string builder methods over string concatenations.
Extracted out a helper function to do then indenting.
Marked improved in test times
