### PR TITLE
Don't run VB enum completion after dot

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/EnumCompletionProviderTests.vb
@@ -467,6 +467,18 @@ End Class
             Await VerifyNoItemsExistAsync(markup)
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(12733, "https://github.com/dotnet/roslyn/issues/12733")>
+        Public Async Function NotAfterDot() As Task
+            Dim markup = <Text>Module Module1
+    Sub Main()
+            Do Until (System.Console.ReadKey.Key = System.ConsoleKey.$$
+        Loop
+    End Sub
+End Module</Text>.Value
+            Await VerifyNoItemsExistAsync(markup)
+        End Function
+
         Friend Overrides Function CreateCompletionProvider() As CompletionProvider
             Return New EnumCompletionProvider()
         End Function

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7511,5 +7511,20 @@ End Class
             Await VerifyItemExistsAsync(text, "x")
         End Function
 
+        <WorkItem(153633, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/153633")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function EnumMembers() As Task
+            Dim text =
+<code><![CDATA[
+Module Module1
+    Sub Main()
+        Do Until (System.Console.ReadKey.Key = System.ConsoleKey.$$
+        Loop
+    End Sub
+End Module
+]]></code>.Value
+            Await VerifyItemExistsAsync(text, "A")
+        End Function
+
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -18,6 +18,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
             End If
 
+            If context.TargetToken.IsKind(SyntaxKind.DotToken) Then
+                Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
+            End If
+
             Dim typeInferenceService = context.GetLanguageService(Of ITypeInferenceService)()
             Dim enumType = typeInferenceService.InferType(context.SemanticModel, position, objectAsDefault:=True, cancellationToken:=cancellationToken)
 
@@ -41,6 +45,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
         Protected Overrides Function GetSymbolsWorker(context As SyntaxContext, position As Integer, options As OptionSet, cancellationToken As CancellationToken) As Task(Of IEnumerable(Of ISymbol))
             If context.SyntaxTree.IsInNonUserCode(context.Position, cancellationToken) OrElse
                 context.SyntaxTree.IsInSkippedText(position, cancellationToken) Then
+                Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
+            End If
+
+            If context.TargetToken.IsKind(SyntaxKind.DotToken) Then
                 Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
             End If
 

--- a/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
+++ b/src/Features/VisualBasic/Portable/Completion/CompletionProviders/EnumCompletionProvider.vb
@@ -18,6 +18,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Completion.Providers
                 Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
             End If
 
+            ' This providers provides fully qualified names, eg "DayOfWeek.Monday"
+            ' Don't run after dot because SymbolCompletionProvider will provide
+            ' members in situations like Dim x = DayOfWeek.$$
             If context.TargetToken.IsKind(SyntaxKind.DotToken) Then
                 Return SpecializedTasks.EmptyEnumerable(Of ISymbol)()
             End If


### PR DESCRIPTION
Members after dot are now provided by SymbolCompletionProvider. Fixes #12733 

@dotnet/roslyn-ide please review