### PR TITLE
Support tuples in type parameter constraints

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -446,10 +446,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics: context.Diagnostics,
                     fromImplements: true);
 
-                yield return TypeSymbolExtensions.
-                    GetTypeRefWithAttributes(this.DeclaringCompilation,
-                                             @interface,
-                                             typeRef);
+                yield return @interface.GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                                                 typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -446,7 +446,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     diagnostics: context.Diagnostics,
                     fromImplements: true);
 
-                yield return GetTypeRefWithAttributes(@interface, typeRef);
+                yield return TypeSymbolExtensions.
+                    GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                             @interface,
+                                             typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/NamedTypeSymbolAdapter.cs
@@ -432,7 +432,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return (ushort)this.Arity; }
         }
 
-        IEnumerable<Cci.InterfaceImplementation> Cci.ITypeDefinition.Interfaces(EmitContext context)
+        IEnumerable<Cci.TypeReferenceWithAttributes> Cci.ITypeDefinition.Interfaces(EmitContext context)
         {
             Debug.Assert(((Cci.ITypeReference)this).AsTypeDefinition(context) != null);
 
@@ -440,26 +440,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             foreach (NamedTypeSymbol @interface in this.GetInterfacesToEmit())
             {
-                var translated = moduleBeingBuilt.Translate(
+                var typeRef = moduleBeingBuilt.Translate(
                     @interface,
                     syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
                     diagnostics: context.Diagnostics,
                     fromImplements: true);
 
-                ImmutableArray<Cci.ICustomAttribute> attrs;
-                if (@interface.ContainsTuple())
-                {
-                    var attr = DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(@interface);
-                    attrs = attr == null
-                        ? ImmutableArray<Cci.ICustomAttribute>.Empty
-                        : ImmutableArray.Create<ICustomAttribute>(attr);
-                }
-                else
-                {
-                    attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
-                }
-
-                yield return new Cci.InterfaceImplementation(translated, attrs);
+                yield return GetTypeRefWithAttributes(@interface, typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
@@ -126,5 +126,23 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
         }
+
+        internal Cci.TypeReferenceWithAttributes GetTypeRefWithAttributes(TypeSymbol type, Cci.ITypeReference typeRef)
+        {
+            ImmutableArray<Cci.ICustomAttribute> attrs;
+            if (type.ContainsTuple())
+            {
+                var attr = DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(type);
+                attrs = attr == null
+                    ? ImmutableArray<Cci.ICustomAttribute>.Empty
+                    : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
+            }
+            else
+            {
+                attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
+            }
+
+            return new Cci.TypeReferenceWithAttributes(typeRef, attrs);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SymbolAdapter.cs
@@ -126,23 +126,5 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
         }
-
-        internal Cci.TypeReferenceWithAttributes GetTypeRefWithAttributes(TypeSymbol type, Cci.ITypeReference typeRef)
-        {
-            ImmutableArray<Cci.ICustomAttribute> attrs;
-            if (type.ContainsTuple())
-            {
-                var attr = DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(type);
-                attrs = attr == null
-                    ? ImmutableArray<Cci.ICustomAttribute>.Empty
-                    : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
-            }
-            else
-            {
-                attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
-            }
-
-            return new Cci.TypeReferenceWithAttributes(typeRef, attrs);
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -239,10 +239,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                          syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
                                                          diagnostics: context.Diagnostics);
 
-                yield return TypeSymbolExtensions.
-                    GetTypeRefWithAttributes(this.DeclaringCompilation,
-                                             type,
-                                             typeRef);
+                yield return type.GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                                           typeRef);
             }
             if (this.HasValueTypeConstraint && !seenValueType)
             {

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Emit;
 using Roslyn.Utilities;
 using System.Diagnostics;
 using Microsoft.CodeAnalysis.Emit;
+using System.Collections.Immutable;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
@@ -219,7 +220,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        IEnumerable<Cci.ITypeReference> Cci.IGenericParameter.GetConstraints(EmitContext context)
+        IEnumerable<Cci.TypeReferenceWithAttributes> Cci.IGenericParameter.GetConstraints(EmitContext context)
         {
             var moduleBeingBuilt = (PEModuleBuilder)context.Module;
             var seenValueType = false;
@@ -234,16 +235,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         seenValueType = true;
                         break;
                 }
-                yield return moduleBeingBuilt.Translate(type,
-                                                        syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                        diagnostics: context.Diagnostics);
+                var typeRef = moduleBeingBuilt.Translate(type,
+                                                         syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                         diagnostics: context.Diagnostics);
+
+                yield return this.GetTypeRefWithAttributes(type, typeRef);
             }
             if (this.HasValueTypeConstraint && !seenValueType)
             {
                 // Add System.ValueType constraint to comply with Dev11 output
-                yield return moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
-                                                             syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
-                                                             diagnostics: context.Diagnostics);
+                var typeRef = moduleBeingBuilt.GetSpecialType(SpecialType.System_ValueType,
+                                                              syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
+                                                              diagnostics: context.Diagnostics);
+
+                yield return new Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray<Cci.ICustomAttribute>.Empty);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/TypeParameterSymbolAdapter.cs
@@ -239,7 +239,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                          syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
                                                          diagnostics: context.Diagnostics);
 
-                yield return this.GetTypeRefWithAttributes(type, typeRef);
+                yield return TypeSymbolExtensions.
+                    GetTypeRefWithAttributes(this.DeclaringCompilation,
+                                             type,
+                                             typeRef);
             }
             if (this.HasValueTypeConstraint && !seenValueType)
             {
@@ -248,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                                               syntaxNodeOpt: (CSharpSyntaxNode)context.SyntaxNodeOpt,
                                                               diagnostics: context.Diagnostics);
 
-                yield return new Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray<Cci.ICustomAttribute>.Empty);
+                yield return new Cci.TypeReferenceWithAttributes(typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             return UnderlyingNamedType.GetPropertiesToEmit();
         }
 
-        protected override IEnumerable<Cci.InterfaceImplementation> GetInterfaces(EmitContext context)
+        protected override IEnumerable<Cci.TypeReferenceWithAttributes> GetInterfaces(EmitContext context)
         {
             Debug.Assert((object)TypeManager.ModuleBeingBuilt == context.Module);
 
@@ -99,25 +99,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
 
             foreach (NamedTypeSymbol @interface in UnderlyingNamedType.GetInterfacesToEmit())
             {
-                var translated = moduleBeingBuilt.Translate(
+                var typeRef = moduleBeingBuilt.Translate(
                     @interface,
                     (CSharpSyntaxNode)context.SyntaxNodeOpt,
                     context.Diagnostics);
 
-                ImmutableArray<Cci.ICustomAttribute> attrs;
-                if (@interface.ContainsTuple())
-                {
-                    var attr = UnderlyingNamedType.DeclaringCompilation.SynthesizeTupleNamesAttributeOpt(@interface);
-                    attrs = attr == null
-                        ? ImmutableArray<Cci.ICustomAttribute>.Empty
-                        : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
-                }
-                else
-                {
-                    attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
-                }
-
-                yield return new Cci.InterfaceImplementation(translated, attrs);
+                yield return UnderlyingNamedType.GetTypeRefWithAttributes(@interface, typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -104,7 +104,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     (CSharpSyntaxNode)context.SyntaxNodeOpt,
                     context.Diagnostics);
 
-                yield return UnderlyingNamedType.GetTypeRefWithAttributes(@interface, typeRef);
+                yield return TypeSymbolExtensions.
+                    GetTypeRefWithAttributes(UnderlyingNamedType.DeclaringCompilation,
+                                             @interface,
+                                             typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedType.cs
@@ -104,10 +104,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
                     (CSharpSyntaxNode)context.SyntaxNodeOpt,
                     context.Diagnostics);
 
-                yield return TypeSymbolExtensions.
-                    GetTypeRefWithAttributes(UnderlyingNamedType.DeclaringCompilation,
-                                             @interface,
-                                             typeRef);
+                yield return @interface.GetTypeRefWithAttributes(
+                    UnderlyingNamedType.DeclaringCompilation,
+                    typeRef);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypeParameter.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/NoPia/EmbeddedTypeParameter.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit.NoPia
             Debug.Assert(underlyingTypeParameter.IsDefinition);
         }
 
-        protected override IEnumerable<Cci.ITypeReference> GetConstraints(EmitContext context)
+        protected override IEnumerable<Cci.TypeReferenceWithAttributes> GetConstraints(EmitContext context)
         {
             return ((Cci.IGenericParameter)UnderlyingTypeParameter).GetConstraints(context);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/PETypeParameterSymbol.cs
@@ -195,6 +195,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                         continue;
                     }
 
+                    typeSymbol = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeSymbol,
+                                                                               constraint,
+                                                                               moduleSymbol);
+
                     symbolsBuilder.Add(typeSymbol);
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1432,20 +1432,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol type,
             Cci.ITypeReference typeRef)
         {
-            ImmutableArray<Cci.ICustomAttribute> attrs;
             if (type.ContainsTuple())
             {
                 var attr = declaringCompilation.SynthesizeTupleNamesAttributeOpt(type);
-                attrs = attr == null
-                    ? ImmutableArray<Cci.ICustomAttribute>.Empty
-                    : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
-            }
-            else
-            {
-                attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
+                if (attr != null)
+                {
+                    return new Cci.TypeReferenceWithAttributes(
+                        typeRef,
+                        ImmutableArray.Create<Cci.ICustomAttribute>(attr));
+                }
             }
 
-            return new Cci.TypeReferenceWithAttributes(typeRef, attrs);
+            return new Cci.TypeReferenceWithAttributes(typeRef);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1428,8 +1428,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         internal static Cci.TypeReferenceWithAttributes GetTypeRefWithAttributes(
+            this TypeSymbol type,
             CSharpCompilation declaringCompilation,
-            TypeSymbol type,
             Cci.ITypeReference typeRef)
         {
             if (type.ContainsTuple())

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbolExtensions.cs
@@ -1426,5 +1426,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             arrayType = arrayType.WithElementType(elementType);
             return true;
         }
+
+        internal static Cci.TypeReferenceWithAttributes GetTypeRefWithAttributes(
+            CSharpCompilation declaringCompilation,
+            TypeSymbol type,
+            Cci.ITypeReference typeRef)
+        {
+            ImmutableArray<Cci.ICustomAttribute> attrs;
+            if (type.ContainsTuple())
+            {
+                var attr = declaringCompilation.SynthesizeTupleNamesAttributeOpt(type);
+                attrs = attr == null
+                    ? ImmutableArray<Cci.ICustomAttribute>.Empty
+                    : ImmutableArray.Create<Cci.ICustomAttribute>(attr);
+            }
+            else
+            {
+                attrs = ImmutableArray<Cci.ICustomAttribute>.Empty;
+            }
+
+            return new Cci.TypeReferenceWithAttributes(typeRef, attrs);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -373,6 +373,190 @@ y: 0
         }
 
         [Fact]
+        public void GenericConstraintAttributes()
+        {
+            var comp = CreateCompilationWithMscorlib(@"
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+public interface ITest<T> 
+{ 
+    T Get { get; }
+}
+
+public class Test : ITest<(int key, int val)>
+{
+    public (int key, int val) Get => (0, 0);
+}
+
+public class Base<T> : ITest<T>
+{
+    public T Get { get; }
+    protected Base(T t)
+    {
+        Get = t;
+    }
+}
+
+public class C<T> where T : ITest<(int key, int val)>
+{
+    public T Get { get; }
+
+    public C(T t)
+    {
+        Get = t;
+    }
+}
+
+public class C2<T> where T : Base<(int key, int val)>
+{
+    public T Get { get; }
+    public C2(T t)
+    {
+        Get = t;
+    }
+}
+
+public sealed class Test2 : Base<(int key, int val)>
+{
+    public Test2() : base((-1, -2)) {}
+}
+
+public class C3<T> where T : IEnumerable<(int key, int val)>
+{
+    public T Get { get; }
+    public C3(T t)
+    {
+        Get = t;
+    }
+}
+
+public struct TestEnumerable : IEnumerable<(int key, int val)>
+{
+    private readonly (int, int)[] _backing;
+
+    public TestEnumerable((int, int)[] backing)
+    {
+        _backing = backing;
+    }
+
+    private class Inner : IEnumerator<(int key, int val)>, IEnumerator
+    {
+        private int index = -1;
+        private readonly (int, int)[] _backing;
+
+        public Inner((int, int)[] backing)
+        {
+            _backing = backing;
+        }
+
+        public (int key, int val) Current => _backing[index];
+
+        object IEnumerator.Current => Current;
+
+        public void Dispose() { }
+
+        public bool MoveNext() =>
+            ++index < _backing.Length ? true : false;
+
+        public void Reset()
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    IEnumerator<(int key, int val)> IEnumerable<(int key, int val)>.GetEnumerator() =>
+        new Inner(_backing);
+
+    IEnumerator IEnumerable.GetEnumerator() => new Inner(_backing);
+}
+",
+            references: s_valueTupleRefs);
+            CompileAndVerify(comp, symbolValidator: m =>
+            {
+                var c = m.GlobalNamespace.GetTypeMember("C");
+                Assert.Equal(1, c.TypeParameters.Length);
+                var param = c.TypeParameters[0];
+                Assert.Equal(1, param.ConstraintTypes.Length);
+                var constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes[0]);
+                Assert.True(constraint.IsGenericType);
+                Assert.Equal(1, constraint.TypeArguments.Length);
+                TypeSymbol typeArg = constraint.TypeArguments[0];
+                Assert.True(typeArg.IsTupleType);
+                Assert.Equal(2, typeArg.TupleElementTypes.Length);
+                Assert.All(typeArg.TupleElementTypes,
+                   t => Assert.Equal(SpecialType.System_Int32, t.SpecialType));
+                Assert.False(typeArg.TupleElementNames.IsDefault);
+                Assert.Equal(2, typeArg.TupleElementNames.Length);
+                Assert.Equal(new[] { "key", "val" }, typeArg.TupleElementNames);
+
+                var c2 = m.GlobalNamespace.GetTypeMember("C2");
+                Assert.Equal(1, c2.TypeParameters.Length);
+                param = c2.TypeParameters[0];
+                Assert.Equal(1, param.ConstraintTypes.Length);
+                constraint = Assert.IsAssignableFrom<NamedTypeSymbol>(param.ConstraintTypes[0]);
+                Assert.True(constraint.IsGenericType);
+                Assert.Equal(1, constraint.TypeArguments.Length);
+                typeArg = constraint.TypeArguments[0];
+                Assert.True(typeArg.IsTupleType);
+                Assert.Equal(2, typeArg.TupleElementTypes.Length);
+                Assert.All(typeArg.TupleElementTypes,
+                   t => Assert.Equal(SpecialType.System_Int32, t.SpecialType));
+                Assert.False(typeArg.TupleElementNames.IsDefault);
+                Assert.Equal(2, typeArg.TupleElementNames.Length);
+                Assert.Equal(new[] { "key", "val" }, typeArg.TupleElementNames);
+            });
+
+            CompileAndVerify(@"
+using System;
+
+class D
+{
+    public static void Main(string[] args)
+    {
+        var c = new C<Test>(new Test());
+        var temp = c.Get.Get;
+        Console.WriteLine(temp);
+        Console.WriteLine(""key: "" + temp.key);
+        Console.WriteLine(""val: "" + temp.val);
+
+        var c2 = new C2<Test2>(new Test2());
+        var temp2 = c2.Get.Get;
+        Console.WriteLine(temp2);
+        Console.WriteLine(""key: "" + temp2.key);
+        Console.WriteLine(""val: "" + temp2.val);
+
+        var backing = new[] { (1, 2), (3, 4), (5, 6) };
+        var c3 = new C3<TestEnumerable>(new TestEnumerable(backing));
+        foreach (var kvp in c3.Get)
+        {
+            Console.WriteLine($""key: {kvp.key}, val: {kvp.val}"");
+        }
+
+        var c4 = new C<Test2>(new Test2());
+        var temp4 = c4.Get.Get;
+        Console.WriteLine(temp4);
+        Console.WriteLine(""key: "" + temp4.key);
+        Console.WriteLine(""val: "" + temp4.val);
+    }
+}", additionalRefs: s_valueTupleRefs.Concat(new[] { comp.EmitToImageReference() }),
+    expectedOutput: @"(0, 0)
+key: 0
+val: 0
+(-1, -2)
+key: -1
+val: -2
+key: 1, val: 2
+key: 3, val: 4
+key: 5, val: 6
+(-1, -2)
+key: -1
+val: -2
+");
+        }
+
+        [Fact]
         public void BadTupleNameMetadata()
         {
             var comp = CreateCompilationWithCustomILSource("",

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -250,8 +250,7 @@ public class C3 : IEnumerable<(int key, int val)>
 
         public void Dispose() { }
 
-        public bool MoveNext() =>
-            ++index < _backing.Length ? true : false;
+        public bool MoveNext() => ++index < _backing.Length;
 
         public void Reset()
         {
@@ -457,8 +456,7 @@ public struct TestEnumerable : IEnumerable<(int key, int val)>
 
         public void Dispose() { }
 
-        public bool MoveNext() =>
-            ++index < _backing.Length ? true : false;
+        public bool MoveNext() => ++index < _backing.Length;
 
         public void Reset()
         {

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/BaseClassTests.cs
@@ -1552,7 +1552,7 @@ class C : I2 { }
                 GetDefaultModulePropertiesForSerialization(), SpecializedCollections.EmptyEnumerable<ResourceDescription>());
             var context = new EmitContext(module, null, new DiagnosticBag());
             var cciInterfaces = typeDef.Interfaces(context)
-                .Select(impl => impl.Interface).Cast<NamedTypeSymbol>().AsImmutable();
+                .Select(impl => impl.TypeRef).Cast<NamedTypeSymbol>().AsImmutable();
             Assert.True(cciInterfaces.SetEquals(bothInterfaces, EqualityComparer<NamedTypeSymbol>.Default));
             context.Diagnostics.Verify();
         }

--- a/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
+++ b/src/Compilers/Core/Portable/CodeGen/PrivateImplementationDetails.cs
@@ -388,8 +388,8 @@ namespace Microsoft.CodeAnalysis.CodeGen
 
         public bool HasDeclarativeSecurity => false;
 
-        public IEnumerable<Cci.InterfaceImplementation> Interfaces(EmitContext context)
-            => SpecializedCollections.EmptyEnumerable<Cci.InterfaceImplementation>();
+        public IEnumerable<Cci.TypeReferenceWithAttributes> Interfaces(EmitContext context)
+            => SpecializedCollections.EmptyEnumerable<Cci.TypeReferenceWithAttributes>();
 
         public bool IsAbstract => false;
 

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedType.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
             protected abstract bool IsPublic { get; }
             protected abstract bool IsAbstract { get; }
             protected abstract Cci.ITypeReference GetBaseClass(TPEModuleBuilder moduleBuilder, TSyntaxNode syntaxNodeOpt, DiagnosticBag diagnostics);
-            protected abstract IEnumerable<Cci.InterfaceImplementation> GetInterfaces(EmitContext context);
+            protected abstract IEnumerable<Cci.TypeReferenceWithAttributes> GetInterfaces(EmitContext context);
             protected abstract bool IsBeforeFieldInit { get; }
             protected abstract bool IsComImport { get; }
             protected abstract bool IsInterface { get; }
@@ -314,7 +314,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 }
             }
 
-            IEnumerable<Cci.InterfaceImplementation> Cci.ITypeDefinition.Interfaces(EmitContext context)
+            IEnumerable<Cci.TypeReferenceWithAttributes> Cci.ITypeDefinition.Interfaces(EmitContext context)
             {
                 return GetInterfaces(context);
             }

--- a/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/Emit/NoPia/CommonEmbeddedTypeParameter.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 this.UnderlyingTypeParameter = underlyingTypeParameter;
             }
 
-            protected abstract IEnumerable<Cci.ITypeReference> GetConstraints(EmitContext context);
+            protected abstract IEnumerable<Cci.TypeReferenceWithAttributes> GetConstraints(EmitContext context);
             protected abstract bool MustBeReferenceType { get; }
             protected abstract bool MustBeValueType { get; }
             protected abstract bool MustHaveDefaultConstructor { get; }
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.Emit.NoPia
                 }
             }
 
-            IEnumerable<Cci.ITypeReference> Cci.IGenericParameter.GetConstraints(EmitContext context)
+            IEnumerable<Cci.TypeReferenceWithAttributes> Cci.IGenericParameter.GetConstraints(EmitContext context)
             {
                 return GetConstraints(context);
             }

--- a/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/InheritedTypeParameter.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Cci
 
         #region IGenericParameter Members
 
-        public IEnumerable<ITypeReference> GetConstraints(EmitContext context)
+        public IEnumerable<TypeReferenceWithAttributes> GetConstraints(EmitContext context)
         {
             return _parentParameter.GetConstraints(context);
         }

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -542,6 +542,15 @@ namespace Microsoft.Cci
             }
         }
 
+        public void Visit(IEnumerable<TypeReferenceWithAttributes> typeRefsWithAttributes)
+        {
+            foreach (var typeRefWithAttributes in typeRefsWithAttributes)
+            {
+                this.Visit(typeRefWithAttributes.TypeRef);
+                this.Visit(typeRefWithAttributes.Attributes);
+            }
+        }
+
         public virtual void Visit(ITypeReference typeReference)
         {
             this.DispatchAsReference(typeReference);

--- a/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataWriter.cs
@@ -1933,6 +1933,10 @@ namespace Microsoft.Cci
             // TODO: this.AddCustomAttributesToTable(assembly.Resources, 18);
 
             this.AddCustomAttributesToTable(sortedGenericParameters, TableIndex.GenericParam);
+            foreach (var param in sortedGenericParameters)
+            {
+                this.AddCustomAttributesToTable(param.GetConstraints(Context));
+            }
         }
 
         private void AddAssemblyAttributesToTable()
@@ -2031,13 +2035,12 @@ namespace Microsoft.Cci
             }
         }
 
-        private void AddCustomAttributesToTable(
-            IEnumerable<InterfaceImplementation> interfaces)
+        private void AddCustomAttributesToTable(IEnumerable<TypeReferenceWithAttributes> typeRefsWithAttributes)
         {
-            foreach (var iface in interfaces)
+            foreach (var typeRefWithAttributes in typeRefsWithAttributes)
             {
-                var ifaceHandle = GetTypeHandle(iface.Interface);
-                foreach (var customAttribute in iface.Attributes)
+                var ifaceHandle = GetTypeHandle(typeRefWithAttributes.TypeRef);
+                foreach (var customAttribute in typeRefWithAttributes.Attributes)
                 {
                     AddCustomAttributeToTable(ifaceHandle, customAttribute);
                 }
@@ -2342,11 +2345,11 @@ namespace Microsoft.Cci
                     name: GetStringHandleForNameAndCheckLength(genericParameter.Name, genericParameter),
                     index: genericParameter.Index);
 
-                foreach (ITypeReference constraint in genericParameter.GetConstraints(Context))
+                foreach (var refWithAttributes in genericParameter.GetConstraints(Context))
                 {
                     metadata.AddGenericParameterConstraint(
                         genericParameter: genericParameterHandle,
-                        constraint: GetTypeHandle(constraint));
+                        constraint: GetTypeHandle(refWithAttributes.TypeRef));
                 }
             }
         }
@@ -2384,7 +2387,7 @@ namespace Microsoft.Cci
                 {
                     metadata.AddInterfaceImplementation(
                         type: typeDefHandle,
-                        implementedInterface: GetTypeHandle(interfaceImpl.Interface));
+                        implementedInterface: GetTypeHandle(interfaceImpl.TypeRef));
                 }
             }
         }

--- a/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
+++ b/src/Compilers/Core/Portable/PEWriter/ReferenceIndexerBase.cs
@@ -269,11 +269,7 @@ namespace Microsoft.Cci
                 this.Visit(typeDefinition.SecurityAttributes);
             }
 
-            foreach (var ifaceImpl in typeDefinition.Interfaces(Context))
-            {
-                this.Visit(ifaceImpl.Attributes);
-                this.VisitTypeReferencesThatNeedTokens(ifaceImpl.Interface);
-            }
+            this.VisitTypeReferencesThatNeedTokens(typeDefinition.Interfaces(Context));
 
             if (typeDefinition.IsGeneric)
             {
@@ -292,13 +288,15 @@ namespace Microsoft.Cci
             this.Visit(typeDefinition.GetProperties(Context));
         }
 
-        public void VisitTypeReferencesThatNeedTokens(IEnumerable<ITypeReference> typeReferences)
+        public void VisitTypeReferencesThatNeedTokens(IEnumerable<TypeReferenceWithAttributes> refsWithAttributes)
         {
-            foreach (ITypeReference typeReference in typeReferences)
+            foreach (var refWithAttributes in refsWithAttributes)
             {
-                VisitTypeReferencesThatNeedTokens(typeReference);
+                this.Visit(refWithAttributes.Attributes);
+                VisitTypeReferencesThatNeedTokens(refWithAttributes.TypeRef);
             }
         }
+
 
         private void VisitTypeReferencesThatNeedTokens(ITypeReference typeReference)
         {

--- a/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
+++ b/src/Compilers/Core/Portable/PEWriter/RootModuleType.cs
@@ -69,9 +69,9 @@ namespace Microsoft.Cci
             get { return false; }
         }
 
-        public IEnumerable<Cci.InterfaceImplementation> Interfaces(EmitContext context)
+        public IEnumerable<Cci.TypeReferenceWithAttributes> Interfaces(EmitContext context)
         {
-            return SpecializedCollections.EmptyEnumerable<Cci.InterfaceImplementation>();
+            return SpecializedCollections.EmptyEnumerable<Cci.TypeReferenceWithAttributes>();
         }
 
         public bool IsAbstract

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -397,6 +397,19 @@ namespace Microsoft.Cci
         ITypeReference GetTargetType(EmitContext context);
     }
 
+    /// <summary>
+    /// A type ref with attributes attached directly to the type reference
+    /// itself. Unlike <see cref="IReference.GetAttributes(EmitContext)"/> a
+    /// <see cref="TypeReferenceWithAttributes"/> will never provide attributes
+    /// for the "pointed at" declaration, and all attributes will be emitted
+    /// directly on the type ref, rather than the declaration.
+    /// </summary>
+    // TODO(https://github.com/dotnet/roslyn/issues/12677):
+    // Consider: This is basically just a work-around for our overly loose
+    // interpretation of IReference and IDefinition. This type would probably
+    // be unnecessary if we added a GetAttributes method onto IDefinition and
+    // properly segregated attributes that are on type references and attributes
+    // that are on underlying type definitions.
     internal struct TypeReferenceWithAttributes
     {
         /// <summary>
@@ -411,10 +424,12 @@ namespace Microsoft.Cci
 
         public TypeReferenceWithAttributes(
             ITypeReference typeRef,
-            ImmutableArray<ICustomAttribute> attributes)
+            ImmutableArray<ICustomAttribute> attributes = default(ImmutableArray<ICustomAttribute>))
         {
             TypeRef = typeRef;
-            Attributes = attributes;
+            Attributes = attributes.IsDefault
+                ? ImmutableArray<ICustomAttribute>.Empty
+                : attributes;
         }
     }
 

--- a/src/Compilers/Core/Portable/PEWriter/Types.cs
+++ b/src/Compilers/Core/Portable/PEWriter/Types.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// A list of classes or interfaces. All type arguments matching this parameter must be derived from all of the classes and implement all of the interfaces.
         /// </summary>
-        IEnumerable<ITypeReference> GetConstraints(EmitContext context);
+        IEnumerable<TypeReferenceWithAttributes> GetConstraints(EmitContext context);
 
         /// <summary>
         /// True if all type arguments matching this parameter are constrained to be reference types.
@@ -397,23 +397,23 @@ namespace Microsoft.Cci
         ITypeReference GetTargetType(EmitContext context);
     }
 
-    internal struct InterfaceImplementation
+    internal struct TypeReferenceWithAttributes
     {
         /// <summary>
-        /// The interface being implemented.
+        /// The type reference.
         /// </summary>
-        public ITypeReference Interface { get; }
+        public ITypeReference TypeRef { get; }
 
         /// <summary>
-        /// The attributes on the interface implementation itself.
+        /// The attributes on the type reference itself.
         /// </summary>
         public ImmutableArray<ICustomAttribute> Attributes { get; }
 
-        public InterfaceImplementation(
-            ITypeReference iface,
+        public TypeReferenceWithAttributes(
+            ITypeReference typeRef,
             ImmutableArray<ICustomAttribute> attributes)
         {
-            Interface = iface;
+            TypeRef = typeRef;
             Attributes = attributes;
         }
     }
@@ -476,7 +476,7 @@ namespace Microsoft.Cci
         /// <summary>
         /// Zero or more interfaces implemented by this type.
         /// </summary>
-        IEnumerable<InterfaceImplementation> Interfaces(EmitContext context);
+        IEnumerable<TypeReferenceWithAttributes> Interfaces(EmitContext context);
 
         /// <summary>
         /// True if the type may not be instantiated.

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -10,7 +10,7 @@ Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
-    Friend Partial Class NamedTypeSymbol
+    Partial Friend Class NamedTypeSymbol
         Implements ITypeReference
         Implements ITypeDefinition
         Implements INamedTypeReference
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Private ReadOnly Property ITypeReferenceIsEnum As Boolean Implements ITypeReference.IsEnum
             Get
                 Debug.Assert(Not Me.IsAnonymousType)
-                Return Me.TypeKind = TYPEKIND.Enum
+                Return Me.TypeKind = TypeKind.Enum
             End Get
         End Property
 
@@ -392,7 +392,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Nothing
         End Function
 
-        Private Iterator Function ITypeDefinitionInterfaces(context As EmitContext) As IEnumerable(Of Cci.InterfaceImplementation) Implements ITypeDefinition.Interfaces
+        Private Iterator Function ITypeDefinitionInterfaces(context As EmitContext) _
+            As IEnumerable(Of Cci.TypeReferenceWithAttributes) Implements ITypeDefinition.Interfaces
             Debug.Assert(Not Me.IsAnonymousType)
             Debug.Assert((DirectCast(Me, ITypeReference)).AsTypeDefinition(context) IsNot Nothing)
 
@@ -404,8 +405,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                             fromImplements:=True)
 
                 ' TODO(https://github.com/dotnet/roslyn/issues/12592):
-                ' Add support for tuple attributes on interface implementations
-                Yield New Cci.InterfaceImplementation(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                ' TODO: Add support for tuple attributes on interface implementations
+                Yield New Cci.TypeReferenceWithAttributes(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NamedTypeSymbolAdapter.vb
@@ -406,7 +406,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ' TODO(https://github.com/dotnet/roslyn/issues/12592):
                 ' TODO: Add support for tuple attributes on interface implementations
-                Yield New Cci.TypeReferenceWithAttributes(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                Yield New Cci.TypeReferenceWithAttributes(translated)
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
 
                 ' TODO(https://github.com/dotnet/roslyn/issues/12592):
                 ' TODO: Add support for tuple attributes on interface implementations
-                Yield New Cci.TypeReferenceWithAttributes(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                Yield New Cci.TypeReferenceWithAttributes(translated)
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedType.vb
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Return UnderlyingNamedType.GetPropertiesToEmit()
         End Function
 
-        Protected Overrides Iterator Function GetInterfaces(context As EmitContext) As IEnumerable(Of Cci.InterfaceImplementation)
+        Protected Overrides Iterator Function GetInterfaces(context As EmitContext) As IEnumerable(Of Cci.TypeReferenceWithAttributes)
             Debug.Assert(TypeManager.ModuleBeingBuilt Is context.Module)
 
             Dim moduleBeingBuilt = DirectCast(context.Module, PEModuleBuilder)
@@ -87,8 +87,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                                                             context.Diagnostics)
 
                 ' TODO(https://github.com/dotnet/roslyn/issues/12592):
-                ' Add support for tuple attributes on interface implementations
-                Yield New Cci.InterfaceImplementation(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                ' TODO: Add support for tuple attributes on interface implementations
+                Yield New Cci.TypeReferenceWithAttributes(translated, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             Next
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypeParameter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypeParameter.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
             Debug.Assert(underlyingTypeParameter.IsDefinition)
         End Sub
 
-        Protected Overrides Function GetConstraints(context As EmitContext) As IEnumerable(Of Cci.ITypeReference)
+        Protected Overrides Function GetConstraints(context As EmitContext) As IEnumerable(Of Cci.TypeReferenceWithAttributes)
             Return DirectCast(UnderlyingTypeParameter, Cci.IGenericParameter).GetConstraints(context)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
@@ -198,14 +198,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 ' TODO(https://github.com/dotnet/roslyn/issues/12592):
                 ' Add support for tuple attributes on interface implementations
-                Yield New Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                Yield New Cci.TypeReferenceWithAttributes(typeRef)
             Next
             If Me.HasValueTypeConstraint AndAlso Not seenValueType Then
                 ' Add System.ValueType constraint to comply with Dev11 C# output
                 Dim typeRef As INamedTypeReference = _module.GetSpecialType(CodeAnalysis.SpecialType.System_ValueType,
                                              DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)
 
-                Yield New Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray(Of Cci.ICustomAttribute).Empty)
+                Yield New Cci.TypeReferenceWithAttributes(typeRef)
             End If
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/TypeParameterSymbolAdapter.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Reflection.Metadata
 Imports Microsoft.Cci
 Imports Microsoft.CodeAnalysis.Emit
@@ -182,19 +183,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private Iterator Function IGenericParameterGetConstraints(context As EmitContext) As IEnumerable(Of ITypeReference) Implements IGenericParameter.GetConstraints
+        Private Iterator Function IGenericParameterGetConstraints(context As EmitContext) _
+            As IEnumerable(Of TypeReferenceWithAttributes) Implements IGenericParameter.GetConstraints
             Dim _module = DirectCast(context.Module, PEModuleBuilder)
             Dim seenValueType = False
             For Each t In Me.ConstraintTypesNoUseSiteDiagnostics
                 If t.SpecialType = SpecialType.System_ValueType Then
                     seenValueType = True
                 End If
-                Yield _module.Translate(t, syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), diagnostics:=context.Diagnostics)
+
+                Dim typeRef As ITypeReference = _module.Translate(t,
+                                                                  syntaxNodeOpt:=DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode),
+                                                                  diagnostics:=context.Diagnostics)
+
+                ' TODO(https://github.com/dotnet/roslyn/issues/12592):
+                ' Add support for tuple attributes on interface implementations
+                Yield New Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             Next
             If Me.HasValueTypeConstraint AndAlso Not seenValueType Then
                 ' Add System.ValueType constraint to comply with Dev11 C# output
-                Yield _module.GetSpecialType(CodeAnalysis.SpecialType.System_ValueType,
+                Dim typeRef As INamedTypeReference = _module.GetSpecialType(CodeAnalysis.SpecialType.System_ValueType,
                                              DirectCast(context.SyntaxNodeOpt, VisualBasicSyntaxNode), context.Diagnostics)
+
+                Yield New Cci.TypeReferenceWithAttributes(typeRef, ImmutableArray(Of Cci.ICustomAttribute).Empty)
             End If
         End Function
 


### PR DESCRIPTION
Similar to PR #12611. This PR implements metadata roundtripping for
tuples used in generic constraints. Completes the generic parameter
constraint work listed in #12347.