### PR TITLE
Remove unused FindAllReferences method.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
@@ -75,44 +75,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
             }
         }
 
-        /// <summary>
-        /// Finds references using <see cref="SymbolFinder.FindReferencesAsync(ISymbol, Solution, CancellationToken)"/>
-        /// </summary>
-        private async Task AddSymbolReferencesAsync(Document document, int position, ArrayBuilder<INavigableItem> builder, IWaitContext waitContext)
-        {
-            var result = await this.FindReferencedSymbolsAsync(document, position, waitContext).ConfigureAwait(false);
-            if (result != null)
-            {
-                var referencedSymbols = result.Item1;
-                var searchSolution = result.Item2;
-
-                var q = from r in referencedSymbols
-                        from loc in r.Locations
-                        select NavigableItemFactory.GetItemFromSymbolLocation(searchSolution, r.Definition, loc.Location);
-
-                builder.AddRange(q);
-            }
-        }
-
-        public async Task<IEnumerable<INavigableItem>> FindReferencesAsync(Document document, int position, IWaitContext waitContext)
-        {
-            var cancellationToken = waitContext.CancellationToken;
-
-            var builder = ArrayBuilder<INavigableItem>.GetInstance();
-            await AddExternalReferencesAsync(document, position, builder, cancellationToken).ConfigureAwait(false);
-
-            // TODO: Merging references from SymbolFinder and external providers might lead to duplicate or counter-intuitive results.
-            // TODO: For now, we avoid merging and just display the results either from SymbolFinder or the external result providers but not both.
-            if (builder.Count == 0)
-            {
-                await AddSymbolReferencesAsync(document, position, builder, waitContext).ConfigureAwait(false);
-            }
-
-            // realize the list here so that the consumer await'ing the result doesn't lazily cause
-            // them to be created on an inappropriate thread.
-            return builder.ToArrayAndFree();
-        }
-
         public bool TryFindReferences(Document document, int position, IWaitContext waitContext)
         {
             var cancellationToken = waitContext.CancellationToken;
@@ -120,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
 
             // First see if we have any external navigable item references.
             // If so, we display the results as navigable items.
-            var succeeded = TryFindAndDisplayNavigableItemsReferencesAsync(document, position, waitContext).WaitAndGetResult(cancellationToken);            
+            var succeeded = TryFindAndDisplayNavigableItemsReferencesAsync(document, position, waitContext).WaitAndGetResult(cancellationToken);
             if (succeeded)
             {
                 return true;

--- a/src/EditorFeatures/Core/Implementation/FindReferences/IFindReferencesService.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/IFindReferencesService.cs
@@ -11,11 +11,6 @@ namespace Microsoft.CodeAnalysis.Editor
     internal interface IFindReferencesService : ILanguageService
     {
         /// <summary>
-        /// Finds the references for the symbol at the specific position in the document.
-        /// </summary>
-        Task<IEnumerable<INavigableItem>> FindReferencesAsync(Document document, int position, IWaitContext waitContext);
-
-        /// <summary>
         /// Finds the references for the symbol at the specific position in the document and then 
         /// presents them.
         /// </summary>


### PR DESCRIPTION
This interface method wasn't called from anywhere.