### PR TITLE
Make MethodToClassRewriter rewrite ConditionalAccess correctly

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -490,6 +490,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return node.Update(rewrittenArgument, method, node.IsExtensionMethod, type);
         }
 
+        public override BoundNode VisitLoweredConditionalAccess(BoundLoweredConditionalAccess node)
+        {
+            BoundExpression receiver = (BoundExpression)this.Visit(node.Receiver);
+            BoundExpression whenNotNull = (BoundExpression)this.Visit(node.WhenNotNull);
+            BoundExpression whenNullOpt = (BoundExpression)this.Visit(node.WhenNullOpt);
+            TypeSymbol type = this.VisitType(node.Type);
+            return node.Update(receiver, VisitMethodSymbol(node.HasValueMethodOpt), whenNotNull, whenNullOpt, node.Id, type);
+        }
+
         protected MethodSymbol VisitMethodSymbol(MethodSymbol method)
         {
             if ((object)method == null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConditionalOperatorTests.cs
@@ -2272,5 +2272,59 @@ class Class1
 ";
             CompileAndVerify(source, expectedOutput: expectedOutput).VerifyIL("Class1.Main", expectedIL);
         }
+
+        [Fact, WorkItem(12439, "https://github.com/dotnet/roslyn/issues/12439")]
+        public void GenericStructInLambda()
+        {
+            var source = @"
+using System;
+
+static class LiveList
+{
+    struct WhereInfo<TSource>
+    {
+        public int Key { get; set; }
+    }
+
+    static void Where<TSource>()
+    {
+        Action subscribe = () =>
+        {
+            WhereInfo<TSource>? previous = null;
+
+            var previousKey = previous?.Key;
+        };
+    }
+}";
+
+            CompileAndVerify(source);
+        }
+
+        [Fact, WorkItem(12439, "https://github.com/dotnet/roslyn/issues/12439")]
+        public void GenericStructInIterator()
+        {
+            var source = @"
+using System;
+using System.Collections.Generic;
+
+static class LiveList
+{
+    struct WhereInfo<TSource>
+    {
+        public int Key { get; set; }
+    }
+
+    static IEnumerable<int> Where<TSource>()
+    {
+        WhereInfo<TSource>? previous = null;
+
+        var previousKey = previous?.Key;
+
+        yield break;
+    }
+}";
+
+            CompileAndVerify(source);
+        }
     }
 }


### PR DESCRIPTION
Fixes #12439.

Before this change, the generated IL for the code in the newly added `GenericStructInLambda()` test contained (only showing the relevant lines):

```il
IL_000b: call instance bool valuetype [mscorlib]System.Nullable`1<valuetype UserQuery/WhereInfo`1<!!0>>::get_HasValue()
IL_001f: call instance !0 valuetype [mscorlib]System.Nullable`1<valuetype UserQuery/WhereInfo`1<!TSource>>::GetValueOrDefault()
```

Notice how the first line uses `!!0`, even though this is not a generic method, which caused `BadImageFormatException` and verification failure.

This happened, because `LambdaRewriter`/`MethodToClassRewriter` did not rewrite `BoundLoweredConditionalAccess.HasValueMethodOpt`, this PR fixes that.