### PR TITLE
Change INavigableItem to support classified presentation.

### DIFF
--- a/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/INavigableItem.cs
@@ -10,9 +10,9 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
         Glyph Glyph { get; }
 
         /// <summary>
-        /// The string to display for this item. If null, the line of text from <see cref="Document"/> is used.
+        /// The tagged parts to display for this item. If default, the line of text from <see cref="Document"/> is used.
         /// </summary>
-        string DisplayString { get; }
+        ImmutableArray<TaggedText> DisplayTaggedParts { get; }
 
         /// <summary>
         /// Return true to display the file path of <see cref="Document"/> and the span of <see cref="SourceSpan"/> when displaying this item.

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.DeclaredSymbolNavigableItem.cs
@@ -15,7 +15,8 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
     {
         internal class DeclaredSymbolNavigableItem : INavigableItem
         {
-            public string DisplayString => _lazyDisplayString.Value;
+            public ImmutableArray<TaggedText> DisplayTaggedParts => _lazyDisplayTaggedParts.Value; 
+
             public Document Document { get; }
             public Glyph Glyph => Symbol?.GetGlyph() ?? Glyph.Error;
             public TextSpan SourceSpan => _declaredSymbolInfo.Span;
@@ -25,7 +26,7 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             public bool DisplayFileLocation => false;
 
             private readonly DeclaredSymbolInfo _declaredSymbolInfo;
-            private readonly Lazy<string> _lazyDisplayString;
+            private readonly Lazy<ImmutableArray<TaggedText>> _lazyDisplayTaggedParts;
             private readonly Lazy<ISymbol> _lazySymbol;
 
             /// <summary>
@@ -40,16 +41,17 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 _declaredSymbolInfo = declaredSymbolInfo;
 
                 _lazySymbol = new Lazy<ISymbol>(FindSymbol);
-                _lazyDisplayString = new Lazy<string>(() =>
+
+                _lazyDisplayTaggedParts = new Lazy<ImmutableArray<TaggedText>>(() =>
                 {
                     try
                     {
                         if (Symbol == null)
                         {
-                            return null;
+                            return default(ImmutableArray<TaggedText>);
                         }
 
-                        return GetSymbolDisplayString(Document.Project, Symbol);
+                        return GetSymbolDisplayTaggedParts(Document.Project, Symbol);
                     }
                     catch (Exception e) when (FatalError.Report(e))
                     {

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.SymbolLocationNavigableItem.cs
@@ -13,35 +13,29 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             private readonly Solution _solution;
             private readonly ISymbol _symbol;
             private readonly Location _location;
-            private readonly string _displayString;
 
             public SymbolLocationNavigableItem(
                 Solution solution,
                 ISymbol symbol,
                 Location location,
-                string displayString)
+                ImmutableArray<TaggedText>? displayTaggedParts)
             {
                 _solution = solution;
                 _symbol = symbol;
                 _location = location;
-                _displayString = displayString;
+                DisplayTaggedParts = displayTaggedParts.GetValueOrDefault();
             }
 
             public bool DisplayFileLocation => true;
 
-            public string DisplayString => _displayString;
+            public ImmutableArray<TaggedText> DisplayTaggedParts { get; }
 
             public Glyph Glyph => _symbol.GetGlyph();
 
             public bool IsImplicitlyDeclared => _symbol.IsImplicitlyDeclared;
 
-            public Document Document
-            {
-                get
-                {
-                    return _location.IsInSource ? _solution.GetDocument(_location.SourceTree) : null;
-                }
-            }
+            public Document Document =>
+                _location.IsInSource ? _solution.GetDocument(_location.SourceTree) : null;
 
             public TextSpan SourceSpan => _location.SourceSpan;
 

--- a/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.cs
+++ b/src/EditorFeatures/Core/Extensibility/Navigation/NavigableItemFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.GeneratedCodeRecognition;
@@ -12,9 +13,12 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
 {
     internal static partial class NavigableItemFactory
     {
-        public static INavigableItem GetItemFromSymbolLocation(Solution solution, ISymbol symbol, Location location, string displayString = null)
+        public static INavigableItem GetItemFromSymbolLocation(
+            Solution solution, ISymbol symbol, Location location,
+            ImmutableArray<TaggedText>? displayTaggedParts)
         {
-            return new SymbolLocationNavigableItem(solution, symbol, location, displayString);
+            return new SymbolLocationNavigableItem(
+                solution, symbol, location, displayTaggedParts);
         }
 
         public static INavigableItem GetItemFromDeclaredSymbolInfo(DeclaredSymbolInfo declaredSymbolInfo, Document document)
@@ -22,10 +26,14 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
             return new DeclaredSymbolNavigableItem(document, declaredSymbolInfo);
         }
 
-        public static IEnumerable<INavigableItem> GetItemsFromPreferredSourceLocations(Solution solution, ISymbol symbol, string displayString = null)
+        public static IEnumerable<INavigableItem> GetItemsFromPreferredSourceLocations(
+            Solution solution,
+            ISymbol symbol, 
+            ImmutableArray<TaggedText>? displayTaggedParts)
         {
             var locations = GetPreferredSourceLocations(solution, symbol);
-            return locations.Select(loc => GetItemFromSymbolLocation(solution, symbol, loc, displayString));
+            return locations.Select(loc => GetItemFromSymbolLocation(
+                solution, symbol, loc, displayTaggedParts));
         }
 
         public static IEnumerable<Location> GetPreferredSourceLocations(
@@ -69,10 +77,10 @@ namespace Microsoft.CodeAnalysis.Editor.Navigation
                 : navigableItems.Where(n => generatedCodeRecognitionService.IsGeneratedCode(n.Document));
         }
 
-        public static string GetSymbolDisplayString(Project project, ISymbol symbol)
+        public static ImmutableArray<TaggedText> GetSymbolDisplayTaggedParts(Project project, ISymbol symbol)
         {
             var symbolDisplayService = project.LanguageServices.GetRequiredService<ISymbolDisplayService>();
-            return symbolDisplayService.ToDisplayString(symbol, GetSymbolDisplayFormat(symbol));
+            return symbolDisplayService.ToDisplayParts(symbol, GetSymbolDisplayFormat(symbol)).ToTaggedText();
         }
 
         private static SymbolDisplayFormat GetSymbolDisplayFormat(ISymbol symbol)

--- a/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/AbstractFindReferencesService.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
         {
             if (result != null && result.Any())
             {
-                var title = result.First().DisplayString;
+                var title = result.First().DisplayTaggedParts.JoinText();
                 foreach (var presenter in _navigableItemPresenters)
                 {
                     presenter.DisplayResult(title, result);

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/AbstractGoToDefinitionService.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/AbstractGoToDefinitionService.cs
@@ -47,7 +47,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
             var symbol = await FindSymbolAsync(document, position, cancellationToken).ConfigureAwait(false);
 
             // Try to compute source definitions from symbol.
-            var items = symbol != null ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(document.Project.Solution, symbol) : null;
+            var items = symbol != null
+                ? NavigableItemFactory.GetItemsFromPreferredSourceLocations(document.Project.Solution, symbol, displayTaggedParts: null)
+                : null;
             if (items == null || items.IsEmpty())
             {
                 // Fallback to asking the navigation definition providers for navigable definition locations.

--- a/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToDefinition/GoToDefinitionHelpers.cs
@@ -67,7 +67,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
             var options = project.Solution.Options;
 
             var preferredSourceLocations = NavigableItemFactory.GetPreferredSourceLocations(solution, symbol).ToArray();
-            var title = NavigableItemFactory.GetSymbolDisplayString(project, symbol);
+            var displayParts = NavigableItemFactory.GetSymbolDisplayTaggedParts(project, symbol);
+            var title = displayParts.JoinText();
+
             if (!preferredSourceLocations.Any())
             {
                 // Attempt to find source locations from external definition providers.
@@ -92,7 +94,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
                     cancellationToken: cancellationToken);
             }
 
-            var navigableItems = preferredSourceLocations.Select(location => NavigableItemFactory.GetItemFromSymbolLocation(solution, symbol, location)).ToImmutableArray();
+            var navigableItems = preferredSourceLocations.Select(location =>
+                NavigableItemFactory.GetItemFromSymbolLocation(
+                    solution, symbol, location,
+                    displayTaggedParts: null)).ToImmutableArray();
             return TryGoToDefinition(navigableItems, title, options, presenters, throwOnHiddenDefinition);
         }
 
@@ -191,7 +196,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToDefinition
             if (externalDefinitions != null && externalDefinitions.Any())
             {
                 var itemsArray = externalDefinitions.ToImmutableArrayOrEmpty();
-                var title = itemsArray[0].DisplayString;
+                var title = itemsArray[0].DisplayTaggedParts.JoinText();
                 return TryGoToDefinition(externalDefinitions.ToImmutableArrayOrEmpty(), title, document.Project.Solution.Workspace.Options, presenters, throwOnHiddenDefinition: true);
             }
 

--- a/src/EditorFeatures/Core/Implementation/GoToImplementation/AbstractGoToImplementationService.cs
+++ b/src/EditorFeatures/Core/Implementation/GoToImplementation/AbstractGoToImplementationService.cs
@@ -137,7 +137,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToImplementation
                     implementation => CreateItemsForImplementation(implementation, mapping.Solution));
 
                 var presenter = _navigableItemPresenters.First();
-                presenter.Value.DisplayResult(NavigableItemFactory.GetSymbolDisplayString(mapping.Project, mapping.Symbol), navigableItems);
+
+                var taggedParts = NavigableItemFactory.GetSymbolDisplayTaggedParts(mapping.Project, mapping.Symbol);
+
+                presenter.Value.DisplayResult(taggedParts.JoinText(), navigableItems);
                 message = null;
                 return true;
             }
@@ -150,7 +153,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.GoToImplementation
             return NavigableItemFactory.GetItemsFromPreferredSourceLocations(
                 solution,
                 implementation,
-                displayString: symbolDisplayService.ToDisplayString(implementation));
+                displayTaggedParts: symbolDisplayService.ToDisplayParts(implementation).ToTaggedText());
         }
 
         private bool TryExternalGotoDefinition(Document document, int position, CancellationToken cancellationToken, out string message)

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.NavigateToItemDisplay.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.NavigateToItemDisplay.cs
@@ -111,13 +111,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 }
             }
 
-            public string Name
-            {
-                get
-                {
-                    return _searchResult.NavigableItem.DisplayString;
-                }
-            }
+            public string Name => _searchResult.NavigableItem.DisplayTaggedParts.JoinText();
 
             public void NavigateTo()
             {

--- a/src/Features/Core/Portable/Common/TaggedText.cs
+++ b/src/Features/Core/Portable/Common/TaggedText.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -36,13 +39,29 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(text));
             }
 
-            this.Tag = tag;
-            this.Text = text;
+            Tag = tag;
+            Text = text;
         }
 
         public override string ToString()
         {
-            return this.Text;
+            return Text;
+        }
+    }
+
+    internal static class TaggedTextExtensions
+    {
+        public static ImmutableArray<TaggedText> ToTaggedText(this IEnumerable<SymbolDisplayPart> displayParts)
+        {
+            return displayParts.Select(d =>
+                new TaggedText(SymbolDisplayPartKindTags.GetTag(d.Kind), d.ToString())).ToImmutableArray();
+        }
+
+        public static string JoinText(this ImmutableArray<TaggedText> values)
+        {
+            return values.IsDefault
+                ? null
+                : string.Join("", values.Select(t => t.Text));
         }
     }
 }

--- a/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionItem.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.Completion
 
         private static string EncodeDescription(ImmutableArray<SymbolDisplayPart> description)
         {
-            return EncodeDescription(description.Select(d => new TaggedText(SymbolDisplayPartKindTags.GetTag(d.Kind), d.ToString())).ToImmutableArray());
+            return EncodeDescription(description.ToTaggedText());
         }
 
         private static string EncodeDescription(ImmutableArray<TaggedText> description)

--- a/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
+++ b/src/Features/Core/Portable/Completion/CommonCompletionUtilities.cs
@@ -157,7 +157,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 textContentBuilder.AddRange(supportedPlatforms.ToDisplayParts());
             }
 
-            return CompletionDescription.Create(textContentBuilder.Select(p => new TaggedText(SymbolDisplayPartKindTags.GetTag(p.Kind), p.ToString())).ToImmutableArray());
+            return CompletionDescription.Create(textContentBuilder.ToTaggedText());
         }
 
         private static void AddOverloadPart(List<SymbolDisplayPart> textContentBuilder, int overloadCount, bool isGeneric)

--- a/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/FindResults/LibraryManager_GoToDefinition.cs
@@ -94,7 +94,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.FindRes
 
         private AbstractTreeItem CreateTreeItem(INavigableItem item, int commonPathElements)
         {
-            var result = new SourceReferenceTreeItem(item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex(), commonPathElements, displayText: item.DisplayString, includeFileLocation: item.DisplayFileLocation);
+            var result = new SourceReferenceTreeItem(
+                item.Document, item.SourceSpan, item.Glyph.GetGlyphIndex(), commonPathElements,
+                displayText: item.DisplayTaggedParts.JoinText(),
+                includeFileLocation: item.DisplayFileLocation);
 
             if (!item.ChildItems.IsEmpty)
             {


### PR DESCRIPTION
This is for the new async FindReferences work.  The new FAR presenter window allows for classified text in it.  That will allow us to actually show classified versions of symbols like we do in quick-info and other locations. 
