### PR TITLE
Don't run the IteratorRewriter on BaseMethodWrapperSymbols

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -727,8 +727,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 get
                 {
                     // BaseMethodWrapperSymbol should not be rewritten by the IteratorRewriter
-                    // https://github.com/dotnet/roslyn/issues/11649
-
                     return null;
                 }
             }

--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -721,6 +721,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 AddSynthesizedAttribute(ref attributes, this.DeclaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
             }
+
+            internal override TypeSymbol IteratorElementType
+            {
+                get
+                {
+                    // BaseMethodWrapperSymbol should not be rewritten by the IteratorRewriter
+                    // https://github.com/dotnet/roslyn/issues/11649
+
+                    return null;
+                }
+            }
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
@@ -339,5 +339,35 @@ namespace RoslynYield
             Assert.NotNull(yieldNode);
             Assert.Equal(SyntaxKind.YieldBreakStatement, yieldNode.Kind());
         }
+
+        [Fact]
+        [WorkItem(11649, "https://github.com/dotnet/roslyn/issues/11649")]
+        public void IteratorRewriterShouldNotRewriteBaseMethodWrapperSymbol()
+        {
+            var text =
+@"using System.Collections.Generic;
+
+class Base
+{
+    protected virtual IEnumerable<int> M()
+    {
+        yield break;
+    }
+
+    class D : Base
+    {
+        protected override IEnumerable<int> M()
+        {
+            base.M(); // the rewriting of D.M() synthesizes a BaseMethodWrapperSymbol for this base call, with return type IEnumerable,
+                      // but it should not in turn be lowered by the IteratorRewriter
+            yield break;
+        }
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(text, options: TestOptions.DebugDll);
+            comp.VerifyDiagnostics();
+            comp.VerifyEmitDiagnostics(); // without the fix for bug 11649, the compilation would fail emitting
+            CompileAndVerify(comp);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
@@ -368,5 +368,44 @@ class Base
             comp.VerifyEmitDiagnostics(); // without the fix for bug 11649, the compilation would fail emitting
             CompileAndVerify(comp);
         }
+
+        [Fact]
+        [WorkItem(11649, "https://github.com/dotnet/roslyn/issues/11649")]
+        public void IteratorRewriterShouldNotRewriteBaseMethodWrapperSymbol2()
+        {
+            var source =
+@"using System.Collections.Generic;
+
+class Base
+{
+    public static void Main()
+    {
+        System.Console.WriteLine(string.Join("","", new D().M()));
     }
+
+    protected virtual IEnumerable<int> M()
+    {
+        yield return 1;
+        yield return 2;
+        yield break;
+    }
+
+    class D : Base
+    {
+        protected override IEnumerable<int> M()
+        {
+            yield return 0;
+            foreach (var n in base.M())
+            {
+                yield return n;
+            }
+            yield return 3;
+            yield break;
+        }
+    }
+}";
+            var comp = CompileAndVerify(source, expectedOutput: "0,1,2,3", options: TestOptions.DebugExe);
+            comp.Compilation.VerifyDiagnostics();
+        }
+   }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/IteratorTests.cs
@@ -365,7 +365,6 @@ class Base
     }
 }";
             var comp = CreateCompilationWithMscorlib(text, options: TestOptions.DebugDll);
-            comp.VerifyDiagnostics();
             comp.VerifyEmitDiagnostics(); // without the fix for bug 11649, the compilation would fail emitting
             CompileAndVerify(comp);
         }


### PR DESCRIPTION
Background:

In the code below, the iterator rewriter is run twice (once on `Base.M()` and then on `D.M()`).
While rewriting `D.M()`, it will synthesize a method symbol which wraps the call to `base.M()`.

Later on, `CompileSynthesizedMethods` will try to run the iterator rewriter on that symbol, because it's return type is `IEnumerable<int>` and all local functions now get this rewrite treatment.
But every time the iterator rewriter runs, it will generate a local (to track the state machine). This local is in a synthesized method with no syntax body, which fails an assertion later during the emit phase, in `SourceMethodSymbol.CalculateLocalSyntaxOffset`.

Fix:

From discussion with @agocke, we think this wrapper method (which is a `BaseMethodWrapperSymbol`) should not be rewritten.
This may become a mute point after the the lowering for local functions gets split into its own pass (which he is working on).

```C#
using System.Collections.Generic;

class Base {
    protected virtual IEnumerable<int> M() {
        yield break;
    }

    class D : Base {
        protected override IEnumerable<int> M() {
            base.M();
            yield break;
        }
    }
}
```

Fixes https://github.com/dotnet/roslyn/issues/11649
@dotnet/roslyn-compiler for review.