### PR TITLE
Support tuples in interface implementations

### DIFF
--- a/Compilers.sln
+++ b/Compilers.sln
@@ -131,6 +131,7 @@ Global
 		src\Compilers\Server\ServerShared\ServerShared.projitems*{06b26dcb-7a12-48ef-ae50-708593abd05f}*SharedItemsImports = 4
 		src\Compilers\Core\AnalyzerDriver\AnalyzerDriver.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
+		src\Compilers\Metadata\Microsoft.CodeAnalysis.Metadata.projitems*{1ee8cad3-55f9-4d91-96b2-084641da9a6c}*SharedItemsImports = 4
 		src\Compilers\VisualBasic\BasicAnalyzerDriver\BasicAnalyzerDriver.projitems*{2523d0e6-df32-4a3e-8ae0-a19bffae2ef6}*SharedItemsImports = 4
 		src\Compilers\Server\ServerShared\ServerShared.projitems*{32691768-af9c-4cae-9d0f-10721091b9aa}*SharedItemsImports = 13
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{4b45ca0c-03a0-400f-b454-3d4bcb16af38}*SharedItemsImports = 4
@@ -143,6 +144,7 @@ Global
 		src\Compilers\Server\ServerShared\ServerShared.projitems*{9508f118-f62e-4c16-a6f4-7c3b56e166ad}*SharedItemsImports = 4
 		src\Compilers\Core\CommandLine\CommandLine.projitems*{ad6f474e-e6d4-4217-91f3-b7af1be31ccc}*SharedItemsImports = 13
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
+		src\Compilers\Metadata\Microsoft.CodeAnalysis.Metadata.projitems*{afde6bea-5038-4a4a-a88e-dbd2e4088eed}*SharedItemsImports = 4
 		src\Compilers\CSharp\CSharpAnalyzerDriver\CSharpAnalyzerDriver.projitems*{b501a547-c911-4a05-ac6e-274a50dff30e}*SharedItemsImports = 4
 		src\Compilers\Core\SharedCollections\SharedCollections.projitems*{c1930979-c824-496b-a630-70f5369a636f}*SharedItemsImports = 13
 		src\Test\Utilities\Shared\TestUtilities.projitems*{ccbd3438-3e84-40a9-83ad-533f23bcfca5}*SharedItemsImports = 4

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Runtime.InteropServices;
+using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE;
 using Microsoft.CodeAnalysis.Emit;
@@ -430,7 +432,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (ushort)this.Arity; }
         }
 
-        IEnumerable<Cci.ITypeReference> Cci.ITypeDefinition.Interfaces(EmitContext context)
+        IEnumerable<Cci.InterfaceImplementation> Cci.ITypeDefinition.Interfaces(EmitContext context)
         {
             Debug.Assert(((Cci.ITypeReference)this).AsTypeDefinition(context) != null);
 
@@ -438,10 +440,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (NamedTypeSymbol @interface in this.GetInterfacesToEmit())
             {
-                yield return moduleBeingBuilt.Translate(@interface,
-                                                        syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                        diagnostics: context.Diagnostics,
-                                                        fromImplements: true);
+                var translated = moduleBeingBuilt.Translate(
+                    @interface,
+                    syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                    diagnostics: context.Diagnostics,
+                    fromImplements: true);
+
+                ImmutableArray<Cci.ICustomAttribute> attrs;
+                if (@interface.ContainsTuple())
+                {
+                    var attr = DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(@interface);
+                    attrs = attr == null
+                        ? ImmutableArray<Cci.ICustomAttribute>.Empty
+                        : ImmutableArray.Create<ICustomAttribute>(attr);
+                }
+                else
+                {
+                    attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
+                }
+
+                yield return new Cci.InterfaceImplementation(translated, attrs);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             return UnderlyingNamedType.GetPropertiesToEmit();
         }
 
-        protected override IEnumerable<Cci.ITypeReference> GetInterfaces(EmitContext context)
+        protected override IEnumerable<Cci.InterfaceImplementation> GetInterfaces(EmitContext context)
         {
             Debug.Assert((object)TypeManager.ModuleBeingBuilt == context.Module);
 
@@ -99,7 +99,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
             foreach (NamedTypeSymbol @interface in UnderlyingNamedType.GetInterfacesToEmit())
             {
-                yield return moduleBeingBuilt.Translate(@interface, (CSharpSyntaxNode)context.SyntaxNodeOpt, context.Diagnostics);
+                var translated = moduleBeingBuilt.Translate(
+                    @interface,
+                    (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                    context.Diagnostics);
+
+                ImmutableArray<Cci.ICustomAttribute> attrs;
+                if (@interface.ContainsTuple())
+                {
+                    var attr = UnderlyingNamedType.DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(@interface);
+                    attrs = attr == null
+                        ? ImmutableArray<Cci.ICustomAttribute>.Empty
+                        : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
+                }
+                else
+                {
+                    attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
+                }
+
+                yield return new Cci.InterfaceImplementation(translated, attrs);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.cs
@@ -464,6 +464,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         EntityHandle interfaceHandle = moduleSymbol.Module.MetadataReader.GetInterfaceImplementation(interfaceImpl).Interface;
                         TypeSymbol typeSymbol = tokenDecoder.GetTypeOfToken(interfaceHandle);
 
+                        typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol, interfaceHandle, moduleSymbol);
+
                         var namedTypeSymbol = typeSymbol as NamedTypeSymbol;
                         symbols[i++] = (object)namedTypeSymbol != null ? namedTypeSymbol : new UnsupportedMetadataTypeSymbol(); // interface tmpList contains a bad type
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -61,7 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
 
-            if (sourceType.IsTupleType)
+            if (sourceType.ContainsTuple())
             {
                 // TODO(https://github.com/dotnet/roslyn/issues/12389):
                 // Need to save/restore tupleness as well

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_Tuples.cs
@@ -532,7 +532,8 @@ class C
                     expectedElementNames: expectedTupleNames);
             }
 
-            private void ValidateTupleNameAttribute(Symbol symbol,
+            private void ValidateTupleNameAttribute(
+                Symbol symbol,
                 bool expectedTupleNamesAttribute,
                 string[] expectedElementNames = null,
                 bool forReturnType = false)

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -4876,18 +4876,17 @@ class UsePia5
 } 
 ";
 
-            DiagnosticDescription[] expected = {
-                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1),
-                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1),
-                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
-                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1)
-                                               };
-
             var compilation1 = CreateCompilationWithMscorlib(consumer, options: TestOptions.ReleaseExe,
                 references: new MetadataReference[] { new CSharpCompilationReference(piaCompilation2, embedInteropTypes: true) });
-            VerifyEmitDiagnostics(compilation1, false, expected);
+            compilation1.VerifyEmitDiagnostics(
+                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1),
+                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1),
+                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1),
+                // error CS0246: The type or namespace name 'ITest33' could not be found (are you missing a using directive or an assembly reference?)
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound).WithArguments("ITest33").WithLocation(1, 1));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -1541,7 +1541,7 @@ class C : I2 { }
             var derivedInterface = global.GetMember<NamedTypeSymbol>("I2");
             var @class = global.GetMember<NamedTypeSymbol>("C");
 
-            var bothInterfaces = ImmutableArray.Create<NamedTypeSymbol>(baseInterface, derivedInterface);
+            var bothInterfaces = ImmutableArray.Create(baseInterface, derivedInterface);
 
             Assert.Equal(baseInterface, derivedInterface.AllInterfaces.Single());
             Assert.Equal(derivedInterface, @class.Interfaces.Single());
@@ -1551,7 +1551,8 @@ class C : I2 { }
             var module = new PEAssemblyBuilder((SourceAssemblySymbol)@class.ContainingAssembly, EmitOptions.Default, OutputKind.DynamicallyLinkedLibrary,
                 GetDefaultModulePropertiesForSerialization(), SpecializedCollections.EmptyEnumerable<ResourceDescription>());
             var context = new EmitContext(module, null, new DiagnosticBag());
-            var cciInterfaces = typeDef.Interfaces(context).Cast<NamedTypeSymbol>().AsImmutable();
+            var cciInterfaces = typeDef.Interfaces(context)
+                .Select(impl => impl.Interface).Cast<NamedTypeSymbol>().AsImmutable();
             Assert.True(cciInterfaces.SetEquals(bothInterfaces, EqualityComparer<NamedTypeSymbol>.Default));
             context.Diagnostics.Verify();
         }

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -388,8 +388,8 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public bool HasDeclarativeSecurity => false;
 
-        public IEnumerable<Cci.ITypeReference> Interfaces(EmitContext context)
-            => SpecializedCollections.EmptyEnumerable<Cci.ITypeReference>();
+        public IEnumerable<Cci.InterfaceImplementation> Interfaces(EmitContext context)
+            => SpecializedCollections.EmptyEnumerable<Cci.InterfaceImplementation>();
 
         public bool IsAbstract => false;
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             protected abstract bool IsPublic { get; }
             protected abstract bool IsAbstract { get; }
             protected abstract Cci.ITypeReference GetBaseClass(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
-            protected abstract IEnumerable<Cci.ITypeReference> GetInterfaces(EmitContext context);
+            protected abstract IEnumerable<Cci.InterfaceImplementation> GetInterfaces(EmitContext context);
             protected abstract bool IsBeforeFieldInit { get; }
             protected abstract bool IsComImport { get; }
             protected abstract bool IsInterface { get; }
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 }
             }
 
-            IEnumerable<Cci.ITypeReference> Cci.ITypeDefinition.Interfaces(EmitContext context)
+            IEnumerable<Cci.InterfaceImplementation> Cci.ITypeDefinition.Interfaces(EmitContext context)
             {
                 return GetInterfaces(context);
             }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1899,10 +1899,17 @@ namespace Microsoft.Cci
             this.AddCustomAttributesToTable(GetFieldDefs(), def => GetFieldDefinitionHandle(def));
 
             // this.AddCustomAttributesToTable(this.typeRefList, 2);
-            this.AddCustomAttributesToTable(GetTypeDefs(), def => GetTypeDefinitionHandle(def));
+            var typeDefs = GetTypeDefs();
+            this.AddCustomAttributesToTable(typeDefs, def => GetTypeDefinitionHandle(def));
             this.AddCustomAttributesToTable(GetParameterDefs(), def => GetParameterHandle(def));
 
-            // TODO: attributes on interface implementation entries 5
+            // Attributes on interface implementation entries 5
+            foreach (ITypeDefinition typeDef in typeDefs)
+            {
+                var interfaceImpls = typeDef.Interfaces(Context);
+                this.AddCustomAttributesToTable(interfaceImpls);
+            }
+
             // TODO: attributes on member reference entries 6
             if (this.IsFullMetadata)
             {
@@ -2020,6 +2027,19 @@ namespace Microsoft.Cci
                 foreach (ICustomAttribute customAttribute in parent.GetAttributes(Context))
                 {
                     AddCustomAttributeToTable(parentHandle, customAttribute);
+                }
+            }
+        }
+
+        private void AddCustomAttributesToTable(
+            IEnumerable<InterfaceImplementation> interfaces)
+        {
+            foreach (var iface in interfaces)
+            {
+                var ifaceHandle = GetTypeHandle(iface.Interface);
+                foreach (var customAttribute in iface.Attributes)
+                {
+                    AddCustomAttributeToTable(ifaceHandle, customAttribute);
                 }
             }
         }
@@ -2360,11 +2380,11 @@ namespace Microsoft.Cci
             foreach (ITypeDefinition typeDef in this.GetTypeDefs())
             {
                 var typeDefHandle = GetTypeDefinitionHandle(typeDef);
-                foreach (ITypeReference interfaceRef in typeDef.Interfaces(Context))
+                foreach (var interfaceImpl in typeDef.Interfaces(Context))
                 {
                     metadata.AddInterfaceImplementation(
                         type: typeDefHandle,
-                        implementedInterface: GetTypeHandle(interfaceRef));
+                        implementedInterface: GetTypeHandle(interfaceImpl.Interface));
                 }
             }
         }

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -269,7 +269,12 @@ namespace Microsoft.Cci
                 this.Visit(typeDefinition.SecurityAttributes);
             }
 
-            this.VisitTypeReferencesThatNeedTokens(typeDefinition.Interfaces(Context));
+            foreach (var ifaceImpl in typeDefinition.Interfaces(Context))
+            {
+                this.Visit(ifaceImpl.Attributes);
+                this.VisitTypeReferencesThatNeedTokens(ifaceImpl.Interface);
+            }
+
             if (typeDefinition.IsGeneric)
             {
                 this.Visit(typeDefinition.GenericParameters);

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Cci
             get { return false; }
         }
 
-        public IEnumerable<ITypeReference> Interfaces(EmitContext context)
+        public IEnumerable<Cci.InterfaceImplementation> Interfaces(EmitContext context)
         {
-            return SpecializedCollections.EmptyEnumerable<ITypeReference>();
+            return SpecializedCollections.EmptyEnumerable<Cci.InterfaceImplementation>();
         }
 
         public bool IsAbstract

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -397,6 +397,27 @@ namespace Microsoft.Cci
         ITypeReference GetTargetType(EmitContext context);
     }
 
+    internal struct InterfaceImplementation
+    {
+        /// <summary>
+        /// The interface being implemented.
+        /// </summary>
+        public ITypeReference Interface { get; }
+
+        /// <summary>
+        /// The attributes on the interface implementation itself.
+        /// </summary>
+        public ImmutableArray<ICustomAttribute> Attributes { get; }
+
+        public InterfaceImplementation(
+            ITypeReference iface,
+            ImmutableArray<ICustomAttribute> attributes)
+        {
+            Interface = iface;
+            Attributes = attributes;
+        }
+    }
+
     /// <summary>
     /// This interface models the metadata representation of a type.
     /// </summary>
@@ -455,7 +476,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// Zero or more interfaces implemented by this type.
         /// </summary>
-        IEnumerable<ITypeReference> Interfaces(EmitContext context);
+        IEnumerable<InterfaceImplementation> Interfaces(EmitContext context);
 
         /// <summary>
         /// True if the type may not be instantiated.

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -392,16 +392,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Private Iterator Function ITypeDefinitionInterfaces(context As EmitContext) As IEnumerable(Of ITypeReference) Implements ITypeDefinition.Interfaces
+        Private Iterator Function ITypeDefinitionInterfaces(context As EmitContext) As IEnumerable(Of Cci.InterfaceImplementation) Implements ITypeDefinition.Interfaces
             Debug.Assert(Not Me.IsAnonymousType)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsTypeDefinition(context) IsNot Nothing)
 
             Dim moduleBeingBuilt As PEModuleBuilder = DirectCast(context.Module, PEModuleBuilder)
             For Each [interface] In GetInterfacesToEmit()
-                Yield moduleBeingBuilt.Translate([interface],
-                                                 syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
-                                                 diagnostics:=context.Diagnostics,
-                                                 fromImplements:=True)
+                Dim translated = moduleBeingBuilt.Translate([interface],
+                                                            syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                                            diagnostics:=context.Diagnostics,
+                                                            fromImplements:=True)
+
+                ' TODO(https://github.com/dotnet/roslyn/issues/12592):
+                ' Add support for tuple attributes on interface implementations
+                Yield New Cci.InterfaceImplementation(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -76,13 +76,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return UnderlyingNamedType.GetPropertiesToEmit()
         End Function
 
-        Protected Overrides Iterator Function GetInterfaces(context As EmitContext) As IEnumerable(Of Cci.ITypeReference)
+        Protected Overrides Iterator Function GetInterfaces(context As EmitContext) As IEnumerable(Of Cci.InterfaceImplementation)
             Debug.Assert(TypeManager.ModuleBeingBuilt Is context.Module)
 
             Dim moduleBeingBuilt = DirectCast(context.Module, PEModuleBuilder)
 
             For Each [interface] In UnderlyingNamedType.GetInterfacesToEmit()
-                Yield moduleBeingBuilt.Translate([interface], DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)
+                Dim translated = moduleBeingBuilt.Translate([interface],
+                                                            DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                                            context.Diagnostics)
+
+                ' TODO(https://github.com/dotnet/roslyn/issues/12592):
+                ' Add support for tuple attributes on interface implementations
+                Yield New Cci.InterfaceImplementation(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             Next
         End Function
 


### PR DESCRIPTION
Currently, if you implement an interface with a tuple type as a
substituted type argument that will be accurately represented in source,
but the names will be lost when emitted to metadata.

This PR implements roundtripping for tuples as generic type arguments to
interface implementations in metadata. This is done by adding support
for emitting attributes on interface implementations to Emit. We now
emit the same attribute on interface implementations that we would
on other areas where types may contain nested tuples. Completes the
interface implementation work referenced in #12347.

This is the same PR as https://github.com/dotnet/roslyn/pull/12577, rebased against `preview-4`