### PR TITLE
don't ngen Microsoft.CodeAnalysis.EditorFeatures.Next.dll

### DIFF
--- a/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
@@ -4,7 +4,6 @@
     <Identity Id="58293943-56F1-4734-82FC-0411DCF49DE1" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Microsoft" />
     <DisplayName>Roslyn Language Services for Visual Studio 15</DisplayName>
     <Description>C# and VB.NET language services for Visual Studio 15.</Description>
-    <ShortcutPath>..\CommonExtensions\Microsoft\ManagedLanguages\VBCSharp\LanguageServices</ShortcutPath>
   </Metadata>
   <Installation Experimental="true">
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.Pro" />
@@ -12,11 +11,6 @@
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VWDExpress" />
     <InstallationTarget Version="[15.0,]" Id="Microsoft.VisualStudio.VSWinExpress" />
   </Installation>
-  <Installer>
-    <Actions>
-      <Action Type="Ngen" Path="Microsoft.CodeAnalysis.EditorFeatures.Next.dll" />
-    </Actions>
-  </Installer>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.6,)" />
     <Dependency Version="[|VisualStudioSetup;GetBuildVersion|,]" DisplayName="Roslyn Language Services" Id="0b5e8ddb-f12d-4131-a71d-77acc26a798f" />


### PR DESCRIPTION
*This PR is identical to #12722 except against `dev15-preview-4` instead of `master`.*

The corresponding VSIX package had the same <ShortcutPath> as Microsoft.CodeAnalysis.EditorFeatures.vsix which caused some problems during setup ngen because symlinks were replaced. The .Next.dll only contains two assembly binding redirect attributes and doesn't need to be ngen'ed.

FYI @shyamnamboodiripad @jmarolf @Pilchie 