### PR TITLE
remove CodeAnalysis from a package's name

### DIFF
--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/Microsoft.CodeAnalysis.LanguageServices.vsmanproj
@@ -17,7 +17,7 @@
   <Target Name="BeforeBuild">
     <MSBuild Projects="MicrosoftCodeAnalysisExpressionEvaluator\Microsoft.CodeAnalysis.ExpressionEvaluator.swixproj" Targets="Build" />
     <MSBuild Projects="MicrosoftCodeAnalysisVisualStudioInteractiveComponents\Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swixproj" Targets="Build" />
-    <MSBuild Projects="MicrosoftCodeAnalysisVisualStudioInteractiveWindow\Microsoft.CodeAnalysis.VisualStudioInteractiveWindow.swixproj" Targets="Build" />
+    <MSBuild Projects="MicrosoftVisualStudioInteractiveWindow\Microsoft.VisualStudioInteractiveWindow.swixproj" Targets="Build" />
     <MSBuild Projects="MicrosoftCodeAnalysisVisualStudioSetup\Microsoft.CodeAnalysis.VisualStudio.Setup.swixproj" Targets="Build" />
     <MSBuild Projects="MicrosoftCodeAnalysisVisualStudioSetupInteractive\Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swixproj" Targets="Build" />
     <MSBuild Projects="MicrosoftCodeAnalysisVisualStudioSetupNext\Microsoft.CodeAnalysis.VisualStudio.Setup.Next.swixproj" Targets="Build" />
@@ -26,7 +26,7 @@
   <ItemGroup>
     <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.ExpressionEvaluator.json" />
     <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.json" />
-    <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.VisualStudioInteractiveWindow.json" />
+    <MergeManifest Include="$(OutputPath)Microsoft.VisualStudioInteractiveWindow.json" />
     <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.VisualStudio.Setup.json" />
     <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.json" />
     <MergeManifest Include="$(OutputPath)Microsoft.CodeAnalysis.VisualStudio.Setup.Next.json" />

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
@@ -19,6 +19,6 @@ vs.dependencies
   vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.Setup
                 version=[$(Version),$(NextVersion))
                 type=Required
-  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow
+  vs.dependency id=Microsoft.VisualStudio.InteractiveWindow
                 version=[$(Version),$(NextVersion))
                 type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
@@ -22,6 +22,6 @@ vs.dependencies
   vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveComponents
                 version=[$(Version),$(NextVersion))
                 type=Required
-  vs.dependency id=Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow
+  vs.dependency id=Microsoft.VisualStudio.InteractiveWindow
                 version=[$(Version),$(NextVersion))
                 type=Required

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudioInteractiveWindow.swixproj
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudioInteractiveWindow.swixproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Package Include="Microsoft.CodeAnalysis.VisualStudioInteractiveWindow.swr" />
+    <Package Include="Microsoft.VisualStudioInteractiveWindow.swr" />
   </ItemGroup>
 
   <Import Project="$(NuGetPackageRoot)\MicroBuild.Core\$(MicroBuildVersion)\build\MicroBuild.Core.targets" />

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudioInteractiveWindow.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudioInteractiveWindow.swr
@@ -1,6 +1,6 @@
 use vs
 
-package name=Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow
+package name=Microsoft.VisualStudio.InteractiveWindow
         version=$(Version)
         vs.package.chip=neutral
         vs.package.language=en-us


### PR DESCRIPTION
The Microsoft.CodeAnalysis.VisualStudio.InteractiveWindow package isn't specific to the Microsoft.CodeAnalysis.* components.

This will also require a corresponding internal change to update the other dependencies.

FYI @shyamnamboodiripad @jmarolf 