### PR TITLE
added MustRunInProc in IBuiltInAnalyzer and some clean up around serializing Solution/Project/DocumentId and how DocumentState is exposed.

### DIFF
--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerActionCounts.cs
@@ -7,34 +7,55 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
     /// </summary>
     internal class AnalyzerActionCounts
     {
-        internal static AnalyzerActionCounts Empty = new AnalyzerActionCounts(AnalyzerActions.Empty);
-
-        internal static AnalyzerActionCounts Create(AnalyzerActions analyzerActions)
+        internal AnalyzerActionCounts(AnalyzerActions analyzerActions) :
+            this(
+                analyzerActions?.CompilationStartActionsCount ?? 0,
+                analyzerActions?.CompilationEndActionsCount ?? 0,
+                analyzerActions?.CompilationActionsCount ?? 0,
+                analyzerActions?.SyntaxTreeActionsCount ?? 0,
+                analyzerActions?.SemanticModelActionsCount ?? 0,
+                analyzerActions?.SymbolActionsCount ?? 0,
+                analyzerActions?.SyntaxNodeActionsCount ?? 0,
+                analyzerActions?.CodeBlockStartActionsCount ?? 0,
+                analyzerActions?.CodeBlockEndActionsCount ?? 0,
+                analyzerActions?.CodeBlockActionsCount ?? 0,
+                analyzerActions?.OperationActionsCount ?? 0,
+                analyzerActions?.OperationBlockStartActionsCount ?? 0,
+                analyzerActions?.OperationBlockEndActionsCount ?? 0,
+                analyzerActions?.OperationBlockActionsCount ?? 0)
         {
-            if (analyzerActions == null)
-            {
-                return Empty;
-            }
-
-            return new AnalyzerActionCounts(analyzerActions);
         }
 
-        private AnalyzerActionCounts(AnalyzerActions analyzerActions)
+        internal AnalyzerActionCounts(
+            int compilationStartActionsCount,
+            int compilationEndActionsCount,
+            int compilationActionsCount,
+            int syntaxTreeActionsCount,
+            int semanticModelActionsCount,
+            int symbolActionsCount,
+            int syntaxNodeActionsCount,
+            int codeBlockStartActionsCount,
+            int codeBlockEndActionsCount,
+            int codeBlockActionsCount,
+            int operationActionsCount,
+            int operationBlockStartActionsCount,
+            int operationBlockEndActionsCount,
+            int operationBlockActionsCount)
         {
-            CompilationStartActionsCount = analyzerActions.CompilationStartActionsCount;
-            CompilationEndActionsCount = analyzerActions.CompilationEndActionsCount;
-            CompilationActionsCount = analyzerActions.CompilationActionsCount;
-            SyntaxTreeActionsCount = analyzerActions.SyntaxTreeActionsCount;
-            SemanticModelActionsCount = analyzerActions.SemanticModelActionsCount;
-            SymbolActionsCount = analyzerActions.SymbolActionsCount;
-            SyntaxNodeActionsCount = analyzerActions.SyntaxNodeActionsCount;
-            CodeBlockStartActionsCount = analyzerActions.CodeBlockStartActionsCount;
-            CodeBlockEndActionsCount = analyzerActions.CodeBlockEndActionsCount;
-            CodeBlockActionsCount = analyzerActions.CodeBlockActionsCount;
-            OperationActionsCount = analyzerActions.OperationActionsCount;
-            OperationBlockStartActionsCount = analyzerActions.OperationBlockStartActionsCount;
-            OperationBlockEndActionsCount = analyzerActions.OperationBlockEndActionsCount;
-            OperationBlockActionsCount = analyzerActions.OperationBlockActionsCount;
+            CompilationStartActionsCount = compilationStartActionsCount;
+            CompilationEndActionsCount = compilationEndActionsCount;
+            CompilationActionsCount = compilationActionsCount;
+            SyntaxTreeActionsCount = syntaxTreeActionsCount;
+            SemanticModelActionsCount = semanticModelActionsCount;
+            SymbolActionsCount = symbolActionsCount;
+            SyntaxNodeActionsCount = syntaxNodeActionsCount;
+            CodeBlockStartActionsCount = codeBlockStartActionsCount;
+            CodeBlockEndActionsCount = codeBlockEndActionsCount;
+            CodeBlockActionsCount = codeBlockActionsCount;
+            OperationActionsCount = operationActionsCount;
+            OperationBlockStartActionsCount = operationBlockStartActionsCount;
+            OperationBlockEndActionsCount = operationBlockEndActionsCount;
+            OperationBlockActionsCount = operationBlockActionsCount;
 
             HasAnyExecutableCodeActions = CodeBlockActionsCount > 0 ||
                 CodeBlockStartActionsCount > 0 ||

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerDriver.cs
@@ -1302,7 +1302,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         {
             var executor = analyzerExecutor.WithCancellationToken(cancellationToken);
             var analyzerActions = await analyzerManager.GetAnalyzerActionsAsync(analyzer, executor).ConfigureAwait(false);
-            return AnalyzerActionCounts.Create(analyzerActions);
+            return new AnalyzerActionCounts(analyzerActions);
         }
 
         /// <summary>
@@ -1707,7 +1707,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
 
             var success = true;
-            
+
             // Execute stateless syntax node actions.
             if (shouldExecuteSyntaxNodeActions)
             {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/AnalyzerTelemetry.cs
@@ -91,5 +91,44 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Telemetry
             _actionCounts = actionCounts;
             ExecutionTime = executionTime;
         }
+
+        /// <summary>
+        /// Create telemetry info for a specific analyzer, such as count of registered actions, the total execution time, etc.
+        /// </summary>
+        public AnalyzerTelemetryInfo(
+            int compilationStartActionsCount,
+            int compilationEndActionsCount,
+            int compilationActionsCount,
+            int syntaxTreeActionsCount,
+            int semanticModelActionsCount,
+            int symbolActionsCount,
+            int syntaxNodeActionsCount,
+            int codeBlockStartActionsCount,
+            int codeBlockEndActionsCount,
+            int codeBlockActionsCount,
+            int operationActionsCount,
+            int operationBlockStartActionsCount,
+            int operationBlockEndActionsCount,
+            int operationBlockActionsCount,
+            TimeSpan executionTime)
+        {
+            _actionCounts = new AnalyzerActionCounts(
+                compilationStartActionsCount,
+                compilationEndActionsCount,
+                compilationActionsCount,
+                syntaxTreeActionsCount,
+                semanticModelActionsCount,
+                symbolActionsCount,
+                syntaxNodeActionsCount,
+                codeBlockStartActionsCount,
+                codeBlockEndActionsCount,
+                codeBlockActionsCount,
+                operationActionsCount,
+                operationBlockStartActionsCount,
+                operationBlockEndActionsCount,
+                operationBlockActionsCount);
+
+            ExecutionTime = executionTime;
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -703,8 +703,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         private ImmutableArray<AnalyzerAction> _syntaxNodeActions = ImmutableArray<AnalyzerAction>.Empty;
         private ImmutableArray<OperationAnalyzerAction> _operationActions = ImmutableArray<OperationAnalyzerAction>.Empty;
 
-        internal static readonly AnalyzerActions Empty = new AnalyzerActions();
-
         internal AnalyzerActions()
         {
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -28,6 +28,7 @@ Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.OperationB
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.Options.get -> Microsoft.CodeAnalysis.Diagnostics.AnalyzerOptions
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.OwningSymbol.get -> Microsoft.CodeAnalysis.ISymbol
 Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
+Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AnalyzerTelemetryInfo(int compilationStartActionsCount, int compilationEndActionsCount, int compilationActionsCount, int syntaxTreeActionsCount, int semanticModelActionsCount, int symbolActionsCount, int syntaxNodeActionsCount, int codeBlockStartActionsCount, int codeBlockEndActionsCount, int codeBlockActionsCount, int operationActionsCount, int operationBlockStartActionsCount, int operationBlockEndActionsCount, int operationBlockActionsCount, System.TimeSpan executionTime) -> void
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.OperationBlockEndActionsCount.get -> int
@@ -666,6 +667,7 @@ Microsoft.CodeAnalysis.Semantics.UnaryOperationKind.UnsignedPrefixIncrement = 77
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveGenericsOptions(Microsoft.CodeAnalysis.SymbolDisplayGenericsOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveLocalOptions(Microsoft.CodeAnalysis.SymbolDisplayLocalOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
 Microsoft.CodeAnalysis.SymbolDisplayFormat.RemoveMiscellaneousOptions(Microsoft.CodeAnalysis.SymbolDisplayMiscellaneousOptions options) -> Microsoft.CodeAnalysis.SymbolDisplayFormat
+Microsoft.CodeAnalysis.Text.SourceText.GetChecksum() -> System.Collections.Immutable.ImmutableArray<byte>
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.OperationKind> operationKinds) -> void
 abstract Microsoft.CodeAnalysis.Diagnostics.OperationBlockStartAnalysisContext.RegisterOperationBlockEndAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationBlockAnalysisContext> action) -> void
 abstract Microsoft.CodeAnalysis.SemanticModel.GetOperationCore(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.IOperation

--- a/src/Compilers/Core/Portable/Text/SourceText.cs
+++ b/src/Compilers/Core/Portable/Text/SourceText.cs
@@ -415,14 +415,11 @@ namespace Microsoft.CodeAnalysis.Text
             }
         }
 
-        internal ImmutableArray<byte> GetChecksum(bool useDefaultEncodingIfNull = false)
+        public ImmutableArray<byte> GetChecksum()
         {
             if (_lazyChecksum.IsDefault)
             {
-                // we shouldn't be asking for a checksum of encoding-less source text, except for SourceText comparison.
-                Debug.Assert(this.Encoding != null || useDefaultEncodingIfNull);
-
-                using (var stream = new SourceTextStream(this, useDefaultEncodingIfNull: useDefaultEncodingIfNull))
+                using (var stream = new SourceTextStream(this, useDefaultEncodingIfNull: true))
                 {
                     ImmutableInterlocked.InterlockedInitialize(ref _lazyChecksum, CalculateChecksum(stream, _checksumAlgorithm));
                 }

--- a/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
+++ b/src/Compilers/Core/Portable/Text/SourceTextComparer.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         public int GetHashCode(SourceText obj)
         {
-            var checksum = obj.GetChecksum(useDefaultEncodingIfNull: true);
+            var checksum = obj.GetChecksum();
             var contentsHash = !checksum.IsDefault ? Hash.CombineValues(checksum) : 0;
             var encodingHash = obj.Encoding != null ? obj.Encoding.GetHashCode() : 0;
 

--- a/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.cs
@@ -143,7 +143,7 @@ class C
                 var newSln = workspace.CurrentSolution.AddAdditionalDocument(additionalDocId, "add.config", SourceText.From("random text"));
                 currentProject = newSln.Projects.Single();
                 var additionalDocument = currentProject.GetAdditionalDocument(additionalDocId);
-                AdditionalText additionalStream = new AdditionalTextDocument(additionalDocument.GetDocumentState());
+                AdditionalText additionalStream = new AdditionalTextDocument(additionalDocument.State);
                 AnalyzerOptions options = new AnalyzerOptions(ImmutableArray.Create(additionalStream));
                 var analyzer = new OptionsDiagnosticAnalyzer<SyntaxKind>(expectedOptions: options);
 
@@ -161,6 +161,8 @@ class C
 
         private class ThrowingDoNotCatchDiagnosticAnalyzer<TLanguageKindEnum> : ThrowingDiagnosticAnalyzer<TLanguageKindEnum>, IBuiltInAnalyzer where TLanguageKindEnum : struct
         {
+            public bool MustRunInProc => true;
+
             public DiagnosticAnalyzerCategory GetAnalyzerCategory()
             {
                 return DiagnosticAnalyzerCategory.SyntaxAnalysis | DiagnosticAnalyzerCategory.SemanticDocumentAnalysis | DiagnosticAnalyzerCategory.ProjectAnalysis;

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingDiagnosticAnalyzer.cs
@@ -18,13 +18,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
         internal const string RenameFromPropertyKey = "RenameFrom";
         internal const string RenameToPropertyKey = "RenameTo";
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(DiagnosticDescriptor);
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptor);
+        public bool MustRunInProc => true;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/EditorFeatures/Test/Diagnostics/AbstractSuppressionAllCodeTests.cs
+++ b/src/EditorFeatures/Test/Diagnostics/AbstractSuppressionAllCodeTests.cs
@@ -135,6 +135,8 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Diagnostics
             private readonly DiagnosticDescriptor _descriptor =
                     new DiagnosticDescriptor("TestId", "Test", "Test", "Test", DiagnosticSeverity.Warning, isEnabledByDefault: true);
 
+            public bool MustRunInProc => true;
+
             public ImmutableArray<SyntaxNode> AllNodes { get; set; }
 
             public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics

--- a/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/DiagnosticServiceTests.vb
@@ -499,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics.UnitTests
                 Dim exceptionDiagnosticsSource = New TestHostDiagnosticUpdateSource(workspace)
 
                 ' check reporting diagnostic to a project that doesn't exist
-                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, workspace, New ProjectId(Guid.NewGuid(), "dummy"))
+                exceptionDiagnosticsSource.ReportAnalyzerDiagnostic(analyzer, expected, workspace, ProjectId.CreateFromSerialized(Guid.NewGuid(), "dummy"))
                 Dim diagnostics = exceptionDiagnosticsSource.TestOnly_GetReportedDiagnostics(analyzer)
                 Assert.Equal(0, diagnostics.Count())
 

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/DiagnosticAnalyzerDriver/DiagnosticAnalyzerDriverTests.vb
@@ -92,7 +92,7 @@ End Class
             currentProject = newSln.Projects.Single()
             Dim additionalDocument = currentProject.GetAdditionalDocument(additionalDocId)
 
-            Dim additionalStream As AdditionalText = New AdditionalTextDocument(additionalDocument.GetDocumentState())
+            Dim additionalStream As AdditionalText = New AdditionalTextDocument(additionalDocument.State)
             Dim options = New AnalyzerOptions(ImmutableArray.Create(additionalStream))
             Dim analyzer = New OptionsDiagnosticAnalyzer(Of SyntaxKind)(expectedOptions:=options)
 

--- a/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/AddBraces/CSharpAddBracesDiagnosticAnalyzer.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -23,6 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
                                                                     isEnabledByDefault: true);
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s_descriptor);
+
+        public bool MustRunInProc => false;
 
         public override void Initialize(AnalysisContext context)
         {
@@ -126,7 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
             }
         }
 
-        private bool AnalyzeIfStatement(IfStatementSyntax ifStatement) => 
+        private bool AnalyzeIfStatement(IfStatementSyntax ifStatement) =>
             !ifStatement.Statement.IsKind(SyntaxKind.Block);
 
         private bool AnalyzeElseClause(ElseClauseSyntax elseClause) =>
@@ -138,13 +142,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.AddBraces
 
         private bool AnalyzeForEachStatement(ForEachStatementSyntax forEachStatement) =>
             !forEachStatement.Statement.IsKind(SyntaxKind.Block);
-            
+
         private bool AnalyzeWhileStatement(WhileStatementSyntax whileStatement) =>
             !whileStatement.Statement.IsKind(SyntaxKind.Block);
-            
+
         private bool AnalyzeDoStatement(DoStatementSyntax doStatement) =>
             !doStatement.Statement.IsKind(SyntaxKind.Block);
-            
+
         private bool AnalyzeUsingStatement(UsingStatementSyntax usingStatement) =>
             !usingStatement.Statement.IsKind(SyntaxKind.Block) &&
             !usingStatement.Statement.IsKind(SyntaxKind.UsingStatement);

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpRemoveUnnecessaryCastDiagnosticAnalyzer.cs
@@ -15,13 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.RemoveUnnecessaryCast
     {
         private static readonly ImmutableArray<SyntaxKind> s_kindsOfInterest = ImmutableArray.Create(SyntaxKind.CastExpression);
 
-        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest
-        {
-            get
-            {
-                return s_kindsOfInterest;
-            }
-        }
+        public override ImmutableArray<SyntaxKind> SyntaxKindsOfInterest => s_kindsOfInterest;
 
         protected override bool IsUnnecessaryCast(SemanticModel model, SyntaxNode node, CancellationToken cancellationToken)
         {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -56,8 +56,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             ImmutableArray.Create(_noneDiagnosticDescriptor, _infoDiagnosticDescriptor,
                                   _warningDiagnosticDescriptor, _errorDiagnosticDescriptor);
 
-        public DiagnosticAnalyzerCategory GetAnalyzerCategory() =>
-            DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+        public DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
+        public bool MustRunInProc => true;
 
         public override void Initialize(AnalysisContext context)
         {
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             State state = null;
             var shouldAnalyze = false;
             var declarationStatement = context.Node;
-            var optionSet = GetOptionSet(context.Options);
+            var optionSet = context.Options.GetOptionSet();
             var semanticModel = context.SemanticModel;
             var cancellationToken = context.CancellationToken;
 
@@ -140,17 +140,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             return isSupportedParentKind &&
                    variableDeclaration.Variables.Count == 1 &&
                    variableDeclaration.Variables.Single().Initializer.IsKind(SyntaxKind.EqualsValueClause);
-        }
-
-        private OptionSet GetOptionSet(AnalyzerOptions analyzerOptions)
-        {
-            var workspaceOptions = analyzerOptions as WorkspaceAnalyzerOptions;
-            if (workspaceOptions != null)
-            {
-                return workspaceOptions.Workspace.Options;
-            }
-
-            return null;
         }
     }
 }

--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -27,7 +27,8 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
             isEnabledByDefault: true,
             customTags: DiagnosticCustomTags.Unnecessary);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(s_descriptor);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptor);
+        public bool MustRunInProc => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/NamingStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/NamingStyleDiagnosticAnalyzerBase.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
 
         // Applicable SymbolKind list is limited due to https://github.com/dotnet/roslyn/issues/8753. 
         // We would prefer to respond to the names of all symbols.
-        private static readonly ImmutableArray<SymbolKind> _symbolKinds = new[] 
+        private static readonly ImmutableArray<SymbolKind> _symbolKinds = new[]
             {
                 SymbolKind.Event,
                 SymbolKind.Field,
@@ -33,6 +33,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             }.ToImmutableArray();
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptorNamingStyle);
+        public bool MustRunInProc => true;
 
         public override void Initialize(AnalysisContext context)
         {
@@ -68,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles
             if (preferences.TryGetApplicableRule(context.Symbol, categorizationService, out applicableRule))
             {
                 string failureReason;
-                if (applicableRule.EnforcementLevel != DiagnosticSeverity.Hidden && 
+                if (applicableRule.EnforcementLevel != DiagnosticSeverity.Hidden &&
                     !applicableRule.IsNameCompliant(context.Symbol.Name, out failureReason))
                 {
                     var descriptor = new DiagnosticDescriptor(IDEDiagnosticIds.NamingRuleId,

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
@@ -43,6 +43,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.QualifyMemberAccess
             s_descriptorQualifyMemberAccessWarning,
             s_descriptorQualifyMemberAccessError);
 
+        public bool MustRunInProc => true;
+
         protected abstract bool IsAlreadyQualifiedMemberAccess(SyntaxNode node);
 
         public override void Initialize(AnalysisContext context)

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryCastDiagnosticAnalyzerBase.cs
@@ -23,13 +23,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.RemoveUnnecessaryCast
 
         #region Interface methods
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(s_descriptor);
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptor);
+        public bool MustRunInProc => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryImportsDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/RemoveUnnecessaryImportsDiagnosticAnalyzerBase.cs
@@ -11,7 +11,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.RemoveUnnecessaryImports
 {
-    internal abstract class RemoveUnnecessaryImportsDiagnosticAnalyzerBase : 
+    internal abstract class RemoveUnnecessaryImportsDiagnosticAnalyzerBase :
         DiagnosticAnalyzer, IBuiltInAnalyzer
     {
         // NOTE: This is a trigger diagnostic, which doesn't show up in the ruleset editor and hence doesn't need a conventional IDE Diagnostic ID string.
@@ -48,19 +48,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.RemoveUnnecessaryImports
             return _classificationIdDescriptor;
         }
 
-        private ImmutableArray<DiagnosticDescriptor> _descriptors;
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                if (_descriptors == null)
-                {
-                    _descriptors = ImmutableArray.Create(s_fixableIdDescriptor, GetClassificationIdDescriptor());
-                }
-
-                return _descriptors;
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_fixableIdDescriptor, GetClassificationIdDescriptor());
+        public bool MustRunInProc => true;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/RudeEditUserDiagnosticAnalyzer.cs
@@ -13,13 +13,8 @@ namespace Microsoft.CodeAnalysis.EditAndContinue
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
     internal class RudeEditDiagnosticAnalyzer : DocumentDiagnosticAnalyzer, IBuiltInAnalyzer
     {
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return RudeEditDiagnosticDescriptors.AllDescriptors;
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => RudeEditDiagnosticDescriptors.AllDescriptors;
+        public bool MustRunInProc => true;
 
         public override Task<ImmutableArray<Diagnostic>> AnalyzeSyntaxAsync(Document document, CancellationToken cancellationToken)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -77,6 +77,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
             }
         }
 
+        public bool MustRunInProc => true;
+
         protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context);
 
         protected abstract bool CanSimplifyTypeNameExpressionCore(SemanticModel model, SyntaxNode node, OptionSet optionSet, out TextSpan issueSpan, out string diagnosticId, CancellationToken cancellationToken);

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/UnboundIdentifiersDiagnosticAnalyzerBase.cs
@@ -19,13 +19,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.AddImport
         protected abstract ImmutableArray<TLanguageKindEnum> SyntaxKindsOfInterest { get; }
         protected abstract bool ConstructorDoesNotExist(SyntaxNode node, SymbolInfo info, SemanticModel semanticModel);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(DiagnosticDescriptor, DiagnosticDescriptor2);
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptor, DiagnosticDescriptor2);
+        public bool MustRunInProc => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/IBuiltInAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/IBuiltInAnalyzer.cs
@@ -8,6 +8,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics
     /// </summary>
     internal interface IBuiltInAnalyzer
     {
+        /// <summary>
+        /// This category will be used to run analyzer more efficiently by restricting scope of analysis
+        /// </summary>
         DiagnosticAnalyzerCategory GetAnalyzerCategory();
+
+        /// <summary>
+        /// This indicates whether this builtin analyzer must run in proc or can be run on remote host such as service hub.
+        /// 
+        /// if the diagnostic analyzer can run in command line as it is, then it should be able to run in remote host. 
+        /// otherwise, it won't unless diagnostic analyzer author make changes in remote host to provide whatever missing
+        /// data command line build doesn't provide such as workspace options/services/MEF and etc.
+        /// 
+        /// at this moment, remote host provide same context as command line build and only that context
+        /// </summary>
+        bool MustRunInProc { get; }
     }
 }

--- a/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/PopulateSwitch/PopulateSwitchDiagnosticAnalyzer.cs
@@ -11,7 +11,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 namespace Microsoft.CodeAnalysis.PopulateSwitch
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-    internal class PopulateSwitchDiagnosticAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
+    internal sealed class PopulateSwitchDiagnosticAnalyzer : DiagnosticAnalyzer, IBuiltInAnalyzer
     {
         private static readonly LocalizableString s_localizableTitle = new LocalizableResourceString(nameof(FeaturesResources.Add_missing_cases), FeaturesResources.ResourceManager, typeof(FeaturesResources));
         private static readonly LocalizableString s_localizableMessage = new LocalizableResourceString(nameof(WorkspacesResources.Populate_switch), WorkspacesResources.ResourceManager, typeof(WorkspacesResources));
@@ -26,6 +26,7 @@ namespace Microsoft.CodeAnalysis.PopulateSwitch
         #region Interface methods
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptor);
+        public bool MustRunInProc => false;
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/VisualStudio/Core/Test/EditAndContinue/VsReadOnlyDocumentTrackerTests.vb
+++ b/src/VisualStudio/Core/Test/EditAndContinue/VsReadOnlyDocumentTrackerTests.vb
@@ -169,7 +169,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.EditAndContinue
             Assert.Equal(Of UInteger)(0, mockVsBuffer._oldFlags) ' Editable
 
             ' the given project does not contain this document
-            Dim newDocumentId = New DocumentId(New ProjectId(New Guid(), "TestProject"), New Guid(), "TestDoc")
+            Dim newDocumentId = DocumentId.CreateFromSerialized(ProjectId.CreateFromSerialized(Guid.NewGuid(), "TestProject"), Guid.NewGuid(), "TestDoc")
             readOnlyDocumentTracker.SetReadOnly(newDocumentId, False) ' Check no NRE
         End Function
 

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -35,6 +35,7 @@ static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyEventA
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyFieldAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyMethodAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
 static Microsoft.CodeAnalysis.Simplification.SimplificationOptions.QualifyPropertyAccess.get -> Microsoft.CodeAnalysis.Options.PerLanguageOption<bool>
+static Microsoft.CodeAnalysis.SolutionId.CreateFromSerialized(System.Guid id, string debugName = null) -> Microsoft.CodeAnalysis.SolutionId
 static readonly Microsoft.CodeAnalysis.CodeStyle.CodeStyleOptions.QualifyEventAccess -> Microsoft.CodeAnalysis.Options.PerLanguageOption<Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<bool>>
 static readonly Microsoft.CodeAnalysis.CodeStyle.CodeStyleOptions.QualifyFieldAccess -> Microsoft.CodeAnalysis.Options.PerLanguageOption<Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<bool>>
 static readonly Microsoft.CodeAnalysis.CodeStyle.CodeStyleOptions.QualifyMethodAccess -> Microsoft.CodeAnalysis.Options.PerLanguageOption<Microsoft.CodeAnalysis.CodeStyle.CodeStyleOption<bool>>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Document.cs
@@ -23,32 +23,15 @@ namespace Microsoft.CodeAnalysis
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     public partial class Document : TextDocument
     {
-        private readonly DocumentState _state;
-
         private WeakReference<SemanticModel> _model;
         private Task<SyntaxTree> _syntaxTreeResultTask;
 
-        internal Document(Project project, DocumentState state)
+        internal Document(Project project, DocumentState state) :
+            base(project, state)
         {
-            Contract.ThrowIfNull(project);
-            Contract.ThrowIfNull(state);
-
-            this.Project = project;
-            _state = state;
         }
 
-        internal DocumentState State
-        {
-            get
-            {
-                return _state;
-            }
-        }
-
-        internal override TextDocumentState GetDocumentState()
-        {
-            return _state;
-        }
+        private DocumentState DocumentState => (DocumentState)State;
 
         /// <summary>
         /// The kind of source code this document contains.
@@ -57,7 +40,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                return _state.SourceCodeKind;
+                return DocumentState.SourceCodeKind;
             }
         }
 
@@ -74,7 +57,7 @@ namespace Microsoft.CodeAnalysis
                 syntaxTree = _syntaxTreeResultTask.Result;
             }
 
-            if (!_state.TryGetSyntaxTree(out syntaxTree))
+            if (!DocumentState.TryGetSyntaxTree(out syntaxTree))
             {
                 return false;
             }
@@ -114,7 +97,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal bool TryGetTopLevelChangeTextVersion(out VersionStamp version)
         {
-            return _state.TryGetTopLevelChangeTextVersion(out version);
+            return DocumentState.TryGetTopLevelChangeTextVersion(out version);
         }
 
         /// <summary>
@@ -138,7 +121,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                return this.State.SupportsSyntaxTree;
+                return DocumentState.SupportsSyntaxTree;
             }
         }
 
@@ -210,7 +193,7 @@ namespace Microsoft.CodeAnalysis
 
             // we can't cache this result, since internally it uses AsyncLazy which
             // care about cancellation token
-            return _state.GetSyntaxTreeAsync(cancellationToken);
+            return DocumentState.GetSyntaxTreeAsync(cancellationToken);
         }
 
         internal SyntaxTree GetSyntaxTreeSynchronously(CancellationToken cancellationToken)
@@ -229,7 +212,7 @@ namespace Microsoft.CodeAnalysis
             }
 
             // Otherwise defer to our state to get this value.
-            return _state.GetSyntaxTree(cancellationToken);
+            return DocumentState.GetSyntaxTree(cancellationToken);
         }
 
         /// <summary>

--- a/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/DocumentId.cs
@@ -19,14 +19,7 @@ namespace Microsoft.CodeAnalysis
 
         private readonly string _debugName;
 
-        private DocumentId(ProjectId projectId, string debugName)
-        {
-            this.ProjectId = projectId;
-            this.Id = Guid.NewGuid();
-            _debugName = debugName;
-        }
-
-        internal DocumentId(ProjectId projectId, Guid guid, string debugName)
+        private DocumentId(ProjectId projectId, Guid guid, string debugName)
         {
             this.ProjectId = projectId;
             this.Id = guid;
@@ -45,7 +38,7 @@ namespace Microsoft.CodeAnalysis
                 throw new ArgumentNullException(nameof(projectId));
             }
 
-            return new DocumentId(projectId, debugName);
+            return new DocumentId(projectId, Guid.NewGuid(), debugName);
         }
 
         public static DocumentId CreateFromSerialized(ProjectId projectId, Guid id, string debugName = null)
@@ -63,12 +56,12 @@ namespace Microsoft.CodeAnalysis
             return new DocumentId(projectId, id, debugName);
         }
 
+        internal string DebugName => _debugName;
+
         internal string GetDebuggerDisplay()
         {
             return string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, _debugName);
         }
-
-        internal string DebugName { get { return _debugName; } }
 
         public override string ToString()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/ProjectId.cs
@@ -19,13 +19,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Guid Id { get; }
 
-        private ProjectId(string debugName)
-        {
-            this.Id = Guid.NewGuid();
-            _debugName = debugName;
-        }
-
-        internal ProjectId(Guid guid, string debugName)
+        private ProjectId(Guid guid, string debugName)
         {
             this.Id = guid;
             _debugName = debugName;
@@ -37,7 +31,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="debugName">An optional name to make this id easier to recognize while debugging.</param>
         public static ProjectId CreateNewId(string debugName = null)
         {
-            return new ProjectId(debugName);
+            return new ProjectId(Guid.NewGuid(), debugName);
         }
 
         public static ProjectId CreateFromSerialized(Guid id, string debugName = null)
@@ -50,14 +44,11 @@ namespace Microsoft.CodeAnalysis
             return new ProjectId(id, debugName);
         }
 
+        internal string DebugName => _debugName;
+
         private string GetDebuggerDisplay()
         {
             return string.Format("({0}, #{1} - {2})", this.GetType().Name, this.Id, _debugName);
-        }
-
-        internal string DebugName
-        {
-            get { return _debugName; }
         }
 
         public override string ToString()

--- a/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/Solution.cs
@@ -1305,7 +1305,7 @@ namespace Microsoft.CodeAnalysis
             CheckNotContainsDocument(document.Id);
             CheckContainsProject(document.Id.ProjectId);
 
-            return this.AddDocument(document.State);
+            return this.AddDocument((DocumentState)document.State);
         }
 
         /// <summary>
@@ -1953,7 +1953,7 @@ namespace Microsoft.CodeAnalysis
                         || _documentIdOfLatestSolutionWithPartialCompilation != documentId)
                     {
                         var tracker = this.GetCompilationTracker(documentId.ProjectId);
-                        var newTracker = tracker.FreezePartialStateWithTree(this, doc.State, tree, cancellationToken);
+                        var newTracker = tracker.FreezePartialStateWithTree(this, (DocumentState)doc.State, tree, cancellationToken);
 
                         var newIdToProjectStateMap = _projectIdToProjectStateMap.SetItem(documentId.ProjectId, newTracker.ProjectState);
                         var newIdToTrackerMap = _projectIdToTrackerMap.SetItem(documentId.ProjectId, newTracker);

--- a/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/SolutionId.cs
@@ -19,9 +19,9 @@ namespace Microsoft.CodeAnalysis
 
         private readonly string _debugName;
 
-        private SolutionId(string debugName)
+        private SolutionId(Guid id, string debugName)
         {
-            this.Id = Guid.NewGuid();
+            this.Id = id;
             _debugName = debugName;
         }
 
@@ -31,10 +31,22 @@ namespace Microsoft.CodeAnalysis
         /// <param name="debugName">An optional name to make this id easier to recognize while debugging.</param>
         public static SolutionId CreateNewId(string debugName = null)
         {
+            return CreateFromSerialized(Guid.NewGuid(), debugName);
+        }
+
+        public static SolutionId CreateFromSerialized(Guid id, string debugName = null)
+        {
+            if (id == Guid.Empty)
+            {
+                throw new ArgumentException(nameof(id));
+            }
+
             debugName = debugName ?? "unsaved";
 
-            return new SolutionId(debugName);
+            return new SolutionId(id, debugName);
         }
+
+        internal string DebugName => _debugName;
 
         private string GetDebuggerDisplay()
         {

--- a/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Solution/TextDocument.cs
@@ -10,12 +10,7 @@ namespace Microsoft.CodeAnalysis
 {
     public class TextDocument
     {
-        private readonly TextDocumentState _state;
-
-        internal virtual TextDocumentState GetDocumentState()
-        {
-            return _state;
-        }
+        internal readonly TextDocumentState State;
 
         /// <summary>
         /// The project this document belongs to.
@@ -32,7 +27,7 @@ namespace Microsoft.CodeAnalysis
             Contract.ThrowIfNull(state);
 
             this.Project = project;
-            _state = state;
+            State = state;
         }
 
         /// <summary>
@@ -41,7 +36,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public DocumentId Id
         {
-            get { return this.GetDocumentState().Id; }
+            get { return State.Id; }
         }
 
         /// <summary>
@@ -49,7 +44,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public string FilePath
         {
-            get { return this.GetDocumentState().FilePath; }
+            get { return State.FilePath; }
         }
 
         /// <summary>
@@ -59,7 +54,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                return this.GetDocumentState().Name;
+                return State.Name;
             }
         }
 
@@ -70,7 +65,7 @@ namespace Microsoft.CodeAnalysis
         {
             get
             {
-                return this.GetDocumentState().Folders;
+                return State.Folders;
             }
         }
 
@@ -79,7 +74,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool TryGetText(out SourceText text)
         {
-            return this.GetDocumentState().TryGetText(out text);
+            return State.TryGetText(out text);
         }
 
         /// <summary>
@@ -87,7 +82,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public bool TryGetTextVersion(out VersionStamp version)
         {
-            return this.GetDocumentState().TryGetTextVersion(out version);
+            return State.TryGetTextVersion(out version);
         }
 
         /// <summary>
@@ -95,7 +90,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Task<SourceText> GetTextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetDocumentState().GetTextAsync(cancellationToken);
+            return State.GetTextAsync(cancellationToken);
         }
 
         /// <summary>
@@ -103,7 +98,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public Task<VersionStamp> GetTextVersionAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetDocumentState().GetTextVersionAsync(cancellationToken);
+            return State.GetTextVersionAsync(cancellationToken);
         }
 
         /// <summary>
@@ -111,7 +106,7 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal Task<VersionStamp> GetTopLevelChangeTextVersionAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.GetDocumentState().GetTopLevelChangeTextVersionAsync(cancellationToken);
+            return State.GetTopLevelChangeTextVersionAsync(cancellationToken);
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -435,7 +435,7 @@ namespace Microsoft.CodeAnalysis
                     // Note: we pass along the newText here so that clients can easily get the text
                     // of an opened document just by calling TryGetText without any blocking.
                     currentSolution = oldSolution.WithDocumentTextLoader(documentId,
-                        new ReuseVersionLoader(oldDocument.State, newText), newText, PreservationMode.PreserveIdentity);
+                        new ReuseVersionLoader((DocumentState)oldDocument.State, newText), newText, PreservationMode.PreserveIdentity);
                 }
 
                 var newSolution = this.SetCurrentSolution(currentSolution);


### PR DESCRIPTION
actual change is in https://github.com/dotnet/roslyn/pull/12762/commits/60e9b84414ef0cc9485006145e1c06de115f5f9e

3 mixed changes.

1. IBuiltInAnalyzer.MustRunInProc
this tells diagnostic system whether this particular builtin diagnostic analyzer can be run out of proc.

2. some clean up around Solution/Project/DocumentId.CreateFromSerialized API

3. some clean up on how DocumentState is exposed from Document.