### PR TITLE
Delay metadata reload

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/AnalyzersTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/AnalyzersTests.cs
@@ -34,7 +34,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void RuleSet_GeneralOption()
         {
@@ -64,7 +64,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void RuleSet_ProjectSettingOverridesGeneralOption()
         {
@@ -97,7 +97,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void RuleSet_SpecificOptions()
         {
@@ -127,7 +127,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void RuleSet_ProjectSettingsOverrideSpecificOptions()
         {
@@ -158,7 +158,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact, WorkItem(1087250, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1087250")]
+        [WpfFact, WorkItem(1087250, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1087250")]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void SetRuleSetFile_RemoveExtraBackslashes()
         {
@@ -176,7 +176,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(1092636, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1092636")]
         [WorkItem(1040247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1040247")]
@@ -220,7 +220,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")]
         public void RuleSet_ProjectNoWarnOverridesOtherSettings()

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpCompilerOptionsTests.cs
@@ -18,7 +18,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
 {
     public class CSharpCompilerOptionsTests
     {
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(530980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530980")]
         public void DocumentationModeSetToDiagnoseIfProducingDocFile()
@@ -36,7 +36,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(530980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530980")]
         public void DocumentationModeSetToParseIfNotProducingDocFile()
@@ -54,7 +54,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void UseOPTID_COMPATIBILITY()
         {
@@ -88,7 +88,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
         ////    }
         ////}
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(1092636, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1092636")]
         [WorkItem(1040247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1040247")]

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpReferencesTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpReferencesTests.cs
@@ -20,7 +20,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
 
     public class CSharpReferenceTests
     {
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddingReferenceToProjectMetadataPromotesToProjectReference()
         {
@@ -42,7 +42,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddCyclicProjectMetadataReferences()
         {
@@ -67,7 +67,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddCyclicProjectReferences()
         {
@@ -87,7 +87,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
             }
         }
 
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         public void AddCyclicProjectReferencesDeep()
         {

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/SourceFileHandlingTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/SourceFileHandlingTests.cs
@@ -9,7 +9,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
 {
     public class SourceFileHandlingTests
     {
-        [Fact]
+        [WpfFact]
         [Trait(Traits.Feature, Traits.Features.ProjectSystemShims)]
         [WorkItem(1100114, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1100114")]
         public void IgnoreAdditionsOfXomlFiles()

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/ConvertedVisualBasicProjectOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/ConvertedVisualBasicProjectOptionsTests.vb
@@ -18,7 +18,7 @@ Imports Roslyn.Utilities
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
 
     Public Class ConvertedVisualBasicProjectOptionsTests
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_GeneralCommandLineOptionOverridesGeneralRuleSetOption()
             Dim convertedOptions = GetConvertedOptions(ruleSetGeneralOption:=ReportDiagnostic.Warn, commandLineGeneralOption:=WarningLevel.WARN_AsError)
 
@@ -26,7 +26,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=0, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions.Count)
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_GeneralWarnAsErrorPromotesWarningFromRuleSet()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {
@@ -40,7 +40,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_GeneralWarnAsErrorDoesNotPromoteInfoFromRuleSet()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {
@@ -54,7 +54,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Info, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_SpecificWarnAsErrorPromotesInfoFromRuleSet()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {
@@ -71,7 +71,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Error, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_SpecificWarnAsErrorMinusResetsRules()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {
@@ -88,7 +88,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Warn, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test001"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_SpecificWarnAsErrorMinusDefaultsRuleNotInRuleSet()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {
@@ -106,7 +106,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Default, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test002"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_GeneralNoWarnTurnsOffAllButErrors()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                {
@@ -126,7 +126,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Assert.Equal(expected:=ReportDiagnostic.Suppress, actual:=convertedOptions.CompilationOptions.SpecificDiagnosticOptions("Test003"))
         End Sub
 
-        <Fact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
+        <WpfFact, WorkItem(468, "https://github.com/dotnet/roslyn/issues/468")>
         Public Sub RuleSet_SpecificNoWarnAlwaysWins()
             Dim ruleSetSpecificOptions = New Dictionary(Of String, ReportDiagnostic) From
                 {

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/DeferredProjectLoadingTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/DeferredProjectLoadingTests.vb
@@ -12,7 +12,7 @@ Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class DeferredProjectLoadingTests
-        <Fact>
+        <WpfFact>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub SimpleDeferredLoading()
             Using testEnvironment = New TestEnvironment(solutionIsFullyLoaded:=False)
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
+        <WpfFact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub DoNotDeferLoadIfInNonBackgroundBatch()
             Using testEnvironment = New TestEnvironment(solutionIsFullyLoaded:=False)
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
+        <WpfFact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddingProjectInBatchDoesntAddAllProjects()
             Using testEnvironment = New TestEnvironment(solutionIsFullyLoaded:=False)
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
+        <WpfFact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddingProjectReferenceInBatchMayPushOtherProjects()
             Using testEnvironment = New TestEnvironment(solutionIsFullyLoaded:=False)
@@ -82,7 +82,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
+        <WpfFact, WorkItem(1094112, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094112")>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddingProjectReferenceAfterBatchMayPushOtherProjects()
             Using testEnvironment = New TestEnvironment(solutionIsFullyLoaded:=False)

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicCompilerOptionsTests.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualBasicCompilerOptions
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(867840, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/867840")>
         Public Sub ConditionalCompilationOptionsIncludesTargetAndVersion()
@@ -27,7 +27,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(530980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530980")>
         Public Sub DocumentationModeSetToDiagnoseIfProducingDocFile()
@@ -47,7 +47,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(530980, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530980")>
         Public Sub DocumentationModeSetToParseIfNotProducingDocFile()
@@ -67,7 +67,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(1092636, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1092636")>
         <WorkItem(1040247, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1040247")>

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicProjectTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicProjectTests.vb
@@ -8,7 +8,7 @@ Imports Microsoft.CodeAnalysis
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualBasicProjectTests
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub RenameProjectUpdatesWorkspace()
             Using environment = New TestEnvironment()

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualBasicSpecialReferencesTests.vb
@@ -7,7 +7,7 @@ Imports Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Visu
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualBasicSpecialReferencesTests
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub ProjectIncludesReferencesToMscorlibSystemAndMicrosoftVisualBasic()
             Using environment = New TestEnvironment()
@@ -25,7 +25,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub ProjectWithoutStandardLibsDoesNotReferenceSystem()
             Using environment = New TestEnvironment()
@@ -45,7 +45,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub ProjectWithoutVisualBasicRuntimeDoesNotReferenceMicrosoftVisualBasic()
             Using environment = New TestEnvironment()
@@ -65,7 +65,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(860964, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860964")>
         Public Sub AddingReferenceToMicrosoftVisualBasicBeforeSettingOptionsShouldNotCrash()
@@ -96,7 +96,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(3477, "https://github.com/dotnet/roslyn/issues/3477")>
         Public Sub ProjectWithEmptySdkPathHasNoReferences()
@@ -113,7 +113,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         <WorkItem(860964, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/860964")>
         Public Sub AddingReferenceToMicrosoftVisualBasicAfterSettingOptionsShouldNotCrash()
@@ -142,7 +142,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddingReferenceToProjectMetadataPromotesToProjectReference()
             Using environment = New TestEnvironment()
@@ -163,7 +163,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddCyclicProjectMetadataReferences()
             Using environment = New TestEnvironment()
@@ -187,7 +187,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddCyclicProjectReferences()
             Using environment = New TestEnvironment()
@@ -206,7 +206,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact()>
+        <WpfFact()>
         <Trait(Traits.Feature, Traits.Features.ProjectSystemShims)>
         Public Sub AddCyclicProjectReferencesDeep()
             Using environment = New TestEnvironment()

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioAnalyzerTests.vb
@@ -12,7 +12,7 @@ Imports Roslyn.Test.Utilities
 
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualStudioAnalyzerTests
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub GetReferenceCalledMultipleTimes()
             Using analyzer = New VisualStudioAnalyzer("C:\Foo\Bar.dll", New MockVsFileChangeEx(), Nothing, Nothing, Nothing, Nothing, Nothing)
                 Dim reference1 = analyzer.GetReference()
@@ -22,7 +22,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             End Using
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub AnalyzerErrorsAreUpdated()
             Dim hostDiagnosticUpdateSource = New HostDiagnosticUpdateSource(Nothing, New MockDiagnosticUpdateSourceRegistrationService())
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/VisualStudioRuleSetTests.vb
@@ -13,7 +13,7 @@ Imports Roslyn.Utilities
 Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
     Public Class VisualStudioRuleSetTests
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub SingleFile()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set3"" Description=""Test"" ToolsVersion=""12.0"">
@@ -48,7 +48,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Directory.Delete(tempPath, recursive:=True)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub TwoFiles()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set1"" Description=""Test"" ToolsVersion=""12.0"">
@@ -95,7 +95,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Directory.Delete(tempPath, recursive:=True)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub IncludeUpdated()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set1"" Description=""Test"" ToolsVersion=""12.0"">
@@ -147,7 +147,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Directory.Delete(tempPath, recursive:=True)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub SameFileRequestedAfterChange()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set3"" Description=""Test"" ToolsVersion=""12.0"">
@@ -190,7 +190,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Directory.Delete(tempPath, recursive:=True)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub SameFileRequestedMultipleTimes()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set3"" Description=""Test"" ToolsVersion=""12.0"">
@@ -227,7 +227,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim
             Directory.Delete(tempPath, recursive:=True)
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub FileWithError()
             Dim ruleSetSource = "<?xml version=""1.0"" encoding=""utf-8""?>
 <RuleSet Name=""New Rule Set3"" Description=""Test"" ToolsVersion=""12.0"">

--- a/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderProviderTests.vb
+++ b/src/VisualStudio/Core/Test/SolutionExplorer/AnalyzersFolderProviderTests.vb
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.SolutionExplorer
             End Using
         End Sub
 
-        <Fact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Diagnostics)>
         Public Sub CreateCollectionSource()
             Using environment = New TestEnvironment()
                 Dim project = CreateVisualBasicProject(environment, "Foo")


### PR DESCRIPTION
Fixes #12189, and restores the behavior of the native C# language service.

The problem here is that we frequently get the file change notification
while something is still writing the file, and so we get an IOException when
we try to read it, resulting in us caching empty metadata and reporting
spurious errors.