### PR TITLE
Fix crash in inline rename

### DIFF
--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.cs
@@ -171,10 +171,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                     Contract.ThrowIfNull(text);
 
                     var textSnapshot = text.FindCorrespondingEditorTextSnapshot();
-                    Contract.ThrowIfNull(textSnapshot);
-                    Contract.ThrowIfNull(textSnapshot.TextBuffer);
-
-                    openBuffers.Add(textSnapshot.TextBuffer);
+                    if (textSnapshot != null)
+                    {
+                        openBuffers.Add(textSnapshot.TextBuffer);
+                    }
                 }
 
                 foreach (var buffer in openBuffers)


### PR DESCRIPTION
This change fixes #7566

The change adds a check for null after trying to get the snapshot of a supposedly open document. This can fail due to the weak reference map used to associate source texts with their editor text snapshots.

@rchande @tmat @Pilchie  please review
