### PR TITLE
Navigable items can state if they are relate to implicitly declared items or not.  We want this as we will not display unreference implicitly declared nav items.

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
@@ -19,6 +19,14 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
         /// </summary>
         bool DisplayFileLocation { get; }
 
+        /// <summary>
+        /// his is intended for symbols that are ordinary symbols in the language sense, and may be
+        /// used by code, but that are simply declared implicitly rather than with explicit language
+        /// syntax.  For example, a default synthesized constructor in C# when the class contains no
+        /// explicit constructors.
+        /// </summary>
+        bool IsImplicitlyDeclared { get; }
+
         Document Document { get; }
         TextSpan SourceSpan { get; }
 

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -28,6 +28,12 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             private readonly Lazy<string> _lazyDisplayString;
             private readonly Lazy<ISymbol> _lazySymbol;
 
+            /// <summary>
+            /// DeclaredSymbolInfos always come from some actual declaration in source.  So they're
+            /// never implicitly declared.
+            /// </summary>
+            public bool IsImplicitlyDeclared => false;
+
             public DeclaredSymbolNavigableItem(Document document, DeclaredSymbolInfo declaredSymbolInfo)
             {
                 Document = document;

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -31,13 +31,9 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
 
             public string DisplayString => _displayString;
 
-            public Glyph Glyph
-            {
-                get
-                {
-                    return _symbol.GetGlyph();
-                }
-            }
+            public Glyph Glyph => _symbol.GetGlyph();
+
+            public bool IsImplicitlyDeclared => _symbol.IsImplicitlyDeclared;
 
             public Document Document
             {
@@ -47,13 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 }
             }
 
-            public TextSpan SourceSpan
-            {
-                get
-                {
-                    return _location.SourceSpan;
-                }
-            }
+            public TextSpan SourceSpan => _location.SourceSpan;
 
             public ImmutableArray<INavigableItem> ChildItems => ImmutableArray<INavigableItem>.Empty;
         }


### PR DESCRIPTION
This is part of the Dev15 async find refs feature.