### PR TITLE
Allow forward references to local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1022,28 +1022,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             Debug.Assert(members.Count > 0);
 
-            if (!hasErrors)
-            {
-                // The common case is that if that members contains a local function symbol,
-                // there is only one element. Still do a foreach for potential error cases.
-                foreach (var member in members)
-                {
-                    if (!(member is LocalFunctionSymbol))
-                    {
-                        continue;
-                    }
-                    Debug.Assert(members.Count == 1 && member.Locations.Length == 1);
-                    var localSymbolLocation = member.Locations[0];
-                    bool usedBeforeDecl =
-                        syntax.SyntaxTree == localSymbolLocation.SourceTree &&
-                        syntax.SpanStart < localSymbolLocation.SourceSpan.Start;
-                    if (usedBeforeDecl)
-                    {
-                        Error(diagnostics, ErrorCode.ERR_VariableUsedBeforeDeclaration, syntax, syntax);
-                    }
-                }
-            }
-
             switch (members[0].Kind)
             {
                 case SymbolKind.Method:

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -401,6 +401,7 @@
     <Compile Include="Lowering\LambdaRewriter\LambdaRewriter.Analysis.cs" />
     <Compile Include="Lowering\LambdaRewriter\LambdaRewriter.cs" />
     <Compile Include="Lowering\LambdaRewriter\LambdaFrame.cs" />
+    <Compile Include="Lowering\LambdaRewriter\LambdaRewriter.LocalFunctionReferenceRewriter.cs" />
     <Compile Include="Lowering\LambdaRewriter\SynthesizedLambdaMethod.cs" />
     <Compile Include="Lowering\LocalRewriter\DynamicSiteContainer.cs" />
     <Compile Include="Lowering\LocalRewriter\LocalRewriter.cs" />

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CodeGen;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System;
+
+namespace Microsoft.CodeAnalysis.CSharp
+{
+    internal sealed partial class LambdaRewriter : MethodToClassRewriter
+    {
+        /// <summary>
+        /// Rewrites local function declarations into closure classes.
+        /// </summary>
+        private sealed class LocalFunctionReferenceRewriter : BoundTreeRewriterWithStackGuard
+        {
+            private readonly LambdaRewriter _lambdaRewriter;
+
+            public LocalFunctionReferenceRewriter(LambdaRewriter lambdaRewriter)
+            {
+                _lambdaRewriter = lambdaRewriter;
+            }
+
+            public override BoundNode VisitCall(BoundCall node)
+            {
+                if (node.Method.MethodKind == MethodKind.LocalFunction)
+                {
+                    BoundExpression receiver;
+                    MethodSymbol method;
+                    var arguments = node.Arguments;
+                    _lambdaRewriter.RemapLocalFunction(node.Syntax, node.Method, out receiver, out method, ref arguments);
+                    node = node.Update(receiver, method, arguments);
+                }
+
+                var visited = base.VisitCall(node);
+                if (visited.Kind != BoundKind.Call)
+                {
+                    return visited;
+                }
+
+                return (BoundCall)visited;
+            }
+
+            public override BoundNode VisitDelegateCreationExpression(BoundDelegateCreationExpression node)
+            {
+                if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
+                {
+                    BoundExpression receiver;
+                    MethodSymbol method;
+                    var arguments = default(ImmutableArray<BoundExpression>);
+                    _lambdaRewriter.RemapLocalFunction(
+                        node.Syntax, node.MethodOpt, out receiver, out method, ref arguments);
+
+                    return new BoundDelegateCreationExpression(
+                        node.Syntax, receiver, method, isExtensionMethod: false, type: node.Type);
+                }
+
+                return base.VisitDelegateCreationExpression(node);
+            }
+
+            public override BoundNode VisitConversion(BoundConversion conversion)
+            {
+                if (conversion.ConversionKind == ConversionKind.MethodGroup &&
+                    conversion.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
+                {
+                    BoundExpression receiver;
+                    MethodSymbol method;
+                    var arguments = default(ImmutableArray<BoundExpression>);
+                    _lambdaRewriter.RemapLocalFunction(
+                        conversion.Syntax, conversion.SymbolOpt, out receiver, out method, ref arguments);
+
+                    return new BoundDelegateCreationExpression(
+                        conversion.Syntax, receiver, method, isExtensionMethod: false, type: conversion.Type);
+                }
+                return base.VisitConversion(conversion);
+            }
+
+            public override BoundNode VisitBlock(BoundBlock node)
+            {
+                var newStatements = ArrayBuilder<BoundStatement>.GetInstance();
+
+                foreach (var statement in node.Statements)
+                {
+                    var replacement = (BoundStatement)this.Visit(statement);
+                    if (replacement != null)
+                    {
+                        newStatements.Add(replacement);
+                    }
+                }
+
+                return node.Update(node.Locals, node.LocalFunctions, newStatements.ToImmutableAndFree());
+            }
+        }
+
+
+        private void RemapLocalFunction(
+            CSharpSyntaxNode syntax,
+            MethodSymbol symbol,
+            out BoundExpression receiver,
+            out MethodSymbol method,
+            ref ImmutableArray<BoundExpression> parameters,
+            ImmutableArray<TypeSymbol> typeArguments = default(ImmutableArray<TypeSymbol>))
+        {
+            Debug.Assert(symbol.MethodKind == MethodKind.LocalFunction);
+
+            var constructed = symbol as ConstructedMethodSymbol;
+            if (constructed != null)
+            {
+                RemapLocalFunction(syntax, constructed.ConstructedFrom, out receiver, out method, ref parameters, this.TypeMap.SubstituteTypes(constructed.TypeArguments).SelectAsArray(t => t.Type));
+                return;
+            }
+
+            var mappedLocalFunction = _localFunctionMap[(LocalFunctionSymbol)symbol];
+
+            var lambda = mappedLocalFunction.Symbol;
+            var frameCount = lambda.ExtraSynthesizedParameterCount;
+            if (frameCount != 0)
+            {
+                Debug.Assert(!parameters.IsDefault);
+                var builder = ArrayBuilder<BoundExpression>.GetInstance();
+                builder.AddRange(parameters);
+                var start = lambda.ParameterCount - frameCount;
+                for (int i = start; i < lambda.ParameterCount; i++)
+                {
+                    // will always be a LambdaFrame, it's always a closure class
+                    var frameType = (NamedTypeSymbol)lambda.Parameters[i].Type.OriginalDefinition;
+                    if (frameType.IsGenericType)
+                    {
+                        var typeParameters = ((LambdaFrame)frameType).ConstructedFromTypeParameters;
+                        var subst = this.TypeMap.SubstituteTypeParameters(typeParameters);
+                        frameType = frameType.Construct(subst);
+                    }
+                    var frame = FrameOfType(syntax, frameType);
+                    builder.Add(frame);
+                }
+                parameters = builder.ToImmutableAndFree();
+            }
+
+            method = lambda;
+            NamedTypeSymbol constructedFrame;
+            RemapLambdaOrLocalFunction(syntax, symbol, typeArguments, mappedLocalFunction.ClosureKind, ref method, out receiver, out constructedFrame);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.cs
@@ -31,11 +31,18 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// in <see cref="_frames"/>.  Each frame is given a single field for each captured
     /// variable in the corresponding scope.  These are maintained in <see cref="MethodToClassRewriter.proxies"/>.
     /// 
-    /// Finally, we walk and rewrite the input bound tree, keeping track of the following:
+    /// Next, we walk and rewrite the input bound tree, keeping track of the following:
     /// (1) The current set of active frame pointers, in <see cref="_framePointers"/>
     /// (2) The current method being processed (this changes within a lambda's body), in <see cref="_currentMethod"/>
     /// (3) The "this" symbol for the current method in <see cref="_currentFrameThis"/>, and
     /// (4) The symbol that is used to access the innermost frame pointer (it could be a local variable or "this" parameter)
+    ///
+    /// Lastly, we visit the top-level method and each of the lowered methods
+    /// to rewrite references (e.g., calls and delegate conversions) to local
+    /// functions. We visit references to local functions separately from
+    /// lambdas because we may see the reference before we lower the target
+    /// local function. Lambdas, on the other hand, are always convertible as
+    /// they are being lowered.
     /// 
     /// There are a few key transformations done in the rewriting.
     /// (1) Lambda expressions are turned into delegate creation expressions, and the body of the lambda is
@@ -43,8 +50,8 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// (2) On entry to a scope with captured variables, we create a frame object and store it in a local variable.
     /// (3) References to captured variables are transformed into references to fields of a frame class.
     /// 
-    /// In addition, the rewriting deposits into <see cref="TypeCompilationState.SynthesizedMethods"/> a (<see cref="MethodSymbol"/>, <see cref="BoundStatement"/>)
-    /// pair for each generated method.
+    /// In addition, the rewriting deposits into <see cref="TypeCompilationState.SynthesizedMethods"/>
+    /// a (<see cref="MethodSymbol"/>, <see cref="BoundStatement"/>) pair for each generated method.
     /// 
     /// <see cref="Rewrite"/> produces its output in two forms.  First, it returns a new bound statement
     /// for the caller to use for the body of the original method.  Second, it returns a collection of
@@ -79,6 +86,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ClosureKind = closureKind;
             }
         }
+
         private readonly Dictionary<LocalFunctionSymbol, MappedLocalFunction> _localFunctionMap = new Dictionary<LocalFunctionSymbol, MappedLocalFunction>();
 
         // for each block with lifted (captured) variables, the corresponding frame type
@@ -237,7 +245,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             analysis.ComputeLambdaScopesAndFrameCaptures();
             rewriter.MakeFrames(closureDebugInfoBuilder);
-            var body = rewriter.AddStatementsIfNeeded((BoundStatement)rewriter.Visit(loweredBody));
+
+            // First, lower everything but references (calls, delegate conversions)
+            // to local functions
+            var body = rewriter.AddStatementsIfNeeded(
+                (BoundStatement)rewriter.Visit(loweredBody));
+
+            // Now lower the references
+            if (rewriter._localFunctionMap.Count != 0)
+            {
+                body = rewriter.RewriteLocalFunctionDefinitions(body);
+            }
+
             CheckLocalsDefined(body);
 
             return body;
@@ -302,20 +321,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (captured.Kind != SymbolKind.Method)
                 {
-                var hoistedField = LambdaCapturedVariable.Create(frame, captured, ref _synthesizedFieldNameIdDispenser);
-                proxies.Add(captured, new CapturedToFrameSymbolReplacement(hoistedField, isReusable: false));
-                CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, hoistedField);
+                    var hoistedField = LambdaCapturedVariable.Create(frame, captured, ref _synthesizedFieldNameIdDispenser);
+                    proxies.Add(captured, new CapturedToFrameSymbolReplacement(hoistedField, isReusable: false));
+                    CompilationState.ModuleBuilderOpt.AddSynthesizedDefinition(frame, hoistedField);
 
-                if (hoistedField.Type.IsRestrictedType())
-                {
-                    foreach (CSharpSyntaxNode syntax in kvp.Value)
+                    if (hoistedField.Type.IsRestrictedType())
                     {
-                        // CS4013: Instance of type '{0}' cannot be used inside an anonymous function, query expression, iterator block or async method
-                        this.Diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, hoistedField.Type);
+                        foreach (CSharpSyntaxNode syntax in kvp.Value)
+                        {
+                            // CS4013: Instance of type '{0}' cannot be used inside an anonymous function, query expression, iterator block or async method
+                            this.Diagnostics.Add(ErrorCode.ERR_SpecialByRefInLambda, syntax.Location, hoistedField.Type);
+                        }
                     }
                 }
             }
-        }
         }
 
         private LambdaFrame GetFrameForScope(BoundNode scope, ArrayBuilder<ClosureDebugInfo> closureDebugInfo)
@@ -590,7 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var result = F(prologue, addedLocals);
 
-            _framePointers.Remove(frame);
+            //_framePointers.Remove(frame);
             _innermostFramePointer = oldInnermostFramePointer;
 
             if ((object)_innermostFramePointer != null)
@@ -690,6 +709,63 @@ namespace Microsoft.CodeAnalysis.CSharp
                 : FramePointer(node.Syntax, _topLevelMethod.ContainingType); // technically, not the correct static type
         }
 
+        public BoundStatement RewriteLocalFunctionDefinitions(BoundStatement loweredBody)
+        {
+            var rewriter = new LocalFunctionReferenceRewriter(this);
+
+            Debug.Assert(_currentMethod == _topLevelMethod);
+
+            // Visit the body first since the state is already set
+            // for the top-level method
+            var newBody = (BoundStatement)rewriter.Visit(loweredBody);
+
+            // Visit all the rewritten methods as well
+            var synthesizedMethods = CompilationState.SynthesizedMethods;
+            if (synthesizedMethods != null)
+            {
+                var oldMethods = synthesizedMethods.ToImmutable();
+                synthesizedMethods.Clear();
+                foreach (var oldMethod in oldMethods)
+                {
+                    var synthesizedLambda = oldMethod.Method as SynthesizedLambdaMethod;
+                    if (synthesizedLambda == null)
+                    {
+                        // The only methods synthesized by the rewriter should
+                        // be lowered closures and frame constructors
+                        Debug.Assert(oldMethod.Method.MethodKind == MethodKind.Constructor ||
+                                     oldMethod.Method.MethodKind == MethodKind.StaticConstructor);
+                        CompilationState.AddSynthesizedMethod(oldMethod.Method, oldMethod.Body);
+                        continue;
+                    }
+
+                    _currentMethod = synthesizedLambda;
+                    var closureKind = synthesizedLambda.ClosureKind;
+                    if (closureKind == ClosureKind.Static || closureKind == ClosureKind.Singleton)
+                    {
+                        // no link from a static lambda to its container
+                        _innermostFramePointer = _currentFrameThis = null;
+                    }
+                    else
+                    {
+                        _currentFrameThis = synthesizedLambda.ThisParameter;
+                        _innermostFramePointer = null;
+                        _framePointers.TryGetValue(synthesizedLambda.ContainingType, out _innermostFramePointer);
+                    }
+
+                    _currentTypeParameters = synthesizedLambda.ContainingType
+                        ?.TypeParameters.Concat(synthesizedLambda.TypeParameters)
+                        ?? synthesizedLambda.TypeParameters;
+                    _currentLambdaBodyTypeMap = synthesizedLambda.TypeMap;
+
+                    var rewrittenBody = (BoundStatement)rewriter.Visit(oldMethod.Body);
+
+                    CompilationState.AddSynthesizedMethod(synthesizedLambda, rewrittenBody);
+                }
+            }
+
+            return newBody;
+        }
+
         private void RemapLambdaOrLocalFunction(
             CSharpSyntaxNode syntax,
             MethodSymbol originalMethod,
@@ -749,62 +825,34 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private void RemapLocalFunction(
-            CSharpSyntaxNode syntax, MethodSymbol symbol,
-            out BoundExpression receiver, out MethodSymbol method,
-            ref ImmutableArray<BoundExpression> parameters,
-            ImmutableArray<TypeSymbol> typeArguments = default(ImmutableArray<TypeSymbol>))
-        {
-            Debug.Assert(symbol.MethodKind == MethodKind.LocalFunction);
-
-            var constructed = symbol as ConstructedMethodSymbol;
-            if (constructed != null)
-            {
-                RemapLocalFunction(syntax, constructed.ConstructedFrom, out receiver, out method, ref parameters, this.TypeMap.SubstituteTypes(constructed.TypeArguments).SelectAsArray(t => t.Type));
-                return;
-            }
-
-            var mappedLocalFunction = _localFunctionMap[(LocalFunctionSymbol)symbol];
-
-            var lambda = mappedLocalFunction.Symbol;
-            var frameCount = lambda.ExtraSynthesizedParameterCount;
-            if (frameCount != 0)
-            {
-                Debug.Assert(!parameters.IsDefault);
-                var builder = ArrayBuilder<BoundExpression>.GetInstance();
-                builder.AddRange(parameters);
-                var start = lambda.ParameterCount - frameCount;
-                for (int i = start; i < lambda.ParameterCount; i++)
-                {
-                    // will always be a LambdaFrame, it's always a closure class
-                    var frameType = (NamedTypeSymbol)lambda.Parameters[i].Type.OriginalDefinition;
-                    if (frameType.IsGenericType)
-                    {
-                        var typeParameters = ((LambdaFrame)frameType).ConstructedFromTypeParameters;
-                        var subst = this.TypeMap.SubstituteTypeParameters(typeParameters);
-                        frameType = frameType.Construct(subst);
-                    }
-                    var frame = FrameOfType(syntax, frameType);
-                    builder.Add(frame);
-                }
-                parameters = builder.ToImmutableAndFree();
-            }
-
-            method = lambda;
-            NamedTypeSymbol constructedFrame;
-            RemapLambdaOrLocalFunction(syntax, symbol, typeArguments, mappedLocalFunction.ClosureKind, ref method, out receiver, out constructedFrame);
-        }
-
+        /// <remarks>
+        /// This pass doesn't rewrite the local function calls themselves
+        /// because we may encounter a call to a local function that has yet
+        /// to be lowered. Here we just want to make sure we lower the
+        /// arguments as they may contain references to captured variables.
+        /// The final lowering of the call will be in the
+        /// <see cref="LocalFunctionReferenceRewriter" />
+        /// </remarks>
         public override BoundNode VisitCall(BoundCall node)
         {
             if (node.Method.MethodKind == MethodKind.LocalFunction)
             {
-                BoundExpression receiver;
-                MethodSymbol method;
-                var arguments = node.Arguments;
-                RemapLocalFunction(node.Syntax, node.Method, out receiver, out method, ref arguments);
-                node = node.Update(receiver, method, arguments);
+                var rewrittenArguments = this.VisitList(node.Arguments);
+
+                return node.Update(
+                    node.ReceiverOpt,
+                    node.Method,
+                    rewrittenArguments,
+                    node.ArgumentNamesOpt,
+                    node.ArgumentRefKindsOpt,
+                    node.IsDelegateCall,
+                    node.Expanded,
+                    node.InvokedAsExtensionMethod,
+                    node.ArgsToParamsOpt,
+                    node.ResultKind,
+                    node.Type);
             }
+
             var visited = base.VisitCall(node);
             if (visited.Kind != BoundKind.Call)
             {
@@ -1034,12 +1082,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 if (node.MethodOpt?.MethodKind == MethodKind.LocalFunction)
                 {
-                    BoundExpression receiver;
-                    MethodSymbol method;
-                    var arguments = default(ImmutableArray<BoundExpression>);
-                    RemapLocalFunction(node.Syntax, node.MethodOpt, out receiver, out method, ref arguments);
-                    var result = new BoundDelegateCreationExpression(node.Syntax, receiver, method, isExtensionMethod: false, type: node.Type);
-                    return result;
+                    return node;
                 }
                 return base.VisitDelegateCreationExpression(node);
             }
@@ -1068,14 +1111,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                if (conversion.ConversionKind == ConversionKind.MethodGroup && conversion.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
+                if (conversion.ConversionKind == ConversionKind.MethodGroup &&
+                    conversion.SymbolOpt?.MethodKind == MethodKind.LocalFunction)
                 {
-                    BoundExpression receiver;
-                    MethodSymbol method;
-                    var arguments = default(ImmutableArray<BoundExpression>);
-                    RemapLocalFunction(conversion.Syntax, conversion.SymbolOpt, out receiver, out method, ref arguments);
-                    var result = new BoundDelegateCreationExpression(conversion.Syntax, receiver, method, isExtensionMethod: false, type: conversion.Type);
-                    return result;
+                    return conversion;
                 }
                 return base.VisitConversion(conversion);
             }
@@ -1207,7 +1246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             {
                                 found = true;
                                 break;
-            }
+                            }
                         }
                         if (found)
                         {
@@ -1228,17 +1267,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
                 else
-            {
-                closureKind = ClosureKind.General;
+                {
+                    closureKind = ClosureKind.General;
                     translatedLambdaContainer = containerAsFrame;
-                closureOrdinal = containerAsFrame.ClosureOrdinal;
-            }
+                    closureOrdinal = containerAsFrame.ClosureOrdinal;
+                }
             }
             else if (_analysis.CapturedVariablesByLambda[node.Symbol].Count == 0)
             {
                 if (_analysis.MethodsConvertedToDelegates.Contains(node.Symbol))
-            {
-                translatedLambdaContainer = containerAsFrame = GetStaticFrame(Diagnostics, node);
+                {
+                    translatedLambdaContainer = containerAsFrame = GetStaticFrame(Diagnostics, node);
                     closureKind = ClosureKind.Singleton;
                     closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
                 }
@@ -1246,9 +1285,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     containerAsFrame = null;
                     translatedLambdaContainer = _topLevelMethod.ContainingType;
-                closureKind = ClosureKind.Static;
-                closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
-            }
+                    closureKind = ClosureKind.Static;
+                    closureOrdinal = LambdaDebugInfo.StaticClosureOrdinal;
+                }
                 structClosures = default(ImmutableArray<TypeSymbol>);
             }
             else
@@ -1321,7 +1360,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _addedStatements = oldAddedStatements;
 
             return synthesizedMethod;
-            }
+        }
 
         private BoundNode RewriteLambdaConversion(BoundLambda node)
             {

--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/SynthesizedLambdaMethod.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                        | (lambdaNode.Symbol.IsAsync ? DeclarationModifiers.Async : 0))
         {
             _topLevelMethod = topLevelMethod;
+            ClosureKind = closureKind;
 
             TypeMap typeMap;
             ImmutableArray<TypeParameterSymbol> typeParameters;
@@ -141,5 +142,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         // The lambda method body needs to be updated when the containing top-level method body is updated.
         bool ISynthesizedMethodBodyImplementationSymbol.HasMethodBodyDependency => true;
+
+        public ClosureKind ClosureKind { get; }
     }
 }

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.shproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.shproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-    <ProjectGuid>c1930979-c824-496b-a630-70f5369a636f</ProjectGuid>
+    <ProjectGuid>cd77a8cc-2885-47a7-b99c-fbf13353400b</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />


### PR DESCRIPTION
This PR addresses changes to local functions described in #10391.
Specifically, it has been decided that it should be legal to reference
local functions defined lexically after the point of reference, i.e.
call a local function defined at the end of a method:

```
    public void Main()
    {
        Local();
        void Local() {}
    }
```

This PR completes the lowering work necessary to correctly emit this
code, although it doesn't modify definite assignment to handle the new
cases created by this change. That work will be completed in a
subsequent PR.