### PR TITLE
Context Menu: Move Insert Comment to Snippets group

### DIFF
--- a/src/VisualStudio/Core/Def/Commands.vsct
+++ b/src/VisualStudio/Core/Def/Commands.vsct
@@ -357,8 +357,8 @@
   </Commands>
 
   <CommandPlacements>
-    <CommandPlacement guid="guidVSStd2K" id="ECMD_INSERTCOMMENT" priority="0x0300">
-      <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_ADVANCED" />
+    <CommandPlacement guid="guidVSStd2K" id="ECMD_INSERTCOMMENT" priority="0x0900">
+      <Parent guid="guidSHLMainMenu" id="IDG_VS_CODEWIN_SNIPPETS" />
     </CommandPlacement>
 
     <!-- Add Rename to the editor context menu below the Refactor item. -->


### PR DESCRIPTION
Addresses internal workitem 204416
With this change, we place "Insert Comment" inside the Snippets group,
with the following hierarchy.

Snippets:

- Surround With...
- Insert Snippet...
- Insert Comment

![image](https://cloud.githubusercontent.com/assets/4213867/17163324/0db975e2-5373-11e6-944a-1feaffb451c9.png)
