### PR TITLE
Changes resulted from reimplementing tuples in VB

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -450,6 +450,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (typesArray.Length < 2)
             {
+                elementNames?.Free();
                 return new ExtendedErrorTypeSymbol(this.Compilation.Assembly.GlobalNamespace, LookupResultKind.NotCreatable, diagnostics.Add(ErrorCode.ERR_TupleTooFewElements, syntax.Location));
             }
 
@@ -487,7 +488,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private static bool CheckTupleMemberName(string name, int position, CSharpSyntaxNode syntax, DiagnosticBag diagnostics, PooledHashSet<string> uniqueFieldNames)
+        private static bool CheckTupleMemberName(string name, int index, CSharpSyntaxNode syntax, DiagnosticBag diagnostics, PooledHashSet<string> uniqueFieldNames)
         {
             int reserved = TupleTypeSymbol.IsElementNameReserved(name);
             if (reserved == 0)
@@ -495,7 +496,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Error(diagnostics, ErrorCode.ERR_TupleReservedMemberNameAnyPosition, syntax, name);
                 return false;
             }
-            else if (reserved > 0 && reserved != position + 1)
+            else if (reserved > 0 && reserved != index + 1)
             {
                 Error(diagnostics, ErrorCode.ERR_TupleReservedMemberName, syntax, name, reserved);
                 return false;

--- a/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
+++ b/src/Compilers/CSharp/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.cs
@@ -444,16 +444,13 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             AddPunctuation(SyntaxKind.OpenParenToken);
 
-            bool first = true;
             for (int i = 0; i < elementTypes.Length; i++)
             {
-                if (!first)
+                if (i != 0)
                 {
                     AddPunctuation(SyntaxKind.CommaToken);
                     AddSpace();
                 }
-
-                first = false;
 
                 elementTypes[i].Accept(this.NotFirstVisitor);
                 if (hasNames)

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -54,7 +54,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private TupleTypeSymbol(ImmutableArray<Location> locations, NamedTypeSymbol underlyingType, ImmutableArray<Location> elementLocations, ImmutableArray<string> elementNames, ImmutableArray<TypeSymbol> elementTypes)
             : base(underlyingType)
         {
-            Debug.Assert(elementLocations.IsDefault || elementNames.IsDefault || elementLocations.Length == elementNames.Length);
             Debug.Assert(elementLocations.IsDefault || elementLocations.Length == elementTypes.Length);
             Debug.Assert(elementNames.IsDefault || elementNames.Length == elementTypes.Length);
             Debug.Assert(!underlyingType.IsTupleType);
@@ -189,27 +188,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int i = 0; i < RestPosition - 1; i++)
             {
-                if (!modifiers.IsDefault && !modifiers[i].IsDefaultOrEmpty)
-                {
-                    typeArgumentsBuilder.Add(new TypeWithModifiers(arguments[i], modifiers[i]));
-                }
-                else
-                {
-                    typeArgumentsBuilder.Add(new TypeWithModifiers(arguments[i]));
-                }
+                typeArgumentsBuilder.Add(new TypeWithModifiers(arguments[i], GetModifiers(modifiers, i)));
             }
 
-            if (!modifiers.IsDefault && !modifiers[RestPosition - 1].IsDefaultOrEmpty)
-            {
-                typeArgumentsBuilder.Add(new TypeWithModifiers(extensionTuple, modifiers[RestPosition - 1]));
-            }
-            else
-            {
-                typeArgumentsBuilder.Add(new TypeWithModifiers(extensionTuple));
-            }
+            typeArgumentsBuilder.Add(new TypeWithModifiers(extensionTuple, GetModifiers(modifiers, RestPosition - 1)));
 
             tupleCompatibleType = tupleCompatibleType.ConstructedFrom.Construct(typeArgumentsBuilder.ToImmutable(), unbound: false);
             return tupleCompatibleType;
+        }
+
+        private static ImmutableArray<CustomModifier> GetModifiers(ImmutableArray<ImmutableArray<CustomModifier>> modifiers, int i)
+        {
+            return modifiers.IsDefaultOrEmpty? ImmutableArray<CustomModifier>.Empty: modifiers[i];
         }
 
         /// <summary>
@@ -572,7 +562,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <param name="relativeMember">A reference to a well-known member type descriptor. Note however that the type in that descriptor is ignored here.</param>
         internal static Symbol GetWellKnownMemberInType(NamedTypeSymbol type, WellKnownMember relativeMember)
         {
-            Debug.Assert(relativeMember >= 0 && relativeMember < WellKnownMember.Count);
+            Debug.Assert(relativeMember >= WellKnownMember.System_ValueTuple_T1__Item1 && relativeMember <= WellKnownMember.System_ValueTuple_TRest__ctor);
             Debug.Assert(type.IsDefinition);
 
             MemberDescriptor relativeDescriptor = WellKnownMembers.GetDescriptor(relativeMember);
@@ -946,60 +936,61 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                if (_lazyUnderlyingDefinitionToMemberMap == null)
-                {
-                    var map = new SmallDictionary<Symbol, Symbol>(ReferenceEqualityComparer.Instance);
-
-                    var underlyingDefinition = _underlyingType.OriginalDefinition;
-                    var members = GetMembers();
-
-                    // Go in reverse because we want members with default name, which precede the ones with
-                    // friendly names, to be in the map.  
-                    for (int i = members.Length - 1; i >= 0; i--)
-                    {
-                        var member = members[i];
-                        switch (member.Kind)
-                        {
-                            case SymbolKind.Method:
-                                map.Add(((MethodSymbol)member).TupleUnderlyingMethod.OriginalDefinition, member);
-                                break;
-
-                            case SymbolKind.Field:
-                                var tupleUnderlyingField = ((FieldSymbol)member).TupleUnderlyingField;
-                                if ((object)tupleUnderlyingField != null)
-                                {
-                                    map[tupleUnderlyingField.OriginalDefinition] = member;
-                                }
-                                break;
-
-                            case SymbolKind.Property:
-                                map.Add(((PropertySymbol)member).TupleUnderlyingProperty.OriginalDefinition, member);
-                                break;
-
-                            case SymbolKind.Event:
-                                var underlyingEvent = ((EventSymbol)member).TupleUnderlyingEvent;
-                                var underlyingAssociatedField = underlyingEvent.AssociatedField;
-                                // The field is not part of the members list
-                                if ((object)underlyingAssociatedField != null)
-                                {
-                                    Debug.Assert((object)underlyingAssociatedField.ContainingSymbol == _underlyingType);
-                                    Debug.Assert(_underlyingType.GetMembers(underlyingAssociatedField.Name).IndexOf(underlyingAssociatedField) < 0);
-                                    map.Add(underlyingAssociatedField.OriginalDefinition, new TupleFieldSymbol(this, underlyingAssociatedField, -i - 1));
-                                }
-
-                                map.Add(underlyingEvent.OriginalDefinition, member);
-                                break;
-
-                            default:
-                                throw ExceptionUtilities.UnexpectedValue(member.Kind);
-                        }
-                    }
-
-                    _lazyUnderlyingDefinitionToMemberMap = map;
-                }
-
-                return _lazyUnderlyingDefinitionToMemberMap;
+                return _lazyUnderlyingDefinitionToMemberMap ??
+                    (_lazyUnderlyingDefinitionToMemberMap = ComputeDefinitionToMemberMap()); 
             }
+        }
+
+        private SmallDictionary<Symbol, Symbol> ComputeDefinitionToMemberMap()
+        {
+            var map = new SmallDictionary<Symbol, Symbol>(ReferenceEqualityComparer.Instance);
+
+            var underlyingDefinition = _underlyingType.OriginalDefinition;
+            var members = GetMembers();
+
+            // Go in reverse because we want members with default name, which precede the ones with
+            // friendly names, to be in the map.  
+            for (int i = members.Length - 1; i >= 0; i--)
+            {
+                var member = members[i];
+                switch (member.Kind)
+                {
+                    case SymbolKind.Method:
+                        map.Add(((MethodSymbol)member).TupleUnderlyingMethod.OriginalDefinition, member);
+                        break;
+
+                    case SymbolKind.Field:
+                        var tupleUnderlyingField = ((FieldSymbol)member).TupleUnderlyingField;
+                        if ((object)tupleUnderlyingField != null)
+                        {
+                            map[tupleUnderlyingField.OriginalDefinition] = member;
+                        }
+                        break;
+
+                    case SymbolKind.Property:
+                        map.Add(((PropertySymbol)member).TupleUnderlyingProperty.OriginalDefinition, member);
+                        break;
+
+                    case SymbolKind.Event:
+                        var underlyingEvent = ((EventSymbol)member).TupleUnderlyingEvent;
+                        var underlyingAssociatedField = underlyingEvent.AssociatedField;
+                        // The field is not part of the members list
+                        if ((object)underlyingAssociatedField != null)
+                        {
+                            Debug.Assert((object)underlyingAssociatedField.ContainingSymbol == _underlyingType);
+                            Debug.Assert(_underlyingType.GetMembers(underlyingAssociatedField.Name).IndexOf(underlyingAssociatedField) < 0);
+                            map.Add(underlyingAssociatedField.OriginalDefinition, new TupleFieldSymbol(this, underlyingAssociatedField, -i - 1));
+                        }
+
+                        map.Add(underlyingEvent.OriginalDefinition, member);
+                        break;
+
+                    default:
+                        throw ExceptionUtilities.UnexpectedValue(member.Kind);
+                }
+            }
+
+            return map;
         }
 
         public TMember GetTupleMemberSymbolForUnderlyingMember<TMember>(TMember underlyingMemberOpt) where TMember : Symbol

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedEventSymbol.cs
@@ -51,41 +51,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract TypeSymbol Type
-        {
-            get;
-        }
-
-        public override abstract MethodSymbol AddMethod
-        {
-            get;
-        }
-
-        public override abstract MethodSymbol RemoveMethod
-        {
-            get;
-        }
-
-        internal override abstract FieldSymbol AssociatedField
-        {
-            get;
-        }
-
-        internal override abstract bool IsExplicitInterfaceImplementation
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<EventSymbol> ExplicitInterfaceImplementations
-        {
-            get;
-        }
-
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
-        }
-
         public override string Name
         {
             get
@@ -177,13 +142,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingEvent.ObsoleteAttributeData;
             }
-        }
-
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
-
-        internal override abstract bool MustCallMethodsDirectly
-        {
-            get;
         }
 
         public override bool IsWindowsRuntimeEvent

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedFieldSymbol.cs
@@ -4,7 +4,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -41,18 +40,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _underlyingField.IsImplicitlyDeclared; }
         }
 
-        internal override abstract TypeSymbol GetFieldType(ConsList<FieldSymbol> fieldsBeingBound);
-
-        public override abstract ImmutableArray<CustomModifier> CustomModifiers
-        {
-            get;
-        }
-
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
-        }
-
         public override Accessibility DeclaredAccessibility
         {
             get
@@ -60,8 +47,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _underlyingField.DeclaredAccessibility;
             }
         }
-
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
 
         public override string Name
         {
@@ -130,11 +115,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingField.TypeLayoutOffset;
             }
-        }
-
-        public override abstract Symbol AssociatedSymbol
-        {
-            get;
         }
 
         public override bool IsReadOnly

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedMethodSymbol.cs
@@ -2,7 +2,6 @@
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 
@@ -50,21 +49,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract ImmutableArray<TypeParameterSymbol> TypeParameters
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<TypeSymbol> TypeArguments
-        {
-            get;
-        }
-
-        public override abstract bool ReturnsVoid
-        {
-            get;
-        }
-
         internal override RefKind RefKind
         {
             get
@@ -73,29 +57,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract TypeSymbol ReturnType
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<CustomModifier> ReturnTypeCustomModifiers
-        {
-            get;
-        }
-
         internal override int ParameterCount
         {
             get { return UnderlyingMethod.ParameterCount; }
-        }
-
-        public override abstract ImmutableArray<ParameterSymbol> Parameters
-        {
-            get;
-        }
-
-        public override abstract Symbol AssociatedSymbol
-        {
-            get;
         }
 
         public override bool IsExtensionMethod
@@ -112,11 +76,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return UnderlyingMethod.HidesBaseMethodsByName;
             }
-        }
-
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
         }
 
         public override ImmutableArray<Location> Locations
@@ -261,11 +220,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return UnderlyingMethod.GetAppliedConditionalSymbols();
         }
 
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
-
-        // Get return type attributes
-        public override abstract ImmutableArray<CSharpAttributeData> GetReturnTypeAttributes();
-
         internal override ObsoleteAttributeData ObsoleteAttributeData
         {
             get
@@ -319,16 +273,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override abstract bool IsExplicitInterfaceImplementation
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<MethodSymbol> ExplicitInterfaceImplementations
-        {
-            get;
-        }
-
         internal override bool IsAccessCheckedOnOverride
         {
             get
@@ -376,7 +320,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return UnderlyingMethod.GenerateDebugInfo;
             }
         }
-
-        internal override abstract int CalculateLocalSyntaxOffset(int localPosition, SyntaxTree localTree);
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedNamedTypeSymbol.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
-using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -49,36 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingType.Arity;
             }
-        }
-
-        public override abstract ImmutableArray<TypeParameterSymbol> TypeParameters
-        {
-            get;
-        }
-
-        internal override abstract ImmutableArray<TypeSymbol> TypeArgumentsNoUseSiteDiagnostics
-        {
-            get;
-        }
-
-        internal override abstract bool HasTypeArgumentsCustomModifiers
-        {
-            get;
-        }
-
-        internal override abstract ImmutableArray<ImmutableArray<CustomModifier>> TypeArgumentsCustomModifiers
-        {
-            get;
-        }
-
-        public override abstract NamedTypeSymbol ConstructedFrom
-        {
-            get;
-        }
-
-        public override abstract NamedTypeSymbol EnumUnderlyingType
-        {
-            get;
         }
 
         public override bool MightContainExtensionMethods
@@ -126,33 +95,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return _underlyingType.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken);
         }
 
-        public override abstract IEnumerable<string> MemberNames
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<Symbol> GetMembers();
-
-        public override abstract ImmutableArray<Symbol> GetMembers(string name);
-
-        internal override abstract IEnumerable<FieldSymbol> GetFieldsToEmit();
-
-        internal override abstract IEnumerable<MethodSymbol> GetMethodsToEmit();
-
-        internal override abstract IEnumerable<PropertySymbol> GetPropertiesToEmit();
-
-        internal override abstract IEnumerable<EventSymbol> GetEventsToEmit();
-
-        internal override abstract ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers();
-
-        internal override abstract ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name);
-
-        public override abstract ImmutableArray<NamedTypeSymbol> GetTypeMembers();
-
-        public override abstract ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name);
-
-        public override abstract ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity);
-
         public override Accessibility DeclaredAccessibility
         {
             get
@@ -175,11 +117,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingType.IsInterface;
             }
-        }
-
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
         }
 
         public override ImmutableArray<Location> Locations
@@ -236,33 +173,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingType.IsMetadataSealed;
             }
-        }
-
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
-
-        internal override abstract IEnumerable<CSharpAttributeData> GetCustomAttributesToEmit(ModuleCompilationState compilationState);
-
-        internal override abstract NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
-        {
-            get;
-        }
-
-        internal override abstract ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved);
-
-        internal override abstract ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit();
-
-        internal override abstract NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved);
-
-        internal override abstract ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved);
-
-        internal override abstract NamedTypeSymbol ComImportCoClass
-        {
-            get;
-        }
-
-        internal override abstract bool IsComImport
-        {
-            get;
         }
 
         internal override ObsoleteAttributeData ObsoleteAttributeData

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedParameterSymbol.cs
@@ -34,11 +34,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public abstract override Symbol ContainingSymbol
-        {
-            get;
-        }
-
         #region Forwarded
 
         public override TypeSymbol Type

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedPropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedPropertySymbol.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Globalization;
@@ -49,21 +48,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract TypeSymbol Type
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<CustomModifier> TypeCustomModifiers
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<ParameterSymbol> Parameters
-        {
-            get;
-        }
-
         public override bool IsIndexer
         {
             get
@@ -72,37 +56,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract MethodSymbol GetMethod
-        {
-            get;
-        }
-
-        public override abstract MethodSymbol SetMethod
-        {
-            get;
-        }
-
         internal override Microsoft.Cci.CallingConvention CallingConvention
         {
             get
             {
                 return _underlyingProperty.CallingConvention;
             }
-        }
-
-        internal override abstract bool IsExplicitInterfaceImplementation
-        {
-            get;
-        }
-
-        public override abstract ImmutableArray<PropertySymbol> ExplicitInterfaceImplementations
-        {
-            get;
-        }
-
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
         }
 
         public override string Name
@@ -204,13 +163,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 return _underlyingProperty.ObsoleteAttributeData;
             }
-        }
-
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
-
-        internal override abstract bool MustCallMethodsDirectly
-        {
-            get;
         }
 
         public override string MetadataName

--- a/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Wrapped/WrappedTypeParameterSymbol.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Threading;
-using Roslyn.Utilities;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -90,11 +89,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        public override abstract Symbol ContainingSymbol
-        {
-            get;
-        }
-
         public override ImmutableArray<Location> Locations
         {
             get
@@ -110,8 +104,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return _underlyingTypeParameter.DeclaringSyntaxReferences;
             }
         }
-
-        public override abstract ImmutableArray<CSharpAttributeData> GetAttributes();
 
         public override string Name
         {
@@ -130,13 +122,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             _underlyingTypeParameter.EnsureAllConstraintsAreResolved();
         }
-
-        internal override abstract ImmutableArray<TypeSymbol> GetConstraintTypes(ConsList<TypeParameterSymbol> inProgress);
-
-        internal override abstract ImmutableArray<NamedTypeSymbol> GetInterfaces(ConsList<TypeParameterSymbol> inProgress);
-
-        internal override abstract NamedTypeSymbol GetEffectiveBaseClass(ConsList<TypeParameterSymbol> inProgress);
-
-        internal override abstract TypeSymbol GetDeducedBaseType(ConsList<TypeParameterSymbol> inProgress);
     }
 }


### PR DESCRIPTION
Moslty CR feedback that is also applicable to the original CS code
Removed unnecessary "override abstract" in tuple/wrapped symbols