### PR TITLE
Overriding should care about tuple element names

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1181,7 +1181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var declaringType = members[0].ContainingType;
 
             HashSet<DiagnosticInfo> unused = null;
-            if (currentType.IsEqualToOrDerivedFrom(declaringType, ignoreDynamic: false, useSiteDiagnostics: ref unused))
+            if (currentType.IsEqualToOrDerivedFrom(declaringType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref unused))
             {
                 return ThisReference(syntax, currentType, wasCompilerGenerated: true);
             }
@@ -1481,7 +1481,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var currentType = this.ContainingType;
             HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
-            if (currentType.IsEqualToOrDerivedFrom(member.ContainingType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+            if (currentType.IsEqualToOrDerivedFrom(member.ContainingType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
             {
                 bool hasErrors = false;
                 if (EnclosingNameofArgument != node)
@@ -1547,7 +1547,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     TypeSymbol hostObjectType = Compilation.GetHostObjectTypeSymbol();
                     HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                    if ((object)hostObjectType != null && hostObjectType.IsEqualToOrDerivedFrom(memberDeclaringType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+                    if ((object)hostObjectType != null && hostObjectType.IsEqualToOrDerivedFrom(memberDeclaringType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
                     {
                         return new BoundHostObjectMemberReference(syntax, hostObjectType) { WasCompilerGenerated = true };
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1188,7 +1188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 candidateType = parameterType;
                             }
-                            else if (!candidateType.Equals(parameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false))
+                            else if (!candidateType.Equals(parameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false, ignoreTupleNames: false))
                             {
                                 // type mismatch
                                 candidateType = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Invocation.cs
@@ -1188,7 +1188,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 candidateType = parameterType;
                             }
-                            else if (!candidateType.Equals(parameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false, ignoreTupleNames: false))
+                            else if (!candidateType.Equals(parameterType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
                             {
                                 // type mismatch
                                 candidateType = null;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2569,7 +2569,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var delegateParameterType = delegateParameters[i].Type;
                     var delegateRefKind = delegateParameters[i].RefKind;
 
-                    if (!lambdaParameterType.Equals(delegateParameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                    if (!lambdaParameterType.Equals(delegateParameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                     {
                         SymbolDistinguisher distinguisher = new SymbolDistinguisher(this.Compilation, lambdaParameterType, delegateParameterType);
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2569,7 +2569,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var delegateParameterType = delegateParameters[i].Type;
                     var delegateRefKind = delegateParameters[i].RefKind;
 
-                    if (!lambdaParameterType.Equals(delegateParameterType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                    if (!lambdaParameterType.Equals(delegateParameterType, TypeCompareKind.AllIgnoreOptions))
                     {
                         SymbolDistinguisher distinguisher = new SymbolDistinguisher(this.Compilation, lambdaParameterType, delegateParameterType);
 

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1114,7 +1114,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     for (int p = 0; p < delegateParameters.Length; ++p)
                     {
                         if (delegateParameters[p].RefKind != anonymousFunction.RefKind(p) ||
-                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), TypeCompareKind.AllIgnoreOptions))
                         {
                             return LambdaConversionResult.MismatchedParameterType;
                         }
@@ -1312,7 +1312,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)type1 != null);
             Debug.Assert((object)type2 != null);
 
-            return type1.Equals(type2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true);
+            return type1.Equals(type2, TypeCompareKind.AllIgnoreOptions);
         }
 
         public static bool HasIdentityConversionToAny<T>(T type, ArrayBuilder<T> targetTypes)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Conversions/ConversionsBase.cs
@@ -1114,7 +1114,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     for (int p = 0; p < delegateParameters.Length; ++p)
                     {
                         if (delegateParameters[p].RefKind != anonymousFunction.RefKind(p) ||
-                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                            !delegateParameters[p].Type.Equals(anonymousFunction.ParameterType(p), ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                         {
                             return LambdaConversionResult.MismatchedParameterType;
                         }
@@ -1312,7 +1312,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)type1 != null);
             Debug.Assert((object)type2 != null);
 
-            return type1.Equals(type2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true);
+            return type1.Equals(type2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true);
         }
 
         public static bool HasIdentityConversionToAny<T>(T type, ArrayBuilder<T> targetTypes)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -654,9 +654,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // Return types must match exactly, parameters might match modulo identity conversion.
                     if (op.Signature.Kind == existingSignature.Kind && // Easy out
                         op.Signature.ReturnType.Equals(existingSignature.ReturnType, TypeCompareKind.ConsiderEverything) &&
-                        op.Signature.LeftType.Equals(existingSignature.LeftType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) &&
-                        op.Signature.RightType.Equals(existingSignature.RightType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) &&
-                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames))
+                        op.Signature.LeftType.Equals(existingSignature.LeftType, TypeCompareKind.IgnoreDynamicAndTupleNames) &&
+                        op.Signature.RightType.Equals(existingSignature.RightType, TypeCompareKind.IgnoreDynamicAndTupleNames) &&
+                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, TypeCompareKind.IgnoreDynamicAndTupleNames))
                     {
                         equivalentToExisting = true;
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -653,10 +653,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Return types must match exactly, parameters might match modulo identity conversion.
                     if (op.Signature.Kind == existingSignature.Kind && // Easy out
-                        op.Signature.ReturnType.Equals(existingSignature.ReturnType, ignoreDynamic: false) &&
-                        op.Signature.LeftType.Equals(existingSignature.LeftType, ignoreDynamic: true) &&
-                        op.Signature.RightType.Equals(existingSignature.RightType, ignoreDynamic: true) &&
-                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, ignoreDynamic: true))
+                        op.Signature.ReturnType.Equals(existingSignature.ReturnType, ignoreDynamic: false, ignoreTupleNames: false) &&
+                        op.Signature.LeftType.Equals(existingSignature.LeftType, ignoreDynamic: true, ignoreTupleNames: true) &&
+                        op.Signature.RightType.Equals(existingSignature.RightType, ignoreDynamic: true, ignoreTupleNames: true) &&
+                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, ignoreDynamic: true, ignoreTupleNames: true))
                     {
                         equivalentToExisting = true;
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -653,10 +653,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     // Return types must match exactly, parameters might match modulo identity conversion.
                     if (op.Signature.Kind == existingSignature.Kind && // Easy out
-                        op.Signature.ReturnType.Equals(existingSignature.ReturnType, ignoreDynamic: false, ignoreTupleNames: false) &&
-                        op.Signature.LeftType.Equals(existingSignature.LeftType, ignoreDynamic: true, ignoreTupleNames: true) &&
-                        op.Signature.RightType.Equals(existingSignature.RightType, ignoreDynamic: true, ignoreTupleNames: true) &&
-                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, ignoreDynamic: true, ignoreTupleNames: true))
+                        op.Signature.ReturnType.Equals(existingSignature.ReturnType, TypeCompareKind.ConsiderEverything) &&
+                        op.Signature.LeftType.Equals(existingSignature.LeftType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) &&
+                        op.Signature.RightType.Equals(existingSignature.RightType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) &&
+                        op.Signature.Method.ContainingType.Equals(existingSignature.Method.ContainingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames))
                     {
                         equivalentToExisting = true;
                         break;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2482,7 +2482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     best = candidate;
                 }
-                else if (best.Equals(candidate, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames))
+                else if (best.Equals(candidate, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
                     if (candidate.IsTupleType)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2482,7 +2482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     best = candidate;
                 }
-                else if (best.Equals(candidate, ignoreDynamic: true))
+                else if (best.Equals(candidate, ignoreDynamic: true, ignoreTupleNames: true))
                 {
                     if (candidate.IsTupleType)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2482,7 +2482,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     best = candidate;
                 }
-                else if (best.Equals(candidate, ignoreDynamic: true, ignoreTupleNames: true))
+                else if (best.Equals(candidate, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames))
                 {
                     if (candidate.IsTupleType)
                     {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -448,7 +448,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 foreach (var pair in containingTypeMapOpt)
                 {
                     NamedTypeSymbol otherType = pair.Key;
-                    if (otherType.IsDerivedFrom(memberContainingType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+                    if (otherType.IsDerivedFrom(memberContainingType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
                     {
                         ArrayBuilder<TMember> others = pair.Value;
 
@@ -641,7 +641,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var otherMember in members)
             {
                 NamedTypeSymbol otherContainingType = otherMember.ContainingType;
-                if (HidesByName(otherMember) && otherContainingType.IsDerivedFrom(memberContainingType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+                if (HidesByName(otherMember) && otherContainingType.IsDerivedFrom(memberContainingType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
                 {
                     return true;
                 }
@@ -843,7 +843,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return true;
                 }
 
-                else if (currentType.IsClassType() && type.IsClassType() && currentType.IsDerivedFrom(type, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+                else if (currentType.IsClassType() && type.IsClassType() && currentType.IsDerivedFrom(type, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
                 {
                     return true;
                 }

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -184,7 +184,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             // An argument that is an array of the appropriate type is not a params argument.
                             (boundArguments.Length > argumentIndex + 1 ||
                              argument.Type.TypeKind != TypeKind.Array ||
-                             !argument.Type.Equals(parameters[parameters.Length - 1].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true)))
+                             !argument.Type.Equals(parameters[parameters.Length - 1].Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)))
                         {
                             return new Argument(ArgumentKind.ParamArray, parameters[parameters.Length - 1], CreateParamArray(parameters[parameters.Length - 1], boundArguments, argumentIndex, invocationSyntax));
                         }

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7262,6 +7262,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both partial method declarations, &apos;{0}&apos; and &apos;{1}&apos;, must use the same tuple element names..
+        /// </summary>
+        internal static string ERR_PartialMethodTupleNameDifference {
+            get {
+                return ResourceManager.GetString("ERR_PartialMethodTupleNameDifference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Both partial method declarations must be unsafe or neither may be unsafe.
         /// </summary>
         internal static string ERR_PartialMethodUnsafeDifference {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3491,7 +3491,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is already listed in interface list with different tuple element names.
+        ///   Looks up a localized string similar to &apos;{0}&apos; is already listed in interface list with different tuple element names, on type &apos;{1}&apos;..
         /// </summary>
         internal static string ERR_DuplicateInterfaceWithTupleNamesInBaseList {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4850,6 +4850,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The tuple element names in the signature of method &apos;{0}&apos; must match the tuple element names of interface method &apos;{1}&apos;..
+        /// </summary>
+        internal static string ERR_ImplBadTupleNames {
+            get {
+                return ResourceManager.GetString("ERR_ImplBadTupleNames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No best type found for implicitly-typed array.
         /// </summary>
         internal static string ERR_ImplicitlyTypedArrayNoBestType {

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4850,7 +4850,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The tuple element names in the signature of method &apos;{0}&apos; must match the tuple element names of interface method &apos;{1}&apos;..
+        ///   Looks up a localized string similar to The tuple element names in the signature of method &apos;{0}&apos; must match the tuple element names of interface method &apos;{1}&apos; (including on the return type)..
         /// </summary>
         internal static string ERR_ImplBadTupleNames {
             get {
@@ -7154,6 +7154,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Both partial method declarations, &apos;{0}&apos; and &apos;{1}&apos;, must use the same tuple element names..
+        /// </summary>
+        internal static string ERR_PartialMethodInconsistentTupleNames {
+            get {
+                return ResourceManager.GetString("ERR_PartialMethodInconsistentTupleNames", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Partial methods with only a defining declaration or removed conditional methods cannot be used in expression trees.
         /// </summary>
         internal static string ERR_PartialMethodInExpressionTree {
@@ -7258,15 +7267,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_PartialMethodToDelegate {
             get {
                 return ResourceManager.GetString("ERR_PartialMethodToDelegate", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Both partial method declarations, &apos;{0}&apos; and &apos;{1}&apos;, must use the same tuple element names..
-        /// </summary>
-        internal static string ERR_PartialMethodTupleNameDifference {
-            get {
-                return ResourceManager.GetString("ERR_PartialMethodTupleNameDifference", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -2366,6 +2366,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos;: cannot change tuple element names when overriding inherited member &apos;{1}&apos;.
+        /// </summary>
+        internal static string ERR_CantChangeTupleNamesOnOverride {
+            get {
+                return ResourceManager.GetString("ERR_CantChangeTupleNamesOnOverride", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos;: type must be &apos;{2}&apos; to match overridden member &apos;{1}&apos;.
         /// </summary>
         internal static string ERR_CantChangeTypeOnOverride {
@@ -3478,6 +3487,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_DuplicateInterfaceInBaseList {
             get {
                 return ResourceManager.GetString("ERR_DuplicateInterfaceInBaseList", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; is already listed in interface list with different tuple element names.
+        /// </summary>
+        internal static string ERR_DuplicateInterfaceWithTupleNamesInBaseList {
+            get {
+                return ResourceManager.GetString("ERR_DuplicateInterfaceWithTupleNamesInBaseList", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3491,7 +3491,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;{0}&apos; is already listed in interface list with different tuple element names, on type &apos;{1}&apos;..
+        ///   Looks up a localized string similar to &apos;{0}&apos; is already listed in the interface list on type &apos;{2}&apos; with different tuple element names, as &apos;{1}&apos;..
         /// </summary>
         internal static string ERR_DuplicateInterfaceWithTupleNamesInBaseList {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2054,6 +2054,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_PartialMethodMustHaveLatent" xml:space="preserve">
     <value>No defining declaration found for implementing declaration of partial method '{0}'</value>
   </data>
+  <data name="ERR_PartialMethodTupleNameDifference" xml:space="preserve">
+    <value>Both partial method declarations, '{0}' and '{1}', must use the same tuple element names.</value>
+  </data>
   <data name="ERR_PartialMethodInconsistentConstraints" xml:space="preserve">
     <value>Partial method declarations of '{0}' have inconsistent type parameter constraints</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1464,7 +1464,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>'{0}' is already listed in interface list</value>
   </data>
   <data name="ERR_DuplicateInterfaceWithTupleNamesInBaseList" xml:space="preserve">
-    <value>'{0}' is already listed in interface list with different tuple element names, on type '{1}'.</value>
+    <value>'{0}' is already listed in the interface list on type '{2}' with different tuple element names, as '{1}'.</value>
   </data>
   <data name="ERR_CycleInInterfaceInheritance" xml:space="preserve">
     <value>Inherited interface '{1}' causes a cycle in the interface hierarchy of '{0}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1224,6 +1224,9 @@
   <data name="ERR_ImplBadConstraints" xml:space="preserve">
     <value>The constraints for type parameter '{0}' of method '{1}' must match the constraints for type parameter '{2}' of interface method '{3}'. Consider using an explicit interface implementation instead.</value>
   </data>
+  <data name="ERR_ImplBadTupleNames" xml:space="preserve">
+    <value>The tuple element names in the signature of method '{0}' must match the tuple element names of interface method '{1}'.</value>
+  </data>
   <data name="ERR_DottedTypeNameNotFoundInAgg" xml:space="preserve">
     <value>The type name '{0}' does not exist in the type '{1}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1409,6 +1409,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_CantChangeAccessOnOverride" xml:space="preserve">
     <value>'{0}': cannot change access modifiers when overriding '{1}' inherited member '{2}'</value>
   </data>
+  <data name="ERR_CantChangeTupleNamesOnOverride" xml:space="preserve">
+    <value>'{0}': cannot change tuple element names when overriding inherited member '{1}'</value>
+  </data>
   <data name="ERR_CantChangeReturnTypeOnOverride" xml:space="preserve">
     <value>'{0}': return type must be '{2}' to match overridden member '{1}'</value>
   </data>
@@ -1456,6 +1459,9 @@ If such a class is used as a base class and if the deriving class defines a dest
   </data>
   <data name="ERR_DuplicateInterfaceInBaseList" xml:space="preserve">
     <value>'{0}' is already listed in interface list</value>
+  </data>
+  <data name="ERR_DuplicateInterfaceWithTupleNamesInBaseList" xml:space="preserve">
+    <value>'{0}' is already listed in interface list with different tuple element names</value>
   </data>
   <data name="ERR_CycleInInterfaceInheritance" xml:space="preserve">
     <value>Inherited interface '{1}' causes a cycle in the interface hierarchy of '{0}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1464,7 +1464,7 @@ If such a class is used as a base class and if the deriving class defines a dest
     <value>'{0}' is already listed in interface list</value>
   </data>
   <data name="ERR_DuplicateInterfaceWithTupleNamesInBaseList" xml:space="preserve">
-    <value>'{0}' is already listed in interface list with different tuple element names</value>
+    <value>'{0}' is already listed in interface list with different tuple element names, on type '{1}'.</value>
   </data>
   <data name="ERR_CycleInInterfaceInheritance" xml:space="preserve">
     <value>Inherited interface '{1}' causes a cycle in the interface hierarchy of '{0}'</value>

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -1225,7 +1225,7 @@
     <value>The constraints for type parameter '{0}' of method '{1}' must match the constraints for type parameter '{2}' of interface method '{3}'. Consider using an explicit interface implementation instead.</value>
   </data>
   <data name="ERR_ImplBadTupleNames" xml:space="preserve">
-    <value>The tuple element names in the signature of method '{0}' must match the tuple element names of interface method '{1}'.</value>
+    <value>The tuple element names in the signature of method '{0}' must match the tuple element names of interface method '{1}' (including on the return type).</value>
   </data>
   <data name="ERR_DottedTypeNameNotFoundInAgg" xml:space="preserve">
     <value>The type name '{0}' does not exist in the type '{1}'</value>
@@ -2054,7 +2054,7 @@ If such a class is used as a base class and if the deriving class defines a dest
   <data name="ERR_PartialMethodMustHaveLatent" xml:space="preserve">
     <value>No defining declaration found for implementing declaration of partial method '{0}'</value>
   </data>
-  <data name="ERR_PartialMethodTupleNameDifference" xml:space="preserve">
+  <data name="ERR_PartialMethodInconsistentTupleNames" xml:space="preserve">
     <value>Both partial method declarations, '{0}' and '{1}', must use the same tuple element names.</value>
   </data>
   <data name="ERR_PartialMethodInconsistentConstraints" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // - i.e assigns int value to a short local.
                 // in that case we should force lhs to be a real local.
                 Debug.Assert(
-                    node.Left.Type.Equals(node.Right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true),
+                    node.Left.Type.Equals(node.Right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true),
                     @"type of the assignment value is not the same as the type of assignment target. 
                 This is not expected by the optimizer and is typically a result of a bug somewhere else.");
 

--- a/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/Optimizer.cs
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 // - i.e assigns int value to a short local.
                 // in that case we should force lhs to be a real local.
                 Debug.Assert(
-                    node.Left.Type.Equals(node.Right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true),
+                    node.Left.Type.Equals(node.Right.Type, TypeCompareKind.AllIgnoreOptions),
                     @"type of the assignment value is not the same as the type of assignment target. 
                 This is not expected by the optimizer and is typically a result of a bug somewhere else.");
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     var visitedSource = (TypeSymbol)_matcher.Visit(source);
                     var visitedOther = (_deepTranslatorOpt != null) ? (TypeSymbol)_deepTranslatorOpt.Visit(other) : other;
 
-                    return visitedSource?.Equals(visitedOther, ignoreDynamic: true, ignoreTupleNames: true) == true;
+                    return visitedSource?.Equals(visitedOther, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) == true;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     var visitedSource = (TypeSymbol)_matcher.Visit(source);
                     var visitedOther = (_deepTranslatorOpt != null) ? (TypeSymbol)_deepTranslatorOpt.Visit(other) : other;
 
-                    return visitedSource?.Equals(visitedOther, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) == true;
+                    return visitedSource?.Equals(visitedOther, TypeCompareKind.IgnoreDynamicAndTupleNames) == true;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -824,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     var visitedSource = (TypeSymbol)_matcher.Visit(source);
                     var visitedOther = (_deepTranslatorOpt != null) ? (TypeSymbol)_deepTranslatorOpt.Visit(other) : other;
 
-                    return visitedSource?.Equals(visitedOther, ignoreDynamic: true) == true;
+                    return visitedSource?.Equals(visitedOther, ignoreDynamic: true, ignoreTupleNames: true) == true;
                 }
             }
         }

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1376,6 +1376,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         ERR_TupleElementNamesAttributeMissing = 8216,
         ERR_ExplicitTupleElementNames = 8217,
+        ERR_CantChangeTupleNamesOnOverride = 8218,
+        ERR_DuplicateInterfaceWithTupleNamesInBaseList = 8219,
 
         #endregion tuple diagnostics introduced in C# 7
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1378,6 +1378,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ExplicitTupleElementNames = 8217,
         ERR_CantChangeTupleNamesOnOverride = 8218,
         ERR_DuplicateInterfaceWithTupleNamesInBaseList = 8219,
+        ERR_ImplBadTupleNames = 8220,
 
         #endregion tuple diagnostics introduced in C# 7
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1379,6 +1379,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CantChangeTupleNamesOnOverride = 8218,
         ERR_DuplicateInterfaceWithTupleNamesInBaseList = 8219,
         ERR_ImplBadTupleNames = 8220,
+        ERR_PartialMethodTupleNameDifference = 8221,
 
         #endregion tuple diagnostics introduced in C# 7
 

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1379,11 +1379,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CantChangeTupleNamesOnOverride = 8218,
         ERR_DuplicateInterfaceWithTupleNamesInBaseList = 8219,
         ERR_ImplBadTupleNames = 8220,
-        ERR_PartialMethodTupleNameDifference = 8221,
+        ERR_PartialMethodInconsistentTupleNames = 8221,
 
         #endregion tuple diagnostics introduced in C# 7
 
-        // huge gap here; available 8216-8889
+        // huge gap here; available 8222-8889
 
         #region diagnostics for ref locals and ref returns introduced in C# 7
         ERR_AutoPropertyCannotBeRefReturning = 8890,

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : null;
 
             _dynamicFactory = new LoweredDynamicOperationFactory(F, methodOrdinal);
-            _awaiterFields = new Dictionary<TypeSymbol, FieldSymbol>(TypeSymbol.EqualsIgnoringDynamicComparer);
+            _awaiterFields = new Dictionary<TypeSymbol, FieldSymbol>(TypeSymbol.EqualsIgnoringDynamicAndTupleNamesComparer);
             _nextAwaiterId = slotAllocatorOpt?.PreviousAwaiterSlotCount ?? 0;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -180,7 +180,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // like compound assignment does (extra flag only passed when it is an expression
             // statement means that this constraint is not violated).
             // Dynamic type will be erased in emit phase. It is considered equivalent to Object in lowered bound trees.
-            Debug.Assert(visited == null || visited.HasErrors || ReferenceEquals(visited.Type, node.Type) || visited.Type.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(visited == null || visited.HasErrors || ReferenceEquals(visited.Type, node.Type) ||
+                    visited.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             return visited;
         }
@@ -235,7 +236,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Conditional("DEBUG")]
         private static void AssertPlaceholderReplacement(BoundValuePlaceholderBase placeholder, BoundExpression value)
         {
-            Debug.Assert(value.Type.Equals(placeholder.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(value.Type.Equals(placeholder.Type, TypeCompareKind.AllIgnoreOptions));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -181,7 +181,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // statement means that this constraint is not violated).
             // Dynamic type will be erased in emit phase. It is considered equivalent to Object in lowered bound trees.
             Debug.Assert(visited == null || visited.HasErrors || ReferenceEquals(visited.Type, node.Type) ||
-                    visited.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                    visited.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             return visited;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // like compound assignment does (extra flag only passed when it is an expression
             // statement means that this constraint is not violated).
             // Dynamic type will be erased in emit phase. It is considered equivalent to Object in lowered bound trees.
-            Debug.Assert(visited == null || visited.HasErrors || ReferenceEquals(visited.Type, node.Type) || visited.Type.Equals(node.Type, ignoreDynamic: true));
+            Debug.Assert(visited == null || visited.HasErrors || ReferenceEquals(visited.Type, node.Type) || visited.Type.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true));
 
             return visited;
         }
@@ -235,7 +235,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         [Conditional("DEBUG")]
         private static void AssertPlaceholderReplacement(BoundValuePlaceholderBase placeholder, BoundExpression value)
         {
-            Debug.Assert(value.Type.Equals(placeholder.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Debug.Assert(value.Type.Equals(placeholder.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = MakeConversionNode(node, node.Syntax, rewrittenOperand, node.Conversion, node.Checked, node.ExplicitCastInCode, node.ConstantValue, rewrittenType);
 
             var toType = node.Type;
-            Debug.Assert(result.Type.Equals(toType, ignoreDynamic: true));
+            Debug.Assert(result.Type.Equals(toType, ignoreDynamic: true, ignoreTupleNames: true));
 
             // 4.1.6 C# spec: To force a value of a floating point type to the exact precision of its type, an explicit cast can be used.
             // It means that explicit casts to (double) or (float) should be preserved on the node.
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // but we need to change the Type property on the resulting BoundExpression to match the rewrittenType.
                     // This is necessary so that subsequent lowering transformations see that the expression is dynamic.
 
-                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false))
+                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: false))
                     {
                         break;
                     }
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // we keep tuple literal conversions in the tree for the purpose of semantic model (for example when they are casts in the source)
                         // for the purpose of lowering/codegeneration thay are identity conversions.
-                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, ignoreDynamic: true));
+                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, ignoreDynamic: true, ignoreTupleNames: true));
                         return rewrittenOperand;
                     }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = MakeConversionNode(node, node.Syntax, rewrittenOperand, node.Conversion, node.Checked, node.ExplicitCastInCode, node.ConstantValue, rewrittenType);
 
             var toType = node.Type;
-            Debug.Assert(result.Type.Equals(toType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Debug.Assert(result.Type.Equals(toType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             // 4.1.6 C# spec: To force a value of a floating point type to the exact precision of its type, an explicit cast can be used.
             // It means that explicit casts to (double) or (float) should be preserved on the node.
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // we keep tuple literal conversions in the tree for the purpose of semantic model (for example when they are casts in the source)
                         // for the purpose of lowering/codegeneration thay are identity conversions.
-                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, TypeCompareKind.IgnoreDynamicAndTupleNames));
                         return rewrittenOperand;
                     }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = MakeConversionNode(node, node.Syntax, rewrittenOperand, node.Conversion, node.Checked, node.ExplicitCastInCode, node.ConstantValue, rewrittenType);
 
             var toType = node.Type;
-            Debug.Assert(result.Type.Equals(toType, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(result.Type.Equals(toType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             // 4.1.6 C# spec: To force a value of a floating point type to the exact precision of its type, an explicit cast can be used.
             // It means that explicit casts to (double) or (float) should be preserved on the node.
@@ -127,7 +127,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // but we need to change the Type property on the resulting BoundExpression to match the rewrittenType.
                     // This is necessary so that subsequent lowering transformations see that the expression is dynamic.
 
-                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: false))
+                    if (_inExpressionLambda || !rewrittenOperand.Type.Equals(rewrittenType, TypeCompareKind.ConsiderEverything))
                     {
                         break;
                     }
@@ -231,7 +231,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     {
                         // we keep tuple literal conversions in the tree for the purpose of semantic model (for example when they are casts in the source)
                         // for the purpose of lowering/codegeneration thay are identity conversions.
-                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, ignoreDynamic: true, ignoreTupleNames: true));
+                        Debug.Assert(rewrittenOperand.Type.Equals(rewrittenType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                         return rewrittenOperand;
                     }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(rewrittenRight != null);
             Debug.Assert(leftConversion.IsValid);
             Debug.Assert((object)rewrittenResultType != null);
-            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, ignoreDynamic: true));
+            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
 
             if (_inExpressionLambda)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // MakeConversion(temp, rewrittenResultType)
             BoundExpression convertedLeft = GetConvertedLeftForNullCoalescingOperator(boundTemp, leftConversion, rewrittenResultType);
-            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, ignoreDynamic: true));
+            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
 
             // (temp != null) ? MakeConversion(temp, LeftConversion) : RightOperand
             BoundExpression conditionalExpression = RewriteConditionalOperator(
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenType: rewrittenResultType);
 
             Debug.Assert(conditionalExpression.ConstantValue == null); // we shouldn't have hit this else case otherwise
-            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, ignoreDynamic: true));
+            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
 
             return new BoundSequence(
                 syntax: syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(rewrittenRight != null);
             Debug.Assert(leftConversion.IsValid);
             Debug.Assert((object)rewrittenResultType != null);
-            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             if (_inExpressionLambda)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // MakeConversion(temp, rewrittenResultType)
             BoundExpression convertedLeft = GetConvertedLeftForNullCoalescingOperator(boundTemp, leftConversion, rewrittenResultType);
-            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             // (temp != null) ? MakeConversion(temp, LeftConversion) : RightOperand
             BoundExpression conditionalExpression = RewriteConditionalOperator(
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenType: rewrittenResultType);
 
             Debug.Assert(conditionalExpression.ConstantValue == null); // we shouldn't have hit this else case otherwise
-            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             return new BoundSequence(
                 syntax: syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_NullCoalescingOperator.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(rewrittenRight != null);
             Debug.Assert(leftConversion.IsValid);
             Debug.Assert((object)rewrittenResultType != null);
-            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Debug.Assert(rewrittenRight.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             if (_inExpressionLambda)
             {
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // MakeConversion(temp, rewrittenResultType)
             BoundExpression convertedLeft = GetConvertedLeftForNullCoalescingOperator(boundTemp, leftConversion, rewrittenResultType);
-            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Debug.Assert(convertedLeft.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             // (temp != null) ? MakeConversion(temp, LeftConversion) : RightOperand
             BoundExpression conditionalExpression = RewriteConditionalOperator(
@@ -128,7 +128,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 rewrittenType: rewrittenResultType);
 
             Debug.Assert(conditionalExpression.ConstantValue == null); // we shouldn't have hit this else case otherwise
-            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Debug.Assert(conditionalExpression.Type.Equals(rewrittenResultType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             return new BoundSequence(
                 syntax: syntax,

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -410,7 +410,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (_lazyAvailableReusableHoistedFields == null)
                 {
-                    _lazyAvailableReusableHoistedFields = new Dictionary<TypeSymbol, ArrayBuilder<StateMachineFieldSymbol>>(TypeSymbol.EqualsIgnoringDynamicComparer);
+                    _lazyAvailableReusableHoistedFields = new Dictionary<TypeSymbol, ArrayBuilder<StateMachineFieldSymbol>>(TypeSymbol.EqualsIgnoringDynamicAndTupleNamesComparer);
                 }
 
                 _lazyAvailableReusableHoistedFields.Add(field.Type, fields = new ArrayBuilder<StateMachineFieldSymbol>());

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, RefKind refKind = RefKind.None)
         {
-            Debug.Assert(left.Type.Equals(right.Type, ignoreDynamic: true) || right.Type.IsErrorType() || left.Type.IsErrorType());
+            Debug.Assert(left.Type.Equals(right.Type, ignoreDynamic: true, ignoreTupleNames: true) || right.Type.IsErrorType() || left.Type.IsErrorType());
             return new BoundAssignmentOperator(Syntax, left, right, left.Type, refKind: refKind) { WasCompilerGenerated = true };
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, RefKind refKind = RefKind.None)
         {
-            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) ||
+            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreDynamicAndTupleNames) ||
                     right.Type.IsErrorType() || left.Type.IsErrorType());
 
             return new BoundAssignmentOperator(Syntax, left, right, left.Type, refKind: refKind) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -380,7 +380,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, RefKind refKind = RefKind.None)
         {
-            Debug.Assert(left.Type.Equals(right.Type, ignoreDynamic: true, ignoreTupleNames: true) || right.Type.IsErrorType() || left.Type.IsErrorType());
+            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) ||
+                    right.Type.IsErrorType() || left.Type.IsErrorType());
+
             return new BoundAssignmentOperator(Syntax, left, right, left.Type, refKind: refKind) { WasCompilerGenerated = true };
         }
 
@@ -655,7 +657,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public BoundExpression Coalesce(BoundExpression left, BoundExpression right)
         {
-            Debug.Assert(left.Type.Equals(right.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Debug.Assert(left.Type.Equals(right.Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
             Debug.Assert(left.Type.IsReferenceType);
 
             return new BoundNullCoalescingOperator(Syntax, left, right, Conversion.Identity, left.Type) { WasCompilerGenerated = true };
@@ -1107,9 +1109,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>
         /// Helper that will use Array.Empty if available and elements have 0 length
-        /// NOTE: it is valid only if we know that the API that is being called will not 
+        /// NOTE: it is valid only if we know that the API that is being called will not
         ///       retain or use the array argument for any purpose (like locking or key in a hash table)
-        ///       Typical example of valid use is Linq.Expressions factories - they do not make any 
+        ///       Typical example of valid use is Linq.Expressions factories - they do not make any
         ///       assumptions about array arguments and do not keep them or rely on their identity.
         /// </summary>
         public BoundExpression ArrayOrEmpty(TypeSymbol elementType, ImmutableArray<BoundExpression> elements)
@@ -1196,7 +1198,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Takes an expression and returns the bound local expression "temp" 
+        /// Takes an expression and returns the bound local expression "temp"
         /// and the bound assignment expression "temp = expr".
         /// </summary>
         public BoundLocal StoreToTemp(

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
@@ -59,13 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool Equals(AnonymousTypeDescriptor desc)
         {
-            return this.Equals(desc, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false);
+            return this.Equals(desc, TypeCompareKind.ConsiderEverything);
         }
 
         /// <summary>
         /// Compares two anonymous type descriptors, takes into account fields names and types, not locations.
         /// </summary>
-        internal bool Equals(AnonymousTypeDescriptor other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal bool Equals(AnonymousTypeDescriptor other, TypeCompareKind comparison)
         {
             // Comparing keys ensures field count and field names are the same
             if (this.Key != other.Key)
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<AnonymousTypeField> otherFields = other.Fields;
             for (int i = 0; i < count; i++)
             {
-                if (!myFields[i].Type.Equals(otherFields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames: false))
+                if (!myFields[i].Type.Equals(otherFields[i].Type, comparison & ~TypeCompareKind.IgnoreTupleNames))
                 {
                     return false;
                 }
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         public override bool Equals(object obj)
         {
-            return obj is AnonymousTypeDescriptor && this.Equals((AnonymousTypeDescriptor)obj, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false);
+            return obj is AnonymousTypeDescriptor && this.Equals((AnonymousTypeDescriptor)obj, TypeCompareKind.ConsiderEverything);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<AnonymousTypeField> otherFields = other.Fields;
             for (int i = 0; i < count; i++)
             {
-                if (!myFields[i].Type.Equals(otherFields[i].Type, comparison & ~TypeCompareKind.IgnoreTupleNames))
+                if (!myFields[i].Type.Equals(otherFields[i].Type, comparison))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeDescriptor.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ImmutableArray<AnonymousTypeField> otherFields = other.Fields;
             for (int i = 0; i < count; i++)
             {
-                if (!myFields[i].Type.Equals(otherFields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
+                if (!myFields[i].Type.Equals(otherFields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames: false))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
@@ -95,7 +95,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(right.Fields.Length == count);
                 for (int i = 0; i < count; i++)
                 {
-                    if (!left.Fields[i].Type.Equals(right.Fields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
+                    if (!left.Fields[i].Type.Equals(right.Fields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames: false))
                     {
                         return false;
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/AnonymousTypeManager.cs
@@ -71,41 +71,5 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var anonymous = (AnonymousTypePublicSymbol)type;
             return anonymous.Manager.ConstructAnonymousTypeSymbol(anonymous.TypeDescriptor.WithNewFieldsTypes(newFieldTypes));
         }
-
-        /// <summary>
-        /// Logical equality on anonymous types that ignores custom modifiers and/or the object/dynamic distinction.
-        /// Differs from IsSameType for arrays, pointers, and generic instantiations.
-        /// </summary>
-        internal static bool IsSameType(TypeSymbol type1, TypeSymbol type2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
-        {
-            Debug.Assert(type1.IsAnonymousType);
-            Debug.Assert(type2.IsAnonymousType);
-
-            if (ignoreCustomModifiersAndArraySizesAndLowerBounds || ignoreDynamic)
-            {
-                AnonymousTypeDescriptor left = ((AnonymousTypePublicSymbol)type1).TypeDescriptor;
-                AnonymousTypeDescriptor right = ((AnonymousTypePublicSymbol)type2).TypeDescriptor;
-
-                if (left.Key != right.Key)
-                {
-                    return false;
-                }
-
-                int count = left.Fields.Length;
-                Debug.Assert(right.Fields.Length == count);
-                for (int i = 0; i < count; i++)
-                {
-                    if (!left.Fields[i].Type.Equals(right.Fields[i].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames: false))
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            else
-            {
-                return type1 == type2;
-            }
-        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<NamedTypeSymbol>.Empty;
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+            internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -347,7 +347,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var other = t2 as AnonymousTypePublicSymbol;
-                return (object)other != null && this.TypeDescriptor.Equals(other.TypeDescriptor, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+                return (object)other != null && this.TypeDescriptor.Equals(other.TypeDescriptor, comparison);
             }
 
             public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousType.TypePublicSymbol.cs
@@ -339,7 +339,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return ImmutableArray<NamedTypeSymbol>.Empty;
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
             {
                 if (ReferenceEquals(this, t2))
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -326,17 +326,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitArrayType(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
-            return this.Equals(t2 as ArrayTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+            return this.Equals(t2 as ArrayTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
         }
 
         internal bool Equals(ArrayTypeSymbol other)
         {
-            return Equals(other, false, false);
+            return Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: true);
         }
 
-        private bool Equals(ArrayTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        private bool Equals(ArrayTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, other))
             {
@@ -344,7 +344,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if ((object)other == null || !other.HasSameShapeAs(this) ||
-                !other.ElementType.Equals(ElementType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
+                !other.ElementType.Equals(ElementType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -326,17 +326,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return visitor.VisitArrayType(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
-            return this.Equals(t2 as ArrayTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+            return this.Equals(t2 as ArrayTypeSymbol, comparison);
         }
 
         internal bool Equals(ArrayTypeSymbol other)
         {
-            return Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: true);
+            return Equals(other, TypeCompareKind.IgnoreTupleNames);
         }
 
-        private bool Equals(ArrayTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        private bool Equals(ArrayTypeSymbol other, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, other))
             {
@@ -344,13 +344,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if ((object)other == null || !other.HasSameShapeAs(this) ||
-                !other.ElementType.Equals(ElementType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames))
+                !other.ElementType.Equals(ElementType, comparison))
             {
                 return false;
             }
 
             // Make sure custom modifiers and bounds are the same.
-            if (!ignoreCustomModifiersAndArraySizesAndLowerBounds)
+            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
             {
                 var mod = this.CustomModifiers;
                 var otherMod = other.CustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -350,7 +350,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Make sure custom modifiers and bounds are the same.
-            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
+            if ((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0)
             {
                 var mod = this.CustomModifiers;
                 var otherMod = other.CustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal bool Equals(ArrayTypeSymbol other)
         {
-            return Equals(other, TypeCompareKind.IgnoreTupleNames);
+            return Equals(other, TypeCompareKind.ConsiderEverything);
         }
 
         private bool Equals(ArrayTypeSymbol other, TypeCompareKind comparison)

--- a/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Attributes/AttributeData.cs
@@ -116,7 +116,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // Native compiler doesn't generate a use-site error if it is not found, we do the same.
                 var wellKnownType = compilation.GetWellKnownType(WellKnownType.System_Security_Permissions_SecurityAttribute);
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                _lazyIsSecurityAttribute = AttributeClass.IsDerivedFrom(wellKnownType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics).ToThreeState();
+                _lazyIsSecurityAttribute = AttributeClass.IsDerivedFrom(wellKnownType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics).ToThreeState();
             }
 
             return _lazyIsSecurityAttribute.Value();

--- a/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             ByRefReturnErrorTypeSymbol other = t2 as ByRefReturnErrorTypeSymbol;
             return (object)other != null && _referencedType.Equals(other._referencedType, comparison) &&
-                   (comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
+                   ((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0 || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                              substitutedReferencedType.CustomModifiers);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if ((object)this == (object)t2)
             {
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             ByRefReturnErrorTypeSymbol other = t2 as ByRefReturnErrorTypeSymbol;
-            return (object)other != null && _referencedType.Equals(other._referencedType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic) &&
+            return (object)other != null && _referencedType.Equals(other._referencedType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames) &&
                    (ignoreCustomModifiersAndArraySizesAndLowerBounds || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ByRefReturnErrorTypeSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                              substitutedReferencedType.CustomModifiers);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if ((object)this == (object)t2)
             {
@@ -52,8 +52,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             ByRefReturnErrorTypeSymbol other = t2 as ByRefReturnErrorTypeSymbol;
-            return (object)other != null && _referencedType.Equals(other._referencedType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames) &&
-                   (ignoreCustomModifiersAndArraySizesAndLowerBounds || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
+            return (object)other != null && _referencedType.Equals(other._referencedType, comparison) &&
+                   (comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) || _countOfCustomModifiersPrecedingByRef == other._countOfCustomModifiersPrecedingByRef);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -516,11 +516,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             public static ImmutableArray<string> Encode(TypeSymbol type)
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();
-                type.VisitType((t, builder, _ignore) => AddNames(t, builder), namesBuilder);
-                Debug.Assert(namesBuilder.Any());
 
-                // If none of the tuples have names, return a default array
-                if (namesBuilder.All(name => name == null))
+                if (TryGetNames(type, namesBuilder))
                 {
                     namesBuilder.Free();
                     return default(ImmutableArray<string>);
@@ -532,11 +529,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             public static ImmutableArray<TypedConstant> Encode(TypeSymbol type, TypeSymbol stringType)
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();
-                type.VisitType((t, builder, _ignore) => AddNames(t, builder), namesBuilder);
-                Debug.Assert(namesBuilder.Any());
 
-                // If none of the tuples have names, return a default array
-                if (namesBuilder.All(name => name == null))
+                if (TryGetNames(type, namesBuilder))
                 {
                     namesBuilder.Free();
                     return default(ImmutableArray<TypedConstant>);
@@ -546,6 +540,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     new TypedConstant(constantType, TypedConstantKind.Primitive, name), stringType);
                 namesBuilder.Free();
                 return names;
+            }
+
+            private static bool TryGetNames(TypeSymbol type, ArrayBuilder<string> namesBuilder)
+            {
+                type.VisitType((t, builder, _ignore) => AddNames(t, builder), namesBuilder);
+                Debug.Assert(namesBuilder.Any());
+                return namesBuilder.All(name => name == null);
             }
 
             private static bool AddNames(TypeSymbol type, ArrayBuilder<string> namesBuilder)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -517,7 +517,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();
 
-                if (TryGetNames(type, namesBuilder))
+                if (!TryGetNames(type, namesBuilder))
                 {
                     namesBuilder.Free();
                     return default(ImmutableArray<string>);
@@ -530,7 +530,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();
 
-                if (TryGetNames(type, namesBuilder))
+                if (!TryGetNames(type, namesBuilder))
                 {
                     namesBuilder.Free();
                     return default(ImmutableArray<TypedConstant>);
@@ -546,7 +546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 type.VisitType((t, builder, _ignore) => AddNames(t, builder), namesBuilder);
                 Debug.Assert(namesBuilder.Any());
-                return namesBuilder.All(name => name == null);
+                return namesBuilder.Any(name => name != null);
             }
 
             private static bool AddNames(TypeSymbol type, ArrayBuilder<string> namesBuilder)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var wkType = GetWellKnownType(wellKnownType);
-            return type.Equals(wkType, ignoreDynamic: false) || type.IsDerivedFrom(wkType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics);
+            return type.Equals(wkType, ignoreDynamic: false, ignoreTupleNames: false) || type.IsDerivedFrom(wkType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics);
         }
 
         internal override bool IsSystemTypeReference(ITypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -155,7 +155,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             var wkType = GetWellKnownType(wellKnownType);
-            return type.Equals(wkType, ignoreDynamic: false, ignoreTupleNames: false) || type.IsDerivedFrom(wkType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics);
+            return type.Equals(wkType, TypeCompareKind.ConsiderEverything) || type.IsDerivedFrom(wkType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics);
         }
 
         internal override bool IsSystemTypeReference(ITypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -511,8 +511,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             return TrySynthesizeAttribute(WellKnownMember.System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames, args);
         }
 
-        private static class TupleNamesEncoder
+        internal static class TupleNamesEncoder
         {
+            // TODO: can this be factored more?
+            public static ImmutableArray<string> Encode(TypeSymbol type)
+            {
+                var namesBuilder = ArrayBuilder<string>.GetInstance();
+                type.VisitType((t, builder, _ignore) => AddNames(t, builder), namesBuilder);
+                Debug.Assert(namesBuilder.Any());
+
+                // If none of the tuples have names, return a default array
+                if (namesBuilder.All(name => name == null))
+                {
+                    namesBuilder.Free();
+                    return default(ImmutableArray<string>);
+                }
+
+                return namesBuilder.ToImmutableAndFree();
+            }
+
             public static ImmutableArray<TypedConstant> Encode(TypeSymbol type, TypeSymbol stringType)
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -513,7 +513,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal static class TupleNamesEncoder
         {
-            // TODO: can this be factored more?
             public static ImmutableArray<string> Encode(TypeSymbol type)
             {
                 var namesBuilder = ArrayBuilder<string>.GetInstance();

--- a/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConstraintsHelper.cs
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // some implemented interfaces are related
             // will have to instantiate interfaces and check
             hasRelatedInterfaces:
-            return type.InterfacesNoUseSiteDiagnostics(basesBeingResolved).HasDuplicates(TypeSymbol.EqualsIgnoringDynamicComparer);
+            return type.InterfacesNoUseSiteDiagnostics(basesBeingResolved).HasDuplicates(TypeSymbol.EqualsIgnoringDynamicAndTupleNamesComparer);
         }
 
         public static bool CheckConstraints(

--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return member1.ReturnType.Equals(member2.ReturnType, ignoreDynamic: true, ignoreTupleNames: true)
-                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], ignoreDynamic: true, ignoreTupleNames: true);
+            return member1.ReturnType.Equals(member2.ReturnType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)
+                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames);
         }
 
         public int GetHashCode(SourceUserDefinedConversionSymbol member)

--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return member1.ReturnType.Equals(member2.ReturnType, ignoreDynamic: true)
-                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], ignoreDynamic: true);
+            return member1.ReturnType.Equals(member2.ReturnType, ignoreDynamic: true, ignoreTupleNames: true)
+                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], ignoreDynamic: true, ignoreTupleNames: true);
         }
 
         public int GetHashCode(SourceUserDefinedConversionSymbol member)

--- a/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ConversionSignatureComparer.cs
@@ -44,8 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            return member1.ReturnType.Equals(member2.ReturnType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)
-                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames);
+            return member1.ReturnType.Equals(member2.ReturnType, TypeCompareKind.IgnoreDynamicAndTupleNames)
+                && member1.ParameterTypes[0].Equals(member2.ParameterTypes[0], TypeCompareKind.IgnoreDynamicAndTupleNames);
         }
 
         public int GetHashCode(SourceUserDefinedConversionSymbol member)

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            if (comparison.HasFlag(TypeCompareKind.IgnoreDynamic))
+            if ((comparison & TypeCompareKind.IgnoreDynamic) != 0)
             {
                 var other = t2 as NamedTypeSymbol;
                 return (object)other != null && other.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Object;

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (int)Microsoft.CodeAnalysis.SpecialType.System_Object;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if ((object)t2 == null)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/DynamicTypeSymbol.cs
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return (int)Microsoft.CodeAnalysis.SpecialType.System_Object;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if ((object)t2 == null)
             {
@@ -195,7 +195,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return true;
             }
 
-            if (ignoreDynamic)
+            if (comparison.HasFlag(TypeCompareKind.IgnoreDynamic))
             {
                 var other = t2 as NamedTypeSymbol;
                 return (object)other != null && other.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Object;

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_container.GetHashCode(), _ordinal);
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as ErrorTypeParameterSymbol;
                 return (object)other != null &&
                     other._ordinal == _ordinal &&
-                    other.ContainingType.Equals(this.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+                    other.ContainingType.Equals(this.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ErrorTypeSymbol.ErrorTypeParameterSymbol.cs
@@ -140,7 +140,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_container.GetHashCode(), _ordinal);
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+            internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -150,7 +150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as ErrorTypeParameterSymbol;
                 return (object)other != null &&
                     other._ordinal == _ordinal &&
-                    other.ContainingType.Equals(this.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+                    other.ContainingType.Equals(this.ContainingType, comparison);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return commonTypeKind;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, t2))
             {
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return
-                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames) :
+                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, comparison) :
                  (object)this.ContainingSymbol == null ? (object)other.ContainingSymbol == null : this.ContainingSymbol.Equals(other.ContainingSymbol)) &&
                 this.Name == other.Name && this.Arity == other.Arity;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ExtendedErrorTypeSymbol.cs
@@ -284,7 +284,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return commonTypeKind;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, t2))
             {
@@ -298,7 +298,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             return
-                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic) :
+                ((object)this.ContainingType != null ? this.ContainingType.Equals(other.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames) :
                  (object)this.ContainingSymbol == null ? (object)other.ContainingSymbol == null : this.ContainingSymbol.Equals(other.ContainingSymbol)) &&
                 this.Name == other.Name && this.Arity == other.Arity;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -725,7 +725,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Does the members match in terms of tuple names (both in their return type and parameters)?
+        /// Do the members differ in terms of tuple names (both in their return type and parameters), but would match ignoring names?
         ///
         /// We'll look at the result of equality without tuple names (1) and with tuple names (2).
         /// The question is whether there is a change in tuple element names only (3).
@@ -737,10 +737,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// `int M()`                vs. `string M()`              | no  | no  |   match   |
         ///
         /// </summary>
-        internal static bool DifferOnlyInTupleNames(Symbol member1, Symbol member2)
+        internal static bool ConsideringTupleNamesCreatesDifference(Symbol member1, Symbol member2)
         {
-            return CSharpWithTupleNamesComparer.Equals(member1, member2) ||
-                !CSharpWithoutTupleNamesComparer.Equals(member1, member2);
+            return !CSharpWithTupleNamesComparer.Equals(member1, member2) &&
+                CSharpWithoutTupleNamesComparer.Equals(member1, member2);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -65,7 +65,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             considerTypeConstraints: false, // constraints are checked by caller instead
             considerCallingConvention: true,
             considerRefOutDifference: true,
-            considerCustomModifiers: false);
+            considerCustomModifiers: false,
+            ignoreTupleNames: true);
 
         /// <summary>
         /// This instance is used as a fallback when it is determined that one member does not implicitly implement
@@ -113,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// This instance checks whether two signatures match including tuples names in both return type and parameters.
         /// </summary>
-        public static readonly MemberSignatureComparer CSharpTupleNamesComparer = new MemberSignatureComparer(
+        public static readonly MemberSignatureComparer CSharpWithTupleNamesComparer = new MemberSignatureComparer(
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,
@@ -124,7 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             ignoreDynamic: true,
             ignoreTupleNames: false);
 
-        public static readonly MemberSignatureComparer CSharpNegativeTupleNamesComparer = new MemberSignatureComparer(
+        public static readonly MemberSignatureComparer CSharpWithoutTupleNamesComparer = new MemberSignatureComparer(
             considerName: true,
             considerExplicitlyImplementedInterfaces: false,
             considerReturnType: true,

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -523,8 +523,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             // the runtime compares custom modifiers using (effectively) SequenceEqual
             return considerCustomModifiers ?
-                returnType1.Equals(returnType2, ignoreDynamic: ignoreDynamic, ignoreTupleNames: ignoreTupleNames) :
-                returnType1.Type.Equals(returnType2.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: ignoreDynamic, ignoreTupleNames: ignoreTupleNames);
+                returnType1.Equals(returnType2, TypeCompareKind.ConsiderEverything.AddIgnoreDynamic(ignoreDynamic).AddIgnoreTupleNames(ignoreTupleNames)) :
+                returnType1.Type.Equals(returnType2.Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds.AddIgnoreDynamic(ignoreDynamic).AddIgnoreTupleNames(ignoreTupleNames));
         }
 
         private static TypeMap GetTypeMap(Symbol member)
@@ -666,12 +666,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // the runtime compares custom modifiers using (effectively) SequenceEqual
                 if (considerCustomModifiers)
                 {
-                    if (!type1.Equals(type2, ignoreDynamic, ignoreTupleNames) || (param1.CountOfCustomModifiersPrecedingByRef != param2.CountOfCustomModifiersPrecedingByRef))
+                    if (!type1.Equals(type2, TypeCompareKind.ConsiderEverything.AddIgnoreDynamic(ignoreDynamic).AddIgnoreTupleNames(ignoreTupleNames)) || 
+                        (param1.CountOfCustomModifiersPrecedingByRef != param2.CountOfCustomModifiersPrecedingByRef))
                     {
                         return false;
                     }
                 }
-                else if (!type1.Type.Equals(type2.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: ignoreDynamic, ignoreTupleNames: ignoreTupleNames))
+                else if (!type1.Type.Equals(type2.Type, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds.AddIgnoreDynamic(ignoreDynamic).AddIgnoreTupleNames(ignoreTupleNames)))
                 {
                     return false;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// `int M()`                vs. `string M()`              | no  | no  |   match   |
         ///
         /// </summary>
-        internal static bool TupleNamesMatchIgnoringOtherDifferences(Symbol member1, Symbol member2)
+        internal static bool DifferOnlyInTupleNames(Symbol member1, Symbol member2)
         {
             return CSharpWithTupleNamesComparer.Equals(member1, member2) ||
                 !CSharpWithoutTupleNamesComparer.Equals(member1, member2);

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -723,16 +723,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// Does the overridenMember match the member in terms of tuple names (both in their return type and parameters)?
         ///
         /// We'll look at the result of equality without tuple names (1) and with tuple names (2).
-        /// The question is whether there is a change in tuple element names only (3). Those are overridenMembers that we'll want to keep.
+        /// The question is whether there is a change in tuple element names only (3).
         ///
-        ///                                                        | (1) | (2) |  (3)   |
-        /// `(int a, int b) M()`     vs. `(int a, int b) M()`      | yes | yes |  keep  |
-        /// `(int a, int b) M()`     vs. `(int x, int y) M()`      | yes | no  | remove |
-        /// `void M((int a, int b))` vs. `void M((int x, int y))`  | yes | no  | remove |
-        /// `int M()`                vs. `string M()`              | no  | no  |  keep  |
+        /// member                   vs. overriddenMember          | (1) | (2) |   (3)   |
+        /// `(int a, int b) M()`     vs. `(int a, int b) M()`      | yes | yes |  match  |
+        /// `(int a, int b) M()`     vs. `(int x, int y) M()`      | yes | no  | changed |
+        /// `void M((int a, int b))` vs. `void M((int x, int y))`  | yes | no  | changed |
+        /// `int M()`                vs. `string M()`              | no  | no  |  match  |
         ///
         /// </summary>
-        internal static bool TupleNamesMatch(Symbol member, Symbol overriddenMember)
+        internal static bool TupleNamesMatchIgnoringOtherDifferences(Symbol member, Symbol overriddenMember)
         {
             return !MemberSignatureComparer.CSharpWithoutTupleNamesComparer.Equals(overriddenMember, member) ||
                     MemberSignatureComparer.CSharpWithTupleNamesComparer.Equals(overriddenMember, member);

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -739,8 +739,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal static bool TupleNamesMatchIgnoringOtherDifferences(Symbol member1, Symbol member2)
         {
-            return MemberSignatureComparer.CSharpWithTupleNamesComparer.Equals(member1, member2) ||
-                !MemberSignatureComparer.CSharpWithoutTupleNamesComparer.Equals(member1, member2);
+            return CSharpWithTupleNamesComparer.Equals(member1, member2) ||
+                !CSharpWithoutTupleNamesComparer.Equals(member1, member2);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSignatureComparer.cs
@@ -718,5 +718,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             return member.Kind == SymbolKind.Method && ((MethodSymbol)member).IsVararg;
         }
+
+        /// <summary>
+        /// Does the overridenMember match the member in terms of tuple names (both in their return type and parameters)?
+        ///
+        /// We'll look at the result of equality without tuple names (1) and with tuple names (2).
+        /// The question is whether there is a change in tuple element names only (3). Those are overridenMembers that we'll want to keep.
+        ///
+        ///                                                        | (1) | (2) |  (3)   |
+        /// `(int a, int b) M()`     vs. `(int a, int b) M()`      | yes | yes |  keep  |
+        /// `(int a, int b) M()`     vs. `(int x, int y) M()`      | yes | no  | remove |
+        /// `void M((int a, int b))` vs. `void M((int x, int y))`  | yes | no  | remove |
+        /// `int M()`                vs. `string M()`              | no  | no  |  keep  |
+        ///
+        /// </summary>
+        internal static bool TupleNamesMatch(Symbol member, Symbol overriddenMember)
+        {
+            return !MemberSignatureComparer.CSharpWithoutTupleNamesComparer.Equals(overriddenMember, member) ||
+                    MemberSignatureComparer.CSharpWithTupleNamesComparer.Equals(overriddenMember, member);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/DynamicTypeDecoder.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
@@ -206,10 +207,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
         private NamedTypeSymbol TransformNamedType(NamedTypeSymbol namedType, bool isContaining = false)
         {
-            // Dig into tuples
             if (namedType.IsTupleType)
             {
-                namedType = namedType.TupleUnderlyingType;
+                return TransformTupleType(namedType, isContaining);
             }
 
             // Native compiler encodes a bool for the given namedType, but none for its containing types.
@@ -268,6 +268,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             {
                 return namedType;
             }
+        }
+
+        private NamedTypeSymbol TransformTupleType(NamedTypeSymbol tupleType, bool isContaining)
+        {
+            Debug.Assert(tupleType.IsTupleType);
+
+            var underlying = tupleType.TupleUnderlyingType;
+            var transformedUnderlying = TransformNamedType(underlying, isContaining);
+            return TupleTypeSymbol.Create(transformedUnderlying, tupleType.TupleElementNames);
         }
 
         private ImmutableArray<TypeSymbol> TransformTypeArguments(ImmutableArray<TypeSymbol> typeArguments)

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -506,7 +506,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 if (scope != targetTypeSymbol &&
                     !(targetTypeSymbol.IsInterfaceType()
                         ? scope.AllInterfacesNoUseSiteDiagnostics.Contains((NamedTypeSymbol)targetTypeSymbol)
-                        : scope.IsDerivedFrom(targetTypeSymbol, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics)))
+                        : scope.IsDerivedFrom(targetTypeSymbol, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics)))
                 {
                     return null;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -78,9 +78,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             EntityHandle targetSymbolToken,
             PEModuleSymbol containingModule)
         {
-            Debug.Assert((object)metadataType != null);
-            Debug.Assert((object)containingModule != null);
-
             ImmutableArray<string> elementNames;
             var hasTupleElementNamesAttribute = containingModule
                 .Module
@@ -93,8 +90,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return new UnsupportedMetadataTypeSymbol();
             }
 
-            var decoder = new TupleTypeDecoder(elementNames,
-                                               containingModule.ContainingAssembly);
+            return DecodeTupleTypesInternal(metadataType, containingModule.ContainingAssembly, elementNames, hasTupleElementNamesAttribute);
+        }
+
+        public static TypeSymbol DecodeTupleTypesIfApplicable(
+            TypeSymbol metadataType,
+            AssemblySymbol containingAssembly,
+            ImmutableArray<string> elementNames)
+        {
+            return DecodeTupleTypesInternal(metadataType, containingAssembly, elementNames, hasTupleElementNamesAttribute: !elementNames.IsDefaultOrEmpty);
+        }
+
+        private static TypeSymbol DecodeTupleTypesInternal(TypeSymbol metadataType, AssemblySymbol containingAssembly, ImmutableArray<string> elementNames, bool hasTupleElementNamesAttribute)
+        {
+            Debug.Assert((object)metadataType != null);
+            Debug.Assert((object)containingAssembly != null);
+
+            var decoder = new TupleTypeDecoder(elementNames, containingAssembly);
             try
             {
                 var decoded = decoder.DecodeType(metadataType);

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(MetadataName, Hash.Combine(_containingModule, Hash.Combine(_namespaceName, arity)));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_containingType, Hash.Combine(MetadataName, arity));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as Nested;
                 return (object)other != null && string.Equals(MetadataName, other.MetadataName, StringComparison.Ordinal) &&
                     arity == other.arity &&
-                    _containingType.Equals(other._containingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+                    _containingType.Equals(other._containingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 // if ignoring dynamic, then treat dynamic the same as the type 'object'
-                if (comparison.HasFlag(TypeCompareKind.IgnoreDynamic) &&
+                if ((comparison & TypeCompareKind.IgnoreDynamic) != 0 &&
                     (object)t2 != null &&
                     t2.TypeKind == TypeKind.Dynamic &&
                     this.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Object)

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -301,7 +301,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(MetadataName, Hash.Combine(_containingModule, Hash.Combine(_namespaceName, arity)));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+            internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -309,7 +309,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 // if ignoring dynamic, then treat dynamic the same as the type 'object'
-                if (ignoreDynamic &&
+                if (comparison.HasFlag(TypeCompareKind.IgnoreDynamic) &&
                     (object)t2 != null &&
                     t2.TypeKind == TypeKind.Dynamic &&
                     this.SpecialType == Microsoft.CodeAnalysis.SpecialType.System_Object)
@@ -404,7 +404,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return Hash.Combine(_containingType, Hash.Combine(MetadataName, arity));
             }
 
-            internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+            internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
             {
                 if (ReferenceEquals(this, t2))
                 {
@@ -414,7 +414,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var other = t2 as Nested;
                 return (object)other != null && string.Equals(MetadataName, other.MetadataName, StringComparison.Ordinal) &&
                     arity == other.arity &&
-                    _containingType.Equals(other._containingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+                    _containingType.Equals(other._containingType, comparison);
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -715,7 +715,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // The checks above are supposed to handle the vast majority of cases.
-            // More complicated cases are handled in a special helper to make the common case scenario simple/fast
             return EqualsComplicatedCases(other, comparison);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NamedTypeSymbol.cs
@@ -670,7 +670,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if ((object)t2 == this) return true;
             if ((object)t2 == null) return false;
 
-            if (comparison.HasFlag(TypeCompareKind.IgnoreDynamic))
+            if ((comparison & TypeCompareKind.IgnoreDynamic) != 0)
             {
                 if (t2.TypeKind == TypeKind.Dynamic)
                 {
@@ -682,7 +682,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (comparison.HasFlag(TypeCompareKind.IgnoreTupleNames))
+            if ((comparison & TypeCompareKind.IgnoreTupleNames) != 0)
             {
                 // If ignoring tuple element names, compare underlying tuple types
                 if (t2.IsTupleType)
@@ -700,7 +700,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var otherOriginalDefinition = other.OriginalDefinition;
 
             if (((object)this == (object)thisOriginalDefinition || (object)other == (object)otherOriginalDefinition) &&
-                !(comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers)))
+                !((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0 && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers)))
             {
                 return false;
             }
@@ -715,6 +715,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // The checks above are supposed to handle the vast majority of cases.
+            // More complicated cases are handled in a special helper to make the common case scenario simple/fast (fewer locals and smaller stack frame)
             return EqualsComplicatedCases(other, comparison);
         }
 
@@ -743,7 +744,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             if (((thisIsNotConstructed || otherIsNotConstructed) &&
-                 !(comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers))) ||
+                 !((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) != 0 && (this.HasTypeArgumentsCustomModifiers || other.HasTypeArgumentsCustomModifiers))) ||
                 this.IsUnboundGenericType != other.IsUnboundGenericType)
             {
                 return false;
@@ -751,7 +752,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             bool hasTypeArgumentsCustomModifiers = this.HasTypeArgumentsCustomModifiers;
 
-            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) && hasTypeArgumentsCustomModifiers != other.HasTypeArgumentsCustomModifiers)
+            if ((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0 && hasTypeArgumentsCustomModifiers != other.HasTypeArgumentsCustomModifiers)
             {
                 return false;
             }
@@ -768,7 +769,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (!typeArguments[i].Equals(otherTypeArguments[i], comparison)) return false;
             }
 
-            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) && hasTypeArgumentsCustomModifiers)
+            if ((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0 && hasTypeArgumentsCustomModifiers)
             {
                 Debug.Assert(other.HasTypeArgumentsCustomModifiers);
                 var modifiers = this.TypeArgumentsCustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaAmbiguousCanonicalTypeSymbol.cs
@@ -75,7 +75,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaIllegalGenericInstantiationSymbol.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/NoPiaMissingCanonicalTypeSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -159,32 +159,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var result = ArrayBuilder<Symbol>.GetInstance(overriddenMembers.Length);
             foreach (var overriddenMember in overriddenMembers)
             {
-                if (IsOverrideMatchingInTupleNames(member, overriddenMember))
+                if (MemberSignatureComparer.TupleNamesMatch(member, overriddenMember))
                 {
                     result.Add(overriddenMember);
                 }
             }
 
             return result.ToImmutableAndFree();
-        }
-
-        /// <summary>
-        /// Does the overridenMember match the member in terms of tuple names (both in their return type and parameters)?
-        ///
-        /// We'll look at the result of equality without tuple names (1) and with tuple names (2).
-        /// The question is whether there is a change in tuple element names only (3). Those are overridenMembers that we'll want to keep.
-        ///
-        ///                                                        | (1) | (2) |  (3)   |
-        /// `(int a, int b) M()`     vs. `(int a, int b) M()`      | yes | yes |  keep  |
-        /// `(int a, int b) M()`     vs. `(int x, int y) M()`      | yes | no  | remove |
-        /// `void M((int a, int b))` vs. `void M((int x, int y))`  | yes | no  | remove |
-        /// `int M()`                vs. `string M()`              | no  | no  |  keep  |
-        ///
-        /// </summary>
-        internal static bool IsOverrideMatchingInTupleNames(Symbol member, Symbol overriddenMember)
-        {
-            return !MemberSignatureComparer.CSharpWithoutTupleNamesComparer.Equals(overriddenMember, member) ||
-                    MemberSignatureComparer.CSharpWithTupleNamesComparer.Equals(overriddenMember, member);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -445,7 +445,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 hiddenBuilder = hiddenAndRelatedBuilder;
             }
 
-            Debug.Assert(overriddenMembers.IsDefaultOrEmpty);
+            Debug.Assert(overriddenMembers.IsEmpty);
 
             ImmutableArray<Symbol> hiddenMembers = hiddenBuilder == null ? ImmutableArray<Symbol>.Empty : hiddenBuilder.ToImmutableAndFree();
             return OverriddenOrHiddenMembersResult.Create(overriddenMembers, hiddenMembers, runtimeOverriddenMembers);

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -159,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var result = ArrayBuilder<Symbol>.GetInstance(overriddenMembers.Length);
             foreach (var overriddenMember in overriddenMembers)
             {
-                if (MemberSignatureComparer.TupleNamesMatch(member, overriddenMember))
+                if (MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(member, overriddenMember))
                 {
                     result.Add(overriddenMember);
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/OverriddenOrHiddenMembersHelpers.cs
@@ -154,20 +154,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return OverriddenOrHiddenMembersResult.Create(overriddenMembers, hiddenMembers, runtimeOverriddenMembers);
         }
 
-        private static ImmutableArray<Symbol> RemoveOverridesWithDifferentTupleElementNames(Symbol member, ImmutableArray<Symbol> overriddenMembers)
-        {
-            var result = ArrayBuilder<Symbol>.GetInstance(overriddenMembers.Length);
-            foreach (var overriddenMember in overriddenMembers)
-            {
-                if (MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(member, overriddenMember))
-                {
-                    result.Add(overriddenMember);
-                }
-            }
-
-            return result.ToImmutableAndFree();
-        }
-
         /// <summary>
         /// In the CLI, accessors are just regular methods and their overriding/hiding rules are the same as for
         /// regular methods.  In C#, however, accessors are intimately connected with their corresponding properties.

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -229,29 +229,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(current, indirections);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
-            return this.Equals(t2 as PointerTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+            return this.Equals(t2 as PointerTypeSymbol, comparison);
         }
 
         internal bool Equals(PointerTypeSymbol other)
         {
-            return this.Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: true);
+            return this.Equals(other, TypeCompareKind.IgnoreTupleNames);
         }
 
-        private bool Equals(PointerTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        private bool Equals(PointerTypeSymbol other, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames))
+            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, comparison))
             {
                 return false;
             }
 
-            if (!ignoreCustomModifiersAndArraySizesAndLowerBounds)
+            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
             {
                 // Make sure custom modifiers are the same.
                 var mod = this.CustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -229,24 +229,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return Hash.Combine(current, indirections);
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
-            return this.Equals(t2 as PointerTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+            return this.Equals(t2 as PointerTypeSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
         }
 
         internal bool Equals(PointerTypeSymbol other)
         {
-            return this.Equals(other, false, false);
+            return this.Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: true);
         }
 
-        private bool Equals(PointerTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        private bool Equals(PointerTypeSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic))
+            if ((object)other == null || !other._pointedAtType.Equals(_pointedAtType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames))
             {
                 return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PointerTypeSymbol.cs
@@ -251,7 +251,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return false;
             }
 
-            if (!comparison.HasFlag(TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
+            if ((comparison & TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) == 0)
             {
                 // Make sure custom modifiers are the same.
                 var mod = this.CustomModifiers;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _ordinal; }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, t2))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CrefTypeParameterSymbol.cs
@@ -87,7 +87,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get { return _ordinal; }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, t2))
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 resultType = typeWithDynamic;
             }
 
-            Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)); // Same custom modifiers as source type.
+            Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
             Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.
             return resultType;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we want to retain the original (incorrect) return type to avoid hiding the return type
             // given in source.
             TypeSymbol returnTypeWithCustomModifiers = constructedSourceMethod.ReturnType;
-            if (returnType.Equals(returnTypeWithCustomModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+            if (returnType.Equals(returnTypeWithCustomModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
             {
                 returnType = CopyTypeCustomModifiers(returnTypeWithCustomModifiers, returnType, RefKind.None, destinationMethod.ContainingAssembly);
             }
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, RefKind refKind, AssemblySymbol containingAssembly)
         {
-            Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
 
             if (sourceType.ContainsTuple())
             {
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
                 TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
-                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
+                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true, ignoreTupleNames: true)); // Same custom modifiers as source type.
                 return resultType;
             }
             else
@@ -85,8 +85,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
                 TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
-                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true)); // Same custom modifiers as source type.
-                Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false)); // Same object/dynamic as destination type.
+                Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true, ignoreTupleNames: true)); // Same custom modifiers as source type.
+                Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false, ignoreTupleNames: false)); // Same object/dynamic as destination type.
                 return resultType;
             }
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // we want to retain the original (incorrect) return type to avoid hiding the return type
             // given in source.
             TypeSymbol returnTypeWithCustomModifiers = constructedSourceMethod.ReturnType;
-            if (returnType.Equals(returnTypeWithCustomModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
+            if (returnType.Equals(returnTypeWithCustomModifiers, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
             {
                 returnType = CopyTypeCustomModifiers(returnTypeWithCustomModifiers, returnType, RefKind.None, destinationMethod.ContainingAssembly);
             }
@@ -59,7 +59,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, RefKind refKind, AssemblySymbol containingAssembly)
         {
-            Debug.Assert(sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Debug.Assert(sourceType.Equals(destinationType, TypeCompareKind.AllIgnoreOptions));
 
             // NOTE: overrides can differ by object/dynamic.  If they do, we'll need to tweak newType before
             // we can use it in place of this.Type.  We do so by computing the dynamic transform flags that
@@ -68,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeSymbol typeWithDynamic = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
             TypeSymbol resultType;
-            if (destinationType.ContainsTuple() && !sourceType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
+            if (destinationType.ContainsTuple() && !sourceType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
             {
                 // We also preserve tuple names, if present and different
                 ImmutableArray<string> names = CSharpCompilation.TupleNamesEncoder.Encode(destinationType);
@@ -79,8 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 resultType = typeWithDynamic;
             }
 
-            Debug.Assert(resultType.Equals(sourceType, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: true, ignoreTupleNames: true)); // Same custom modifiers as source type.
-            Debug.Assert(resultType.Equals(destinationType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: false, ignoreTupleNames: false)); // Same object/dynamic and tuple names as destination type.
+            Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)); // Same custom modifiers as source type.
+            Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.
             return resultType;
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -59,25 +59,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <returns><paramref name="destinationType"/> with custom modifiers copied from <paramref name="sourceType"/>.</returns>
         internal static TypeSymbol CopyTypeCustomModifiers(TypeSymbol sourceType, TypeSymbol destinationType, RefKind refKind, AssemblySymbol containingAssembly)
         {
-            Debug.Assert(sourceType.Equals(destinationType, TypeCompareKind.AllIgnoreOptions));
+            // NOTE: differences in tuple names in scenarios were we'd want to copy custom modifiers are
+            // handled earlier, so this method does not have to worry about copying tuple element names
+            Debug.Assert(sourceType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic));
 
             // NOTE: overrides can differ by object/dynamic.  If they do, we'll need to tweak newType before
             // we can use it in place of this.Type.  We do so by computing the dynamic transform flags that
             // code gen uses and then passing them to the dynamic type decoder that metadata reading uses.
             ImmutableArray<bool> flags = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(destinationType, refKind);
-            TypeSymbol typeWithDynamic = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
-
-            TypeSymbol resultType;
-            if (destinationType.ContainsTuple() && !sourceType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
-            {
-                // We also preserve tuple names, if present and different
-                ImmutableArray<string> names = CSharpCompilation.TupleNamesEncoder.Encode(destinationType);
-                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeWithDynamic, containingAssembly, names);
-            }
-            else
-            {
-                resultType = typeWithDynamic;
-            }
+            TypeSymbol resultType = DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(sourceType, containingAssembly, refKind, flags);
 
             Debug.Assert(resultType.Equals(sourceType, TypeCompareKind.IgnoreDynamicAndTupleNames)); // Same custom modifiers as source type.
             Debug.Assert(resultType.Equals(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds)); // Same object/dynamic and tuple names as destination type.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_InterfaceMemberNotFound, memberLocation, implementingMember);
             }
 
-            if (!MemberSignatureComparer.TupleNamesMatch(implementingMember, implementedMember))
+            if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(implementingMember, implementedMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
                 return null;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_InterfaceMemberNotFound, memberLocation, implementingMember);
             }
 
-            if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(implementingMember, implementedMember))
+            if (!MemberSignatureComparer.DifferOnlyInTupleNames(implementingMember, implementedMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
                 return null;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -260,6 +260,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_InterfaceMemberNotFound, memberLocation, implementingMember);
             }
 
+            if (!MemberSignatureComparer.TupleNamesMatch(implementingMember, implementedMember))
+            {
+                diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
+                return null;
+            }
+
             // In constructed types, it is possible that two method signatures could differ by only ref/out
             // after substitution.  We look for this as part of explicit implementation because, if someone
             // tried to implement the ambiguous interface implicitly, we would separately raise an error about

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -260,7 +260,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 diagnostics.Add(ErrorCode.ERR_InterfaceMemberNotFound, memberLocation, implementingMember);
             }
 
-            if (!MemberSignatureComparer.DifferOnlyInTupleNames(implementingMember, implementedMember))
+            if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implementingMember, implementedMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
                 return null;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // These object are unique (per index).
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/IndexedTypeParameterSymbol.cs
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         // These object are unique (per index).
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             return ReferenceEquals(this, t2);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We do an extra check before copying the type to handle the case where the overriding
             // event (incorrectly) has a different type than the overridden event.  In such cases,
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
+            if (type.Equals(overriddenEventType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
             {
                 type = CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type, RefKind.None, containingAssembly);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We do an extra check before copying the type to handle the case where the overriding
             // event (incorrectly) has a different type than the overridden event.  In such cases,
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
             {
                 type = CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type, RefKind.None, containingAssembly);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceEventSymbol.cs
@@ -531,7 +531,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // We do an extra check before copying the type to handle the case where the overriding
             // event (incorrectly) has a different type than the overridden event.  In such cases,
             // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+            if (type.Equals(overriddenEventType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
             {
                 type = CustomModifierUtils.CopyTypeCustomModifiers(overriddenEventType, type, RefKind.None, containingAssembly);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2380,7 +2380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodMustHaveLatent, method.Locations[0], method);
                     }
-                    else if ((object)method.OtherPartOfPartial != null && !MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(method, method.OtherPartOfPartial))
+                    else if ((object)method.OtherPartOfPartial != null && !MemberSignatureComparer.DifferOnlyInTupleNames(method, method.OtherPartOfPartial))
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, method.Locations[0], method, method.OtherPartOfPartial);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2380,7 +2380,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodMustHaveLatent, method.Locations[0], method);
                     }
-                    else if ((object)method.OtherPartOfPartial != null && !MemberSignatureComparer.DifferOnlyInTupleNames(method, method.OtherPartOfPartial))
+                    else if ((object)method.OtherPartOfPartial != null && MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(method, method.OtherPartOfPartial))
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, method.Locations[0], method, method.OtherPartOfPartial);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1892,13 +1892,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int p = 0; p < op1.ParameterCount; ++p)
             {
-                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                 {
                     return false;
                 }
             }
 
-            if (!op1.ReturnType.Equals(op2.ReturnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+            if (!op1.ReturnType.Equals(op2.ReturnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
             {
                 return false;
             }
@@ -2566,7 +2566,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var propertyParamType = ((i == numParams - 1) && !getNotSet) ? propertySymbol.Type : propertyParams[i].Type;
-                if (!propertyParamType.Equals(methodParam.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                if (!propertyParamType.Equals(methodParam.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                 {
                     return false;
                 }
@@ -2584,7 +2584,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return
                 methodParams.Length == 1 &&
                 methodParams[0].RefKind == RefKind.None &&
-                eventSymbol.Type.Equals(methodParams[0].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true);
+                eventSymbol.Type.Equals(methodParams[0].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true);
         }
 
         private void AddEnumMembers(MembersAndInitializersBuilder result, EnumDeclarationSyntax syntax, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1081,8 +1081,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 Debug.Assert(s_emptyTypeMembers.Count == 0);
-                return symbols.Count > 0 ? 
-                    symbols.ToDictionary(s => s.Name, StringOrdinalComparer.Instance) : 
+                return symbols.Count > 0 ?
+                    symbols.ToDictionary(s => s.Name, StringOrdinalComparer.Instance) :
                     s_emptyTypeMembers;
             }
             finally
@@ -2379,6 +2379,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     if (method.IsPartialImplementation && (object)method.OtherPartOfPartial == null)
                     {
                         diagnostics.Add(ErrorCode.ERR_PartialMethodMustHaveLatent, method.Locations[0], method);
+                    }
+                    else if ((object)method.OtherPartOfPartial != null && !MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(method, method.OtherPartOfPartial))
+                    {
+                        diagnostics.Add(ErrorCode.ERR_PartialMethodTupleNameDifference, method.Locations[0], method, method.OtherPartOfPartial);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -2382,7 +2382,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     }
                     else if ((object)method.OtherPartOfPartial != null && !MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(method, method.OtherPartOfPartial))
                     {
-                        diagnostics.Add(ErrorCode.ERR_PartialMethodTupleNameDifference, method.Locations[0], method, method.OtherPartOfPartial);
+                        diagnostics.Add(ErrorCode.ERR_PartialMethodInconsistentTupleNames, method.Locations[0], method, method.OtherPartOfPartial);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1892,13 +1892,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             for (int p = 0; p < op1.ParameterCount; ++p)
             {
-                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                if (!op1.ParameterTypes[p].Equals(op2.ParameterTypes[p], TypeCompareKind.AllIgnoreOptions))
                 {
                     return false;
                 }
             }
 
-            if (!op1.ReturnType.Equals(op2.ReturnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+            if (!op1.ReturnType.Equals(op2.ReturnType, TypeCompareKind.AllIgnoreOptions))
             {
                 return false;
             }
@@ -2570,7 +2570,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var propertyParamType = ((i == numParams - 1) && !getNotSet) ? propertySymbol.Type : propertyParams[i].Type;
-                if (!propertyParamType.Equals(methodParam.Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                if (!propertyParamType.Equals(methodParam.Type, TypeCompareKind.AllIgnoreOptions))
                 {
                     return false;
                 }
@@ -2588,7 +2588,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return
                 methodParams.Length == 1 &&
                 methodParams[0].RefKind == RefKind.None &&
-                eventSymbol.Type.Equals(methodParams[0].Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true);
+                eventSymbol.Type.Equals(methodParams[0].Type, TypeCompareKind.AllIgnoreOptions);
         }
 
         private void AddEnumMembers(MembersAndInitializersBuilder result, EnumDeclarationSyntax syntax, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -708,7 +708,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 diagnostics.Add(ErrorCode.ERR_CantChangeRefReturnOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overridingProperty.RefKind != RefKind.None ? "not " : "");
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the ref kind is mismatched
                             }
-                            else if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                            else if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
@@ -745,7 +745,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             TypeSymbol overriddenMemberType = overriddenEvent.Type;
 
                             // Ignore custom modifiers because this diagnostic is based on the C# semantics.
-                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                            if (!overridingMemberType.Equals(overriddenMemberType, TypeCompareKind.AllIgnoreOptions))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
-                    else if (!OverriddenOrHiddenMembersHelpers.IsOverrideMatchingInTupleNames(overridingMember, overriddenMember))
+                    else if (!MemberSignatureComparer.TupleNamesMatch(overridingMember, overriddenMember))
                     {
                         diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
-                    else if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(overridingMember, overriddenMember))
+                    else if (!MemberSignatureComparer.DifferOnlyInTupleNames(overridingMember, overriddenMember))
                     {
                         diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
-                    else if (!MemberSignatureComparer.TupleNamesMatch(overridingMember, overriddenMember))
+                    else if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(overridingMember, overriddenMember))
                     {
                         diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -667,7 +667,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
-                    else if (!MemberSignatureComparer.DifferOnlyInTupleNames(overridingMember, overriddenMember))
+                    else if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(overridingMember, overriddenMember))
                     {
                         diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -667,6 +667,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         diagnostics.Add(ErrorCode.ERR_CantChangeAccessOnOverride, overridingMemberLocation, overridingMember, accessibility, overriddenMember);
                         suppressAccessors = true;
                     }
+                    else if (!OverriddenOrHiddenMembersHelpers.IsOverrideMatchingInTupleNames(overridingMember, overriddenMember))
+                    {
+                        diagnostics.Add(ErrorCode.ERR_CantChangeTupleNamesOnOverride, overridingMemberLocation, overridingMember, overriddenMember);
+                    }
                     else
                     {
                         // As in dev11, we don't compare obsoleteness to the immediately-overridden member,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol_ImplementationChecks.cs
@@ -704,7 +704,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 diagnostics.Add(ErrorCode.ERR_CantChangeRefReturnOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overridingProperty.RefKind != RefKind.None ? "not " : "");
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the ref kind is mismatched
                             }
-                            else if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                            else if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched
@@ -741,7 +741,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             TypeSymbol overriddenMemberType = overriddenEvent.Type;
 
                             // Ignore custom modifiers because this diagnostic is based on the C# semantics.
-                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                            if (!overridingMemberType.Equals(overriddenMemberType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                             {
                                 diagnostics.Add(ErrorCode.ERR_CantChangeTypeOnOverride, overridingMemberLocation, overridingMember, overriddenMember, overriddenMemberType);
                                 suppressAccessors = true; //we get really unhelpful errors from the accessor if the type is mismatched

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -264,6 +264,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     if (!interfaceLocations.ContainsKey(t))
                     {
+                        foreach (var baseInterface in baseInterfaces)
+                        {
+                            if (t.Equals(baseInterface, ignoreTupleNames: true))
+                            {
+                                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, decl.NameLocation, t, this);
+                                break;
+                            }
+                        }
+
                         baseInterfaces.Add(t);
                         interfaceLocations.Add(t, decl.NameLocation);
                     }
@@ -427,11 +436,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             if (t == baseType)
                             {
                                 diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceInBaseList, location, baseType);
-                                continue;
-                            }
-                            else if (t.Equals(baseType, ignoreTupleNames: true))
-                            {
-                                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, baseType);
                                 continue;
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -141,7 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         if (@interface.Equals(seenInterface, TypeCompareKind.IgnoreTupleNames))
                         {
-                            diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, @interface, this);
+                            diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, @interface, seenInterface, this);
                             break;
                         }
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -429,6 +429,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceInBaseList, location, baseType);
                                 continue;
                             }
+                            else if (t.Equals(baseType, ignoreTupleNames: true))
+                            {
+                                diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, baseType);
+                                continue;
+                            }
                         }
 
                         if (this.IsStatic)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceNamedTypeSymbol_Bases.cs
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     foreach (var seenInterface in seenInterfaces)
                     {
-                        if (@interface.Equals(seenInterface, ignoreTupleNames: true))
+                        if (@interface.Equals(seenInterface, TypeCompareKind.IgnoreTupleNames))
                         {
                             diagnostics.Add(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, location, @interface, this);
                             break;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // We do an extra check before copying the type to handle the case where the overriding
                     // property (incorrectly) has a different type than the overridden property.  In such cases,
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
+                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
                     {
                         _lazyType = CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType, _lazyType, RefKind.None, this.ContainingAssembly);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // We do an extra check before copying the type to handle the case where the overriding
                     // property (incorrectly) has a different type than the overridden property.  In such cases,
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true))
+                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true))
                     {
                         _lazyType = CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType, _lazyType, RefKind.None, this.ContainingAssembly);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbol.cs
@@ -255,7 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // We do an extra check before copying the type to handle the case where the overriding
                     // property (incorrectly) has a different type than the overridden property.  In such cases,
                     // we want to retain the original (incorrect) type to avoid hiding the type given in source.
-                    if (_lazyType.Equals(overriddenPropertyType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: false))
+                    if (_lazyType.Equals(overriddenPropertyType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic))
                     {
                         _lazyType = CustomModifierUtils.CopyTypeCustomModifiers(overriddenPropertyType, _lazyType, RefKind.None, this.ContainingAssembly);
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceUserDefinedOperatorSymbolBase.cs
@@ -397,12 +397,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
 
-                if (same.IsDerivedFrom(different, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics)) // tomat: ignoreDynamic should be true, but we don't want to introduce breaking change. See bug 605326.
+                if (same.IsDerivedFrom(different, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics)) // tomat: ignoreDynamic should be true, but we don't want to introduce breaking change. See bug 605326.
                 {
                     // '{0}': user-defined conversions to or from a base class are not allowed
                     diagnostics.Add(ErrorCode.ERR_ConversionWithBase, this.Locations[0], this);
                 }
-                else if (different.IsDerivedFrom(same, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics)) // tomat: ignoreDynamic should be true, but we don't want to introduce breaking change. See bug 605326.
+                else if (different.IsDerivedFrom(same, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics)) // tomat: ignoreDynamic should be true, but we don't want to introduce breaking change. See bug 605326.
                 {
                     // '{0}': user-defined conversions to or from a derived class are not allowed
                     diagnostics.Add(ErrorCode.ERR_ConversionWithDerived, this.Locations[0], this);
@@ -497,7 +497,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 // CS0559: The parameter type for ++ or -- operator must be the containing type
                 diagnostics.Add(ErrorCode.ERR_BadIncDecSignature, this.Locations[0]);
             }
-            else if (!this.ReturnType.EffectiveTypeNoUseSiteDiagnostics.IsEqualToOrDerivedFrom(parameterType, ignoreDynamic: false, useSiteDiagnostics: ref useSiteDiagnostics))
+            else if (!this.ReturnType.EffectiveTypeNoUseSiteDiagnostics.IsEqualToOrDerivedFrom(parameterType, ignoreDynamicAndTupleNames: false, useSiteDiagnostics: ref useSiteDiagnostics))
             {
                 // CS0448: The return type for ++ or -- operator must match the parameter type
                 //         or be derived from the parameter type

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedEntryPointSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var taskType = compilation.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task);
 #if DEBUG
                 HashSet<DiagnosticInfo> useSiteDiagnostics = null;
-                Debug.Assert(taskType.IsErrorType() || initializerMethod.ReturnType.IsDerivedFrom(taskType, ignoreDynamic: true, useSiteDiagnostics: ref useSiteDiagnostics));
+                Debug.Assert(taskType.IsErrorType() || initializerMethod.ReturnType.IsDerivedFrom(taskType, ignoreDynamicAndTupleNames: true, useSiteDiagnostics: ref useSiteDiagnostics));
 #endif
                 ReportUseSiteDiagnostics(taskType, diagnostics);
                 var getAwaiterMethod = taskType.IsErrorType() ?

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedIntrinsicOperatorSymbol.cs
@@ -21,17 +21,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public SynthesizedIntrinsicOperatorSymbol(TypeSymbol leftType, string name, TypeSymbol rightType, TypeSymbol returnType, bool isCheckedBuiltin)
         {
-            if (leftType.Equals(rightType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true))
+            if (leftType.Equals(rightType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
             {
                 _containingType = leftType;
             }
-            else if (rightType.Equals(returnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true))
+            else if (rightType.Equals(returnType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds))
             {
                 _containingType = rightType;
             }
             else
             {
-                Debug.Assert(leftType.Equals(returnType, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+                Debug.Assert(leftType.Equals(returnType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
                 _containingType = leftType;
             }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -196,7 +196,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private static ImmutableArray<CustomModifier> GetModifiers(ImmutableArray<ImmutableArray<CustomModifier>> modifiers, int i)
         {
-            return modifiers.IsDefaultOrEmpty? ImmutableArray<CustomModifier>.Empty: modifiers[i];
+            return modifiers.IsDefaultOrEmpty ? ImmutableArray<CustomModifier>.Empty : modifiers[i];
         }
 
         /// <summary>
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             get
             {
                 return _lazyUnderlyingDefinitionToMemberMap ??
-                    (_lazyUnderlyingDefinitionToMemberMap = ComputeDefinitionToMemberMap()); 
+                    (_lazyUnderlyingDefinitionToMemberMap = ComputeDefinitionToMemberMap());
             }
         }
 
@@ -1095,40 +1095,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic, bool ignoreTupleNames)
         {
-            if (ignoreDynamic)
+            if (ignoreTupleNames)
             {
                 if (t2?.IsTupleType == true)
                 {
                     t2 = t2.TupleUnderlyingType;
                 }
 
-                return _underlyingType.Equals(t2, ignoreCustomModifiers, ignoreDynamic);
+                return _underlyingType.Equals(t2, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames);
             }
 
-            return this.Equals(t2 as TupleTypeSymbol, ignoreCustomModifiers, ignoreDynamic);
+            return this.Equals(t2 as TupleTypeSymbol, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames);
         }
 
         internal bool Equals(TupleTypeSymbol other)
         {
-            return Equals(other, false, false);
+            return Equals(other, ignoreCustomModifiers: false, ignoreDynamic: false, ignoreTupleNames: false);
         }
 
-        private bool Equals(TupleTypeSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic)
+        private bool Equals(TupleTypeSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if ((object)other == null || !other._underlyingType.Equals(_underlyingType, ignoreCustomModifiers, ignoreDynamic))
+            if ((object)other == null || !other._underlyingType.Equals(_underlyingType, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames))
             {
                 return false;
             }
 
             // Make sure field names are the same.
-            if (!ignoreDynamic)
+            if (!ignoreTupleNames)
             {
                 if (this._elementNames.IsDefault)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1095,40 +1095,40 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
-            if (ignoreTupleNames)
+            if (comparison.HasFlag(TypeCompareKind.IgnoreTupleNames) )
             {
                 if (t2?.IsTupleType == true)
                 {
                     t2 = t2.TupleUnderlyingType;
                 }
 
-                return _underlyingType.Equals(t2, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames);
+                return _underlyingType.Equals(t2, comparison);
             }
 
-            return this.Equals(t2 as TupleTypeSymbol, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames);
+            return this.Equals(t2 as TupleTypeSymbol, comparison);
         }
 
         internal bool Equals(TupleTypeSymbol other)
         {
-            return Equals(other, ignoreCustomModifiers: false, ignoreDynamic: false, ignoreTupleNames: false);
+            return Equals(other, TypeCompareKind.ConsiderEverything);
         }
 
-        private bool Equals(TupleTypeSymbol other, bool ignoreCustomModifiers, bool ignoreDynamic, bool ignoreTupleNames)
+        private bool Equals(TupleTypeSymbol other, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, other))
             {
                 return true;
             }
 
-            if ((object)other == null || !other._underlyingType.Equals(_underlyingType, ignoreCustomModifiers, ignoreDynamic, ignoreTupleNames))
+            if ((object)other == null || !other._underlyingType.Equals(_underlyingType, comparison))
             {
                 return false;
             }
 
             // Make sure field names are the same.
-            if (!ignoreTupleNames)
+            if (!comparison.HasFlag(TypeCompareKind.IgnoreTupleNames))
             {
                 if (this._elementNames.IsDefault)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -1097,7 +1097,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
-            if (comparison.HasFlag(TypeCompareKind.IgnoreTupleNames) )
+            if ((comparison & TypeCompareKind.IgnoreTupleNames) != 0)
             {
                 if (t2?.IsTupleType == true)
                 {
@@ -1128,7 +1128,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Make sure field names are the same.
-            if (!comparison.HasFlag(TypeCompareKind.IgnoreTupleNames))
+            if ((comparison & TypeCompareKind.IgnoreTupleNames) == 0)
             {
                 if (this._elementNames.IsDefault)
                 {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -493,17 +493,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
-            return this.Equals(t2 as TypeParameterSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+            return this.Equals(t2 as TypeParameterSymbol, comparison);
         }
 
         internal bool Equals(TypeParameterSymbol other)
         {
-            return Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: false);
+            return Equals(other, TypeCompareKind.ConsiderEverything);
         }
 
-        private bool Equals(TypeParameterSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        private bool Equals(TypeParameterSymbol other, TypeCompareKind comparison)
         {
             if (ReferenceEquals(this, other))
             {
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Type parameters may be equal but not reference equal due to independent alpha renamings.
-            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
+            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, comparison);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeParameterSymbol.cs
@@ -493,17 +493,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return false;
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
-            return this.Equals(t2 as TypeParameterSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+            return this.Equals(t2 as TypeParameterSymbol, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
         }
 
         internal bool Equals(TypeParameterSymbol other)
         {
-            return Equals(other, false, false);
+            return Equals(other, ignoreCustomModifiersAndArraySizesAndLowerBounds: false, ignoreDynamic: false, ignoreTupleNames: false);
         }
 
-        private bool Equals(TypeParameterSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        private bool Equals(TypeParameterSymbol other, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if (ReferenceEquals(this, other))
             {
@@ -516,7 +516,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             // Type parameters may be equal but not reference equal due to independent alpha renamings.
-            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic);
+            return other.ContainingSymbol.ContainingType.Equals(this.ContainingSymbol.ContainingType, ignoreCustomModifiersAndArraySizesAndLowerBounds, ignoreDynamic, ignoreTupleNames);
         }
 
         public override int GetHashCode()

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var t = this.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics);
             while ((object)t != null)
             {
-                var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamicAndTupleNames) : TypeCompareKind.ConsiderEverything;
+                var comparison = ignoreDynamicAndTupleNames ? TypeCompareKind.IgnoreDynamicAndTupleNames : TypeCompareKind.ConsiderEverything;
                 if (type.Equals(t, comparison))
                 {
                     return true;
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal bool IsEqualToOrDerivedFrom(TypeSymbol type, bool ignoreDynamicAndTupleNames, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamicAndTupleNames) : TypeCompareKind.ConsiderEverything;
+            var comparison = ignoreDynamicAndTupleNames ? TypeCompareKind.IgnoreDynamicAndTupleNames : TypeCompareKind.ConsiderEverything;
             return this.Equals(type, comparison) || this.IsDerivedFrom(type, ignoreDynamicAndTupleNames, ref useSiteDiagnostics);
         }
 
@@ -1080,7 +1080,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (!MemberSignatureComparer.DifferOnlyInTupleNames(implicitImpl, interfaceMember))
+            if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implicitImpl, interfaceMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, implicitImpl.Locations[0], implicitImpl, interfaceMember);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// A comparer that treats dynamic and object as "the same" types, and also ignores tuple element names differences.
         /// </summary>
-        internal static readonly EqualityComparer<TypeSymbol> EqualsIgnoringDynamicAndTupleNamesComparer = new EqualsIgnoringComparer(TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames);
+        internal static readonly EqualityComparer<TypeSymbol> EqualsIgnoringDynamicAndTupleNamesComparer = new EqualsIgnoringComparer(TypeCompareKind.IgnoreDynamicAndTupleNames);
 
         /// <summary>
         /// The original definition of this symbol. If this symbol is constructed from another
@@ -272,7 +272,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var t = this.BaseTypeWithDefinitionUseSiteDiagnostics(ref useSiteDiagnostics);
             while ((object)t != null)
             {
-                var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) : TypeCompareKind.ConsiderEverything;
+                var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamicAndTupleNames) : TypeCompareKind.ConsiderEverything;
                 if (type.Equals(t, comparison))
                 {
                     return true;
@@ -289,7 +289,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal bool IsEqualToOrDerivedFrom(TypeSymbol type, bool ignoreDynamicAndTupleNames, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
-            var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames) : TypeCompareKind.ConsiderEverything;
+            var comparison = ignoreDynamicAndTupleNames ? (TypeCompareKind.IgnoreDynamicAndTupleNames) : TypeCompareKind.ConsiderEverything;
             return this.Equals(type, comparison) || this.IsDerivedFrom(type, ignoreDynamicAndTupleNames, ref useSiteDiagnostics);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -324,8 +324,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return RuntimeHelpers.GetHashCode(this);
         }
 
-        private sealed class EqualsIgnoringComparer : EqualityComparer<TypeSymbol>
+        internal sealed class EqualsIgnoringComparer : EqualityComparer<TypeSymbol>
         {
+            public static EqualsIgnoringComparer InstanceIgnoringTupleNames { get; } = new EqualsIgnoringComparer(TypeCompareKind.IgnoreTupleNames);
+
             private readonly TypeCompareKind _comparison;
 
             public EqualsIgnoringComparer(TypeCompareKind comparison)

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1080,7 +1080,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(implicitImpl, interfaceMember))
+            if (!MemberSignatureComparer.DifferOnlyInTupleNames(implicitImpl, interfaceMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, implicitImpl.Locations[0], implicitImpl, interfaceMember);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1079,6 +1079,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            if (!MemberSignatureComparer.TupleNamesMatch(implicitImpl, interfaceMember))
+            {
+                diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, implicitImpl.Locations[0], implicitImpl, interfaceMember);
+            }
+
             // In constructed types, it is possible to see multiple members with the same (runtime) signature.
             // Now that we know which member will implement the interface member, confirm that it is the only
             // such member.

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -1079,7 +1079,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
-            if (!MemberSignatureComparer.TupleNamesMatch(implicitImpl, interfaceMember))
+            if (!MemberSignatureComparer.TupleNamesMatchIgnoringOtherDifferences(implicitImpl, interfaceMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, implicitImpl.Locations[0], implicitImpl, interfaceMember);
             }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                          ref substitution);
 #if DEBUG
             Debug.Assert(!result ||
-                SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t1)).Equals(SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t2)), ignoreDynamic: false, ignoreTupleNames: true));
+                SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t1)).Equals(SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t2)), TypeCompareKind.IgnoreTupleNames));
 #endif
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                          ref substitution);
 #if DEBUG
             Debug.Assert(!result ||
-                SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t1)) == SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t2)));
+                SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t1)).Equals(SubstituteAllTypeParameters(substitution, new TypeWithModifiers(t2)), ignoreDynamic: false, ignoreTupleNames: true));
 #endif
             return result;
         }
@@ -143,6 +143,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         NamedTypeSymbol nt1 = (NamedTypeSymbol)t1.Type;
                         NamedTypeSymbol nt2 = (NamedTypeSymbol)t2.Type;
+
+                        if (nt1.IsTupleType)
+                        {
+                            if (!nt2.IsTupleType)
+                            {
+                                return false;
+                            }
+
+                            var t1Types = nt1.TupleUnderlyingType;
+                            var t2Types = nt2.TupleUnderlyingType;
+                            return CanUnifyHelper(new TypeWithModifiers(nt1.TupleUnderlyingType), new TypeWithModifiers(nt2.TupleUnderlyingType), ref substitution);
+                        }
 
                         if (!nt1.IsGenericType)
                         {

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -151,8 +151,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 return false;
                             }
 
-                            var t1Types = nt1.TupleUnderlyingType;
-                            var t2Types = nt2.TupleUnderlyingType;
                             return CanUnifyHelper(new TypeWithModifiers(nt1.TupleUnderlyingType), new TypeWithModifiers(nt2.TupleUnderlyingType), ref substitution);
                         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithModifiers.cs
@@ -37,12 +37,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool Equals(TypeWithModifiers other)
         {
-            return Equals(other, ignoreDynamic: false);
+            return Equals(other, ignoreDynamic: false, ignoreTupleNames: false);
         }
 
-        public bool Equals(TypeWithModifiers other, bool ignoreDynamic)
+        public bool Equals(TypeWithModifiers other, bool ignoreDynamic, bool ignoreTupleNames)
         {
-            return ((object)this.Type == null ? (object)other.Type == null : this.Type.Equals(other.Type, ignoreDynamic: ignoreDynamic)) &&
+            return ((object)this.Type == null ? (object)other.Type == null : this.Type.Equals(other.Type, ignoreDynamic: ignoreDynamic, ignoreTupleNames: ignoreTupleNames)) &&
                    (this.CustomModifiers.IsDefault ?
                       other.CustomModifiers.IsDefault :
                       (!other.CustomModifiers.IsDefault && this.CustomModifiers.SequenceEqual(other.CustomModifiers)));

--- a/src/Compilers/CSharp/Portable/Symbols/TypeWithModifiers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeWithModifiers.cs
@@ -37,12 +37,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool Equals(TypeWithModifiers other)
         {
-            return Equals(other, ignoreDynamic: false, ignoreTupleNames: false);
+            return Equals(other, TypeCompareKind.ConsiderEverything);
         }
 
-        public bool Equals(TypeWithModifiers other, bool ignoreDynamic, bool ignoreTupleNames)
+        public bool Equals(TypeWithModifiers other, TypeCompareKind comparison)
         {
-            return ((object)this.Type == null ? (object)other.Type == null : this.Type.Equals(other.Type, ignoreDynamic: ignoreDynamic, ignoreTupleNames: ignoreTupleNames)) &&
+            Debug.Assert((comparison & ~TypeCompareKind.IgnoreDynamic & ~TypeCompareKind.IgnoreTupleNames) == 0);
+
+            return ((object)this.Type == null ? (object)other.Type == null : this.Type.Equals(other.Type, comparison)) &&
                    (this.CustomModifiers.IsDefault ?
                       other.CustomModifiers.IsDefault :
                       (!other.CustomModifiers.IsDefault && this.CustomModifiers.SequenceEqual(other.CustomModifiers)));

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic)
+        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
         {
             if ((object)t2 == (object)this)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/UnboundGenericType.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool Equals(TypeSymbol t2, bool ignoreCustomModifiersAndArraySizesAndLowerBounds, bool ignoreDynamic, bool ignoreTupleNames)
+        internal override bool Equals(TypeSymbol t2, TypeCompareKind comparison)
         {
             if ((object)t2 == (object)this)
             {

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -109,6 +109,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
                     {
+                        if (type.IsTupleType)
+                        {
+                            return type.TupleUnderlyingType.HasCustomModifiers(flagNonDefaultArraySizesOrLowerBounds);
+                        }
+
                         bool isDefinition = type.IsDefinition;
 
                         if (!isDefinition)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15286,33 +15286,40 @@ class Derived : Base
             var source = @"
 public class Base
 {
+    public virtual (int a, int b) M1() { return (1, 2); }
     public virtual (int a, int b) M2() { return (1, 2); }
     public virtual (int a, int b)[] M3() { return new[] { (1, 2) }; }
     public virtual System.Nullable<(int a, int b)> M4() { return (1, 2); }
     public virtual ((int a, int b) c, int d) M5() { return ((1, 2), 3); }
+    public virtual (dynamic a, dynamic b) M6() { return (1, 2); }
 }
 public class Derived : Base
 {
+    public override (int a, int b) M1() { return (1, 2); }
     public override (int notA, int notB) M2() { return (1, 2); }
     public override (int notA, int notB)[] M3() { return new[] { (1, 2) }; }
     public override System.Nullable<(int notA, int notB)> M4() { return (1, 2); }
     public override ((int notA, int notB) c, int d) M5() { return ((1, 2), 3); }
+    public override (dynamic notA, dynamic) M6() { return (1, 2); }
 }
 ";
-            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
             comp.VerifyDiagnostics(
-                // (12,44): error CS8218: 'Derived.M3()': cannot change tuple element names when overriding inherited member 'Base.M3()'
-                //     public override (int notA, int notB)[] M3() { return new[] { (1, 2) }; }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M3").WithArguments("Derived.M3()", "Base.M3()").WithLocation(12, 44),
-                // (13,59): error CS8218: 'Derived.M4()': cannot change tuple element names when overriding inherited member 'Base.M4()'
-                //     public override System.Nullable<(int notA, int notB)> M4() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M4").WithArguments("Derived.M4()", "Base.M4()").WithLocation(13, 59),
-                // (14,53): error CS8218: 'Derived.M5()': cannot change tuple element names when overriding inherited member 'Base.M5()'
-                //     public override ((int notA, int notB) c, int d) M5() { return ((1, 2), 3); }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M5").WithArguments("Derived.M5()", "Base.M5()").WithLocation(14, 53),
-                // (11,42): error CS8218: 'Derived.M2()': cannot change tuple element names when overriding inherited member 'Base.M2()'
+                // (14,42): error CS8218: 'Derived.M2()': cannot change tuple element names when overriding inherited member 'Base.M2()'
                 //     public override (int notA, int notB) M2() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M2").WithArguments("Derived.M2()", "Base.M2()").WithLocation(11, 42)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M2").WithArguments("Derived.M2()", "Base.M2()").WithLocation(14, 42),
+                // (15,44): error CS8218: 'Derived.M3()': cannot change tuple element names when overriding inherited member 'Base.M3()'
+                //     public override (int notA, int notB)[] M3() { return new[] { (1, 2) }; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M3").WithArguments("Derived.M3()", "Base.M3()").WithLocation(15, 44),
+                // (16,59): error CS8218: 'Derived.M4()': cannot change tuple element names when overriding inherited member 'Base.M4()'
+                //     public override System.Nullable<(int notA, int notB)> M4() { return (1, 2); }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M4").WithArguments("Derived.M4()", "Base.M4()").WithLocation(16, 59),
+                // (17,53): error CS8218: 'Derived.M5()': cannot change tuple element names when overriding inherited member 'Base.M5()'
+                //     public override ((int notA, int notB) c, int d) M5() { return ((1, 2), 3); }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M5").WithArguments("Derived.M5()", "Base.M5()").WithLocation(17, 53),
+                // (18,45): error CS8218: 'Derived.M6()': cannot change tuple element names when overriding inherited member 'Base.M6()'
+                //     public override (dynamic notA, dynamic) M6() { return (1, 2); }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M6").WithArguments("Derived.M6()", "Base.M6()").WithLocation(18, 45)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5463,13 +5463,13 @@ class C
             var tuple4 = (TypeSymbol)comp.CreateTupleTypeSymbol((INamedTypeSymbol)tuple1.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "a", "b"));
 
             Assert.True(tuple1.Equals(tuple2));
-            Assert.True(tuple1.Equals(tuple2, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(tuple1.Equals(tuple2, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             Assert.False(tuple1.Equals(tuple3));
-            Assert.True(tuple1.Equals(tuple3, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(tuple1.Equals(tuple3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             Assert.False(tuple1.Equals(tuple4));
-            Assert.True(tuple1.Equals(tuple4, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(tuple1.Equals(tuple4, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
         }
 
         [Fact]
@@ -8675,12 +8675,12 @@ class C
         private static void AssertTupleTypeEquality(TypeSymbol tuple)
         {
             Assert.True(tuple.Equals(tuple));
-            Assert.True(tuple.Equals(tuple, false, ignoreDynamic: false, ignoreTupleNames: false));
-            Assert.True(tuple.Equals(tuple, false, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.False(tuple.Equals(tuple.TupleUnderlyingType, ignoreDynamic: false, ignoreTupleNames: false));
-            Assert.False(tuple.TupleUnderlyingType.Equals(tuple, ignoreDynamic: false, ignoreTupleNames: false));
-            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, false, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, false, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(tuple.Equals(tuple, TypeCompareKind.ConsiderEverything));
+            Assert.True(tuple.Equals(tuple, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.False(tuple.Equals(tuple.TupleUnderlyingType, TypeCompareKind.ConsiderEverything));
+            Assert.False(tuple.TupleUnderlyingType.Equals(tuple, TypeCompareKind.ConsiderEverything));
+            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
             var members = tuple.GetMembers();
 
@@ -10413,16 +10413,16 @@ namespace System
                 var t5 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("b", "a"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t5, false, true, true));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2"));
@@ -10432,20 +10432,20 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, false, true, true));
-                Assert.True(t6.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("Item2", "Item1"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t6, false, true, true));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
             }
 
@@ -10465,16 +10465,16 @@ namespace System
                                                   ImmutableArray.Create("a", "b", "c", "d", "e", "f", "g", "i", "h"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t5, false, true, true));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
@@ -10486,21 +10486,21 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, false, true, true));
-                Assert.True(t6.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
                                     ImmutableArray.Create("Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item9", "Item8"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t6, false, true, true));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
 
                 var t9 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
@@ -10519,12 +10519,12 @@ namespace System
 
                 Assert.False(t1.Equals(t11));
                 AssertTupleTypeMembersEquality(t1, t11);
-                Assert.True(t1.Equals(t11, false, true, true));
-                Assert.True(t11.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t11, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t11.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 Assert.False(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType));
-                Assert.True(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType, false, true, true));
+                Assert.True(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 Assert.False(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType));
-                Assert.True(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, false, true, true));
+                Assert.True(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
                 AssertTestDisplayString(t11.GetMembers(),
                     "System.Int32 ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, (System.Int32 a, System.Int32 b)>.Item1",
@@ -10576,12 +10576,12 @@ namespace System
 
                 Assert.False(t1.Equals(t12));
                 AssertTupleTypeMembersEquality(t1, t12);
-                Assert.True(t1.Equals(t12, false, true, true));
-                Assert.True(t12.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t12, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t12.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 Assert.False(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType));
-                Assert.True(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType, false, true, true));
+                Assert.True(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 Assert.False(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType));
-                Assert.True(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, false, true, true));
+                Assert.True(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
 
                 AssertTestDisplayString(t12.GetMembers(),
                     "System.Int32 (System.Int32 Item1, System.Int32 Item2, System.Int32 Item3, System.Int32 Item4, System.Int32 Item5, System.Int32 Item6, System.Int32 Item7, System.Int32 Item8, System.Int32 Item9).Item1",
@@ -10647,16 +10647,16 @@ namespace System
                 var t5 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("c", "b", "a"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, false, true, true));
-                Assert.True(t3.Equals(t5, false, true, true));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2", "Item3"));
@@ -10666,20 +10666,20 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, false, true, true));
-                Assert.True(t6.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("Item2", "Item3", "Item1"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t1, false, true, true));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, false, true, true));
-                Assert.True(t8.Equals(t6, false, true, true));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15281,7 +15281,7 @@ class Derived : Base
         }
 
         [Fact]
-        public void OverridenMethodWithDifferentTupleNamesInReturn()
+        public void OverriddenMethodWithDifferentTupleNamesInReturn()
         {
             var source = @"
 public class Base
@@ -15638,7 +15638,7 @@ public class C : I0
         }
 
         [Fact]
-        public void InterfaceHiddingAnotherInterfaceWithDifferentTupleNames()
+        public void InterfaceHidingAnotherInterfaceWithDifferentTupleNames()
         {
             var source = @"
 public interface I0

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15927,6 +15927,46 @@ public class C4<T2> : I0<(int a, int b)>, I0<(T2 a, T2 b)> { }
         }
 
         [Fact]
+        public void AmbiguousExtensionMethodWithDifferentTupleNames()
+        {
+            var source = @"
+public static class C1
+{
+    public static void M(this string self, (int, int) x) { System.Console.Write($""C1.M({x}) ""); }
+}
+public static class C2
+{
+    public static void M(this string self, (int a, int b) x) { System.Console.Write($""C2.M({x}) ""); }
+}
+public static class C3
+{
+    public static void M(this string self, (int c, int d) x) { System.Console.Write($""C3.M({x}) ""); }
+}
+public class D
+{
+    public static void Main()
+    {
+        ""string"".M((1, 1));
+        ""string"".M((a: 1, b: 1));
+        ""string"".M((c: 1, d: 1));
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef, SystemCoreRef });
+            comp.VerifyDiagnostics(
+                // (18,18): error CS0121: The call is ambiguous between the following methods or properties: 'C1.M(string, (int, int))' and 'C2.M(string, (int a, int b))'
+                //         "string".M((1, 1));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C1.M(string, (int, int))", "C2.M(string, (int a, int b))").WithLocation(18, 18),
+                // (19,18): error CS0121: The call is ambiguous between the following methods or properties: 'C1.M(string, (int, int))' and 'C2.M(string, (int a, int b))'
+                //         "string".M((a: 1, b: 1));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C1.M(string, (int, int))", "C2.M(string, (int a, int b))").WithLocation(19, 18),
+                // (20,18): error CS0121: The call is ambiguous between the following methods or properties: 'C1.M(string, (int, int))' and 'C2.M(string, (int a, int b))'
+                //         "string".M((c: 1, d: 1));
+                Diagnostic(ErrorCode.ERR_AmbigCall, "M").WithArguments("C1.M(string, (int, int))", "C2.M(string, (int a, int b))").WithLocation(20, 18)
+                );
+        }
+
+        [Fact]
         public void InheritFromMetadataWithDifferentNames()
         {
             const string ilSource = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15721,9 +15721,9 @@ public class C3 : I0<int>, I0<int> { }
                 // (4,39): error CS0528: 'I0<(int a, int b)>' is already listed in interface list
                 // public class C2 : I0<(int a, int b)>, I0<(int a, int b)> { }
                 Diagnostic(ErrorCode.ERR_DuplicateInterfaceInBaseList, "I0<(int a, int b)>").WithArguments("I0<(int a, int b)>").WithLocation(4, 39),
-                // (3,14): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C1'.
+                // (3,14): error CS8219: 'I0<(int notA, int notB)>' is already listed in the interface list on type 'C1' with different tuple element names, as 'I0<(int a, int b)>'.
                 // public class C1 : I0<(int a, int b)>, I0<(int notA, int notB)> { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C1").WithArguments("I0<(int notA, int notB)>", "C1").WithLocation(3, 14)
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C1").WithArguments("I0<(int notA, int notB)>", "I0<(int a, int b)>", "C1").WithLocation(3, 14)
                 );
         }
 
@@ -15847,12 +15847,12 @@ public partial class D : I0<(int a, int b)> { }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (3,22): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C'.
+                // (3,22): error CS8219: 'I0<(int notA, int notB)>' is already listed in the interface list on type 'C' with different tuple element names, as 'I0<(int a, int b)>'.
                 // public partial class C : I0<(int a, int b)> { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "C").WithLocation(3, 22),
-                // (3,22): error CS8219: 'I0<(int, int)>' is already listed in interface list with different tuple element names, on type 'C'.
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "I0<(int a, int b)>", "C").WithLocation(3, 22),
+                // (3,22): error CS8219: 'I0<(int, int)>' is already listed in the interface list on type 'C' with different tuple element names, as 'I0<(int a, int b)>'.
                 // public partial class C : I0<(int a, int b)> { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int, int)>", "C").WithLocation(3, 22)
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int, int)>", "I0<(int a, int b)>", "C").WithLocation(3, 22)
                 );
         }
 
@@ -15893,9 +15893,9 @@ public class D : I1, I3 { }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (7,14): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C'.
+                // (7,14): error CS8219: 'I0<(int notA, int notB)>' is already listed in the interface list on type 'C' with different tuple element names, as 'I0<(int a, int b)>'.
                 // public class C : I1, I2 { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "C").WithLocation(7, 14)
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "I0<(int a, int b)>", "C").WithLocation(7, 14)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15383,12 +15383,18 @@ public class Derived : Base
                 // (12,44): error CS8218: 'Derived.P2': cannot change tuple element names when overriding inherited member 'Base.P2'
                 //     public override (int notA, int notB)[] P2 { get; set; }
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P2").WithArguments("Derived.P2", "Base.P2").WithLocation(12, 44),
+                // (12,49): error CS8218: 'Derived.P2.get': cannot change tuple element names when overriding inherited member 'Base.P2.get'
+                //     public override (int notA, int notB)[] P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("Derived.P2.get", "Base.P2.get").WithLocation(12, 49),
                 // (12,54): error CS8218: 'Derived.P2.set': cannot change tuple element names when overriding inherited member 'Base.P2.set'
                 //     public override (int notA, int notB)[] P2 { get; set; }
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P2.set", "Base.P2.set").WithLocation(12, 54),
                 // (13,43): error CS8218: 'Derived.P3': cannot change tuple element names when overriding inherited member 'Base.P3'
                 //     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P3").WithArguments("Derived.P3", "Base.P3").WithLocation(13, 43),
+                // (13,48): error CS8218: 'Derived.P3.get': cannot change tuple element names when overriding inherited member 'Base.P3.get'
+                //     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("Derived.P3.get", "Base.P3.get").WithLocation(13, 48),
                 // (13,71): error CS8218: 'Derived.P3.set': cannot change tuple element names when overriding inherited member 'Base.P3.set'
                 //     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P3.set", "Base.P3.set").WithLocation(13, 71),
@@ -15421,25 +15427,54 @@ using System;
 public class Base
 {
     public virtual event Func<(int a, int b)> E1;
-    //public virtual (int a, int b) P1 { get { return (1, 2); } set { } }
-    //public virtual (int a, int b)[] P2 { get; set; }
-    //public virtual (int a, int b)? P3 { get { return (1, 2); } set { } }
-    //public virtual ((int a, int b) c, int d) P4 { get; set; }
+    public virtual event Func<(int a, int b)> E2;
+    public virtual event Func<(int a, int b)[]> E3;
+    public virtual event Func<((int a, int b) c, int d)> E4;
+
+    void M() { E1(); E2(); E3(); E4(); }
 }
 public class Derived : Base
 {
     public override event Func<(int a, int b)> E1;
-    //public override (int notA, int notB) P1 { get { return (1, 2); } set { } }
-    //public override (int notA, int notB)[] P2 { get; set; }
-    //public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
-    //public override ((int notA, int notB) c, int d) P4 { get; set; }
+    public override event Func<(int notA, int notB)> E2;
+    public override event Func<(int notA, int notB)[]> E3;
+    public override event Func<((int notA, int) c, int d)> E4;
+
+    void M() { E1(); E2(); E3(); E4(); }
 }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // TODO: wrong error
+                // (15,54): error CS8218: 'Derived.E2': cannot change tuple element names when overriding inherited member 'Base.E2'
+                //     public override event Func<(int notA, int notB)> E2;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E2").WithArguments("Derived.E2", "Base.E2").WithLocation(15, 54),
+                // (15,54): error CS8218: 'Derived.E2.add': cannot change tuple element names when overriding inherited member 'Base.E2.add'
+                //     public override event Func<(int notA, int notB)> E2;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E2").WithArguments("Derived.E2.add", "Base.E2.add").WithLocation(15, 54),
+                // (15,54): error CS8218: 'Derived.E2.remove': cannot change tuple element names when overriding inherited member 'Base.E2.remove'
+                //     public override event Func<(int notA, int notB)> E2;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E2").WithArguments("Derived.E2.remove", "Base.E2.remove").WithLocation(15, 54),
+                // (16,56): error CS8218: 'Derived.E3': cannot change tuple element names when overriding inherited member 'Base.E3'
+                //     public override event Func<(int notA, int notB)[]> E3;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E3").WithArguments("Derived.E3", "Base.E3").WithLocation(16, 56),
+                // (16,56): error CS8218: 'Derived.E3.add': cannot change tuple element names when overriding inherited member 'Base.E3.add'
+                //     public override event Func<(int notA, int notB)[]> E3;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E3").WithArguments("Derived.E3.add", "Base.E3.add").WithLocation(16, 56),
+                // (16,56): error CS8218: 'Derived.E3.remove': cannot change tuple element names when overriding inherited member 'Base.E3.remove'
+                //     public override event Func<(int notA, int notB)[]> E3;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E3").WithArguments("Derived.E3.remove", "Base.E3.remove").WithLocation(16, 56),
+                // (17,60): error CS8218: 'Derived.E4': cannot change tuple element names when overriding inherited member 'Base.E4'
+                //     public override event Func<((int notA, int) c, int d)> E4;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E4").WithArguments("Derived.E4", "Base.E4").WithLocation(17, 60),
+                // (17,60): error CS8218: 'Derived.E4.add': cannot change tuple element names when overriding inherited member 'Base.E4.add'
+                //     public override event Func<((int notA, int) c, int d)> E4;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E4").WithArguments("Derived.E4.add", "Base.E4.add").WithLocation(17, 60),
+                // (17,60): error CS8218: 'Derived.E4.remove': cannot change tuple element names when overriding inherited member 'Base.E4.remove'
+                //     public override event Func<((int notA, int) c, int d)> E4;
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "E4").WithArguments("Derived.E4.remove", "Base.E4.remove").WithLocation(17, 60)
                 );
         }
+
         [Fact]
         public void HiddenMethodsWithDifferentTupleNames()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4174,7 +4174,7 @@ class C : I
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (9,40): error CS8220: The tuple element names in the signature of method 'C.M((string, string))' must match the tuple element names of interface method 'I.M((string, string))'.
+                // (9,40): error CS8220: The tuple element names in the signature of method 'C.M((string, string))' must match the tuple element names of interface method 'I.M((string, string))' (including on the return type).
                 //     public System.ValueTuple<int, int> M(System.ValueTuple<string, string> a)
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M((string, string))", "I.M((string, string))").WithLocation(9, 40)
                 );
@@ -5463,13 +5463,13 @@ class C
             var tuple4 = (TypeSymbol)comp.CreateTupleTypeSymbol((INamedTypeSymbol)tuple1.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "a", "b"));
 
             Assert.True(tuple1.Equals(tuple2));
-            Assert.True(tuple1.Equals(tuple2, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple1.Equals(tuple2, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             Assert.False(tuple1.Equals(tuple3));
-            Assert.True(tuple1.Equals(tuple3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple1.Equals(tuple3, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             Assert.False(tuple1.Equals(tuple4));
-            Assert.True(tuple1.Equals(tuple4, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple1.Equals(tuple4, TypeCompareKind.IgnoreDynamicAndTupleNames));
         }
 
         [Fact]
@@ -8304,15 +8304,15 @@ class D : C, I<(int a, int b), (int c, int d)>
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
+                // (9,49): error CS8220: The tuple element names in the signature of method 'C.M(((int, int), (int, int)))' must match the tuple element names of interface method 'I<(int b, int a), (int a, int b)>.M(((int b, int a) paramA, (int a, int b) paramB))' (including on the return type).
+                //     public virtual ((int, int) x, (int, int) y) M(((int, int), (int, int)) x)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M(((int, int), (int, int)))", "I<(int b, int a), (int a, int b)>.M(((int b, int a) paramA, (int a, int b) paramB))").WithLocation(9, 49),
                 // (17,54): error CS8218: 'D.M(((int a, int b), (int b, int a)))': cannot change tuple element names when overriding inherited member 'C.M(((int, int), (int, int)))'
                 //     public override ((int b, int a), (int b, int a)) M(((int a, int b), (int b, int a)) y)
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M(((int a, int b), (int b, int a)))", "C.M(((int, int), (int, int)))").WithLocation(17, 54),
-                // (17,54): error CS8220: The tuple element names in the signature of method 'D.M(((int a, int b), (int b, int a)))' must match the tuple element names of interface method 'I<(int a, int b), (int c, int d)>.M(((int a, int b) paramA, (int c, int d) paramB))'.
+                // (17,54): error CS8220: The tuple element names in the signature of method 'D.M(((int a, int b), (int b, int a)))' must match the tuple element names of interface method 'I<(int a, int b), (int c, int d)>.M(((int a, int b) paramA, (int c, int d) paramB))' (including on the return type).
                 //     public override ((int b, int a), (int b, int a)) M(((int a, int b), (int b, int a)) y)
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("D.M(((int a, int b), (int b, int a)))", "I<(int a, int b), (int c, int d)>.M(((int a, int b) paramA, (int c, int d) paramB))").WithLocation(17, 54),
-                // (9,49): error CS8220: The tuple element names in the signature of method 'C.M(((int, int), (int, int)))' must match the tuple element names of interface method 'I<(int b, int a), (int a, int b)>.M(((int b, int a) paramA, (int a, int b) paramB))'.
-                //     public virtual ((int, int) x, (int, int) y) M(((int, int), (int, int)) x)
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M(((int, int), (int, int)))", "I<(int b, int a), (int a, int b)>.M(((int b, int a) paramA, (int a, int b) paramB))").WithLocation(9, 49)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("D.M(((int a, int b), (int b, int a)))", "I<(int a, int b), (int c, int d)>.M(((int a, int b) paramA, (int c, int d) paramB))").WithLocation(17, 54)
                 );
         }
 
@@ -8676,11 +8676,11 @@ class C
         {
             Assert.True(tuple.Equals(tuple));
             Assert.True(tuple.Equals(tuple, TypeCompareKind.ConsiderEverything));
-            Assert.True(tuple.Equals(tuple, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple.Equals(tuple, TypeCompareKind.IgnoreDynamicAndTupleNames));
             Assert.False(tuple.Equals(tuple.TupleUnderlyingType, TypeCompareKind.ConsiderEverything));
             Assert.False(tuple.TupleUnderlyingType.Equals(tuple, TypeCompareKind.ConsiderEverything));
-            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, TypeCompareKind.IgnoreDynamicAndTupleNames));
+            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
             var members = tuple.GetMembers();
 
@@ -10413,16 +10413,16 @@ namespace System
                 var t5 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("b", "a"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2"));
@@ -10432,20 +10432,20 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m1Tuple.TupleUnderlyingType, ImmutableArray.Create("Item2", "Item1"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
             }
 
@@ -10465,16 +10465,16 @@ namespace System
                                                   ImmutableArray.Create("a", "b", "c", "d", "e", "f", "g", "i", "h"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
@@ -10486,21 +10486,21 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
                                     ImmutableArray.Create("Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item9", "Item8"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
 
                 var t9 = TupleTypeSymbol.Create(m2Tuple.TupleUnderlyingType,
@@ -10519,12 +10519,12 @@ namespace System
 
                 Assert.False(t1.Equals(t11));
                 AssertTupleTypeMembersEquality(t1, t11);
-                Assert.True(t1.Equals(t11, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t11.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t11, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t11.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 Assert.False(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType));
-                Assert.True(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.TupleUnderlyingType.Equals(t11.TupleUnderlyingType, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 Assert.False(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType));
-                Assert.True(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t11.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
                 AssertTestDisplayString(t11.GetMembers(),
                     "System.Int32 ValueTuple<System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, System.Int32, (System.Int32 a, System.Int32 b)>.Item1",
@@ -10576,12 +10576,12 @@ namespace System
 
                 Assert.False(t1.Equals(t12));
                 AssertTupleTypeMembersEquality(t1, t12);
-                Assert.True(t1.Equals(t12, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t12.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t12, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t12.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 Assert.False(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType));
-                Assert.True(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.TupleUnderlyingType.Equals(t12.TupleUnderlyingType, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 Assert.False(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType));
-                Assert.True(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t12.TupleUnderlyingType.Equals(t1.TupleUnderlyingType, TypeCompareKind.IgnoreDynamicAndTupleNames));
 
                 AssertTestDisplayString(t12.GetMembers(),
                     "System.Int32 (System.Int32 Item1, System.Int32 Item2, System.Int32 Item3, System.Int32 Item4, System.Int32 Item5, System.Int32 Item6, System.Int32 Item7, System.Int32 Item8, System.Int32 Item9).Item1",
@@ -10647,16 +10647,16 @@ namespace System
                 var t5 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("c", "b", "a"));
 
                 Assert.False(t1.Equals(t3));
-                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t3);
 
                 Assert.True(t3.Equals(t4));
                 AssertTupleTypeMembersEquality(t3, t4);
 
                 Assert.False(t5.Equals(t3));
-                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t5.Equals(t3, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t3.Equals(t5, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t5, t3);
 
                 var t6 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("Item1", "Item2", "Item3"));
@@ -10666,20 +10666,20 @@ namespace System
                 AssertTupleTypeMembersEquality(t6, t7);
 
                 Assert.False(t1.Equals(t6));
-                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t6.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t6);
 
                 var t8 = TupleTypeSymbol.Create(m3Tuple.TupleUnderlyingType, ImmutableArray.Create("Item2", "Item3", "Item1"));
 
                 Assert.False(t1.Equals(t8));
-                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t1.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t1, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t1, t8);
 
                 Assert.False(t6.Equals(t8));
-                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
-                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                Assert.True(t6.Equals(t8, TypeCompareKind.IgnoreDynamicAndTupleNames));
+                Assert.True(t8.Equals(t6, TypeCompareKind.IgnoreDynamicAndTupleNames));
                 AssertTupleTypeMembersEquality(t6, t8);
             }
         }
@@ -15610,16 +15610,16 @@ public class C : I0
 
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (12,13): error CS8220: The tuple element names in the signature of method 'C.M2((int notA, int notB))' must match the tuple element names of interface method 'I0.M2((int a, int b))'.
+                // (12,13): error CS8220: The tuple element names in the signature of method 'C.M2((int notA, int notB))' must match the tuple element names of interface method 'I0.M2((int a, int b))' (including on the return type).
                 //     void I0.M2((int notA, int notB) z) { }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M2").WithArguments("C.M2((int notA, int notB))", "I0.M2((int a, int b))").WithLocation(12, 13),
-                // (13,32): error CS8220: The tuple element names in the signature of method 'C.MR1()' must match the tuple element names of interface method 'I0.MR1()'.
+                // (13,32): error CS8220: The tuple element names in the signature of method 'C.MR1()' must match the tuple element names of interface method 'I0.MR1()' (including on the return type).
                 //     (int notMissing, int b) I0.MR1() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR1").WithArguments("C.MR1()", "I0.MR1()").WithLocation(13, 32),
-                // (14,29): error CS8220: The tuple element names in the signature of method 'C.MR2()' must match the tuple element names of interface method 'I0.MR2()'.
+                // (14,29): error CS8220: The tuple element names in the signature of method 'C.MR2()' must match the tuple element names of interface method 'I0.MR2()' (including on the return type).
                 //     (int notA, int notB) I0.MR2() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR2").WithArguments("C.MR2()", "I0.MR2()").WithLocation(14, 29),
-                // (11,13): error CS8220: The tuple element names in the signature of method 'C.M1((int notMissing, int b))' must match the tuple element names of interface method 'I0.M1((int, int b))'.
+                // (11,13): error CS8220: The tuple element names in the signature of method 'C.M1((int notMissing, int b))' must match the tuple element names of interface method 'I0.M1((int, int b))' (including on the return type).
                 //     void I0.M1((int notMissing, int b) z) { }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M1").WithArguments("C.M1((int notMissing, int b))", "I0.M1((int, int b))").WithLocation(11, 13),
                 // (9,18): error CS0535: 'C' does not implement interface member 'I0.MR2()'
@@ -15790,10 +15790,10 @@ public class D2 : D1, I0<(int notA, int notB)>
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (20,17): error CS8220: The tuple element names in the signature of method 'D1.set((int notA, int notB))' must match the tuple element names of interface method 'I0<(int a, int b)>.set((int a, int b))'.
+                // (20,17): error CS8220: The tuple element names in the signature of method 'D1.set((int notA, int notB))' must match the tuple element names of interface method 'I0<(int a, int b)>.set((int a, int b))' (including on the return type).
                 //     public void set((int notA, int notB) y) { }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "set").WithArguments("D1.set((int notA, int notB))", "I0<(int a, int b)>.set((int a, int b))").WithLocation(20, 17),
-                // (19,33): error CS8220: The tuple element names in the signature of method 'D1.get()' must match the tuple element names of interface method 'I0<(int a, int b)>.get()'.
+                // (19,33): error CS8220: The tuple element names in the signature of method 'D1.get()' must match the tuple element names of interface method 'I0<(int a, int b)>.get()' (including on the return type).
                 //     public (int notA, int notB) get() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "get").WithArguments("D1.get()", "I0<(int a, int b)>.get()").WithLocation(19, 33),
                 // (25,10): error CS0540: 'D2.I0<(int a, int b)>.set((int a, int b))': containing type does not implement interface 'I0<(int a, int b)>'
@@ -15826,10 +15826,10 @@ public partial class C
             comp.VerifyDiagnostics(
                 // (4,18): error CS8221: Both partial method declarations, 'C.M1((int a, int b))' and 'C.M1((int notA, int notB))', must use the same tuple element names.
                 //     partial void M1((int a, int b) x);
-                Diagnostic(ErrorCode.ERR_PartialMethodTupleNameDifference, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(4, 18),
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M1").WithArguments("C.M1((int a, int b))", "C.M1((int notA, int notB))").WithLocation(4, 18),
                 // (5,18): error CS8221: Both partial method declarations, 'C.M2((int a, int b))' and 'C.M2((int, int))', must use the same tuple element names.
                 //     partial void M2((int a, int b) x);
-                Diagnostic(ErrorCode.ERR_PartialMethodTupleNameDifference, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(5, 18)
+                Diagnostic(ErrorCode.ERR_PartialMethodInconsistentTupleNames, "M2").WithArguments("C.M2((int a, int b))", "C.M2((int, int))").WithLocation(5, 18)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15679,5 +15679,26 @@ public class C : I0<(int a, int b)>
                 Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "get").WithArguments("C.get()", "I0<(int a, int b)>.get()").WithLocation(9, 33)
                 );
         }
+
+        [Fact]
+        public void PartialMethodsWithDifferentTupleNames()
+        {
+            var source = @"
+public partial class C
+{
+    partial void set((int a, int b) y);
+}
+public partial class C
+{
+    partial void set((int notA, int notB) y) { }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (4,18): error CS8221: Both partial method declarations, 'C.set((int a, int b))' and 'C.set((int notA, int notB))', must use the same tuple element names.
+                //     partial void set((int a, int b) y);
+                Diagnostic(ErrorCode.ERR_PartialMethodTupleNameDifference, "set").WithArguments("C.set((int a, int b))", "C.set((int notA, int notB))").WithLocation(4, 18)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -4312,9 +4312,9 @@ class D : C
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (11,36): error CS0115: 'D.M((int g, int h))': no suitable method found to override
+                // (11,36): error CS8218: 'D.M((int g, int h))': cannot change tuple element names when overriding inherited member 'C.M((int c, int d))'
                 //     public override (int e, int f) M((int g, int h) y)
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M").WithArguments("D.M((int g, int h))").WithLocation(11, 36)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M((int g, int h))", "C.M((int c, int d))").WithLocation(11, 36)
                 );
         }
 
@@ -8307,12 +8307,12 @@ class D : C, I<(int a, int b), (int c, int d)>
     }
 }
 ";
-
+            // TODO: there should be an error on C.M()
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (17,54): error CS0115: 'D.M(((int a, int b), (int b, int a)))': no suitable method found to override
+                // (17,54): error CS8218: 'D.M(((int a, int b), (int b, int a)))': cannot change tuple element names when overriding inherited member 'C.M(((int, int), (int, int)))'
                 //     public override ((int b, int a), (int b, int a)) M(((int a, int b), (int b, int a)) y)
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M").WithArguments("D.M(((int a, int b), (int b, int a)))").WithLocation(17, 54)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("D.M(((int a, int b), (int b, int a)))", "C.M(((int, int), (int, int)))").WithLocation(17, 54)
                 );
         }
 
@@ -8678,9 +8678,9 @@ class C
             Assert.True(tuple.Equals(tuple, false, ignoreDynamic: false, ignoreTupleNames: false));
             Assert.True(tuple.Equals(tuple, false, ignoreDynamic: true, ignoreTupleNames: true));
             Assert.False(tuple.Equals(tuple.TupleUnderlyingType, ignoreDynamic: false, ignoreTupleNames: false));
-            Assert.False(tuple.TupleUnderlyingType.Equals(tuple,  ignoreDynamic:false, ignoreTupleNames:false));
-            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, false,  ignoreDynamic:true, ignoreTupleNames:true));
-            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, false,  ignoreDynamic:true, ignoreTupleNames:true));
+            Assert.False(tuple.TupleUnderlyingType.Equals(tuple, ignoreDynamic: false, ignoreTupleNames: false));
+            Assert.True(tuple.Equals(tuple.TupleUnderlyingType, false, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(tuple.TupleUnderlyingType.Equals(tuple, false, ignoreDynamic: true, ignoreTupleNames: true));
 
             var members = tuple.GetMembers();
 
@@ -15301,18 +15301,18 @@ public class Derived : Base
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (12,44): error CS0115: 'Derived.M3()': no suitable method found to override
+                // (12,44): error CS8218: 'Derived.M3()': cannot change tuple element names when overriding inherited member 'Base.M3()'
                 //     public override (int notA, int notB)[] M3() { return new[] { (1, 2) }; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M3").WithArguments("Derived.M3()").WithLocation(12, 44),
-                // (13,59): error CS0115: 'Derived.M4()': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M3").WithArguments("Derived.M3()", "Base.M3()").WithLocation(12, 44),
+                // (13,59): error CS8218: 'Derived.M4()': cannot change tuple element names when overriding inherited member 'Base.M4()'
                 //     public override System.Nullable<(int notA, int notB)> M4() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("Derived.M4()").WithLocation(13, 59),
-                // (14,53): error CS0115: 'Derived.M5()': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M4").WithArguments("Derived.M4()", "Base.M4()").WithLocation(13, 59),
+                // (14,53): error CS8218: 'Derived.M5()': cannot change tuple element names when overriding inherited member 'Base.M5()'
                 //     public override ((int notA, int notB) c, int d) M5() { return ((1, 2), 3); }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M5").WithArguments("Derived.M5()").WithLocation(14, 53),
-                // (11,42): error CS0115: 'Derived.M2()': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M5").WithArguments("Derived.M5()", "Base.M5()").WithLocation(14, 53),
+                // (11,42): error CS8218: 'Derived.M2()': cannot change tuple element names when overriding inherited member 'Base.M2()'
                 //     public override (int notA, int notB) M2() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M2").WithArguments("Derived.M2()").WithLocation(11, 42)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M2").WithArguments("Derived.M2()", "Base.M2()").WithLocation(11, 42)
                 );
         }
 
@@ -15337,18 +15337,18 @@ public class Derived : Base
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (12,26): error CS0115: 'Derived.M2((int notA, int notB)[])': no suitable method found to override
+                // (12,26): error CS8218: 'Derived.M2((int notA, int notB)[])': cannot change tuple element names when overriding inherited member 'Base.M2((int a, int b)[])'
                 //     public override void M2((int notA, int notB)[] x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M2").WithArguments("Derived.M2((int notA, int notB)[])").WithLocation(12, 26),
-                // (13,26): error CS0115: 'Derived.M3((int notA, int notB)?)': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M2").WithArguments("Derived.M2((int notA, int notB)[])", "Base.M2((int a, int b)[])").WithLocation(12, 26),
+                // (13,26): error CS8218: 'Derived.M3((int notA, int notB)?)': cannot change tuple element names when overriding inherited member 'Base.M3((int a, int b)?)'
                 //     public override void M3(System.Nullable<(int notA, int notB)> x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M3").WithArguments("Derived.M3((int notA, int notB)?)").WithLocation(13, 26),
-                // (14,26): error CS0115: 'Derived.M4(((int notA, int notB) c, int d))': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M3").WithArguments("Derived.M3((int notA, int notB)?)", "Base.M3((int a, int b)?)").WithLocation(13, 26),
+                // (14,26): error CS8218: 'Derived.M4(((int notA, int notB) c, int d))': cannot change tuple element names when overriding inherited member 'Base.M4(((int a, int b) c, int d))'
                 //     public override void M4(((int notA, int notB) c, int d) x) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M4").WithArguments("Derived.M4(((int notA, int notB) c, int d))").WithLocation(14, 26),
-                // (11,26): error CS0115: 'Derived.M1((int notA, int notB))': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M4").WithArguments("Derived.M4(((int notA, int notB) c, int d))", "Base.M4(((int a, int b) c, int d))").WithLocation(14, 26),
+                // (11,26): error CS8218: 'Derived.M1((int notA, int notB))': cannot change tuple element names when overriding inherited member 'Base.M1((int a, int b))'
                 //     public override void M1((int notA, int notB) y) { }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "M1").WithArguments("Derived.M1((int notA, int notB))").WithLocation(11, 26)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M1").WithArguments("Derived.M1((int notA, int notB))", "Base.M1((int a, int b))").WithLocation(11, 26)
                 );
         }
 
@@ -15358,14 +15358,14 @@ public class Derived : Base
             var source = @"
 public class Base
 {
-    public virtual (int a, int b) P1 { get; set; }
+    public virtual (int a, int b) P1 { get { return (1, 2); } set { } }
     public virtual (int a, int b)[] P2 { get; set; }
     public virtual (int a, int b)? P3 { get { return (1, 2); } set { } }
     public virtual ((int a, int b) c, int d) P4 { get; set; }
 }
 public class Derived : Base
 {
-    public override (int notA, int notB) P1 { get; set; }
+    public override (int notA, int notB) P1 { get { return (1, 2); } set { } }
     public override (int notA, int notB)[] P2 { get; set; }
     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
     public override ((int notA, int notB) c, int d) P4 { get; set; }
@@ -15373,18 +15373,36 @@ public class Derived : Base
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (12,44): error CS0115: 'Derived.P2': no suitable method found to override
+                // (12,44): error CS8218: 'Derived.P2': cannot change tuple element names when overriding inherited member 'Base.P2'
                 //     public override (int notA, int notB)[] P2 { get; set; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "P2").WithArguments("Derived.P2").WithLocation(12, 44),
-                // (13,43): error CS0115: 'Derived.P3': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P2").WithArguments("Derived.P2", "Base.P2").WithLocation(12, 44),
+                // (12,54): error CS8218: 'Derived.P2.set': cannot change tuple element names when overriding inherited member 'Base.P2.set'
+                //     public override (int notA, int notB)[] P2 { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P2.set", "Base.P2.set").WithLocation(12, 54),
+                // (13,43): error CS8218: 'Derived.P3': cannot change tuple element names when overriding inherited member 'Base.P3'
                 //     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "P3").WithArguments("Derived.P3").WithLocation(13, 43),
-                // (14,53): error CS0115: 'Derived.P4': no suitable method found to override
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P3").WithArguments("Derived.P3", "Base.P3").WithLocation(13, 43),
+                // (13,71): error CS8218: 'Derived.P3.set': cannot change tuple element names when overriding inherited member 'Base.P3.set'
+                //     public override (int notA, int notB)? P3 { get { return (1, 2); } set { } }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P3.set", "Base.P3.set").WithLocation(13, 71),
+                // (14,53): error CS8218: 'Derived.P4': cannot change tuple element names when overriding inherited member 'Base.P4'
                 //     public override ((int notA, int notB) c, int d) P4 { get; set; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "P4").WithArguments("Derived.P4").WithLocation(14, 53),
-                // (11,42): error CS0115: 'Derived.P1': no suitable method found to override
-                //     public override (int notA, int notB) P1 { get; set; }
-                Diagnostic(ErrorCode.ERR_OverrideNotExpected, "P1").WithArguments("Derived.P1").WithLocation(11, 42)
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P4").WithArguments("Derived.P4", "Base.P4").WithLocation(14, 53),
+                // (14,58): error CS8218: 'Derived.P4.get': cannot change tuple element names when overriding inherited member 'Base.P4.get'
+                //     public override ((int notA, int notB) c, int d) P4 { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("Derived.P4.get", "Base.P4.get").WithLocation(14, 58),
+                // (14,63): error CS8218: 'Derived.P4.set': cannot change tuple element names when overriding inherited member 'Base.P4.set'
+                //     public override ((int notA, int notB) c, int d) P4 { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P4.set", "Base.P4.set").WithLocation(14, 63),
+                // (11,42): error CS8218: 'Derived.P1': cannot change tuple element names when overriding inherited member 'Base.P1'
+                //     public override (int notA, int notB) P1 { get { return (1, 2); } set { } }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P1").WithArguments("Derived.P1", "Base.P1").WithLocation(11, 42),
+                // (11,47): error CS8218: 'Derived.P1.get': cannot change tuple element names when overriding inherited member 'Base.P1.get'
+                //     public override (int notA, int notB) P1 { get { return (1, 2); } set { } }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("Derived.P1.get", "Base.P1.get").WithLocation(11, 47),
+                // (11,70): error CS8218: 'Derived.P1.set': cannot change tuple element names when overriding inherited member 'Base.P1.set'
+                //     public override (int notA, int notB) P1 { get { return (1, 2); } set { } }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("Derived.P1.set", "Base.P1.set").WithLocation(11, 70)
                 );
         }
 
@@ -15498,6 +15516,88 @@ public class Derived : Base
                 // (11,17): warning CS0114: 'Derived.M1((int notA, int notB))' hides inherited member 'Base.M1((int a, int b))'. To make the current member override that implementation, add the override keyword. Otherwise add the new keyword.
                 //     public void M1((int notA, int notB) y) { }
                 Diagnostic(ErrorCode.WRN_NewOrOverrideExpected, "M1").WithArguments("Derived.M1((int notA, int notB))", "Base.M1((int a, int b))").WithLocation(11, 17)
+                );
+        }
+
+        [Fact]
+        public void NamesDontMatterInInterfaceImplementation()
+        {
+            var source = @"
+public interface I0
+{
+    void M1((int a, int b) x);
+    void M2((int a, int b) x);
+    (int a, int b) MR1();
+    (int a, int b) MR2();
+}
+public class C : I0
+{
+    public void M1((int a, int b) z) { }
+    public void M2((int notA, int notB) z) { }
+    public (int a, int b) MR1() { return (1, 2); }
+    public (int notA, int notB) MR2() { return (1, 2); }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NamesDontMatterInHiddingInterfaceMethods()
+        {
+            var source = @"
+public interface I0
+{
+    void M1((int a, int b) x);
+    void M2((int a, int b) x);
+    void M3((int a, int b) x);
+    void M4((int a, int b) x);
+    (int a, int b) M5();
+    (int a, int b) M6();
+}
+public interface I1 : I0
+{
+    void M1((int notA, int notB) x);
+    void M2((int a, int b) x);
+    new void M3((int a, int b) x);
+    new void M4((int notA, int notB) x);
+    (int notA, int notB) M5();
+    (int a, int b) M6();
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (18,20): warning CS0108: 'I1.M6()' hides inherited member 'I0.M6()'. Use the new keyword if hiding was intended.
+                //     (int a, int b) M6();
+                Diagnostic(ErrorCode.WRN_NewRequired, "M6").WithArguments("I1.M6()", "I0.M6()").WithLocation(18, 20),
+                // (14,10): warning CS0108: 'I1.M2((int a, int b))' hides inherited member 'I0.M2((int a, int b))'. Use the new keyword if hiding was intended.
+                //     void M2((int a, int b) x);
+                Diagnostic(ErrorCode.WRN_NewRequired, "M2").WithArguments("I1.M2((int a, int b))", "I0.M2((int a, int b))").WithLocation(14, 10),
+                // (17,26): warning CS0108: 'I1.M5()' hides inherited member 'I0.M5()'. Use the new keyword if hiding was intended.
+                //     (int notA, int notB) M5();
+                Diagnostic(ErrorCode.WRN_NewRequired, "M5").WithArguments("I1.M5()", "I0.M5()").WithLocation(17, 26),
+                // (13,10): warning CS0108: 'I1.M1((int notA, int notB))' hides inherited member 'I0.M1((int a, int b))'. Use the new keyword if hiding was intended.
+                //     void M1((int notA, int notB) x);
+                Diagnostic(ErrorCode.WRN_NewRequired, "M1").WithArguments("I1.M1((int notA, int notB))", "I0.M1((int a, int b))").WithLocation(13, 10)
+                );
+        }
+
+        [Fact]
+        public void NamesDontMatterInDuplicateInterfaceDetection()
+        {
+            var source = @"
+public interface I0<T> { }
+public class C : I0<(int a, int b)>, I0<(int notA, int notB)> { }
+public class D : I0<int>, I0<int> { }
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (4,27): error CS0528: 'I0<int>' is already listed in interface list
+                // public class D : I0<int>, I0<int> { }
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceInBaseList, "I0<int>").WithArguments("I0<int>").WithLocation(4, 27),
+                // (3,38): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names
+                // public class C : I0<(int a, int b)>, I0<(int notA, int notB)> { }
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "I0<(int notA, int notB)>").WithArguments("I0<(int notA, int notB)>").WithLocation(3, 38)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -15800,12 +15800,12 @@ public partial class D : I0<(int a, int b)> { }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (4,22): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C'.
-                // public partial class C : I0<(int notA, int notB)> { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "C").WithLocation(4, 22),
-                // (5,22): error CS8219: 'I0<(int, int)>' is already listed in interface list with different tuple element names, on type 'C'.
-                // public partial class C : I0<(int, int)> { }
-                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int, int)>", "C").WithLocation(5, 22)
+                // (3,22): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C'.
+                // public partial class C : I0<(int a, int b)> { }
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "C").WithLocation(3, 22),
+                // (3,22): error CS8219: 'I0<(int, int)>' is already listed in interface list with different tuple element names, on type 'C'.
+                // public partial class C : I0<(int a, int b)> { }
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int, int)>", "C").WithLocation(3, 22)
                 );
         }
 
@@ -15846,14 +15846,15 @@ public class D : I1, I3 { }
 ";
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // TODO: should be error
+                // (7,14): error CS8219: 'I0<(int notA, int notB)>' is already listed in interface list with different tuple element names, on type 'C'.
+                // public class C : I1, I2 { }
+                Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C").WithArguments("I0<(int notA, int notB)>", "C").WithLocation(7, 14)
                 );
         }
 
         [Fact]
         public void InheritFromMetadataWithDifferentNames()
         {
-
             const string ilSource = @"
 .assembly extern mscorlib { }
 .assembly extern System.ValueTuple

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -240,41 +240,41 @@ class X {
             string s = f7Type.ToTestDisplayString();
 
             Assert.False(f1Type.Equals(f2Type));
-            Assert.True(f1Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f2Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f1Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f2Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f1Type.Equals(f2Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f2Type.Equals(f1Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f1Type.Equals(f1Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f2Type.Equals(f2Type, TypeCompareKind.AllIgnoreOptions));
 
             Assert.False(f3Type.Equals(f4Type));
-            Assert.True(f3Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f4Type.Equals(f3Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.False(f4Type.Equals(f5Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.False(f5Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f3Type.Equals(f4Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f4Type.Equals(f3Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.False(f4Type.Equals(f5Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.False(f5Type.Equals(f4Type, TypeCompareKind.AllIgnoreOptions));
 
             Assert.False(f6Type.Equals(f7Type));
             Assert.False(f6Type.Equals(f8Type));
             Assert.False(f7Type.Equals(f8Type));
-            Assert.True(f6Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f7Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f8Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f7Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f8Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f6Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f6Type.Equals(f7Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f7Type.Equals(f6Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f6Type.Equals(f6Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f7Type.Equals(f7Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f8Type.Equals(f7Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f7Type.Equals(f8Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f8Type.Equals(f8Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f7Type.Equals(f7Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f8Type.Equals(f6Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f6Type.Equals(f8Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f8Type.Equals(f8Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(f6Type.Equals(f6Type, TypeCompareKind.AllIgnoreOptions));
 
-            Assert.False(f9Type.Equals(f10Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.False(f10Type.Equals(f9Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.False(f9Type.Equals(f10Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.False(f10Type.Equals(f9Type, TypeCompareKind.AllIgnoreOptions));
 
             Assert.False(g1Type.Equals(g2Type));
-            Assert.True(g1Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(g2Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(g1Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
-            Assert.True(g2Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(g1Type.Equals(g2Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(g2Type.Equals(g1Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(g1Type.Equals(g1Type, TypeCompareKind.AllIgnoreOptions));
+            Assert.True(g2Type.Equals(g2Type, TypeCompareKind.AllIgnoreOptions));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/ConversionTests.cs
@@ -240,41 +240,41 @@ class X {
             string s = f7Type.ToTestDisplayString();
 
             Assert.False(f1Type.Equals(f2Type));
-            Assert.True(f1Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f2Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f1Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f2Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f1Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f2Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f1Type.Equals(f1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f2Type.Equals(f2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
 
             Assert.False(f3Type.Equals(f4Type));
-            Assert.True(f3Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f4Type.Equals(f3Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.False(f4Type.Equals(f5Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.False(f5Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f3Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f4Type.Equals(f3Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.False(f4Type.Equals(f5Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.False(f5Type.Equals(f4Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
 
             Assert.False(f6Type.Equals(f7Type));
             Assert.False(f6Type.Equals(f8Type));
             Assert.False(f7Type.Equals(f8Type));
-            Assert.True(f6Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(f6Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f7Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f8Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f7Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f7Type.Equals(f7Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f8Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f6Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f8Type.Equals(f8Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(f6Type.Equals(f6Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
 
-            Assert.False(f9Type.Equals(f10Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.False(f10Type.Equals(f9Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.False(f9Type.Equals(f10Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.False(f10Type.Equals(f9Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
 
             Assert.False(g1Type.Equals(g2Type));
-            Assert.True(g1Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(g2Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(g1Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
-            Assert.True(g2Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true));
+            Assert.True(g1Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(g2Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(g1Type.Equals(g1Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
+            Assert.True(g2Type.Equals(g2Type, ignoreCustomModifiersAndArraySizesAndLowerBounds: true, ignoreDynamic: true, ignoreTupleNames: true));
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/CustomModifiersTests.cs
@@ -187,7 +187,7 @@ class CL3
             var withoutModifiers = withModifiers.OriginalDefinition.Construct(withModifiers.TypeArguments);
             Assert.True(withModifiers.HasTypeArgumentsCustomModifiers);
             Assert.False(withoutModifiers.HasTypeArgumentsCustomModifiers);
-            Assert.True(withoutModifiers.Equals(withModifiers, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Assert.True(withoutModifiers.Equals(withModifiers, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
             Assert.NotEqual(withoutModifiers, withModifiers);
 
             CompileAndVerify(compilation, expectedOutput: "Overridden");
@@ -799,11 +799,11 @@ class Module1
 
             Assert.True(base1.HasTypeArgumentsCustomModifiers);
             Assert.True(base2.HasTypeArgumentsCustomModifiers);
-            Assert.True(base1.Equals(base2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Assert.True(base1.Equals(base2, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
             Assert.NotEqual(base1, base2);
 
             Assert.True(base3.HasTypeArgumentsCustomModifiers);
-            Assert.True(base1.Equals(base3, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Assert.True(base1.Equals(base3, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
             Assert.Equal(base1, base3);
             Assert.NotSame(base1, base3);
         }
@@ -1687,8 +1687,8 @@ Implemented B");
             Assert.False(t1.Equals(t2));
             Assert.False(t2.Equals(t1));
 
-            Assert.True(t1.Equals(t2, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
-            Assert.True(t2.Equals(t1, ignoreCustomModifiersAndArraySizesAndLowerBounds: true));
+            Assert.True(t1.Equals(t2, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
+            Assert.True(t2.Equals(t1, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds));
         }
 
         [Fact, WorkItem(7674, "https://github.com/dotnet/roslyn/issues/7674")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -820,16 +820,13 @@ class C : I
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]
-        public void TupleWithCustomModifiersInInterface()
+        public void TupleWithCustomModifiersInInterfaceMethod()
         {
             var il = @"
 .assembly extern mscorlib { .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 34 E0 89) }
 .assembly extern System.Core {}
 .assembly extern System.ValueTuple { .publickeytoken = (CC 7B 13 FF CD 2D DD 51 ) .ver 4:0:1:0 }
-
-.assembly '<<GeneratedFileName>>'
-{
-}
+.assembly '<<GeneratedFileName>>' { }
 
 .class interface public abstract auto ansi I
 {
@@ -853,20 +850,23 @@ class C : I
 }
 ";
             var ilRef = CompileIL(il, appendDefaultHeader: false);
-            var comp = CreateCompilation(source1, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
-            comp.VerifyDiagnostics();
+            var comp1 = CreateCompilation(source1, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp1.VerifyDiagnostics();
 
-            var global = comp.GlobalNamespace;
-            var interfaceMethod = global.GetMember<MethodSymbol>("I.M");
-            var classMethod = global.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
+            var interfaceMethod1 = comp1.GlobalNamespace.GetMember<MethodSymbol>("I.M");
+            var classMethod1 = comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
 
-            Assert.Equal("(System.Object a, System.Object b) I.M((System.Object c, System.Object d) x)", interfaceMethod.ToTestDisplayString());
+            Assert.Equal("(System.Object a, System.Object b) I.M((System.Object c, System.Object d) x)", interfaceMethod1.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    interfaceMethod.ReturnType.TupleUnderlyingType.ToTestDisplayString());
-
-            Assert.Equal("(System.Object a, System.Object b) C.I.M((System.Object c, System.Object d) x)", classMethod.ToTestDisplayString());
+                    interfaceMethod1.ReturnType.TupleUnderlyingType.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
-                    classMethod.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+                    interfaceMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
+            Assert.Equal("(System.Object a, System.Object b) C.I.M((System.Object c, System.Object d) x)", classMethod1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod1.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
 
             var source2 = @"
 class C : I
@@ -884,6 +884,12 @@ class C : I
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.M((object c, object d))").WithLocation(2, 11)
                 );
 
+            var classMethod2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
+
+            Assert.Equal("(System.Object a, System.Object b) C.M((System.Object, System.Object) x)", classMethod2.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod2.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
             var source3 = @"
 class C : I
 {
@@ -899,6 +905,309 @@ class C : I
                 // class C : I
                 Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.M((object c, object d))").WithLocation(2, 11)
                 );
+
+            var classMethod3 = comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
+
+            Assert.Equal("(System.Object, System.Object) C.M((System.Object c, System.Object d) x)", classMethod3.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod3.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>",
+                    classMethod3.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
+            var source4 = @"
+class C : I
+{
+    public (object a, object b) M((object c, object d) x) { return x; }
+}
+";
+            var comp4 = CreateCompilation(source4, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp4.VerifyDiagnostics();
+
+            var classMethod4 = comp4.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("M");
+
+            Assert.Equal("(System.Object a, System.Object b) C.M((System.Object c, System.Object d) x)", classMethod4.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod4.ReturnType.TupleUnderlyingType.ToTestDisplayString()); // modopts not copied
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod4.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString()); // modopts not copied
+        }
+
+        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        public void TupleWithCustomModifiersInInterfaceProperty()
+        {
+            var il = @"
+.assembly extern mscorlib { .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 34 E0 89) }
+.assembly extern System.Core {}
+.assembly extern System.ValueTuple { .publickeytoken = (CC 7B 13 FF CD 2D DD 51 ) .ver 4:0:1:0 }
+.assembly '<<GeneratedFileName>>' { }
+
+.class interface public abstract auto ansi I
+{
+  .method public hidebysig newslot specialname abstract virtual
+          instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong), object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
+          get_P() cil managed
+  {
+    .param [0]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+  } // end of method I::get_P
+
+  .method public hidebysig newslot specialname abstract virtual
+          instance void  set_P(class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong), object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> 'value') cil managed
+  {
+    .param [1]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+  } // end of method I::set_P
+
+  .property instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong), object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
+          P()
+  {
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+    .get instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> I::get_P()
+    .set instance void I::set_P(class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>)
+  } // end of property I::P
+} // end of class I
+";
+
+            var source1 = @"
+class C : I
+{
+    (object a, object b) I.P { get; set; }
+}
+";
+            var ilRef = CompileIL(il, appendDefaultHeader: false);
+            var comp1 = CreateCompilation(source1, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp1.VerifyDiagnostics();
+
+            var interfaceProperty1 = comp1.GlobalNamespace.GetMember<PropertySymbol>("I.P");
+            var classProperty1 = comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("I.P");
+
+            Assert.Equal("(System.Object a, System.Object b) I.P { get; set; }", interfaceProperty1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    interfaceProperty1.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            Assert.Equal("(System.Object a, System.Object b) C.I.P { get; set; }", classProperty1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classProperty1.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            var source2 = @"
+class C : I
+{
+    (object, object) I.P { get; set; }
+}
+";
+            var comp2 = CreateCompilation(source2, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp2.VerifyDiagnostics(
+                // (4,24): error CS8220: The tuple element names in the signature of method 'C.P' must match the tuple element names of interface method 'I.P' (including on the return type).
+                //     (object, object) I.P { get; set; }
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "P").WithArguments("C.P", "I.P").WithLocation(4, 24),
+                // (2,11): error CS0535: 'C' does not implement interface member 'I.P'
+                // class C : I
+                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.P").WithLocation(2, 11)
+                );
+
+            var classProperty2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("I.P");
+
+            Assert.Equal("(System.Object, System.Object) C.P { get; set; }", classProperty2.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classProperty2.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            var source3 = @"
+class C : I
+{
+    public (object a, object b) P { get; set; }
+}
+";
+            var comp3 = CreateCompilation(source3, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp3.VerifyDiagnostics();
+
+            var classProperty3 = comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("P");
+
+            Assert.Equal("(System.Object a, System.Object b) C.P { get; set; }", classProperty3.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classProperty3.Type.TupleUnderlyingType.ToTestDisplayString());
+        }
+
+        [ClrOnlyFact(ClrOnlyReason.Ilasm)]
+        public void TupleWithCustomModifiersInOverride()
+        {
+            // This IL is based on this code, but with modopts added
+            //public class Base
+            //{
+            //    public virtual (object a, object b) P { get; set; }
+            //    public virtual (object a, object b) M((object c, object d) x) { return x; }
+            //}
+
+            var il = @"
+.assembly extern mscorlib { .ver 4:0:0:0 .publickeytoken = (B7 7A 5C 56 19 34 E0 89) }
+.assembly extern System.Core {}
+.assembly extern System.ValueTuple { .publickeytoken = (CC 7B 13 FF CD 2D DD 51 ) .ver 4:0:1:0 }
+.assembly '<<GeneratedFileName>>' { }
+
+.class public auto ansi beforefieldinit Base
+       extends [mscorlib]System.Object
+{
+  .field private class [System.ValueTuple]System.ValueTuple`2<object,object> '<P>k__BackingField'
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+  .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+  .custom instance void [mscorlib]System.Diagnostics.DebuggerBrowsableAttribute::.ctor(valuetype [mscorlib]System.Diagnostics.DebuggerBrowsableState) = ( 01 00 00 00 00 00 00 00 )
+  .method public hidebysig newslot specialname virtual
+          instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
+          get_P() cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+    .param [0]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      class [System.ValueTuple]System.ValueTuple`2<object,object> Base::'<P>k__BackingField'
+    IL_0006:  ret
+  } // end of method Base::get_P
+
+  .method public hidebysig newslot specialname virtual
+          instance void  set_P(class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> 'value') cil managed
+  {
+    .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilerGeneratedAttribute::.ctor() = ( 01 00 00 00 )
+    .param [1]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  ldarg.1
+    IL_0002:  stfld      class [System.ValueTuple]System.ValueTuple`2<object,object> Base::'<P>k__BackingField'
+    IL_0007:  ret
+  } // end of method Base::set_P
+
+  .method public hidebysig newslot virtual
+          instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
+          M(class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> x) cil managed
+  {
+    .param [0]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+    .param [1]
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 63 01 64 00 00 )             // .......c.d..
+    // Code size       7 (0x7)
+    .maxstack  1
+    .locals init (class [System.ValueTuple]System.ValueTuple`2<object,object> V_0)
+    IL_0000:  nop
+    IL_0001:  ldarg.1
+    IL_0002:  stloc.0
+    IL_0003:  br.s       IL_0005
+
+    IL_0005:  ldloc.0
+    IL_0006:  ret
+  } // end of method Base::M
+
+  .method public hidebysig specialname rtspecialname
+          instance void  .ctor() cil managed
+  {
+    // Code size       8 (0x8)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0006:  nop
+    IL_0007:  ret
+  } // end of method Base::.ctor
+
+  .property instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>
+          P()
+  {
+    .custom instance void [System.ValueTuple]System.Runtime.CompilerServices.TupleElementNamesAttribute::.ctor(string[]) = ( 01 00 02 00 00 00 01 61 01 62 00 00 )             // .......a.b..
+    .get instance class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)> Base::get_P()
+    .set instance void Base::set_P(class [System.ValueTuple]System.ValueTuple`2<object modopt([mscorlib]System.Runtime.CompilerServices.IsLong),object modopt([mscorlib]System.Runtime.CompilerServices.IsLong)>)
+  } // end of property Base::P
+} // end of class Base
+";
+
+            var source1 = @"
+class C : Base
+{
+    public override (object a, object b) P { get; set; }
+    public override (object a, object b) M((object c, object d) y) { return y; }
+}
+";
+            var ilRef = CompileIL(il, appendDefaultHeader: false);
+            var comp1 = CreateCompilation(source1, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp1.VerifyDiagnostics();
+
+            var baseMethod1 = comp1.GlobalNamespace.GetMember<MethodSymbol>("Base.M");
+
+            Assert.Equal("(System.Object a, System.Object b) Base.M((System.Object c, System.Object d) x)", baseMethod1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    baseMethod1.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    baseMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
+            var baseProperty1 = comp1.GlobalNamespace.GetMember<PropertySymbol>("Base.P");
+
+            Assert.Equal("(System.Object a, System.Object b) Base.P { get; set; }", baseProperty1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    baseProperty1.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            var classProperty1 = comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("P");
+            var classMethod1 = comp1.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("M");
+
+            Assert.Equal("(System.Object a, System.Object b) C.P { get; set; }", classProperty1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classProperty1.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            Assert.Equal("(System.Object a, System.Object b) C.M((System.Object c, System.Object d) y)", classMethod1.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod1.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod1.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
+            var source2 = @"
+class C : Base
+{
+    public override (object, object) P { get; set; }
+    public override (object, object) M((object c, object d) y) { return y; }
+}
+";
+            var comp2 = CreateCompilation(source2, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp2.VerifyDiagnostics(
+                // (5,38): error CS8218: 'C.M((object c, object d))': cannot change tuple element names when overriding inherited member 'Base.M((object c, object d))'
+                //     public override (object, object) M((object c, object d) y) { return y; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("C.M((object c, object d))", "Base.M((object c, object d))").WithLocation(5, 38),
+                // (4,38): error CS8218: 'C.P': cannot change tuple element names when overriding inherited member 'Base.P'
+                //     public override (object, object) P { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "P").WithArguments("C.P", "Base.P").WithLocation(4, 38),
+                // (4,42): error CS8218: 'C.P.get': cannot change tuple element names when overriding inherited member 'Base.P.get'
+                //     public override (object, object) P { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "get").WithArguments("C.P.get", "Base.P.get").WithLocation(4, 42),
+                // (4,47): error CS8218: 'C.P.set': cannot change tuple element names when overriding inherited member 'Base.P.set'
+                //     public override (object, object) P { get; set; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "set").WithArguments("C.P.set", "Base.P.set").WithLocation(4, 47)
+                );
+
+            var classProperty2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("P");
+            var classMethod2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("M");
+
+            Assert.Equal("(System.Object, System.Object) C.P { get; set; }", classProperty2.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>",
+                    classProperty2.Type.TupleUnderlyingType.ToTestDisplayString());
+
+            Assert.Equal("(System.Object, System.Object) C.M((System.Object c, System.Object d) y)", classMethod2.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod2.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+
+            var source3 = @"
+class C : Base
+{
+    public override (object a, object b) P { get; set; }
+    public override (object a, object b) M((object, object) y) { return y; }
+}
+";
+            var comp3 = CreateCompilation(source3, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
+            comp3.VerifyDiagnostics(
+                // (5,42): error CS8218: 'C.M((object, object))': cannot change tuple element names when overriding inherited member 'Base.M((object c, object d))'
+                //     public override (object a, object b) M((object, object) y) { return y; }
+                Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M").WithArguments("C.M((object, object))", "Base.M((object c, object d))").WithLocation(5, 42)
+                );
+
+            var classMethod3 = comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("M");
+
+            Assert.Equal("(System.Object a, System.Object b) C.M((System.Object, System.Object) y)", classMethod3.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod3.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                    classMethod3.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
         }
 
         [ClrOnlyFact(ClrOnlyReason.Ilasm)]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/TypeTests.cs
@@ -1796,7 +1796,7 @@ class Foo {
             var Func_Dynamic = (Foo.GetMembers("Z")[0] as FieldSymbol).Type;
             var Func_Object = (Foo.GetMembers("W")[0] as FieldSymbol).Type;
 
-            var comparator = TypeSymbol.EqualsIgnoringDynamicComparer;
+            var comparator = TypeSymbol.EqualsIgnoringDynamicAndTupleNamesComparer;
             Assert.NotEqual(Object, Dynamic);
             Assert.Equal(comparator.GetHashCode(Dynamic), comparator.GetHashCode(Object));
             Assert.True(comparator.Equals(Dynamic, Object));

--- a/src/Compilers/Core/Portable/CodeAnalysis.csproj
+++ b/src/Compilers/Core/Portable/CodeAnalysis.csproj
@@ -101,6 +101,7 @@
     <Compile Include="StrongName\CryptoBlobParser.cs" />
     <Compile Include="Symbols\ISourceAssemblySymbol.cs" />
     <Compile Include="Symbols\IAssemblySymbolInternal.cs" />
+    <Compile Include="Symbols\TypeCompareKind.cs" />
     <Compile Include="Syntax\SyntaxTreeComparer.cs" />
     <Compile Include="Syntax\ICompilationUnitSyntax.cs" />
     <Compile Include="Syntax\ISkippedTokensTriviaSyntax.cs" />

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis
         IgnoreCustomModifiersAndArraySizesAndLowerBounds = 1,
         IgnoreDynamic = 2,
         IgnoreTupleNames = 4,
-        IgnoreDynamicAndTupleNames = 6,
+        IgnoreDynamicAndTupleNames = IgnoreDynamic | IgnoreTupleNames,
         AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames
     }
 

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the different kinds of comparison between types.
+    /// </summary>
+    [Flags]
+    internal enum TypeCompareKind
+    {
+        ConsiderEverything = 0,
+        IgnoreCustomModifiersAndArraySizesAndLowerBounds = 1,
+        IgnoreDynamic = 2,
+        IgnoreTupleNames = 4,
+        AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames
+    }
+
+    internal static class TypeCompareKindExtension
+    {
+        public static TypeCompareKind AddIgnoreCustomModifiersAndArraySizesAndLowerBounds(this TypeCompareKind self, bool condition)
+        {
+            return condition ? (self | TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) : self;
+        }
+
+        public static TypeCompareKind AddIgnoreDynamic(this TypeCompareKind self, bool condition)
+        {
+            return condition ? (self | TypeCompareKind.IgnoreDynamic) : self;
+        }
+
+        public static TypeCompareKind AddIgnoreTupleNames(this TypeCompareKind self, bool condition)
+        {
+            return condition ? (self | TypeCompareKind.IgnoreTupleNames) : self;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
+++ b/src/Compilers/Core/Portable/Symbols/TypeCompareKind.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis
         IgnoreCustomModifiersAndArraySizesAndLowerBounds = 1,
         IgnoreDynamic = 2,
         IgnoreTupleNames = 4,
+        IgnoreDynamicAndTupleNames = 6,
         AllIgnoreOptions = IgnoreCustomModifiersAndArraySizesAndLowerBounds | IgnoreDynamic | IgnoreTupleNames
     }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -155,8 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var result = variable.ToBoundExpression(syntax);
             Debug.Assert(node.Kind == BoundKind.BaseReference
-                ? result.Type.BaseType.Equals(node.Type, ignoreDynamic: true)
-                : result.Type.Equals(node.Type, ignoreDynamic: true));
+                ? result.Type.BaseType.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true)
+                : result.Type.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true));
             return result;
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -155,8 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var result = variable.ToBoundExpression(syntax);
             Debug.Assert(node.Kind == BoundKind.BaseReference
-                ? result.Type.BaseType.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true)
-                : result.Type.Equals(node.Type, ignoreDynamic: true, ignoreTupleNames: true));
+                ? result.Type.BaseType.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)
+                : result.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
             return result;
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/CapturedVariableRewriter.cs
@@ -155,8 +155,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var result = variable.ToBoundExpression(syntax);
             Debug.Assert(node.Kind == BoundKind.BaseReference
-                ? result.Type.BaseType.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames)
-                : result.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamic | TypeCompareKind.IgnoreTupleNames));
+                ? result.Type.BaseType.Equals(node.Type, TypeCompareKind.IgnoreDynamicAndTupleNames)
+                : result.Type.Equals(node.Type, TypeCompareKind.IgnoreDynamicAndTupleNames));
             return result;
         }
 


### PR DESCRIPTION
From LDM 7/15, new errors will be introduced to when conflicting tuple element names are used across type declarations.

For instance, implementing an interface or overriding a method will give an error if the tuple element names don't match. 
```C#
interface I0<T> { T M(); }
class C : I0<(int a, int b)> { (int notA, int notB) M(); } // error
```
```C#
class Base { public virtual (int a, int b) M() { return (1, 2); }
class Derived : Base { public override (int notA, int notB) M() { return (1, 2); } }
```

This also applies to partial types and methods.
```C#
interface I0<T> { T M(); }
partial class C : I0<(int a, int b)> { ... }
partial class C : I0<(int notA, int notB)> { ... } // error
```

The core of this change is to introduce a separate parameter to the `TypeSymbol.Equals` implementations. Previously, we used `ignoreDynamic` to mean both "ignore dynamic" and "ignore tuple names".
The new signature splits them apart. It is ` bool Equals(TypeSymbol t2, bool ignoreCustomModifiers, bool ignoreDynamic, bool ignoreTupleNames)`.

In most cases, `ignoreTupleNames` gets the same value as `ignoreDynamic`, but there are a few exceptions.
For instance, the comparison for anonymous types (`AnonymousTypeDescriptor` and `AnonymousTypeManager`) always considers tuple names.

I'm planning to add more tests for custom modifiers on parameters, as the logic to transfer tuples names when copying custom modifiers (in `CopyTypeCustomModifiers`) is no longer reached after I added another upstream check.

Addresses https://github.com/dotnet/roslyn/issues/12584
Relates to #10945