### PR TITLE
Allow partial names in tuples

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -661,7 +661,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             var elementTypes = ArrayBuilder<TypeSymbol>.GetInstance(arguments.Count);
             var elementLocations = ArrayBuilder<Location>.GetInstance(arguments.Count);
             ArrayBuilder<string> elementNames = null;
-            int countOfExplicitNames = 0;
 
             // prepare and check element names and types
             for (int i = 0; i < numElements; i++)
@@ -675,7 +674,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     name = nameSyntax.Identifier.ValueText;
                     elementLocations.Add(nameSyntax.Location);
 
-                    countOfExplicitNames++;
                     if (!CheckTupleMemberName(name, i, argumentSyntax.NameColon.Name, diagnostics, uniqueFieldNames))
                     {
                         hasErrors = true;
@@ -701,12 +699,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             uniqueFieldNames.Free();
-
-            if (countOfExplicitNames != 0 && countOfExplicitNames != elementTypes.Count)
-            {
-                hasErrors = true;
-                Error(diagnostics, ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, node);
-            }
 
             var elementNamesArray = elementNames == null ?
                                 default(ImmutableArray<string>) :

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // set of names already used
             var uniqueFieldNames = PooledHashSet<string>.GetInstance();
-            int countOfExplicitNames = 0;
+            bool hasExplicitNames = false;
 
             for (int i = 0; i < numElements; i++)
             {
@@ -426,7 +426,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     name = nameSyntax.Identifier.ValueText;
 
                     // validate name if we have one
-                    countOfExplicitNames++;
+                    hasExplicitNames = true;
                     CheckTupleMemberName(name, i, nameSyntax, diagnostics, uniqueFieldNames);
                     locations.Add(nameSyntax.Location);
                 }
@@ -440,13 +440,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             uniqueFieldNames.Free();
 
-            if (countOfExplicitNames != 0)
+            if (hasExplicitNames)
             {
-                if (countOfExplicitNames != numElements)
-                {
-                    Error(diagnostics, ErrorCode.ERR_TupleExplicitNamesOnAllMembersOrNone, syntax);
-                }
-
                 // If the tuple type with names is bound in a declaration
                 // context then we must have the TupleElementNamesAttribute to emit
                 if (syntax.IsTypeInContextWhichNeedsTupleNamesAttribute())
@@ -489,7 +484,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // but in case we need to handle this in error cases
             if (elementNames != null)
             {
-                elementNames.Add(name ?? TupleTypeSymbol.TupleMemberName(position));
+                elementNames.Add(name);
             }
             else
             {
@@ -498,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     elementNames = ArrayBuilder<string>.GetInstance(tupleSize);
                     for (int j = 1; j < position; j++)
                     {
-                        elementNames.Add(TupleTypeSymbol.TupleMemberName(j));
+                        elementNames.Add(null);
                     }
                     elementNames.Add(name);
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2803,7 +2803,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (elementNames.Length != cardinality)
                 {
-                    throw new ArgumentException(string.Format(CodeAnalysisResources.A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1, cardinality, elementNames.Length), nameof(elementNames));
+                    throw new ArgumentException(CodeAnalysisResources.TupleElementNameCountMismatch, nameof(elementNames));
                 }
 
                 if (elementNames.All(n => n == null))

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2794,7 +2794,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Check that if any names are provided, their number matches the expected cardinality and they are not null.
+        /// Check that if any names are provided, and their number matches the expected cardinality.
         /// </summary>
         private static void CheckTupleElementNames(int cardinality, ImmutableArray<string> elementNames)
         {
@@ -2803,14 +2803,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                 if (elementNames.Length != cardinality)
                 {
                     throw new ArgumentException(CodeAnalysisResources.TupleNamesAllOrNone, nameof(elementNames));
-                }
-
-                for (int i = 0; i < elementNames.Length; i++)
-                {
-                    if ((object)elementNames[i] == null)
-                    {
-                        throw new ArgumentNullException($"{nameof(elementNames)}[{i}]");
-                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2776,7 +2776,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentException(CodeAnalysisResources.TuplesNeedAtLeastTwoElements, nameof(elementNames));
             }
 
-            CheckTupleElementNames(elementTypes.Length, elementNames);
+            elementNames = CheckTupleElementNames(elementTypes.Length, elementNames);
 
             var typesBuilder = ArrayBuilder<TypeSymbol>.GetInstance(elementTypes.Length);
             for (int i = 0; i < elementTypes.Length; i++)
@@ -2795,16 +2795,24 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Check that if any names are provided, and their number matches the expected cardinality.
+        /// Returns a normalized version of the element names (empty array if all the names are null).
         /// </summary>
-        private static void CheckTupleElementNames(int cardinality, ImmutableArray<string> elementNames)
+        private static ImmutableArray<string> CheckTupleElementNames(int cardinality, ImmutableArray<string> elementNames)
         {
             if (!elementNames.IsDefault)
             {
-                if (elementNames.Length != cardinality || elementNames.All(n => n == null))
+                if (elementNames.Length != cardinality)
                 {
-                    throw new ArgumentException(CodeAnalysisResources.TupleNamesAllOrNone, nameof(elementNames));
+                    throw new ArgumentException(string.Format(CodeAnalysisResources.A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1, cardinality, elementNames.Length), nameof(elementNames));
+                }
+
+                if (elementNames.All(n => n == null))
+                {
+                    return default(ImmutableArray<string>);
                 }
             }
+
+            return elementNames;
         }
 
         protected override INamedTypeSymbol CommonCreateTupleTypeSymbol(INamedTypeSymbol underlyingType, ImmutableArray<string> elementNames)
@@ -2822,7 +2830,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentException(CodeAnalysisResources.TupleUnderlyingTypeMustBeTupleCompatible, nameof(underlyingType));
             }
 
-            CheckTupleElementNames(cardinality, elementNames);
+            elementNames = CheckTupleElementNames(cardinality, elementNames);
 
             return TupleTypeSymbol.Create(csharpUnderlyingTuple, elementNames);
         }

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -2800,7 +2800,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (!elementNames.IsDefault)
             {
-                if (elementNames.Length != cardinality)
+                if (elementNames.Length != cardinality || elementNames.All(n => n == null))
                 {
                     throw new ArgumentException(CodeAnalysisResources.TupleNamesAllOrNone, nameof(elementNames));
                 }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1361,7 +1361,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleReservedMemberName = 8201,
         ERR_TupleReservedMemberNameAnyPosition = 8202,
         ERR_TupleDuplicateMemberName = 8203,
-        ERR_TupleExplicitNamesOnAllMembersOrNone = 8204,
+        // 8204 available
 
         ERR_PredefinedTypeMemberNotFoundInAssembly = 8205,
         ERR_MissingDeconstruct = 8206,

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int i = 0; i < elementNames.Length; i++)
                 {
-                    if (elementNames[i] != TupleTypeSymbol.TupleMemberName(i + 1))
+                    if (elementNames[i] != null || elementNames[i] != TupleTypeSymbol.TupleMemberName(i + 1))
                     {
                         return true;
                     }
@@ -456,7 +456,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 first = false;
 
                 elementTypes[i].Accept(this.NotFirstVisitor);
-                if (hasNames)
+                if (hasNames && elementNames[i] != null)
                 {
                     AddSpace();
                     builder.Add(CreatePart(SymbolDisplayPartKind.FieldName, symbol, elementNames[i]));

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -424,7 +424,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 for (int i = 0; i < elementNames.Length; i++)
                 {
-                    if (elementNames[i] != null || elementNames[i] != TupleTypeSymbol.TupleMemberName(i + 1))
+                    if (elementNames[i] != TupleTypeSymbol.TupleMemberName(i + 1))
                     {
                         return true;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -548,7 +548,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                     else
                     {
-                        Debug.Assert(!type.TupleElementNames.Contains(null));
                         namesBuilder.AddRange(type.TupleElementNames);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -280,21 +280,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 throw new InvalidOperationException();
             }
 
-            // Check to see if any of the elements are null or if they're
-            // all null
+            // Check to see if all the elements are null
             var start = _namesIndex - numberOfElements;
             bool allNull = true;
 
             for (int i = 0; i < numberOfElements; i++)
             {
-                if (_elementNames[start + i] == null)
-                {
-                    if (!allNull)
-                    {
-                        break;
-                    }
-                }
-                else
+                if (_elementNames[start + i] != null)
                 {
                     allNull = false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -284,13 +284,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             // all null
             var start = _namesIndex - numberOfElements;
             bool allNull = true;
-            bool anyNull = false;
 
             for (int i = 0; i < numberOfElements; i++)
             {
                 if (_elementNames[start + i] == null)
                 {
-                    anyNull = true;
                     if (!allNull)
                     {
                         break;
@@ -306,12 +304,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 _namesIndex = start;
                 return default(ImmutableArray<string>);
-            }
-
-            // All tuples must either have names or none may
-            if (anyNull)
-            {
-                throw new InvalidOperationException();
             }
 
             var builder = ArrayBuilder<string>.GetInstance(numberOfElements);

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -828,8 +828,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     members.Add(new TupleFieldSymbol(this, fieldSymbol, -members.Count - 1));
 
                                     // Add a field with the given name
-                                    members.Add(new TupleRenamedElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex], tupleFieldIndex,
-                                                                                            _elementLocations.IsDefault ? null : _elementLocations[tupleFieldIndex]));
+                                    if (namesOfVirtualFields[tupleFieldIndex] != null)
+                                    {
+                                        members.Add(new TupleRenamedElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex], tupleFieldIndex,
+                                                                                                _elementLocations.IsDefault ? null : _elementLocations[tupleFieldIndex]));
+                                    }
                                 }
 
                                 namesOfVirtualFields[tupleFieldIndex] = null; // mark as handled

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -232,12 +232,6 @@ namespace System
         // = {string[3](""e1"", ""e2"", ""e3"")}
         = ( 01 00 03 00 00 00 02 65 31 02 65 32 02 65 33 )
 
-    // In source, all or no names must be specified for a tuple
-    .field public class [System.ValueTuple]System.ValueTuple`2<int32, int32> MismatchedNames
-    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
-        // = {string[2](""e1"", null)}
-        = ( 01 00 02 00 00 00 02 65 31 FF )
-
     .method public hidebysig instance class [System.ValueTuple]System.ValueTuple`2<int32,int32> 
             TooFewNamesMethod() cil managed
     {
@@ -259,7 +253,7 @@ namespace System
     {
       .param [0]
       .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
-        // = {string[3](""e1"", ""e2"", ""e3"")}
+           // = {string[3](""e1"", ""e2"", ""e3"")}
            = ( 01 00 03 00 00 00 02 65 31 02 65 32 02 65 33 )
       // Code size       8 (0x8)
       .maxstack  8
@@ -269,20 +263,6 @@ namespace System
                                                                                                           !1)
       IL_0007:  ret
     } // end of method C::TooManyNamesMethod
-
-    .method public hidebysig instance void MismatchedNamesMethod(
-        class [System.ValueTuple]System.ValueTuple`1<class [System.ValueTuple]System.ValueTuple`2<int32,int32>> c) cil managed
-    {
-      .param [1]
-      .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
-        // First null is fine (unnamed tuple) but the second is half-named
-        // = {string[3](null, ""e1"", null)}
-        = ( 01 00 03 00 00 00 FF 02 65 31 FF )
-      // Code size       2 (0x2)
-      .maxstack  8
-      IL_0000:  nop
-      IL_0001:  ret
-    } // end of method C::MismatchedNamesMethod
 } // end of class C
 ",
 references: s_valueTupleRefs);
@@ -307,10 +287,6 @@ references: s_valueTupleRefs);
             Assert.True(tooManyNames.Type.IsErrorType());
             Assert.IsType<UnsupportedMetadataTypeSymbol>(tooManyNames.Type);
 
-            var mismatchedNames = c.GetMember<FieldSymbol>("MismatchedNames");
-            Assert.True(mismatchedNames.Type.IsErrorType());
-            Assert.IsType<UnsupportedMetadataTypeSymbol>(mismatchedNames.Type);
-
             var tooFewNamesMethod = c.GetMember<MethodSymbol>("TooFewNamesMethod");
             Assert.True(tooFewNamesMethod.ReturnType.IsErrorType());
             Assert.IsType<UnsupportedMetadataTypeSymbol>(tooFewNamesMethod.ReturnType);
@@ -318,11 +294,105 @@ references: s_valueTupleRefs);
             var tooManyNamesMethod = c.GetMember<MethodSymbol>("TooManyNamesMethod");
             Assert.True(tooManyNamesMethod.ReturnType.IsErrorType());
             Assert.IsType<UnsupportedMetadataTypeSymbol>(tooManyNamesMethod.ReturnType);
+        }
 
-            var mismatchedNamesMethod = c.GetMember<MethodSymbol>("MismatchedNamesMethod");
-            var mismatchedParamType = mismatchedNamesMethod.Parameters.Single().Type;
-            Assert.True(mismatchedParamType.IsErrorType());
-            Assert.IsType<UnsupportedMetadataTypeSymbol>(mismatchedParamType);
+        [Fact]
+        public void MetadataForPartiallyNamedTuples()
+        {
+            var comp = CreateCompilationWithCustomILSource("",
+@"
+.assembly extern mscorlib { }
+.assembly extern System.ValueTuple
+{
+  .publickeytoken = (CC 7B 13 FF CD 2D DD 51 )
+  .ver 4:0:1:0
+}
+
+.class public auto ansi C
+       extends [mscorlib]System.Object
+{
+    .field public class [System.ValueTuple]System.ValueTuple`2<int32, int32> ValidField
+
+    .field public int32 ValidFieldWithAttribute
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
+        // = {string[1](""name1"")}
+        = ( 01 00 01 00 00 00 05 6E 61 6D 65 31 )
+
+    // In source, all or no names must be specified for a tuple
+    .field public class [System.ValueTuple]System.ValueTuple`2<int32, int32> PartialNames
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
+        // = {string[2](""e1"", null)}
+        = ( 01 00 02 00 00 00 02 65 31 FF )
+
+    .field public class [System.ValueTuple]System.ValueTuple`2<int32, int32> AllNullNames
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
+        // = {string[2](null, null)}
+        = ( 01 00 02 00 00 00 ff ff 00 00 )
+
+    .method public hidebysig instance void PartialNamesMethod(
+        class [System.ValueTuple]System.ValueTuple`1<class [System.ValueTuple]System.ValueTuple`2<int32,int32>> c) cil managed
+    {
+      .param [1]
+      .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
+        // First null is fine (unnamed tuple) but the second is half-named
+        // = {string[3](null, ""e1"", null)}
+        = ( 01 00 03 00 00 00 FF 02 65 31 FF )
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method C::PartialNamesMethod
+
+    .method public hidebysig instance void AllNullNamesMethod(
+        class [System.ValueTuple]System.ValueTuple`1<class [System.ValueTuple]System.ValueTuple`2<int32,int32>> c) cil managed
+    {
+      .param [1]
+      .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[])
+        // First null is fine (unnamed tuple) but the second is half-named
+        // = {string[3](null, null, null)}
+        = ( 01 00 03 00 00 00 ff ff ff 00 00 )
+      // Code size       2 (0x2)
+      .maxstack  8
+      IL_0000:  nop
+      IL_0001:  ret
+    } // end of method C::AllNullNamesMethod
+} // end of class C
+",
+references: s_valueTupleRefs);
+
+            var c = comp.GlobalNamespace.GetMember<NamedTypeSymbol>("C");
+
+            var validField = c.GetMember<FieldSymbol>("ValidField");
+            Assert.False(validField.Type.IsErrorType());
+            Assert.True(validField.Type.IsTupleType);
+            Assert.True(validField.Type.TupleElementNames.IsDefault);
+
+            var validFieldWithAttribute = c.GetMember<FieldSymbol>("ValidFieldWithAttribute");
+            Assert.True(validFieldWithAttribute.Type.IsErrorType());
+            Assert.False(validFieldWithAttribute.Type.IsTupleType);
+            Assert.IsType<UnsupportedMetadataTypeSymbol>(validFieldWithAttribute.Type);
+
+            var partialNames = c.GetMember<FieldSymbol>("PartialNames");
+            Assert.False(partialNames.Type.IsErrorType());
+            Assert.True(partialNames.Type.IsTupleType);
+            Assert.Equal("(System.Int32 e1, System.Int32)", partialNames.Type.ToTestDisplayString());
+
+            var allNullNames = c.GetMember<FieldSymbol>("AllNullNames");
+            Assert.False(allNullNames.Type.IsErrorType());
+            Assert.True(allNullNames.Type.IsTupleType);
+            Assert.Equal("(System.Int32, System.Int32)", allNullNames.Type.ToTestDisplayString());
+
+            var partialNamesMethod = c.GetMember<MethodSymbol>("PartialNamesMethod");
+            var partialParamType = partialNamesMethod.Parameters.Single().Type;
+            Assert.False(partialParamType.IsErrorType());
+            Assert.True(partialParamType.IsTupleType);
+            Assert.Equal("((System.Int32 e1, System.Int32))", partialParamType.ToTestDisplayString());
+
+            var allNullNamesMethod = c.GetMember<MethodSymbol>("AllNullNamesMethod");
+            var allNullParamType = allNullNamesMethod.Parameters.Single().Type;
+            Assert.False(allNullParamType.IsErrorType());
+            Assert.True(allNullParamType.IsTupleType);
+            Assert.Equal("((System.Int32, System.Int32))", allNullParamType.ToTestDisplayString());
         }
 
         [Fact]
@@ -4343,6 +4413,17 @@ class C
             try
             {
                 comp.CreateTupleTypeSymbol(vt2, new[] { "Item1" }.AsImmutable());
+                Assert.True(false);
+            }
+            catch (ArgumentException e)
+            {
+                Assert.Contains(CodeAnalysisResources.TupleNamesAllOrNone, e.Message);
+            }
+
+            // if names are provided, they can't all be null
+            try
+            {
+                comp.CreateTupleTypeSymbol(vt2, new string[] { null, null }.AsImmutable());
                 Assert.True(false);
             }
             catch (ArgumentException e)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4417,7 +4417,7 @@ class C
             }
             catch (ArgumentException e)
             {
-                Assert.Contains("A tuple of 2 elements can have 2 names or none, but not 1.", e.Message);
+                Assert.Contains(CodeAnalysisResources.TupleElementNameCountMismatch, e.Message);
             }
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4417,18 +4417,7 @@ class C
             }
             catch (ArgumentException e)
             {
-                Assert.Contains(CodeAnalysisResources.TupleNamesAllOrNone, e.Message);
-            }
-
-            // if names are provided, they can't all be null
-            try
-            {
-                comp.CreateTupleTypeSymbol(vt2, new string[] { null, null }.AsImmutable());
-                Assert.True(false);
-            }
-            catch (ArgumentException e)
-            {
-                Assert.Contains(CodeAnalysisResources.TupleNamesAllOrNone, e.Message);
+                Assert.Contains("A tuple of 2 elements can have 2 names or none, but not 1.", e.Message);
             }
         }
 
@@ -4441,7 +4430,7 @@ class C
             TypeSymbol intType = comp.GetSpecialType(SpecialType.System_Int32);
             TypeSymbol stringType = comp.GetSpecialType(SpecialType.System_String);
             var vt2 = comp.GetWellKnownType(WellKnownType.System_ValueTuple_T2).Construct(intType, stringType);
-            var tupleWithoutNames = comp.CreateTupleTypeSymbol(vt2, default(ImmutableArray<string>));
+            var tupleWithoutNames = comp.CreateTupleTypeSymbol(vt2, ImmutableArray.Create<string>(null, null));
 
             Assert.True(tupleWithoutNames.IsTupleType);
             Assert.Equal("(System.Int32, System.String)", tupleWithoutNames.ToTestDisplayString());
@@ -4734,7 +4723,7 @@ End Class";
             ITypeSymbol intType = comp.GetSpecialType(SpecialType.System_Int32);
             ITypeSymbol stringType = comp.GetSpecialType(SpecialType.System_String);
 
-            var tupleWithoutNames = comp.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType), default(ImmutableArray<string>));
+            var tupleWithoutNames = comp.CreateTupleTypeSymbol(ImmutableArray.Create(intType, stringType), ImmutableArray.Create<string>(null, null));
 
             Assert.True(tupleWithoutNames.IsTupleType);
             Assert.Equal("(System.Int32, System.String)", tupleWithoutNames.ToTestDisplayString());

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A tuple of {0} elements can have {0} names or none, but not {1}..
+        /// </summary>
+        internal static string A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1 {
+            get {
+                return ResourceManager.GetString("A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Absolute path expected..
         /// </summary>
         internal static string AbsolutePathExpected {
@@ -1150,15 +1159,6 @@ namespace Microsoft.CodeAnalysis {
         internal static string SymWriterNotDeterministic {
             get {
                 return ResourceManager.GetString("SymWriterNotDeterministic", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to If names are used in a tuple type, then there must be the same number of names and elements, and the names cannot all be null..
-        /// </summary>
-        internal static string TupleNamesAllOrNone {
-            get {
-                return ResourceManager.GetString("TupleNamesAllOrNone", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1154,7 +1154,7 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If names are used in a tuple type, then there must be the same number of names and elements..
+        ///   Looks up a localized string similar to If names are used in a tuple type, then there must be the same number of names and elements, and the names cannot all be null..
         /// </summary>
         internal static string TupleNamesAllOrNone {
             get {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -62,15 +62,6 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A tuple of {0} elements can have {0} names or none, but not {1}..
-        /// </summary>
-        internal static string A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1 {
-            get {
-                return ResourceManager.GetString("A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Absolute path expected..
         /// </summary>
         internal static string AbsolutePathExpected {
@@ -1159,6 +1150,15 @@ namespace Microsoft.CodeAnalysis {
         internal static string SymWriterNotDeterministic {
             get {
                 return ResourceManager.GetString("SymWriterNotDeterministic", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to If tuple element names are specified, the number of element names must match the cardinality of the tuple..
+        /// </summary>
+        internal static string TupleElementNameCountMismatch {
+            get {
+                return ResourceManager.GetString("TupleElementNameCountMismatch", resourceCulture);
             }
         }
         

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -513,8 +513,8 @@
     <value>Exception occurred with following context:
 {0}</value>
   </data>
-  <data name="TupleNamesAllOrNone" xml:space="preserve">
-    <value>If names are used in a tuple type, then there must be the same number of names and elements, and the names cannot all be null.</value>
+  <data name="A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1" xml:space="preserve">
+    <value>A tuple of {0} elements can have {0} names or none, but not {1}.</value>
   </data>
   <data name="TuplesNeedAtLeastTwoElements" xml:space="preserve">
     <value>Tuples must have at least two elements.</value>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -513,8 +513,8 @@
     <value>Exception occurred with following context:
 {0}</value>
   </data>
-  <data name="A_tuple_of_0_elements_can_have_0_names_or_none_but_not_1" xml:space="preserve">
-    <value>A tuple of {0} elements can have {0} names or none, but not {1}.</value>
+  <data name="TupleElementNameCountMismatch" xml:space="preserve">
+    <value>If tuple element names are specified, the number of element names must match the cardinality of the tuple.</value>
   </data>
   <data name="TuplesNeedAtLeastTwoElements" xml:space="preserve">
     <value>Tuples must have at least two elements.</value>

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -514,7 +514,7 @@
 {0}</value>
   </data>
   <data name="TupleNamesAllOrNone" xml:space="preserve">
-    <value>If names are used in a tuple type, then there must be the same number of names and elements.</value>
+    <value>If names are used in a tuple type, then there must be the same number of names and elements, and the names cannot all be null.</value>
   </data>
   <data name="TuplesNeedAtLeastTwoElements" xml:space="preserve">
     <value>Tuples must have at least two elements.</value>

--- a/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ExtractMethod/ExtractMethodTests.cs
@@ -462,6 +462,18 @@ withScriptOption: true);
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         [WorkItem(11196, "https://github.com/dotnet/roslyn/issues/11196")]
+        public async Task TestTupleDeclarationWithSomeNames()
+        {
+            await TestAsync(
+@"class Program { static void Main ( string [ ] args ) { [| (int a, int) x = (1, 2); |]  System . Console . WriteLine ( x.a ); } } " + TestResources.NetFX.ValueTuple.tuplelib_cs,
+@"class Program { static void Main ( string [ ] args ) { (int a, int) x = {|Rename:NewMethod|}(); System.Console.WriteLine(x.a); } private static (int a, int) NewMethod() { return (1, 2); } }" + TestResources.NetFX.ValueTuple.tuplelib_cs,
+index: 0,
+parseOptions: TestOptions.Regular,
+withScriptOption: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
+        [WorkItem(11196, "https://github.com/dotnet/roslyn/issues/11196")]
         public async Task TestTupleLiteralWithNames()
         {
             await TestAsync(

--- a/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/IntroduceVariable/IntroduceVariableTests.cs
@@ -2817,7 +2817,7 @@ var expected =
             var expected =
 @"class C
 {
-    private static readonly (int a, string Item2) {|Rename:p|} = (a: 1, ""hello"");
+    private static readonly (int a, string) {|Rename:p|} = (a: 1, ""hello"");
     var i = p.ToString() + p.ToString();
 }";
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -808,7 +808,9 @@ withScriptOption: true);
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
         public async Task TupleWithOneName()
         {
-            await TestMissingAsync(@"class C { void M() { new [|C|]((a: 1, ""hello"")); } }",
+            await TestAsync(
+@"class C { void M() { new [|C|]((a: 1, ""hello"")); } }",
+@"class C { private (int a, string) p; public C((int a, string) p) { this.p = p; } void M() { new C((a: 1, ""hello"")); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateMethod/GenerateMethodTests.cs
@@ -3035,32 +3035,32 @@ class C
 }");
         }
 
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
-            public async Task MethodWithTuple()
-            {
-                await TestAsync(
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        public async Task MethodWithTuple()
+        {
+            await TestAsync(
 @"class Class { void Method() { (int, string) d = [|NewMethod|]((1, ""hello"")); } }",
 @"using System; class Class { void Method() { (int, string) d = NewMethod((1, ""hello"")); } private (int, string) NewMethod((int, string) p) { throw new NotImplementedException(); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
-            }
+        }
 
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task MethodWithTupleWithNames()
-            {
-                await TestAsync(
+        {
+            await TestAsync(
 @"class Class { void Method() { (int a, string b) d = [|NewMethod|]((c: 1, d: ""hello"")); } }",
 @"using System; class Class { void Method() { (int a, string b) d = NewMethod((c: 1, d: ""hello"")); } private (int a, string b) NewMethod((int c, string d) p) { throw new NotImplementedException(); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
-            }
+        }
 
-            [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)]
         public async Task MethodWithTupleWithOneName()
-            {
-                await TestAsync(
+        {
+            await TestAsync(
 @"class Class { void Method() { (int a, string) d = [|NewMethod|]((c: 1, ""hello"")); } }",
-@"using System; class Class { void Method() { (int a, string) d = NewMethod((c: 1, ""hello"")); } private (int a, string Item2) NewMethod((int c, string Item2) p) { throw new NotImplementedException(); } }",
+@"using System; class Class { void Method() { (int a, string) d = NewMethod((c: 1, ""hello"")); } private (int a, string) NewMethod((int c, string) p) { throw new NotImplementedException(); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateVariable/GenerateVariableTests.cs
@@ -2957,7 +2957,7 @@ withScriptOption: true);
         {
             await TestAsync(
 @"class Class { void Method((int a, string) i) { Method([|tuple|]); } }",
-@"class Class { private (int a, string Item2) tuple; void Method((int a, string) i) { Method(tuple); } }",
+@"class Class { private (int a, string) tuple; void Method((int a, string) i) { Method(tuple); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
@@ -2977,7 +2977,7 @@ withScriptOption: true);
         {
             await TestAsync(
 @"class Class { void Method() { [|tuple|] = (a: 1, ""hello""); } }",
-@"class Class { private (int a, string Item2) tuple; void Method() { tuple = (a: 1, ""hello""); } }",
+@"class Class { private (int a, string) tuple; void Method() { tuple = (a: 1, ""hello""); } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/UseImplicitOrExplicitType/UseExplicitTypeTests.cs
@@ -1039,7 +1039,7 @@ withScriptOption: true);
         {
             await TestAsync(
 @"class C { static void M() { [|var|] s = (a: 1, ""hello""); } }",
-@"class C { static void M() { (int a, string Item2) s = (a: 1, ""hello""); }}",
+@"class C { static void M() { (int a, string) s = (a: 1, ""hello""); }}",
 options: ExplicitTypeEverywhere(),
 parseOptions: TestOptions.Regular,
 withScriptOption: true);

--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -170,7 +170,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
                 for (int i = 0; i < types.Length; i++)
                 {
-                    var name = hasNames ? SyntaxFactory.IdentifierName(names[i]) : null;
+                    var name = (hasNames && names[i] != null) ? SyntaxFactory.IdentifierName(names[i]) : null;
                     list = list.Add(SyntaxFactory.TupleElement(types[i].GenerateTypeSyntax(), name));
                 }
 

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyReader.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis
                 if ((SymbolKeyType)Data[Position] == SymbolKeyType.Null)
                 {
                     Eat(SymbolKeyType.Null);
-                    return CreateNullForString() ;
+                    return CreateNullForString();
                 }
 
                 EatDoubleQuote();
@@ -278,7 +278,7 @@ namespace Microsoft.CodeAnalysis
 
         private class GetHashCodeReader : Reader<int, int>
         {
-            private static readonly ObjectPool<GetHashCodeReader> s_pool = 
+            private static readonly ObjectPool<GetHashCodeReader> s_pool =
                 new ObjectPool<GetHashCodeReader>(() => new GetHashCodeReader());
 
             private GetHashCodeReader()

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyReader.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyReader.cs
@@ -114,6 +114,12 @@ namespace Microsoft.CodeAnalysis
 
             protected TStringResult ReadStringNoSpace()
             {
+                if ((SymbolKeyType)Data[Position] == SymbolKeyType.Null)
+                {
+                    Eat(SymbolKeyType.Null);
+                    return CreateNullForString() ;
+                }
+
                 EatDoubleQuote();
 
                 var start = Position;
@@ -148,6 +154,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             protected abstract TStringResult CreateResultForString(int start, int end, bool hasEmbeddedQuote);
+            protected abstract TStringResult CreateNullForString();
 
             private void EatDoubleQuote()
             {
@@ -310,6 +317,11 @@ namespace Microsoft.CodeAnalysis
                 return result;
             }
 
+            protected override int CreateNullForString()
+            {
+                return 0;
+            }
+
             public int ReadSymbolKeyArrayHashCode()
             {
                 return HashArray(ReadSymbolKeyArray());
@@ -437,6 +449,11 @@ namespace Microsoft.CodeAnalysis
                 _builder.Append(DoubleQuoteChar);
                 return null;
             }
+
+            protected override object CreateNullForString()
+            {
+                return null;
+            }
         }
 
         private class SymbolKeyReader : Reader<SymbolKeyResolution, string>
@@ -495,6 +512,11 @@ namespace Microsoft.CodeAnalysis
                     ? substring.Replace("\"\"", "\"")
                     : substring;
                 return result;
+            }
+
+            protected override string CreateNullForString()
+            {
+                return null;
             }
 
             protected override SymbolKeyResolution ReadWorker(SymbolKeyType type)

--- a/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyWriter.cs
+++ b/src/Workspaces/Core/Portable/SymbolId/SymbolKey.SymbolKeyWriter.cs
@@ -190,9 +190,16 @@ namespace Microsoft.CodeAnalysis
             {
                 // Strings are quoted, with all embedded quotes being doubled to escape them.
                 WriteSpace();
-                _stringBuilder.Append('"');
-                _stringBuilder.Append(value.Replace("\"", "\"\""));
-                _stringBuilder.Append('"');
+                if (value == null)
+                {
+                    WriteType(SymbolKeyType.Null);
+                }
+                else
+                {
+                    _stringBuilder.Append('"');
+                    _stringBuilder.Append(value.Replace("\"", "\"\""));
+                    _stringBuilder.Append('"');
+                }
             }
 
             internal void WriteSymbolKeyArray<TSymbol>(ImmutableArray<TSymbol> symbols)


### PR DESCRIPTION
This change allows partially named tuple types and expressions.
For example, `(int a, int, int Item3) field1;` or `var t = (a: 1, 2, Item3: 3);`.

`CreateTupleTypeSymbol` API is updated to relax its requirements on element names. But if you pass element names, they cannot all be null.
Updated some refactoring tests and also the serialization of `SymbolKey` (some names may be null).