### PR TITLE
Fix #12421 - Make CSharpSyntaxFactsService a singleton

### DIFF
--- a/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
+++ b/src/EditorFeatures/CSharpTest/ExtractMethod/MiscTests.cs
@@ -179,7 +179,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ExtractMethod
             {
                 Assert.Equal(typeof(TLanguageService), typeof(ISyntaxFactsService));
 
-                return (TLanguageService)((object)new CSharpSyntaxFactsService());
+                return (TLanguageService)((object)CSharpSyntaxFactsService.Instance);
             }
         }
     }

--- a/src/EditorFeatures/Test/TestExportProvider.cs
+++ b/src/EditorFeatures/Test/TestExportProvider.cs
@@ -91,7 +91,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxTreeFactoryServiceFactory), // BasicServicesCore
                 typeof(CodeAnalysis.CSharp.CodeGeneration.CSharpCodeGenerationServiceFactory),
                 typeof(CodeAnalysis.VisualBasic.CodeGeneration.VisualBasicCodeGenerationServiceFactory),
-                typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxFactsService),
+                typeof(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxFactsServiceFactory),
                 typeof(Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxFactsServiceFactory),
                 typeof(CodeAnalysis.CSharp.CSharpSymbolDeclarationService),
                 typeof(CodeAnalysis.VisualBasic.VisualBasicSymbolDeclarationService),

--- a/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
+++ b/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
@@ -184,6 +184,7 @@
     <Compile Include="LanguageServices\CSharpCompilationFactoryService.cs" />
     <Compile Include="LanguageServices\CSharpSemanticFactsService.cs" />
     <Compile Include="LanguageServices\CSharpSymbolDeclarationService.cs" />
+    <Compile Include="LanguageServices\CSharpSyntaxFactsServiceFactory.cs" />
     <Compile Include="LanguageServices\CSharpSyntaxFactsService.cs" />
     <Compile Include="LanguageServices\CSharpSyntaxTreeFactory.PathSyntaxReference.cs" />
     <Compile Include="LanguageServices\CSharpSyntaxTreeFactoryService.cs" />

--- a/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SyntaxTokenExtensions.cs
@@ -74,7 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
         private static bool IsWord(SyntaxToken token)
         {
-            return new CSharpSyntaxFactsService().IsWord(token);
+            return CSharpSyntaxFactsService.Instance.IsWord(token);
         }
 
         public static SyntaxToken GetNextNonZeroWidthTokenOrEndOfFile(this SyntaxToken token)

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsService.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Composition;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -12,7 +11,6 @@ using Microsoft.CodeAnalysis.Collections;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.Host.Mef;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
@@ -20,9 +18,14 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    [ExportLanguageService(typeof(ISyntaxFactsService), LanguageNames.CSharp), Shared]
     internal class CSharpSyntaxFactsService : AbstractSyntaxFactsService, ISyntaxFactsService
     {
+        internal static readonly CSharpSyntaxFactsService Instance = new CSharpSyntaxFactsService();
+
+        private CSharpSyntaxFactsService()
+        {
+        }
+
         public bool IsAwaitKeyword(SyntaxToken token)
         {
             return token.IsKind(SyntaxKind.AwaitKeyword);

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpSyntaxFactsServiceFactory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Host;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Microsoft.CodeAnalysis.LanguageServices;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    [ExportLanguageServiceFactory(typeof(ISyntaxFactsService), LanguageNames.CSharp), Shared]
+    internal class CSharpSyntaxFactsServiceFactory : ILanguageServiceFactory
+    {
+        public ILanguageService CreateLanguageService(HostLanguageServices languageServices)
+        {
+            return CSharpSyntaxFactsService.Instance;
+        }
+    }
+}


### PR DESCRIPTION
Closes #12421 (the C# half #12424), making `CSharpSyntaxFactsService` a singleton.