### PR TITLE
Decouple the InteractiveWorkspace from needing a InteractiveEvaluator

### DIFF
--- a/src/Interactive/EditorFeatures/Core/Completion/CompletionProviders/ReplCommandCompletionProvider.cs
+++ b/src/Interactive/EditorFeatures/Core/Completion/CompletionProviders/ReplCommandCompletionProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Completion.CompletionProviders
                 var workspace = ws as InteractiveWorkspace;
                 if (workspace != null)
                 {
-                    var window = workspace.Engine.CurrentWindow;
+                    var window = workspace.Window;
                     var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
 
                     if (await ShouldDisplayCommandCompletionsAsync(tree, position, cancellationToken).ConfigureAwait(false))

--- a/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
+++ b/src/Interactive/EditorFeatures/Core/Extensibility/Interactive/InteractiveEvaluator.cs
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
 
             _contentType = contentType;
             _responseFilePath = responseFilePath;
-            _workspace = new InteractiveWorkspace(this, hostServices);
+            _workspace = new InteractiveWorkspace(hostServices);
             _contentTypeChangedHandler = new EventHandler<ContentTypeChangedEventArgs>(LanguageBufferContentTypeChanged);
             _classifierAggregator = classifierAggregator;
             _initialWorkingDirectory = initialWorkingDirectory;
@@ -134,6 +134,7 @@ namespace Microsoft.CodeAnalysis.Editor.Interactive
                 }
 
                 _currentWindow = value;
+                _workspace.Window = value;
 
                 _interactiveHost.Output = _currentWindow.OutputWriter;
                 _interactiveHost.ErrorOutput = _currentWindow.ErrorOutputWriter;

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveDocumentNavigationService.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveDocumentNavigationService.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
                 return false;
             }
 
-            var textView = interactiveWorkspace.Engine.CurrentWindow.TextView;
+            var textView = interactiveWorkspace.Window.TextView;
             var document = interactiveWorkspace.CurrentSolution.GetDocument(documentId);
 
             var textSnapshot = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None).FindCorrespondingEditorTextSnapshot();

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveGlobalUndoServiceFactory.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveGlobalUndoServiceFactory.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
             private ITextUndoHistory GetHistory(Workspace workspace)
             {
                 var interactiveWorkspace = (InteractiveWorkspace)workspace;
-                var textBuffer = interactiveWorkspace.Engine.CurrentWindow.TextView.TextBuffer;
+                var textBuffer = interactiveWorkspace.Window.TextView.TextBuffer;
                 ITextUndoHistory textUndoHistory;
 
                 Contract.ThrowIfFalse(_undoHistoryRegistry.TryGetHistory(textBuffer, out textUndoHistory));

--- a/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
+++ b/src/Interactive/EditorFeatures/Core/Implementation/Interactive/InteractiveWorkspace.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.SolutionCrawler;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.VisualStudio.InteractiveWindow;
 using Microsoft.VisualStudio.Text;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
@@ -13,15 +14,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Interactive
     {
         private readonly ISolutionCrawlerRegistrationService _registrationService;
 
-        internal InteractiveEvaluator Engine { get; }
+        internal IInteractiveWindow Window { get; set; }
         private SourceTextContainer _openTextContainer;
         private DocumentId _openDocumentId;
 
-        internal InteractiveWorkspace(InteractiveEvaluator engine, HostServices hostServices)
-            : base(hostServices, "Interactive")
+        internal InteractiveWorkspace(HostServices hostServices)
+            : base(hostServices, WorkspaceKind.Interactive)
         {
-            this.Engine = engine;
-
             // register work coordinator for this workspace
             _registrationService = this.Services.GetService<ISolutionCrawlerRegistrationService>();
             _registrationService.Register(this);


### PR DESCRIPTION
Everything only needed the IInteractiveWindow. This makes life easier for TypeScript.

*Review:* @dotnet/roslyn-interactive, @paulvanbrenk, @mousetraps, @CyrusNajmabadi