### PR TITLE
make SourceText::GetChecksum and AnalyzerTelemetry constructor public.

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
@@ -7,34 +7,55 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
     /// </summary>
     internal class AnalyzerActionCounts
     {
-        internal static AnalyzerActionCounts Empty = new AnalyzerActionCounts(AnalyzerActions.Empty);
-
-        internal static AnalyzerActionCounts Create(AnalyzerActions analyzerActions)
+        internal AnalyzerActionCounts(AnalyzerActions analyzerActions) :
+            this(
+                analyzerActions?.CompilationStartActionsCount ?? 0,
+                analyzerActions?.CompilationEndActionsCount ?? 0,
+                analyzerActions?.CompilationActionsCount ?? 0,
+                analyzerActions?.SyntaxTreeActionsCount ?? 0,
+                analyzerActions?.SemanticModelActionsCount ?? 0,
+                analyzerActions?.SymbolActionsCount ?? 0,
+                analyzerActions?.SyntaxNodeActionsCount ?? 0,
+                analyzerActions?.CodeBlockStartActionsCount ?? 0,
+                analyzerActions?.CodeBlockEndActionsCount ?? 0,
+                analyzerActions?.CodeBlockActionsCount ?? 0,
+                analyzerActions?.OperationActionsCount ?? 0,
+                analyzerActions?.OperationBlockStartActionsCount ?? 0,
+                analyzerActions?.OperationBlockEndActionsCount ?? 0,
+                analyzerActions?.OperationBlockActionsCount ?? 0)
         {
-            if (analyzerActions == null)
-            {
-                return Empty;
-            }
-
-            return new AnalyzerActionCounts(analyzerActions);
         }
 
-        private AnalyzerActionCounts(AnalyzerActions analyzerActions)
+        internal AnalyzerActionCounts(
+            int compilationStartActionsCount,
+            int compilationEndActionsCount,
+            int compilationActionsCount,
+            int syntaxTreeActionsCount,
+            int semanticModelActionsCount,
+            int symbolActionsCount,
+            int syntaxNodeActionsCount,
+            int codeBlockStartActionsCount,
+            int codeBlockEndActionsCount,
+            int codeBlockActionsCount,
+            int operationActionsCount,
+            int operationBlockStartActionsCount,
+            int operationBlockEndActionsCount,
+            int operationBlockActionsCount)
         {
-            CompilationStartActionsCount = analyzerActions.CompilationStartActionsCount;
-            CompilationEndActionsCount = analyzerActions.CompilationEndActionsCount;
-            CompilationActionsCount = analyzerActions.CompilationActionsCount;
-            SyntaxTreeActionsCount = analyzerActions.SyntaxTreeActionsCount;
-            SemanticModelActionsCount = analyzerActions.SemanticModelActionsCount;
-            SymbolActionsCount = analyzerActions.SymbolActionsCount;
-            SyntaxNodeActionsCount = analyzerActions.SyntaxNodeActionsCount;
-            CodeBlockStartActionsCount = analyzerActions.CodeBlockStartActionsCount;
-            CodeBlockEndActionsCount = analyzerActions.CodeBlockEndActionsCount;
-            CodeBlockActionsCount = analyzerActions.CodeBlockActionsCount;
-            OperationActionsCount = analyzerActions.OperationActionsCount;
-            OperationBlockStartActionsCount = analyzerActions.OperationBlockStartActionsCount;
-            OperationBlockEndActionsCount = analyzerActions.OperationBlockEndActionsCount;
-            OperationBlockActionsCount = analyzerActions.OperationBlockActionsCount;
+            CompilationStartActionsCount = compilationStartActionsCount;
+            CompilationEndActionsCount = compilationEndActionsCount;
+            CompilationActionsCount = compilationActionsCount;
+            SyntaxTreeActionsCount = syntaxTreeActionsCount;
+            SemanticModelActionsCount = semanticModelActionsCount;
+            SymbolActionsCount = symbolActionsCount;
+            SyntaxNodeActionsCount = syntaxNodeActionsCount;
+            CodeBlockStartActionsCount = codeBlockStartActionsCount;
+            CodeBlockEndActionsCount = codeBlockEndActionsCount;
+            CodeBlockActionsCount = codeBlockActionsCount;
+            OperationActionsCount = operationActionsCount;
+            OperationBlockStartActionsCount = operationBlockStartActionsCount;
+            OperationBlockEndActionsCount = operationBlockEndActionsCount;
+            OperationBlockActionsCount = operationBlockActionsCount;
 
             HasAnyExecutableCodeActions = CodeBlockActionsCount > 0 ||
                 CodeBlockStartActionsCount > 0 ||

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1302,7 +1302,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var executor = analyzerExecutor.WithCancellationToken(cancellationToken);
             var analyzerActions = await analyzerManager.GetAnalyzerActionsAsync(analyzer, executor).ConfigureAwait(false);
-            return AnalyzerActionCounts.Create(analyzerActions);
+            return new AnalyzerActionCounts(analyzerActions);
         }
 
         /// <summary>
@@ -1707,7 +1707,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var success = true;
-            
+
             // Execute stateless syntax node actions.
             if (shouldExecuteSyntaxNodeActions)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
@@ -91,5 +91,44 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
             _actionCounts = actionCounts;
             ExecutionTime = executionTime;
         }
+
+        /// <summary>
+        /// Create telemetry info for a specific analyzer, such as count of registered actions, the total execution time, etc.
+        /// </summary>
+        public AnalyzerTelemetryInfo(
+            int compilationStartActionsCount,
+            int compilationEndActionsCount,
+            int compilationActionsCount,
+            int syntaxTreeActionsCount,
+            int semanticModelActionsCount,
+            int symbolActionsCount,
+            int syntaxNodeActionsCount,
+            int codeBlockStartActionsCount,
+            int codeBlockEndActionsCount,
+            int codeBlockActionsCount,
+            int operationActionsCount,
+            int operationBlockStartActionsCount,
+            int operationBlockEndActionsCount,
+            int operationBlockActionsCount,
+            TimeSpan executionTime)
+        {
+            _actionCounts = new AnalyzerActionCounts(
+                compilationStartActionsCount,
+                compilationEndActionsCount,
+                compilationActionsCount,
+                syntaxTreeActionsCount,
+                semanticModelActionsCount,
+                symbolActionsCount,
+                syntaxNodeActionsCount,
+                codeBlockStartActionsCount,
+                codeBlockEndActionsCount,
+                codeBlockActionsCount,
+                operationActionsCount,
+                operationBlockStartActionsCount,
+                operationBlockEndActionsCount,
+                operationBlockActionsCount);
+
+            ExecutionTime = executionTime;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -661,8 +661,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableArray<AnalyzerAction> _syntaxNodeActions = ImmutableArray<AnalyzerAction>.Empty;
         private ImmutableArray<OperationAnalyzerAction> _operationActions = ImmutableArray<OperationAnalyzerAction>.Empty;
 
-        internal static readonly AnalyzerActions Empty = new AnalyzerActions();
-
         internal AnalyzerActions()
         {
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -28,6 +28,7 @@ Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.OperationB
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.Options.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.OwningSymbol.get -> Microsoft.CodeAnalysis.ISymbol
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AnalyzerTelemetryInfo(int compilationStartActionsCount, int compilationEndActionsCount, int compilationActionsCount, int syntaxTreeActionsCount, int semanticModelActionsCount, int symbolActionsCount, int syntaxNodeActionsCount, int codeBlockStartActionsCount, int codeBlockEndActionsCount, int codeBlockActionsCount, int operationActionsCount, int operationBlockStartActionsCount, int operationBlockEndActionsCount, int operationBlockActionsCount, System.TimeSpan executionTime) -> void
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockEndActionsCount.get -> int
@@ -666,6 +667,7 @@ Microsoft.CodeAnalysis.Semantics.UnaryOperationKind.UnsignedPrefixIncrement = 77
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveGenericsOptions(Microsoft.CodeAnalysis.SymbolDisplayGenericsOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveLocalOptions(Microsoft.CodeAnalysis.SymbolDisplayLocalOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveMiscellaneousOptions(Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
+Microsoft.CodeAnalysis.Text.SourceText.GetChecksum() -> System.Collections.Immutable.ImmutableArray<byte>
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -415,14 +415,11 @@ namespace Microsoft.CodeAnalysis.Text
             }
         }
 
-        internal ImmutableArray<byte> GetChecksum(bool useDefaultEncodingIfNull = false)
+        public ImmutableArray<byte> GetChecksum()
         {
             if (_lazyChecksum.IsDefault)
             {
-                // we shouldn't be asking for a checksum of encoding-less source text, except for SourceText comparison.
-                Debug.Assert(this.Encoding != null || useDefaultEncodingIfNull);
-
-                using (var stream = new SourceTextStream(this, useDefaultEncodingIfNull: useDefaultEncodingIfNull))
+                using (var stream = new SourceTextStream(this, useDefaultEncodingIfNull: true))
                 {
                     ImmutableInterlocked.InterlockedInitialize(ref _lazyChecksum, CalculateChecksum(stream, _checksumAlgorithm));
                 }

--- a/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         public int GetHashCode(SourceText obj)
         {
-            var checksum = obj.GetChecksum(useDefaultEncodingIfNull: true);
+            var checksum = obj.GetChecksum();
             var contentsHash = !checksum.IsDefault ? Hash.CombineValues(checksum) : 0;
             var encodingHash = obj.Encoding != null ? obj.Encoding.GetHashCode() : 0;
 


### PR DESCRIPTION
2 are needed for OOP work.

right now, I made one already exist public but rather I think we need to add one without parameter and only make that public.

...

AnalyzerTelemetry is just a simple data holder type. it is needed to be created once it crossed wire.

...

this is actual change among commits.
"make SourceText::GetChecksum and AnalyzerTelemetry contructor public."

https://github.com/dotnet/roslyn/pull/12757/commits/f6d610eac51f173a4c64df622c3cbb2f74e94c0c