### PR TITLE
Move type to file: offer outer.inner.cs pattern on nested types

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -157,6 +157,7 @@
     <Compile Include="CodeActions\InvertIf\InvertIfTests.cs" />
     <Compile Include="CodeActions\LambdaSimplifier\LambdaSimplifierTests.cs" />
     <Compile Include="CodeActions\MoveType\CSharpMoveTypeTestsBase.cs" />
+    <Compile Include="CodeActions\MoveType\MoveTypeTests.ActionCountTests.cs" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.MoveToNewFile.cs" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameType.cs" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameFile.cs" />

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Threading.Tasks;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
+{
+    public partial class MoveTypeTests : CSharpMoveTypeTestsBase
+    {
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_ActionCounts_RenameOnly()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1[||]
+    {
+    }
+}";
+            // Fixes offered will be rename type to match file, rename file to match type.
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_ActionCounts_MoveOnly()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1[||]
+    {
+    }
+
+    class test1 /* this matches file name assigned by TestWorkspace*/
+    {
+    }
+}";
+            // Fixes offered will be move type to new file.
+            await TestActionCountAsync(code, count: 1);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_ActionCounts_RenameAndMove()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1[||]
+    {
+    }
+
+    class Class2
+    {
+    }
+}";
+            // Fixes offered will be move type, rename type to match file, rename file to match type.
+            await TestActionCountAsync(code, count: 3);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveType_ActionCounts_All()
+        {
+            var code =
+@"namespace N1
+{
+    class OuterType
+    {
+        class InnerType[||]
+        {
+        }
+    }
+
+    class Class1
+    {
+    }
+}";
+            // Fixes offered will be
+            // 1. move type to InnerType.cs
+            // 2. move type to OuterType.InnerType.cs
+            // 3. rename file to InnerType.cs
+            // 4. rename file to OuterType.InnerType.cs
+            // 5. rename type to test1 (which is the default document name given by TestWorkspace).
+            await TestActionCountAsync(code, count: 5);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -9,6 +9,36 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
     public partial class MoveTypeTests : CSharpMoveTypeTestsBase
     {
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestMissing_OnMatchingFileName()
+        {
+            var code =
+@"[||]class test1 { }";
+
+            await TestMissingAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestMissing_Nested_OnMatchingFileName_Simple()
+        {
+            var code =
+@"class outer
+{ 
+    [||]class test1 { }
+}";
+
+            await TestMissingAsync(code);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task TestMatchingFileName_CaseSensitive()
+        {
+            var code =
+@"[||]class Test1 { }";
+
+            await TestActionCountAsync(code, count: 2);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public async Task TestForSpans1()
         {
             var code =
@@ -275,6 +305,43 @@ class Class2 { }";
     }
 }";
             await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task MoveNestedTypeToNewFile_Simple_DottedName()
+        {
+            var code =
+@"namespace N1
+{
+    class Class1 
+    {
+        [||]class Class2 { }
+    }
+    
+}";
+
+            var codeAfterMove =
+@"namespace N1
+{
+    partial class Class1
+    {
+
+    }
+}";
+
+            var expectedDocumentName = "Class1.Class2.cs";
+
+            var destinationDocumentText =
+@"namespace N1
+{
+    partial class Class1 
+    {
+        class Class2
+        {
+        }
+    }
+}";
+            await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText, index: 1);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameFile.cs
@@ -34,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task TypeNameMatchesFileName_RenameFile()
+        public async Task TestMissing_TypeNameMatchesFileName_RenameFile()
         {
             // testworkspace creates files like test1.cs, test2.cs and so on.. 
             // so type name matches filename here and rename file action should not be offered.
@@ -45,7 +45,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile()
+        public async Task TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile()
         {
             var code =
 @"[||]class Class1 { }
@@ -74,6 +74,34 @@ class Class2 { }";
 [||]class Class2 { }";
 
             var expectedDocumentName = "Class2.cs";
+
+            await TestRenameFileToMatchTypeAsync(code, expectedDocumentName);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task NestedFile_Simple_RenameFile()
+        {
+            var code =
+@"class OuterType
+{
+    [||]class InnerType { }
+}";
+
+            var expectedDocumentName = "InnerType.cs";
+
+            await TestRenameFileToMatchTypeAsync(code, expectedDocumentName);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        public async Task NestedFile_DottedName_RenameFile()
+        {
+            var code =
+@"class OuterType
+{
+    [||]class InnerType { }
+}";
+
+            var expectedDocumentName = "OuterType.InnerType.cs";
 
             await TestRenameFileToMatchTypeAsync(code, expectedDocumentName);
         }

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.RenameType.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task TypeNameMatchesFileName_RenameType()
+        public async Task TestMissing_TypeNameMatchesFileName_RenameType()
         {
             // testworkspace creates files like test1.cs, test2.cs and so on.. 
             // so type name matches filename here and rename file action should not be offered.
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
-        public async Task MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType()
+        public async Task TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType()
         {
             var code =
 @"[||]class Class1 { }

--- a/src/EditorFeatures/Test/MoveType/AbstractMoveTypeTest.cs
+++ b/src/EditorFeatures/Test/MoveType/AbstractMoveTypeTest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.MoveType
             bool compareTokens)
         {
             var actions = await GetCodeActionsAsync(workspace, fixAllActionEquivalenceKey: null);
-            var action = actions.Single(a => a.Title.StartsWith(operation));
+            var action = actions.Single(a => a.Title.Equals(operation, StringComparison.CurrentCulture));
             var operations = await action.GetOperationsAsync(CancellationToken.None);
 
             return await TestOperationsAsync(workspace,

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -133,6 +133,7 @@
     <Compile Include="CodeActions\IntroduceVariable\IntroduceVariableTests.vb" />
     <Compile Include="CodeActions\InvertIf\InvertIfTests.vb" />
     <Compile Include="CodeActions\MoveType\BasicMoveTypeTestsBase.vb" />
+    <Compile Include="CodeActions\MoveType\MoveTypeTests.ActionCountTests.vb" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.MoveToNewFile.vb" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameType.vb" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameFile.vb" />

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.ActionCountTests.vb
@@ -1,0 +1,70 @@
+' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.MoveType
+    Partial Public Class MoveTypeTests
+        Inherits BasicMoveTypeTestsBase
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_ActionCounts_RenameOnly() As Task
+            Dim code =
+<File>
+[||]Class Class1
+End Class
+</File>.ConvertTestSourceTag()
+
+            'Fixes offered will be rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=2)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_ActionCounts_MoveOnly() As Task
+            Dim code =
+<File>
+[||]Class Class1
+End Class
+
+Class test1 'this matches file name assigned by TestWorkspace
+End Class
+</File>.ConvertTestSourceTag()
+
+            ' Fixes offered will be move type to new file.
+            Await TestActionCountAsync(code, count:=1)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_ActionCounts_RenameAndMove() As Task
+            Dim code =
+<File>
+[||]Class Class1
+End Class
+
+Class Class2
+End Class
+</File>.ConvertTestSourceTag()
+
+            ' Fixes offered will be move type, rename type to match file, rename file to match type.
+            Await TestActionCountAsync(code, count:=3)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveType_ActionCounts_All() As Task
+            Dim code =
+<File>
+Class Class1
+    Class Class2[||]
+    End Class
+End Class
+Class Class3
+End Class
+</File>.ConvertTestSourceTag()
+
+            ' Fixes offered will be
+            ' 1. move type to InnerType.vb
+            ' 2. move type to OuterType.InnerType.vb
+            ' 3. rename file to InnerType.vb
+            ' 4. rename file to OuterType.InnerType.vb
+            ' 5. rename type to test1 (which Is the default document name given by TestWorkspace).
+            Await TestActionCountAsync(code, count:=5)
+        End Function
+    End Class
+End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
@@ -5,6 +5,30 @@ Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeRefactorings.M
         Inherits BasicMoveTypeTestsBase
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function TestMissing_OnMatchingFileName() As Task
+            Dim code =
+<File>
+[||]Class test1
+End Class
+</File>.ConvertTestSourceTag()
+
+            Await TestMissingAsync(code)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function TestMissing_Nested_OnMatchingFileName_Simple() As Task
+            Dim code =
+<File>
+Class Outer
+    [||]Class test1
+    End Class
+End Class
+</File>.ConvertTestSourceTag()
+
+            Await TestMissingAsync(code)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
         Public Async Function MultipleTypesInFileWithNoContainerNamespace() As Task
             Dim code =
 <File>
@@ -27,6 +51,60 @@ Class Class1
 End Class
 </File>
             Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveNestedTypeToNewFile_Simple() As Task
+            Dim code =
+<File>
+Public Class Class1
+    Class Class2[||]
+    End Class
+End Class
+</File>
+            Dim codeAfterMove =
+<File>
+Public Partial Class Class1
+End Class
+</File>
+            Dim expectedDocumentName = "Class2.vb"
+
+            Dim destinationDocumentText =
+<File>
+Public Partial Class Class1
+    Class Class2
+
+    End Class
+End Class
+</File>
+            Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText)
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveNestedTypeToNewFile_Simple_DottedName() As Task
+            Dim code =
+<File>
+Public Class Class1
+    Class Class2[||]
+    End Class
+End Class
+</File>
+            Dim codeAfterMove =
+<File>
+Public Partial Class Class1
+End Class
+</File>
+            Dim expectedDocumentName = "Class1.Class2.vb"
+
+            Dim destinationDocumentText =
+<File>
+Public Partial Class Class1
+    Class Class2
+
+    End Class
+End Class
+</File>
+            Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText, index:=1)
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameFile.vb
@@ -15,7 +15,7 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function TypeNameMatchesFileName_RenameFile() As Task
+        Public Async Function TestMissing_TypeNameMatchesFileName_RenameFile() As Task
             ' testworkspace creates files Like test1.cs, test2.cs And so on.. 
             ' so type name matches filename here And rename file action should Not be offered.
             Dim code =
@@ -28,7 +28,7 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile() As Task
+        Public Async Function TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameFile() As Task
             Dim code =
 <File>
 [||]Class Class1

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.RenameType.vb
@@ -21,7 +21,7 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function TypeNameMatchesFileName_RenameType() As Task
+        Public Async Function TestMissing_TypeNameMatchesFileName_RenameType() As Task
             ' testworkspace creates files Like test1.cs, test2.cs And so on.. 
             ' so type name matches filename here And rename file action should Not be offered.
             Dim code =
@@ -34,7 +34,7 @@ End Class
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
-        Public Async Function MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType() As Task
+        Public Async Function TestMissing_MultipleTopLevelTypesInFileAndAtleastOneMatchesFileName_RenameType() As Task
             Dim code =
 <File>
 [||]Class Class1

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.Editor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.Editor.cs
@@ -17,15 +17,18 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             public Editor(
                 TService service,
                 State state,
+                string fileName,
                 CancellationToken cancellationToken)
             {
                 State = state;
                 Service = service;
+                FileName = fileName;
                 CancellationToken = cancellationToken;
             }
 
             protected State State { get; }
             protected TService Service { get; }
+            protected string FileName { get; }
             protected CancellationToken CancellationToken { get; }
             protected SemanticDocument SemanticDocument => State.SemanticDocument;
 

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeCodeAction.cs
@@ -17,15 +17,18 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             private readonly TService _service;
             private readonly OperationKind _operationKind;
             private readonly string _title;
+            private readonly string _fileName;
 
             public MoveTypeCodeAction(
                 TService service,
                 State state,
-                OperationKind operationKind)
+                OperationKind operationKind,
+                string fileName)
             {
                 _state = state;
                 _service = service;
                 _operationKind = operationKind;
+                _fileName = fileName;
                 _title = CreateDisplayText();
             }
 
@@ -34,11 +37,11 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 switch (_operationKind)
                 {
                     case OperationKind.MoveType:
-                        return string.Format(FeaturesResources.Move_type_to_0, _state.TargetFileNameCandidate);
+                        return string.Format(FeaturesResources.Move_type_to_0, _fileName);
                     case OperationKind.RenameType:
                         return string.Format(FeaturesResources.Rename_type_to_0, _state.DocumentName);
                     case OperationKind.RenameFile:
-                        return string.Format(FeaturesResources.Rename_file_to_0, _state.TargetFileNameCandidate);
+                        return string.Format(FeaturesResources.Rename_file_to_0, _fileName);
                 }
 
                 throw ExceptionUtilities.Unreachable;
@@ -57,11 +60,11 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 switch (_operationKind)
                 {
                     case OperationKind.MoveType:
-                        return new MoveTypeEditor(_service, _state, cancellationToken);
+                        return new MoveTypeEditor(_service, _state, _fileName, cancellationToken);
                     case OperationKind.RenameType:
-                        return new RenameTypeEditor(_service, _state, cancellationToken);
+                        return new RenameTypeEditor(_service, _state, _fileName, cancellationToken);
                     case OperationKind.RenameFile:
-                        return new RenameFileEditor(_service, _state, cancellationToken);
+                        return new RenameFileEditor(_service, _state, _fileName, cancellationToken);
                 }
 
                 throw ExceptionUtilities.Unreachable;

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -23,7 +23,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             public MoveTypeEditor(
                 TService service,
                 State state,
-                CancellationToken cancellationToken) : base(service, state, cancellationToken)
+                string fileName,
+                CancellationToken cancellationToken) : base(service, state, fileName, cancellationToken)
             {
             }
 
@@ -46,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 
                 // Fork, update and add as new document.
                 var projectToBeUpdated = SemanticDocument.Document.Project;
-                var newDocumentId = DocumentId.CreateNewId(projectToBeUpdated.Id, State.TargetFileNameCandidate);
+                var newDocumentId = DocumentId.CreateNewId(projectToBeUpdated.Id, FileName);
 
                 var solutionWithNewDocument = await AddNewDocumentWithSingleTypeDeclarationAndImportsAsync(newDocumentId).ConfigureAwait(false);
 
@@ -70,8 +71,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             private async Task<Solution> AddNewDocumentWithSingleTypeDeclarationAndImportsAsync(
                 DocumentId newDocumentId)
             {
-                Debug.Assert(SemanticDocument.Document.Name != State.TargetFileNameCandidate,
-                             $"New document name is same as old document name:{State.TargetFileNameCandidate}");
+                Debug.Assert(SemanticDocument.Document.Name != FileName,
+                             $"New document name is same as old document name:{FileName}");
 
                 var root = SemanticDocument.Root;
                 var projectToBeUpdated = SemanticDocument.Document.Project;
@@ -89,7 +90,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 var modifiedRoot = documentEditor.GetChangedRoot();
 
                 // add an empty document to solution, so that we'll have options from the right context.
-                var solutionWithNewDocument = projectToBeUpdated.Solution.AddDocument(newDocumentId, State.TargetFileNameCandidate, text: string.Empty);
+                var solutionWithNewDocument = projectToBeUpdated.Solution.AddDocument(newDocumentId, FileName, text: string.Empty);
 
                 // update the text for the new document
                 solutionWithNewDocument = solutionWithNewDocument.WithDocumentSyntaxRoot(newDocumentId, modifiedRoot, PreservationMode.PreserveIdentity);

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 return new CodeActionOperation[]
                 {
                     new ApplyChangesOperation(newSolution),
-                    new OpenDocumentOperation(newDocumentId)
+                    new OpenDocumentOperation(newDocumentId, activateIfAlreadyOpen: true)
                 };
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameFileEditor.cs
@@ -11,8 +11,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
     {
         private class RenameFileEditor : Editor
         {
-            public RenameFileEditor(TService service, State state, CancellationToken cancellationToken)
-                : base(service, state, cancellationToken)
+            public RenameFileEditor(TService service, State state, string fileName, CancellationToken cancellationToken)
+                : base(service, state, fileName, cancellationToken)
             {
             }
 
@@ -29,13 +29,13 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 var solution = SemanticDocument.Document.Project.Solution;
                 var text = SemanticDocument.Text;
                 var oldDocumentId = SemanticDocument.Document.Id;
-                var newDocumentId = DocumentId.CreateNewId(SemanticDocument.Document.Project.Id, State.TargetFileNameCandidate);
+                var newDocumentId = DocumentId.CreateNewId(SemanticDocument.Document.Project.Id, FileName);
 
                 // currently, document rename is accomplished by a remove followed by an add.
                 // the workspace takes care of resolving conflicts if the document name is not unique in the project
                 // by adding numeric suffixes to the new document being added.
                 var newSolution = solution.RemoveDocument(oldDocumentId);
-                newSolution = newSolution.AddDocument(newDocumentId, State.TargetFileNameCandidate, text);
+                newSolution = newSolution.AddDocument(newDocumentId, FileName, text);
 
                 return new CodeActionOperation[]
                 {

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.RenameTypeEditor.cs
@@ -13,8 +13,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
     {
         private class RenameTypeEditor : Editor
         {
-            public RenameTypeEditor(TService service, State state, CancellationToken cancellationToken)
-                : base(service, state, cancellationToken)
+            public RenameTypeEditor(TService service, State state, string fileName, CancellationToken cancellationToken)
+                : base(service, state, fileName, cancellationToken)
             {
             }
 
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 // if no such conflicts exist, proceed with RenameSymbolAsync.
                 var solution = SemanticDocument.Document.Project.Solution;
                 var symbol = State.SemanticDocument.SemanticModel.GetDeclaredSymbol(State.TypeNode, CancellationToken);
-                var newSolution = await Renamer.RenameSymbolAsync(solution, symbol, State.DocumentName, SemanticDocument.Document.Options, CancellationToken).ConfigureAwait(false);
+                var newSolution = await Renamer.RenameSymbolAsync(solution, symbol, FileName, SemanticDocument.Document.Options, CancellationToken).ConfigureAwait(false);
                 return SpecializedCollections.SingletonEnumerable(new ApplyChangesOperation(newSolution));
             }
         }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.State.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -19,7 +18,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             public TTypeDeclarationSyntax TypeNode { get; set; }
             public string TypeName { get; set; }
             public string DocumentName { get; set; }
-            public string TargetFileNameCandidate { get; set; }
             public bool IsDocumentNameAValidIdentifier { get; set; }
 
             private State(TService service, SemanticDocument document)
@@ -74,16 +72,13 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 DocumentName = Path.GetFileNameWithoutExtension(this.SemanticDocument.Document.Name);
                 IsDocumentNameAValidIdentifier = syntaxFacts.IsValidIdentifier(DocumentName);
 
-                // TODO: Make this check better, it won't detect Outer.Inner.cs cases.
-                if (string.Equals(DocumentName, TypeName, StringComparison.CurrentCulture))
-                {
-                    // if type name matches document name in a case sensitive manner, we have nothing more to do.
-                    return false;
-                }
-
-                TargetFileNameCandidate = Path.Combine(typeSymbol.Name + Path.GetExtension(this.SemanticDocument.Document.Name));
-
-                return true;
+                // if type name matches document name, per style conventions, we have nothing to do.
+                return !_service.TypeMatchesDocumentName(
+                    TypeNode,
+                    TypeName,
+                    DocumentName,
+                    SemanticDocument.SemanticModel,
+                    cancellationToken);
             }
         }
     }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.cs
@@ -4,11 +4,13 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
 {
@@ -57,35 +59,51 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
         {
             var actions = new List<CodeAction>();
             var manyTypes = MultipleTopLevelTypeDeclarationInSourceDocument(state.SemanticDocument.Root);
+            var isNestedType = IsNestedType(state.TypeNode);
+
+            var suggestedFileNames = GetSuggestedFileNames(
+                state.TypeNode,
+                isNestedType,
+                state.TypeName,
+                state.SemanticDocument.Document.Name,
+                state.SemanticDocument.SemanticModel,
+                cancellationToken);
 
             // (1) Add Move type to new file code action:
             // case 1: There are multiple type declarations in current document. offer, move to new file.
             // case 2: This is a nested type, offer to move to new file.
-            // case 3: If there is a single type decl in current file, *do not* offer move to new file.
-            if (manyTypes || IsNestedType(state.TypeNode))
+            // case 3: If there is a single type decl in current file, *do not* offer move to new file,
+            //         rename actions are sufficient in this case.
+            if (manyTypes || isNestedType)
             {
-                actions.Add(GetCodeAction(state, operationKind: OperationKind.MoveType));
+                foreach (var fileName in suggestedFileNames)
+                {
+                    actions.Add(GetCodeAction(state, fileName, operationKind: OperationKind.MoveType));
+                }
             }
 
             // (2) Add rename file and rename type code actions:
             // Case: No type declaration in file matches the file name.
             if (!AnyTopLevelTypeMatchesDocumentName(state, cancellationToken))
             {
-                actions.Add(GetCodeAction(state, operationKind: OperationKind.RenameFile));
+                foreach (var fileName in suggestedFileNames)
+                {
+                    actions.Add(GetCodeAction(state, fileName, operationKind: OperationKind.RenameFile));
+                }
 
                 // only if the document name can be legal identifier in the language,
                 // offer to rename type with document name
                 if (state.IsDocumentNameAValidIdentifier)
                 {
-                    actions.Add(GetCodeAction(state, operationKind: OperationKind.RenameType));
+                    actions.Add(GetCodeAction(state, fileName: state.DocumentName, operationKind: OperationKind.RenameType));
                 }
             }
 
             return actions.ToImmutableArray();
         }
 
-        private CodeAction GetCodeAction(State state, OperationKind operationKind) =>
-            new MoveTypeCodeAction((TService)this, state, operationKind);
+        private CodeAction GetCodeAction(State state, string fileName, OperationKind operationKind) =>
+            new MoveTypeCodeAction((TService)this, state, operationKind, fileName);
 
         private bool IsNestedType(TTypeDeclarationSyntax typeNode) =>
             typeNode.Parent is TTypeDeclarationSyntax;
@@ -103,17 +121,82 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             root.DescendantNodes(n => (n is TCompilationUnitSyntax || n is TNamespaceDeclarationSyntax))
                 .OfType<TTypeDeclarationSyntax>();
 
-        private static bool AnyTopLevelTypeMatchesDocumentName(State state, CancellationToken cancellationToken)
+        private bool AnyTopLevelTypeMatchesDocumentName(State state, CancellationToken cancellationToken)
         {
             var root = state.SemanticDocument.Root;
             var semanticModel = state.SemanticDocument.SemanticModel;
 
             return TopLevelTypeDeclarations(root).Any(
-                typeDeclaration => 
+                typeDeclaration =>
                 {
                     var typeName = semanticModel.GetDeclaredSymbol(typeDeclaration, cancellationToken).Name;
-                    return string.Equals(state.DocumentName, typeName, StringComparison.CurrentCulture);
+                    return TypeMatchesDocumentName(typeDeclaration, typeName, state.DocumentName, semanticModel, cancellationToken);
                 });
         }
+
+        /// <summary>
+        /// checks if type name matches its parent document name, per style rules.
+        /// </summary>
+        /// <remarks>
+        /// Note: For a nested type, a matching document name could be just the type name or a
+        /// dotted qualified name of its type hierarchy.
+        /// </remarks>
+        protected bool TypeMatchesDocumentName(
+            TTypeDeclarationSyntax typeNode,
+            string typeName,
+            string documentName,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken)
+        {
+            // trim extensions, if present.
+            documentName = Path.GetFileNameWithoutExtension(documentName);
+
+            // If it is not a nested type, we compare the unqualified type name with the document name.
+            // If it is a nested type, the type name `Outer.Inner` matches file names `Inner.cs` and `Outer.Inner.cs`
+            var namesMatch = typeName.Equals(documentName, StringComparison.CurrentCulture);
+            if (!namesMatch)
+            {
+                var typeNameParts = GetTypeNamePartsForNestedTypeNode(typeNode, semanticModel, cancellationToken);
+                var fileNameParts = documentName.Split('.');
+
+                // qualified type name `Outer.Inner` matches file names `Inner.cs` and `Outer.Inner.cs`
+                return typeNameParts.SequenceEqual(fileNameParts, StringComparer.CurrentCulture);
+            }
+
+            return namesMatch;
+        }
+
+        private IEnumerable<string> GetSuggestedFileNames(
+            TTypeDeclarationSyntax typeNode,
+            bool isNestedType,
+            string typeName,
+            string documentNameWithExtension,
+            SemanticModel semanticModel,
+            CancellationToken cancellationToken)
+        {
+            var fileExtension = Path.GetExtension(documentNameWithExtension);
+
+            var standaloneName = typeName + fileExtension;
+
+            // If it is a nested type, we should match type hierarchy's name parts with the file name.
+            if (isNestedType)
+            {
+                var typeNameParts = GetTypeNamePartsForNestedTypeNode(typeNode, semanticModel, cancellationToken);
+                var dottedName = typeNameParts.Join(".") + fileExtension;
+
+                return new List<string> { standaloneName, dottedName };
+            }
+            else
+            {
+                return SpecializedCollections.SingletonEnumerable(standaloneName);
+            }
+        }
+
+        private static IEnumerable<string> GetTypeNamePartsForNestedTypeNode(
+            TTypeDeclarationSyntax typeNode, SemanticModel semanticModel, CancellationToken cancellationToken) =>
+                typeNode.AncestorsAndSelf()
+                        .OfType<TTypeDeclarationSyntax>()
+                        .Select(n => semanticModel.GetDeclaredSymbol(n, cancellationToken).Name)
+                        .Reverse();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12728

- In case of nested types, the accepted style of naming the file is either by the standalone typename or with a dotted name derived from its type hierarchy. 

```C#
class A
{
    class B { }
}
```
In the code sample above, acceptable file names for type B is B.cs or A.B.cs

Offer these as suggested filenames if the file is named something other than either of these two. These suggestions are then picked up and surfaced as "Move to.." and/or "Rename file to.. " code actions.

- Also, fixes an unrelated glitch in "rename file" scenario (w. 1a3569b). 
Rename file is internally implemented as a remove followed by an add. The remove causes the file to be closed. So we open the new document following the add, but did not make it the active document. This means that the active file per user's context has changed after invoking "rename file". The fix is to open the new document and activate it.