### PR TITLE
Move type to file: allow syncing filename and type name if no type in file matches filename

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
@@ -45,13 +45,37 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MoreThanOneTopLevelTypeInFile_RenameFile()
+        public async Task MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile()
+        {
+            var code =
+@"[||]class Class1 { }
+class test1 { }";
+
+            await TestRenameFileToMatchTypeAsync(code, expectedCodeAction: false);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName_RenameFile()
         {
             var code =
 @"[||]class Class1 { }
 class Class2 { }";
 
-            await TestRenameFileToMatchTypeAsync(code, expectedCodeAction: false);
+            var expectedDocumentName = "Class1.cs";
+
+            await TestRenameFileToMatchTypeAsync(code, expectedDocumentName);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName2_RenameFile()
+        {
+            var code =
+@"class Class1 { }
+[||]class Class2 { }";
+
+            var expectedDocumentName = "Class2.cs";
+
+            await TestRenameFileToMatchTypeAsync(code, expectedDocumentName);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
@@ -50,13 +50,41 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MoreThanOneTopLevelTypeInFile_RenameType()
+        public async Task MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType()
+        {
+            var code =
+@"[||]class Class1 { }
+class test1 { }";
+
+            await TestRenameTypeToMatchFileAsync(code, expectedCodeAction: false);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameType()
         {
             var code =
 @"[||]class Class1 { }
 class Class2 { }";
 
-            await TestRenameTypeToMatchFileAsync(code, expectedCodeAction: false);
+            var codeWithTypeRenamedToMatchFileName =
+@"class [|test1|] { }
+class Class2 { }";
+
+            await TestRenameTypeToMatchFileAsync(code, codeWithTypeRenamedToMatchFileName);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MultipleTopLevelTypesInFileAndNoneMatchFileName2_RenameType()
+        {
+            var code =
+@"class Class1 { }
+[||]class Class2 { }";
+
+            var codeWithTypeRenamedToMatchFileName =
+@"class Class1 { }
+class [|test1|] { }";
+
+            await TestRenameTypeToMatchFileAsync(code, codeWithTypeRenamedToMatchFileName);
         }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
@@ -28,7 +28,21 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function MoreThanOneTypeInFile_RenameFile() As Task
+        Public Async Function MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile() As Task
+            Dim code =
+<File>
+[||]Class Class1
+End Class
+
+Class test1
+End Class
+</File>
+
+            Await TestRenameFileToMatchTypeAsync(code, expectedCodeAction:=False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameFile() As Task
             Dim code =
 <File>
 [||]Class Class1
@@ -38,7 +52,8 @@ Class Class2
 End Class
 </File>
 
-            Await TestRenameFileToMatchTypeAsync(code, expectedCodeAction:=False)
+            Dim expectedDocumentName = "Class1.vb"
+            Await TestRenameFileToMatchTypeAsync(code, expectedDocumentName)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
@@ -34,7 +34,21 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function MoreThanOneTypeInFile_RenameType() As Task
+        Public Async Function MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType() As Task
+            Dim code =
+<File>
+[||]Class Class1
+End Class
+
+Class test1
+End Class
+</File>
+
+            Await TestRenameTypeToMatchFileAsync(code, expectedCodeAction:=False)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MultipleTopLevelTypesInFileAndNoneMatchFileName1_RenameType() As Task
             Dim code =
 <File>
 [||]Class Class1
@@ -44,7 +58,16 @@ Class Class2
 End Class
 </File>
 
-            Await TestRenameTypeToMatchFileAsync(code, expectedCodeAction:=False)
+            Dim codeAfterRenamingType =
+<File>
+Class [|test1|]
+End Class
+
+Class Class2
+End Class
+</File>
+
+            Await TestRenameTypeToMatchFileAsync(code, codeAfterRenamingType)
         End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
@@ -27,26 +27,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             RenameFile
         }
 
-        protected bool ShouldAnalyze(SyntaxNode root, TextSpan span)
-        {
-            return GetNodeToAnalyze(root, span) is TTypeDeclarationSyntax;
-        }
-
-        protected virtual SyntaxNode GetNodeToAnalyze(SyntaxNode root, TextSpan span)
-        {
-            return root.FindNode(span);
-        }
-
-        private bool IsNestedType(TTypeDeclarationSyntax typeNode) =>
-            typeNode.Parent is TTypeDeclarationSyntax;
-
-        /// <summary>
-        /// checks if there is a single top level type declaration in a document
-        /// </summary>
-        private bool MultipleTopLevelTypeDeclarationInSourceDocument(SyntaxNode root) =>
-            root.DescendantNodes(n => (n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax))
-            .OfType<TTypeDeclarationSyntax>()
-            .Count() > 1;
+        protected virtual SyntaxNode GetNodeToAnalyze(SyntaxNode root, TextSpan span) => root.FindNode(span);
 
         public async Task<ImmutableArray<CodeAction>> GetRefactoringAsync(Document document, TextSpan textSpan, CancellationToken cancellationToken)
         {
@@ -68,6 +49,9 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             Debug.Assert(actions.Count() != 0, "No code actions found for MoveType Refactoring");
             return actions;
         }
+
+        private bool ShouldAnalyze(SyntaxNode root, TextSpan span) =>
+            GetNodeToAnalyze(root, span) is TTypeDeclarationSyntax;
 
         private ImmutableArray<CodeAction> CreateActions(State state, CancellationToken cancellationToken)
         {
@@ -97,11 +81,18 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             return actions.ToImmutableArray();
         }
 
-        private CodeAction GetCodeAction(
-            State state,
-            OperationKind operationKind)
-        {
-            return new MoveTypeCodeAction((TService)this, state, operationKind);
-        }
+        private CodeAction GetCodeAction(State state, OperationKind operationKind) => 
+            new MoveTypeCodeAction((TService)this, state, operationKind);
+        
+        private bool IsNestedType(TTypeDeclarationSyntax typeNode) =>
+            typeNode.Parent is TTypeDeclarationSyntax;
+
+        /// <summary>
+        /// checks if there is a single top level type declaration in a document
+        /// </summary>
+        private bool MultipleTopLevelTypeDeclarationInSourceDocument(SyntaxNode root) =>
+            root.DescendantNodes(n => (n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax))
+            .OfType<TTypeDeclarationSyntax>()
+            .Count() > 1;
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
@@ -58,16 +58,19 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             var actions = new List<CodeAction>();
             var manyTypes = MultipleTopLevelTypeDeclarationInSourceDocument(state.SemanticDocument.Root);
 
+            // (1) Add Move type to new file code action:
+            // case 1: There are multiple type declarations in current document. offer, move to new file.
+            // case 2: This is a nested type, offer to move to new file.
+            // case 3: If there is a single type decl in current file, *do not* offer move to new file.
             if (manyTypes || IsNestedType(state.TypeNode))
             {
-                // If there are multiple type declarations in current document. offer, move to new file.
-                // Or if this is a nested type, offer to move to new file.
                 actions.Add(GetCodeAction(state, operationKind: OperationKind.MoveType));
             }
-            else
+
+            // (2) Add rename file and rename type code actions:
+            // Case: No type declaration in file matches the file name.
+            if (!AnyTopLevelTypeMatchesDocumentName(state, cancellationToken))
             {
-                // one type declaration in current document. No moving around required, just sync
-                // document name and type name by offering rename in both directions between type and document.
                 actions.Add(GetCodeAction(state, operationKind: OperationKind.RenameFile));
 
                 // only if the document name can be legal identifier in the language,
@@ -81,18 +84,36 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             return actions.ToImmutableArray();
         }
 
-        private CodeAction GetCodeAction(State state, OperationKind operationKind) => 
+        private CodeAction GetCodeAction(State state, OperationKind operationKind) =>
             new MoveTypeCodeAction((TService)this, state, operationKind);
-        
+
         private bool IsNestedType(TTypeDeclarationSyntax typeNode) =>
             typeNode.Parent is TTypeDeclarationSyntax;
 
         /// <summary>
         /// checks if there is a single top level type declaration in a document
         /// </summary>
+        /// <remarks>
+        /// optimized for perf, uses Skip(1).Any() instead of Count() > 1
+        /// </remarks>
         private bool MultipleTopLevelTypeDeclarationInSourceDocument(SyntaxNode root) =>
+            TopLevelTypeDeclarations(root).Skip(1).Any();
+
+        private static IEnumerable<TTypeDeclarationSyntax> TopLevelTypeDeclarations(SyntaxNode root) =>
             root.DescendantNodes(n => (n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax))
-            .OfType<TTypeDeclarationSyntax>()
-            .Count() > 1;
+                .OfType<TTypeDeclarationSyntax>();
+
+        private static bool AnyTopLevelTypeMatchesDocumentName(State state, CancellationToken cancellationToken)
+        {
+            var root = state.SemanticDocument.Root;
+            var semanticModel = state.SemanticDocument.SemanticModel;
+
+            return TopLevelTypeDeclarations(root).Any(
+                typeDeclaration => 
+                {
+                    var typeName = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken).Name;
+                    return string.Equals(state.DocumentName, typeName, StringComparison.CurrentCulture);
+                });
+        }
     }
 }


### PR DESCRIPTION
Fixes #12727 

Look through all the top level type declarations in a file and if

1. none of them match the filename, offer "rename type to match file" and "rename file to match type" code actions on each of those types.
2. at least one such type matches file name, do not offer "rename file/type" codeactions on any of those types.