### PR TITLE
Add dependencies between Swixproj

### DIFF
--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisExpressionEvaluator/Microsoft.CodeAnalysis.ExpressionEvaluator.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisExpressionEvaluator/Microsoft.CodeAnalysis.ExpressionEvaluator.swr
@@ -14,3 +14,8 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)ExpressionEvaluatorPackage.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
+                version=[15.0,16.0)
+                type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
@@ -14,3 +14,11 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)Roslyn.VisualStudio.InteractiveComponents.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
+                version=[15.0,16.0)
+                type=Required
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow
+                version=[15.0,16.0)
+                type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
@@ -14,3 +14,14 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)Roslyn.VisualStudio.Setup.Interactive.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
+                version=[15.0,16.0)
+                type=Required
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveComponents
+                version=[15.0,16.0)
+                type=Required
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow
+                version=[15.0,16.0)
+                type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupNext/Microsoft.CodeAnalysis.VisualStudio.Setup.Next.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupNext/Microsoft.CodeAnalysis.VisualStudio.Setup.Next.swr
@@ -14,3 +14,8 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)Roslyn.VisualStudio.Setup.Next.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
+                version=[15.0,16.0)
+                type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioTelemetry/Microsoft.CodeAnalysis.VisualStudio.Telemetry.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioTelemetry/Microsoft.CodeAnalysis.VisualStudio.Telemetry.swr
@@ -14,3 +14,8 @@ vs.localizedResources
 
 vs.payloads
   vs.payload source=$(OutputPath)Microsoft.VisualStudio.LanguageServices.Telemetry.vsix
+
+vs.dependencies
+  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
+                version=[15.0,16.0)
+                type=Required


### PR DESCRIPTION
The Swixproj projects encapsulating each Vsix should mention the
dependencies betweeen them similar to the dependencies stated in the
contained Vsixes.

Tagging @dotnet/roslyn @shyamnamboodiripad @jmarolf @brettfo @jaredpar for review 