### PR TITLE
Vb tuple conversions

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -191,12 +191,6 @@ Friend Class MockNamedTypeSymbol
         End Get
     End Property
 
-    Public Overrides ReadOnly Property EnumUnderlyingType As NamedTypeSymbol
-        Get
-            Throw New InvalidOperationException()
-        End Get
-    End Property
-
     Public Overloads Overrides Function GetAttributes() As ImmutableArray(Of VisualBasicAttributeData)
         Return ImmutableArray.Create(Of VisualBasicAttributeData)()
     End Function

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1583,24 +1583,22 @@ DoneWithDiagnostics:
             Dim isNullableTupleConversion = (convKind = ConversionKind.WideningNullable) Or (convKind = ConversionKind.NarrowingNullable)
             Debug.Assert(Not isNullableTupleConversion OrElse destination.IsNullableType())
 
-            Dim destinationWithoutNullable = destination
+            Dim targetType = destination
 
             If isNullableTupleConversion Then
-                destinationWithoutNullable = destination.GetNullableUnderlyingType()
+                targetType = destination.GetNullableUnderlyingType()
             End If
 
-            Dim targetType As NamedTypeSymbol = DirectCast(destinationWithoutNullable, NamedTypeSymbol)
+            Dim arguments = sourceTuple.Arguments
+            If Not targetType.IsTupleOrCompatibleWithTupleOfCardinality(arguments.Length) Then
+                Return sourceTuple
+            End If
+
             If targetType.IsTupleType Then
                 Dim destTupleType = DirectCast(targetType, TupleTypeSymbol)
                 ' do not lose the original element names in the literal if different from names in the target
                 ' Come back to this, what about locations? (https:'github.com/dotnet/roslyn/issues/11013)
                 targetType = destTupleType.WithElementNames(sourceTuple.ArgumentNamesOpt)
-            End If
-
-            Dim arguments = sourceTuple.Arguments
-
-            If Not targetType.IsTupleOrCompatibleWithTupleOfCardinality(arguments.Length) Then
-                Return sourceTuple
             End If
 
             Dim convertedArguments = ArrayBuilder(Of BoundExpression).GetInstance(arguments.Length)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -454,6 +454,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                          Not argument.IsNothingLiteral() OrElse
                          TypeOf argument.Syntax.Parent Is BinaryExpressionSyntax OrElse
                          TypeOf argument.Syntax.Parent Is UnaryExpressionSyntax OrElse
+                         TypeOf argument.Syntax.Parent Is TupleExpressionSyntax OrElse
                          (TypeOf argument.Syntax.Parent Is AssignmentStatementSyntax AndAlso argument.Syntax.Parent.Kind <> SyntaxKind.SimpleAssignmentStatement),
                          "Applying yet another conversion to an implicit conversion from NOTHING, probably MakeRValue was called too early.")
 
@@ -1230,6 +1231,11 @@ DoneWithDiagnostics:
                     argument = ReclassifyInterpolatedStringExpression(conversionSemantics, tree, convKind, isExplicit, DirectCast(argument, BoundInterpolatedStringExpression), targetType, diagnostics)
                     Return argument.Kind = BoundKind.Conversion
 
+                Case BoundKind.TupleLiteral
+
+                    argument = ReclassifyTupleLiteral(convKind, isExplicit, DirectCast(argument, BoundTupleLiteral), targetType, diagnostics)
+                    Return True
+
             End Select
 
             Return False
@@ -1561,6 +1567,64 @@ DoneWithDiagnostics:
 
             Return node
 
+        End Function
+
+        Private Function ReclassifyTupleLiteral(convKind As ConversionKind, isExplicit As Boolean, sourceTuple As BoundTupleLiteral, destination As TypeSymbol, diagnostics As DiagnosticBag) As BoundExpression
+            ' We have a successful tuple conversion rather than producing a separate conversion node 
+            ' which is a conversion on top of a tuple literal, tuple conversion is an element-wise conversion of arguments.
+            Debug.Assert((convKind = ConversionKind.WideningNullable) = destination.IsNullableType())
+
+            Dim destinationWithoutNullable = destination
+
+            If convKind = ConversionKind.WideningNullable Then
+                destinationWithoutNullable = destination.GetNullableUnderlyingType()
+            End If
+
+            Dim targetType As NamedTypeSymbol = DirectCast(destinationWithoutNullable, NamedTypeSymbol)
+            If targetType.IsTupleType Then
+                Dim destTupleType = DirectCast(targetType, TupleTypeSymbol)
+                ' do not lose the original element names in the literal if different from names in the target
+                ' Come back to this, what about locations? (https:'github.com/dotnet/roslyn/issues/11013)
+                targetType = destTupleType.WithElementNames(sourceTuple.ArgumentNamesOpt)
+            End If
+
+            Dim arguments = sourceTuple.Arguments
+            Dim convertedArguments = ArrayBuilder(Of BoundExpression).GetInstance(arguments.Length)
+
+            Dim targetElementTypes As ImmutableArray(Of TypeSymbol) = targetType.GetElementTypesOfTupleOrCompatible()
+            Debug.Assert(targetElementTypes.Length = arguments.Length, "converting a tuple literal to incompatible type?")
+
+            For i As Integer = 0 To arguments.Length - 1
+                Dim argument = arguments(i)
+                Dim destType = targetElementTypes(i)
+
+                convertedArguments.Add(ApplyConversion(argument.Syntax, destType, argument, isExplicit, diagnostics))
+            Next
+
+            Dim result As BoundExpression = New BoundConvertedTupleLiteral(
+                sourceTuple.Syntax,
+                sourceTuple.Type,
+                convertedArguments.ToImmutableAndFree(),
+                targetType)
+
+            If sourceTuple.Type <> destination Then
+                ' literal cast is applied to the literal 
+                result = New BoundConversion(sourceTuple.Syntax, result, convKind, checked:=False, explicitCastInCode:=isExplicit, type:=destination)
+            End If
+
+            ' If we had a cast in the code, keep conversion in the tree.
+            ' even though the literal is already converted to the target type.
+            If isExplicit Then
+                result = New BoundConversion(
+                    sourceTuple.Syntax,
+                    result,
+                    ConversionKind.Identity,
+                    checked:=False,
+                    explicitCastInCode:=isExplicit,
+                    type:=destination)
+            End If
+
+            Return result
         End Function
 
         Private Sub WarnOnNarrowingConversionBetweenSealedClassAndAnInterface(

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -348,7 +348,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 CollectTupleFieldMemberNames(name, i + 1, numElements, elementNames)
 
-                Dim boundArgument As BoundExpression = BindRValue(argumentSyntax.Expression, diagnostics)
+                Dim boundArgument As BoundExpression = BindValue(argumentSyntax.Expression, diagnostics)
                 boundArguments.Add(boundArgument)
 
                 Dim elementType = GetTupleFieldType(boundArgument, argumentSyntax, diagnostics, hasErrors)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -175,6 +175,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 constructedType.CheckConstraints(syntaxArguments, diagnostics)
             End If
 
+            constructedType = DirectCast(TupleTypeSymbol.TransformToTupleIfCompatible(constructedType), NamedTypeSymbol)
+
             Return constructedType
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -116,17 +116,91 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return returnValue
         End Function
 
-        Private Function RewriteTupleConversion(node As BoundConversion) As BoundNode
-            Dim loweredOperand = VisitExpression(node.Operand)
+        Private Function RewriteTupleConversion(node As BoundConversion) As BoundExpression
+            Dim syntax = node.Syntax
+            Dim rewrittenOperand = VisitExpression(node.Operand)
+            Dim rewrittenType = DirectCast(VisitType(node.Type), NamedTypeSymbol)
 
-            If node.Type.IsSameTypeIgnoringCustomModifiers(loweredOperand.Type) Then
+            Return MakeTupleConversion(syntax, rewrittenOperand, rewrittenType, node.Checked)
+        End Function
+
+        Private Function MakeTupleConversion(syntax As VisualBasicSyntaxNode, rewrittenOperand As BoundExpression, destinationType As TypeSymbol, isChecked As Boolean) As BoundExpression
+            If destinationType.IsSameTypeIgnoringCustomModifiers(rewrittenOperand.Type) Then
                 'binder keeps some tuple conversions just for the purpose of semantic model
                 'otherwisw they are as good as identity conversions
 
-                Return loweredOperand
+                Return rewrittenOperand
             End If
 
-            Throw New NotImplementedException
+            Dim destElementTypes = destinationType.GetElementTypesOfTupleOrCompatible()
+            Dim numElements = destElementTypes.Length
+
+            Dim srcElementFields As ImmutableArray(Of FieldSymbol)
+            Dim srcType As TypeSymbol = rewrittenOperand.Type
+
+            If (srcType.IsTupleType) Then
+                srcElementFields = DirectCast(srcType, TupleTypeSymbol).TupleElementFields
+            Else
+                ' The following codepath should be very uncommon (if reachable at all)
+                ' we should generally not see tuple compatible types in bound trees and 
+                ' see actual tuple types instead.
+                Debug.Assert(srcType.IsTupleCompatible())
+
+                ' PERF: if allocations here become nuisance, consider caching the TupleTypeSymbol
+                '       in the type symbols that can actually be tuple compatible
+                srcElementFields = TupleTypeSymbol.Create(DirectCast(srcType, NamedTypeSymbol)).TupleElementFields
+            End If
+
+            Dim fieldAccessorsBuilder = ArrayBuilder(Of BoundExpression).GetInstance(numElements)
+            Dim assignmentToTemp As BoundExpression = Nothing
+            Dim tupleTemp As SynthesizedLocal = Nothing
+            Dim savedTuple As BoundExpression = CaptureOperand(rewrittenOperand, tupleTemp, assignmentToTemp)
+
+            Dim factory As New SyntheticBoundNodeFactory(_topMethod, _currentMethodOrLambda, syntax, _compilationState, _diagnostics)
+
+            For i As Integer = 0 To numElements - 1
+                Dim field = srcElementFields(i)
+
+                Dim useSiteInfo As DiagnosticInfo = field.CalculateUseSiteErrorInfo()
+
+                If useSiteInfo IsNot Nothing AndAlso useSiteInfo.Severity = DiagnosticSeverity.Error Then
+                    ReportDiagnostic(rewrittenOperand, useSiteInfo, _diagnostics)
+                End If
+
+                Dim fieldAccess = MakeTupleFieldAccess(syntax, field, savedTuple, constantValueOpt:=Nothing, isLValue:=False)
+                Dim elementType = destElementTypes(i)
+                Dim conv = Conversions.ClassifyConversion(fieldAccess.Type, elementType, useSiteDiagnostics:=Nothing)
+
+                Dim convertedFieldAccess = If(conv.Value Is Nothing,
+                                                TransformRewrittenConversion(factory.Convert(elementType, fieldAccess, conv.Key, isChecked)),
+                                                MakeUserDefinedTupleFieldConversion(factory, elementType, fieldAccess, conv.Value, isChecked))
+
+                fieldAccessorsBuilder.Add(convertedFieldAccess)
+            Next
+
+            Dim result = MakeTupleCreationExpression(syntax, DirectCast(destinationType, NamedTypeSymbol), fieldAccessorsBuilder.ToImmutableAndFree())
+            Return factory.Sequence(tupleTemp, assignmentToTemp, result)
+        End Function
+
+        Private Function MakeUserDefinedTupleFieldConversion(factory As SyntheticBoundNodeFactory, elementType As TypeSymbol, fieldAccess As BoundExpression, method As MethodSymbol, isChecked As Boolean) As BoundExpression
+            ' User defined conversion here would be applied like:
+            '                    field -> [predefined conv] -> [call] -> [predefined conv] -> result
+            '
+            ' NOTE: predefined conversions here may themselves be tuple conversions,
+            '       which may contain more tuple conversions and so on, so we have to lower them.
+            '       We do not want to lower the field access though, so use a placeholder instead.
+            Dim placeholder = New BoundRValuePlaceholder(fieldAccess.Syntax, fieldAccess.Type)
+
+            Dim convIn = factory.Convert(method.Parameters(0).Type, placeholder, isChecked)
+            Dim [call] = factory.Call(Nothing, method, convIn)
+            Dim convOut = factory.Convert(elementType, [call], isChecked)
+
+            ' lower the conversions
+            AddPlaceholderReplacement(placeholder, fieldAccess)
+            Dim result = VisitExpression(convOut)
+            RemovePlaceholderReplacement(placeholder)
+
+            Return result
         End Function
 
         Private Function RewriteLambdaRelaxationConversion(node As BoundConversion) As BoundNode
@@ -437,8 +511,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Else
                     _diagnostics.Add(node, useSiteDiagnostics)
-                    operand = TransformRewrittenConversion(
-                                New BoundConversion(node.Syntax,
+
+                    If (convKind And ConversionKind.Tuple) <> 0 Then
+                        operand = MakeTupleConversion(node.Syntax, operand, unwrappedResultType, node.Checked)
+
+                    Else
+                        operand = TransformRewrittenConversion(New BoundConversion(node.Syntax,
                                                     operand,
                                                     convKind,
                                                     node.Checked,
@@ -448,6 +526,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     node.RelaxationLambdaOpt,
                                                     node.RelaxationReceiverPlaceholderOpt,
                                                     unwrappedResultType))
+                    End If
                 End If
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_NullableHelpers.vb
@@ -109,6 +109,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' capture into local.
+            Return CaptureOperand(operand, temp, init)
+        End Function
+
+        Private Function CaptureOperand(operand As BoundExpression, <Out> ByRef temp As SynthesizedLocal, <Out> ByRef init As BoundExpression) As BoundExpression
             temp = New SynthesizedLocal(Me._currentMethodOrLambda, operand.Type, SynthesizedLocalKind.LoweringTemp)
             Dim localAccess = New BoundLocal(operand.Syntax, temp, True, temp.Type)
             init = New BoundAssignmentOperator(operand.Syntax, localAccess, operand, True, operand.Type)

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_TupleLiteralExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_TupleLiteralExpression.vb
@@ -9,6 +9,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return VisitTupleExpression(node)
         End Function
 
+        Public Overrides Function VisitConvertedTupleLiteral(node As BoundConvertedTupleLiteral) As BoundNode
+            Return VisitTupleExpression(node)
+        End Function
+
         Private Function VisitTupleExpression(node As BoundTupleExpression) As BoundNode
             Dim rewrittenArguments As ImmutableArray(Of BoundExpression) = VisitList(node.Arguments)
             Return RewriteTupleCreationExpression(node, rewrittenArguments)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -383,6 +383,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ' Interpolated string conversions
         InterpolatedString = [Widening] Or (1 << 25)
 
+        ' Tuple conversions
+        Tuple = (1 << 26)
+        WideningTuple = [Widening] Or Tuple
+        NarrowingTuple = [Narrowing] Or Tuple
+
         ' Bits 28 - 31 are reserved for failure flags.
     End Enum
 
@@ -1038,6 +1043,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case BoundKind.InterpolatedStringExpression
                     Return ClassifyInterpolatedStringConversion(DirectCast(source, BoundInterpolatedStringExpression), destination, binder)
 
+                Case BoundKind.TupleLiteral
+                    Return ClassifyTupleConversion(DirectCast(source, BoundTupleLiteral), destination, binder, useSiteDiagnostics)
             End Select
 
             Return Nothing 'ConversionKind.NoConversion
@@ -1200,6 +1207,36 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Return Nothing
 
+        End Function
+
+        Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+            Dim arguments = source.Arguments
+
+            ' check if the type is actually compatible type for a tuple of given cardinality
+            If Not destination.IsTupleOrCompatibleWithTupleOfCardinality(arguments.Count) Then
+                Return Nothing 'ConversionKind.NoConversion
+            End If
+
+            Dim targetElementTypes As ImmutableArray(Of TypeSymbol) = destination.GetElementTypesOfTupleOrCompatible()
+            Debug.Assert(arguments.Count = targetElementTypes.Length)
+
+            ' check arguments against flattened list of target element types 
+            Dim result As ConversionKind = ConversionKind.WideningTuple
+
+            For i As Integer = 0 To arguments.Count - 1
+                Dim argument = arguments(i)
+                Dim elementConversion = ClassifyConversion(argument, targetElementTypes(i), binder, useSiteDiagnostics).Key
+
+                If NoConversion(elementConversion) Then
+                    Return Nothing
+                End If
+
+                If IsNarrowingConversion(elementConversion) Then
+                    result = ConversionKind.NarrowingTuple
+                End If
+            Next
+
+            Return result
         End Function
 
         Private Shared Function ClassifyArrayInitialization(source As BoundArrayInitialization, targetElementType As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1228,7 +1228,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim elementConversion = ClassifyConversion(argument, targetElementTypes(i), binder, useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then
-                    Return Nothing
+                    Return Nothing 'ConversionKind.NoConversion
                 End If
 
                 If IsNarrowingConversion(elementConversion) Then
@@ -3506,7 +3506,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim elementConversion = ClassifyConversion(argumentType, targetElementTypes(i), useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then
-                    Return Nothing
+                    Return Nothing 'ConversionKind.NoConversion
                 End If
 
                 If IsNarrowingConversion(elementConversion) Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
@@ -140,12 +140,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides ReadOnly Property EnumUnderlyingType As NamedTypeSymbol
-            Get
-                Throw New InvalidOperationException()
-            End Get
-        End Property
-
         Public Overrides ReadOnly Property Name As String
             Get
                 Return String.Empty

--- a/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/InstanceTypeSymbol.vb
@@ -69,10 +69,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' !!! All other code should use Construct methods.                                        !!! 
         ''' </summary>
         Friend Overrides Function InternalSubstituteTypeParameters(substitution As TypeSubstitution) As TypeWithModifiers
-            Return New TypeWithModifiers(InternalSubstituteTypeParametersInNamedType(substitution))
+            Return New TypeWithModifiers(SubstituteTypeParametersInNamedType(substitution))
         End Function
 
-        Private Overloads Function InternalSubstituteTypeParametersInNamedType(substitution As TypeSubstitution) As NamedTypeSymbol
+        Private Function SubstituteTypeParametersInNamedType(substitution As TypeSubstitution) As NamedTypeSymbol
 
             If substitution IsNot Nothing Then
                 ' The substitution might target one of this type's children.

--- a/src/Compilers/VisualBasic/Portable/Symbols/MethodSignatureComparer.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MethodSignatureComparer.vb
@@ -570,16 +570,16 @@ Done:
                     If checkTypes Then
                         Dim type1 As TypeWithModifiers
                         If typeSubstitution1 IsNot Nothing Then
-                            type1 = SubstituteType(typeSubstitution1, New TypeWithModifiers(param1.OriginalDefinition.Type, param1.OriginalDefinition.CustomModifiers))
+                            type1 = SubstituteType(typeSubstitution1, New TypeWithModifiers(param1.OriginalDefinition.Type.GetTupleUnderlyingTypeOrSelf(), param1.OriginalDefinition.CustomModifiers))
                         Else
-                            type1 = New TypeWithModifiers(param1.Type, param1.CustomModifiers)
+                            type1 = New TypeWithModifiers(param1.Type.GetTupleUnderlyingTypeOrSelf(), param1.CustomModifiers)
                         End If
 
                         Dim type2 As TypeWithModifiers
                         If typeSubstitution2 IsNot Nothing Then
-                            type2 = SubstituteType(typeSubstitution2, New TypeWithModifiers(param2.OriginalDefinition.Type, param2.OriginalDefinition.CustomModifiers))
+                            type2 = SubstituteType(typeSubstitution2, New TypeWithModifiers(param2.OriginalDefinition.Type.GetTupleUnderlyingTypeOrSelf(), param2.OriginalDefinition.CustomModifiers))
                         Else
-                            type2 = New TypeWithModifiers(param2.Type, param2.CustomModifiers)
+                            type2 = New TypeWithModifiers(param2.Type.GetTupleUnderlyingTypeOrSelf(), param2.CustomModifiers)
                         End If
 
                         If Not type1.Type.IsSameTypeIgnoringCustomModifiers(type2.Type) Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleMethodSymbol.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly _typeParameters As ImmutableArray(Of TypeParameterSymbol)
 
-        Private ReadOnly _lazyParameters As ImmutableArray(Of ParameterSymbol)
+        Private _lazyParameters As ImmutableArray(Of ParameterSymbol)
 
         Public Overrides ReadOnly Property IsTupleMethod As Boolean
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -592,7 +592,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Function CollectTupleElementFields() As ImmutableArray(Of FieldSymbol)
-            Dim builder = ArrayBuilder(Of FieldSymbol).GetInstance(_elementTypes.Length)
+            Dim builder = ArrayBuilder(Of FieldSymbol).GetInstance(_elementTypes.Length, Nothing)
 
             For Each member In GetMembers()
                 If member.Kind <> SymbolKind.Field Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -40,16 +40,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Function GetEnumUnderlyingType(type As TypeSymbol) As TypeSymbol
             Debug.Assert(type IsNot Nothing)
 
-            If type.IsEnumType() Then
-                Return DirectCast(type, NamedTypeSymbol).EnumUnderlyingType
-            End If
-
-            Return Nothing
+            Return TryCast(type, NamedTypeSymbol)?.EnumUnderlyingType
         End Function
 
         <Extension()>
         Public Function GetEnumUnderlyingTypeOrSelf(type As TypeSymbol) As TypeSymbol
             Return If(GetEnumUnderlyingType(type), type)
+        End Function
+
+        <Extension()>
+        Public Function GetTupleUnderlyingType(type As TypeSymbol) As TypeSymbol
+            Debug.Assert(type IsNot Nothing)
+
+            Return TryCast(type, NamedTypeSymbol)?.TupleUnderlyingType
+        End Function
+
+        <Extension()>
+        Public Function GetTupleUnderlyingTypeOrSelf(type As TypeSymbol) As TypeSymbol
+            Return If(GetTupleUnderlyingType(type), type)
         End Function
 
         <Extension()>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -442,6 +442,57 @@ Sum: 10, Count: 4")
 
         End Sub
 
+        <Fact()>
+        Public Sub Overloading001()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+
+Module m1
+    Sub Test(x as (a as integer, b as Integer))
+    End Sub
+
+    Sub Test(x as (c as integer, d as Integer))
+    End Sub
+End module
+
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+    BC30269: 'Public Sub Test(x As (a As Integer, b As Integer))' has multiple definitions with identical signatures.
+    Sub Test(x as (a as integer, b as Integer))
+        ~~~~
+</errors>)
+
+        End Sub
+
+        <Fact()>
+        Public Sub Overloading002()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+
+Module m1
+    Sub Test(x as (integer,Integer))
+    End Sub
+
+    Sub Test(x as (a as integer, b as Integer))
+    End Sub
+End module
+
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30269: 'Public Sub Test(x As (Integer, Integer))' has multiple definitions with identical signatures.
+    Sub Test(x as (integer,Integer))
+        ~~~~
+</errors>)
+
+        End Sub
 
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -561,34 +561,1091 @@ End Module
     <file name="a.vb">
 Imports System
 Module C
-
     Sub Main()
-        Dim x = CType((String, String),(Nothing, Nothing))
+        Dim x = CType((Nothing, 1),(String, Byte))
         System.Console.WriteLine(x.ToString())
     End Sub
 End Module
 
     </file>
 </compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
-(, )
+(, 1)
             ]]>)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
   // Code size       28 (0x1c)
   .maxstack  3
-  .locals init (System.ValueTuple(Of String, String) V_0) //x
+  .locals init (System.ValueTuple(Of String, Byte) V_0) //x
   IL_0000:  ldloca.s   V_0
   IL_0002:  ldnull
-  IL_0003:  ldnull
-  IL_0004:  call       "Sub System.ValueTuple(Of String, String)..ctor(String, String)"
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       "Sub System.ValueTuple(Of String, Byte)..ctor(String, Byte)"
   IL_0009:  ldloca.s   V_0
-  IL_000b:  constrained. "System.ValueTuple(Of String, String)"
+  IL_000b:  constrained. "System.ValueTuple(Of String, Byte)"
   IL_0011:  callvirt   "Function Object.ToString() As String"
   IL_0016:  call       "Sub System.Console.WriteLine(String)"
   IL_001b:  ret
 }
 ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped004()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = DirectCast((Nothing, 1),(String, String))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, 1)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       33 (0x21)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of String, String) V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldnull
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Integer) As String"
+  IL_0009:  call       "Sub System.ValueTuple(Of String, String)..ctor(String, String)"
+  IL_000e:  ldloca.s   V_0
+  IL_0010:  constrained. "System.ValueTuple(Of String, String)"
+  IL_0016:  callvirt   "Function Object.ToString() As String"
+  IL_001b:  call       "Sub System.Console.WriteLine(String)"
+  IL_0020:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped005()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as integer = 100
+        Dim x = CType((Nothing, i),(String, byte))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (Integer V_0, //i
+                System.ValueTuple(Of String, Byte) V_1) //x
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  ldnull
+  IL_0006:  ldloc.0
+  IL_0007:  conv.ovf.u1
+  IL_0008:  call       "Sub System.ValueTuple(Of String, Byte)..ctor(String, Byte)"
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  constrained. "System.ValueTuple(Of String, Byte)"
+  IL_0015:  callvirt   "Function Object.ToString() As String"
+  IL_001a:  call       "Sub System.Console.WriteLine(String)"
+  IL_001f:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped006()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as integer = 100
+        Dim x = DirectCast((Nothing, i),(String, byte))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (Integer V_0, //i
+                System.ValueTuple(Of String, Byte) V_1) //x
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  ldnull
+  IL_0006:  ldloc.0
+  IL_0007:  conv.ovf.u1
+  IL_0008:  call       "Sub System.ValueTuple(Of String, Byte)..ctor(String, Byte)"
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  constrained. "System.ValueTuple(Of String, Byte)"
+  IL_0015:  callvirt   "Function Object.ToString() As String"
+  IL_001a:  call       "Sub System.Console.WriteLine(String)"
+  IL_001f:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped007()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as integer = 100
+        Dim x = TryCast((Nothing, i),(String, byte))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       32 (0x20)
+  .maxstack  3
+  .locals init (Integer V_0, //i
+                System.ValueTuple(Of String, Byte) V_1) //x
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  stloc.0
+  IL_0003:  ldloca.s   V_1
+  IL_0005:  ldnull
+  IL_0006:  ldloc.0
+  IL_0007:  conv.ovf.u1
+  IL_0008:  call       "Sub System.ValueTuple(Of String, Byte)..ctor(String, Byte)"
+  IL_000d:  ldloca.s   V_1
+  IL_000f:  constrained. "System.ValueTuple(Of String, Byte)"
+  IL_0015:  callvirt   "Function Object.ToString() As String"
+  IL_001a:  call       "Sub System.Console.WriteLine(String)"
+  IL_001f:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionWidening()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (x as byte, y as byte) = (a:=100, b:=100)
+        Dim x as (integer, double) = i
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       48 (0x30)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Double) V_0, //x
+                System.ValueTuple(Of Byte, Byte) V_1)
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_0009:  stloc.1
+  IL_000a:  ldloc.1
+  IL_000b:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0010:  ldloc.1
+  IL_0011:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0016:  conv.r8
+  IL_0017:  newobj     "Sub System.ValueTuple(Of Integer, Double)..ctor(Integer, Double)"
+  IL_001c:  stloc.0
+  IL_001d:  ldloca.s   V_0
+  IL_001f:  constrained. "System.ValueTuple(Of Integer, Double)"
+  IL_0025:  callvirt   "Function Object.ToString() As String"
+  IL_002a:  call       "Sub System.Console.WriteLine(String)"
+  IL_002f:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNarrowing()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (Integer, String) = (100, 100)
+        Dim x as (Byte, Byte) = i
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       58 (0x3a)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Byte, Byte) V_0, //x
+                System.ValueTuple(Of Integer, String) V_1)
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Integer) As String"
+  IL_0009:  newobj     "Sub System.ValueTuple(Of Integer, String)..ctor(Integer, String)"
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  ldfld      "System.ValueTuple(Of Integer, String).Item1 As Integer"
+  IL_0015:  conv.ovf.u1
+  IL_0016:  ldloc.1
+  IL_0017:  ldfld      "System.ValueTuple(Of Integer, String).Item2 As String"
+  IL_001c:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToByte(String) As Byte"
+  IL_0021:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_0026:  stloc.0
+  IL_0027:  ldloca.s   V_0
+  IL_0029:  constrained. "System.ValueTuple(Of Byte, Byte)"
+  IL_002f:  callvirt   "Function Object.ToString() As String"
+  IL_0034:  call       "Sub System.Console.WriteLine(String)"
+  IL_0039:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNarrowingUnchecked()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (Integer, String) = (100, 100)
+        Dim x as (Byte, Byte) = i
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, options:=TestOptions.ReleaseExe.WithOverflowChecks(False), expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       58 (0x3a)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Byte, Byte) V_0, //x
+                System.ValueTuple(Of Integer, String) V_1)
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToString(Integer) As String"
+  IL_0009:  newobj     "Sub System.ValueTuple(Of Integer, String)..ctor(Integer, String)"
+  IL_000e:  stloc.1
+  IL_000f:  ldloc.1
+  IL_0010:  ldfld      "System.ValueTuple(Of Integer, String).Item1 As Integer"
+  IL_0015:  conv.u1
+  IL_0016:  ldloc.1
+  IL_0017:  ldfld      "System.ValueTuple(Of Integer, String).Item2 As String"
+  IL_001c:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToByte(String) As Byte"
+  IL_0021:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_0026:  stloc.0
+  IL_0027:  ldloca.s   V_0
+  IL_0029:  constrained. "System.ValueTuple(Of Byte, Byte)"
+  IL_002f:  callvirt   "Function Object.ToString() As String"
+  IL_0034:  call       "Sub System.Console.WriteLine(String)"
+  IL_0039:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionObject()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (object, object) = (1, (2,3))
+        Dim x as (integer, (integer, integer)) = ctype(i, (integer, (integer, integer)))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(1, (2, 3))
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       86 (0x56)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of Integer, (Integer, Integer)) V_0, //x
+                System.ValueTuple(Of Object, Object) V_1,
+                System.ValueTuple(Of Integer, Integer) V_2)
+  IL_0000:  ldc.i4.1
+  IL_0001:  box        "Integer"
+  IL_0006:  ldc.i4.2
+  IL_0007:  ldc.i4.3
+  IL_0008:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_000d:  box        "System.ValueTuple(Of Integer, Integer)"
+  IL_0012:  newobj     "Sub System.ValueTuple(Of Object, Object)..ctor(Object, Object)"
+  IL_0017:  stloc.1
+  IL_0018:  ldloc.1
+  IL_0019:  ldfld      "System.ValueTuple(Of Object, Object).Item1 As Object"
+  IL_001e:  call       "Function Microsoft.VisualBasic.CompilerServices.Conversions.ToInteger(Object) As Integer"
+  IL_0023:  ldloc.1
+  IL_0024:  ldfld      "System.ValueTuple(Of Object, Object).Item2 As Object"
+  IL_0029:  dup
+  IL_002a:  brtrue.s   IL_0038
+  IL_002c:  pop
+  IL_002d:  ldloca.s   V_2
+  IL_002f:  initobj    "System.ValueTuple(Of Integer, Integer)"
+  IL_0035:  ldloc.2
+  IL_0036:  br.s       IL_003d
+  IL_0038:  unbox.any  "System.ValueTuple(Of Integer, Integer)"
+  IL_003d:  newobj     "Sub System.ValueTuple(Of Integer, (Integer, Integer))..ctor(Integer, (Integer, Integer))"
+  IL_0042:  stloc.0
+  IL_0043:  ldloca.s   V_0
+  IL_0045:  constrained. "System.ValueTuple(Of Integer, (Integer, Integer))"
+  IL_004b:  callvirt   "Function Object.ToString() As String"
+  IL_0050:  call       "Sub System.Console.WriteLine(String)"
+  IL_0055:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionOverloadResolution()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim b as (byte, byte) = (100, 100)
+        Test(b)
+        Dim i as (integer, integer) = b
+        Test(i)
+        Dim l as (Long, integer) = b
+        Test(l)
+    End Sub
+
+    Sub Test(x as (integer, integer))
+        System.Console.Writeline("integer")
+    End SUb
+
+    Sub Test(x as (Long, Long))
+        System.Console.Writeline("long")
+    End SUb
+
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+integer
+integer
+long            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size      101 (0x65)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of Byte, Byte) V_0,
+                System.ValueTuple(Of Long, Integer) V_1)
+  IL_0000:  ldc.i4.s   100
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_0009:  dup
+  IL_000a:  stloc.0
+  IL_000b:  ldloc.0
+  IL_000c:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0011:  ldloc.0
+  IL_0012:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0017:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_001c:  call       "Sub C.Test((Integer, Integer))"
+  IL_0021:  dup
+  IL_0022:  stloc.0
+  IL_0023:  ldloc.0
+  IL_0024:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0029:  ldloc.0
+  IL_002a:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_002f:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0034:  call       "Sub C.Test((Integer, Integer))"
+  IL_0039:  stloc.0
+  IL_003a:  ldloc.0
+  IL_003b:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0040:  conv.u8
+  IL_0041:  ldloc.0
+  IL_0042:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0047:  newobj     "Sub System.ValueTuple(Of Long, Integer)..ctor(Long, Integer)"
+  IL_004c:  stloc.1
+  IL_004d:  ldloc.1
+  IL_004e:  ldfld      "System.ValueTuple(Of Long, Integer).Item1 As Long"
+  IL_0053:  ldloc.1
+  IL_0054:  ldfld      "System.ValueTuple(Of Long, Integer).Item2 As Integer"
+  IL_0059:  conv.i8
+  IL_005a:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_005f:  call       "Sub C.Test((Long, Long))"
+  IL_0064:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNullable001()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (x as byte, y as byte)? = (a:=100, b:=100)
+        Dim x as (integer, double) = CType(i, (integer, double))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       62 (0x3e)
+  .maxstack  3
+  .locals init ((x As Byte, y As Byte)? V_0, //i
+                System.ValueTuple(Of Integer, Double) V_1, //x
+                System.ValueTuple(Of Byte, Byte) V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  ldc.i4.s   100
+  IL_0006:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_000b:  call       "Sub (x As Byte, y As Byte)?..ctor((x As Byte, y As Byte))"
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       "Function (x As Byte, y As Byte)?.get_Value() As (x As Byte, y As Byte)"
+  IL_0017:  stloc.2
+  IL_0018:  ldloc.2
+  IL_0019:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_001e:  ldloc.2
+  IL_001f:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0024:  conv.r8
+  IL_0025:  newobj     "Sub System.ValueTuple(Of Integer, Double)..ctor(Integer, Double)"
+  IL_002a:  stloc.1
+  IL_002b:  ldloca.s   V_1
+  IL_002d:  constrained. "System.ValueTuple(Of Integer, Double)"
+  IL_0033:  callvirt   "Function Object.ToString() As String"
+  IL_0038:  call       "Sub System.Console.WriteLine(String)"
+  IL_003d:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNullable002()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (x as byte, y as byte) = (a:=100, b:=100)
+        Dim x as (integer, double)? = CType(i, (integer, double))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       57 (0x39)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of Byte, Byte) V_0, //i
+                (Integer, Double)? V_1, //x
+                System.ValueTuple(Of Byte, Byte) V_2)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  ldc.i4.s   100
+  IL_0006:  call       "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_000b:  ldloca.s   V_1
+  IL_000d:  ldloc.0
+  IL_000e:  stloc.2
+  IL_000f:  ldloc.2
+  IL_0010:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0015:  ldloc.2
+  IL_0016:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_001b:  conv.r8
+  IL_001c:  newobj     "Sub System.ValueTuple(Of Integer, Double)..ctor(Integer, Double)"
+  IL_0021:  call       "Sub (Integer, Double)?..ctor((Integer, Double))"
+  IL_0026:  ldloca.s   V_1
+  IL_0028:  constrained. "(Integer, Double)?"
+  IL_002e:  callvirt   "Function Object.ToString() As String"
+  IL_0033:  call       "Sub System.Console.WriteLine(String)"
+  IL_0038:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNullable003()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as (x as byte, y as byte)? = (a:=100, b:=100)
+        Dim x = CType(i, (integer, double)?)
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       87 (0x57)
+  .maxstack  3
+  .locals init ((x As Byte, y As Byte)? V_0, //i
+                (Integer, Double)? V_1, //x
+                (Integer, Double)? V_2,
+                System.ValueTuple(Of Byte, Byte) V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  ldc.i4.s   100
+  IL_0006:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_000b:  call       "Sub (x As Byte, y As Byte)?..ctor((x As Byte, y As Byte))"
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       "Function (x As Byte, y As Byte)?.get_HasValue() As Boolean"
+  IL_0017:  brtrue.s   IL_0024
+  IL_0019:  ldloca.s   V_2
+  IL_001b:  initobj    "(Integer, Double)?"
+  IL_0021:  ldloc.2
+  IL_0022:  br.s       IL_0043
+  IL_0024:  ldloca.s   V_0
+  IL_0026:  call       "Function (x As Byte, y As Byte)?.GetValueOrDefault() As (x As Byte, y As Byte)"
+  IL_002b:  stloc.3
+  IL_002c:  ldloc.3
+  IL_002d:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0032:  ldloc.3
+  IL_0033:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0038:  conv.r8
+  IL_0039:  newobj     "Sub System.ValueTuple(Of Integer, Double)..ctor(Integer, Double)"
+  IL_003e:  newobj     "Sub (Integer, Double)?..ctor((Integer, Double))"
+  IL_0043:  stloc.1
+  IL_0044:  ldloca.s   V_1
+  IL_0046:  constrained. "(Integer, Double)?"
+  IL_004c:  callvirt   "Function Object.ToString() As String"
+  IL_0051:  call       "Sub System.Console.WriteLine(String)"
+  IL_0056:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleConversionNullable004()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim i as ValueTuple(of byte, byte)? = (a:=100, b:=100)
+        Dim x = CType(i, ValueTuple(of integer, double)?)
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(100, 100)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       87 (0x57)
+  .maxstack  3
+  .locals init ((Byte, Byte)? V_0, //i
+                (Integer, Double)? V_1, //x
+                (Integer, Double)? V_2,
+                System.ValueTuple(Of Byte, Byte) V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.s   100
+  IL_0004:  ldc.i4.s   100
+  IL_0006:  newobj     "Sub System.ValueTuple(Of Byte, Byte)..ctor(Byte, Byte)"
+  IL_000b:  call       "Sub (Byte, Byte)?..ctor((Byte, Byte))"
+  IL_0010:  ldloca.s   V_0
+  IL_0012:  call       "Function (Byte, Byte)?.get_HasValue() As Boolean"
+  IL_0017:  brtrue.s   IL_0024
+  IL_0019:  ldloca.s   V_2
+  IL_001b:  initobj    "(Integer, Double)?"
+  IL_0021:  ldloc.2
+  IL_0022:  br.s       IL_0043
+  IL_0024:  ldloca.s   V_0
+  IL_0026:  call       "Function (Byte, Byte)?.GetValueOrDefault() As (Byte, Byte)"
+  IL_002b:  stloc.3
+  IL_002c:  ldloc.3
+  IL_002d:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0032:  ldloc.3
+  IL_0033:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0038:  conv.r8
+  IL_0039:  newobj     "Sub System.ValueTuple(Of Integer, Double)..ctor(Integer, Double)"
+  IL_003e:  newobj     "Sub (Integer, Double)?..ctor((Integer, Double))"
+  IL_0043:  stloc.1
+  IL_0044:  ldloca.s   V_1
+  IL_0046:  constrained. "(Integer, Double)?"
+  IL_004c:  callvirt   "Function Object.ToString() As String"
+  IL_0051:  call       "Sub System.Console.WriteLine(String)"
+  IL_0056:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub ImplicitConversions02()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = (a:=1, b:=1)
+        Dim y As C1 = x
+        x = y
+        System.Console.WriteLine(x)
+
+        x = CType(CType(x, C1), (integer, integer))
+        System.Console.WriteLine(x)
+
+    End Sub
+End Module
+
+Class C1
+    Public Shared Widening Operator CType(arg as (long, long)) as C1
+        return new C1()
+    End Operator
+
+    Public Shared Widening Operator CType(arg as C1) as (c As Byte, d as Byte)
+        return (2, 2)
+    End Operator
+End Class
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(2, 2)
+(2, 2)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size      125 (0x7d)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0,
+                System.ValueTuple(Of Byte, Byte) V_1)
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_000e:  conv.i8
+  IL_000f:  ldloc.0
+  IL_0010:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_0015:  conv.i8
+  IL_0016:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_001b:  call       "Function C1.op_Implicit((Long, Long)) As C1"
+  IL_0020:  call       "Function C1.op_Implicit(C1) As (c As Byte, d As Byte)"
+  IL_0025:  stloc.1
+  IL_0026:  ldloc.1
+  IL_0027:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_002c:  ldloc.1
+  IL_002d:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0032:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0037:  dup
+  IL_0038:  box        "System.ValueTuple(Of Integer, Integer)"
+  IL_003d:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0042:  stloc.0
+  IL_0043:  ldloc.0
+  IL_0044:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0049:  conv.i8
+  IL_004a:  ldloc.0
+  IL_004b:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_0050:  conv.i8
+  IL_0051:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_0056:  call       "Function C1.op_Implicit((Long, Long)) As C1"
+  IL_005b:  call       "Function C1.op_Implicit(C1) As (c As Byte, d As Byte)"
+  IL_0060:  stloc.1
+  IL_0061:  ldloc.1
+  IL_0062:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0067:  ldloc.1
+  IL_0068:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_006d:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0072:  box        "System.ValueTuple(Of Integer, Integer)"
+  IL_0077:  call       "Sub System.Console.WriteLine(Object)"
+  IL_007c:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub ExplicitConversions02()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = (a:=1, b:=1)
+        Dim y As C1 = CType(x, C1)
+        x = CTYpe(y, (integer, integer))
+        System.Console.WriteLine(x)
+
+        x = CType(CType(x, C1), (integer, integer))
+        System.Console.WriteLine(x)
+
+    End Sub
+End Module
+
+Class C1
+    Public Shared Narrowing Operator CType(arg as (long, long)) as C1
+        return new C1()
+    End Operator
+
+    Public Shared Narrowing Operator CType(arg as C1) as (c As Byte, d as Byte)
+        return (2, 2)
+    End Operator
+End Class
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(2, 2)
+(2, 2)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size      125 (0x7d)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0,
+                System.ValueTuple(Of Byte, Byte) V_1)
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.1
+  IL_0002:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0007:  stloc.0
+  IL_0008:  ldloc.0
+  IL_0009:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_000e:  conv.i8
+  IL_000f:  ldloc.0
+  IL_0010:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_0015:  conv.i8
+  IL_0016:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_001b:  call       "Function C1.op_Explicit((Long, Long)) As C1"
+  IL_0020:  call       "Function C1.op_Explicit(C1) As (c As Byte, d As Byte)"
+  IL_0025:  stloc.1
+  IL_0026:  ldloc.1
+  IL_0027:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_002c:  ldloc.1
+  IL_002d:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0032:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0037:  dup
+  IL_0038:  box        "System.ValueTuple(Of Integer, Integer)"
+  IL_003d:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0042:  stloc.0
+  IL_0043:  ldloc.0
+  IL_0044:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0049:  conv.i8
+  IL_004a:  ldloc.0
+  IL_004b:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_0050:  conv.i8
+  IL_0051:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_0056:  call       "Function C1.op_Explicit((Long, Long)) As C1"
+  IL_005b:  call       "Function C1.op_Explicit(C1) As (c As Byte, d As Byte)"
+  IL_0060:  stloc.1
+  IL_0061:  ldloc.1
+  IL_0062:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0067:  ldloc.1
+  IL_0068:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_006d:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0072:  box        "System.ValueTuple(Of Integer, Integer)"
+  IL_0077:  call       "Sub System.Console.WriteLine(Object)"
+  IL_007c:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub ImplicitConversions03()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = (a:=1, b:=1)
+        Dim y As C1 = x
+        Dim x1 as (integer, integer)? = y
+        System.Console.WriteLine(x1)
+
+        x1 = CType(CType(x, C1), (integer, integer)?)
+        System.Console.WriteLine(x1)
+
+    End Sub
+End Module
+
+Class C1
+    Public Shared Widening Operator CType(arg as (long, long)) as C1
+        return new C1()
+    End Operator
+
+    Public Shared Widening Operator CType(arg as C1) as (c As Byte, d as Byte)
+        return (2, 2)
+    End Operator
+End Class
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(2, 2)
+(2, 2)
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size      140 (0x8c)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0, //x
+                C1 V_1, //y
+                System.ValueTuple(Of Integer, Integer) V_2,
+                System.ValueTuple(Of Byte, Byte) V_3)
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldc.i4.1
+  IL_0003:  ldc.i4.1
+  IL_0004:  call       "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_0009:  ldloc.0
+  IL_000a:  stloc.2
+  IL_000b:  ldloc.2
+  IL_000c:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0011:  conv.i8
+  IL_0012:  ldloc.2
+  IL_0013:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_0018:  conv.i8
+  IL_0019:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_001e:  call       "Function C1.op_Implicit((Long, Long)) As C1"
+  IL_0023:  stloc.1
+  IL_0024:  ldloc.1
+  IL_0025:  call       "Function C1.op_Implicit(C1) As (c As Byte, d As Byte)"
+  IL_002a:  stloc.3
+  IL_002b:  ldloc.3
+  IL_002c:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0031:  ldloc.3
+  IL_0032:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0037:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_003c:  newobj     "Sub (Integer, Integer)?..ctor((Integer, Integer))"
+  IL_0041:  box        "(Integer, Integer)?"
+  IL_0046:  call       "Sub System.Console.WriteLine(Object)"
+  IL_004b:  ldloc.0
+  IL_004c:  stloc.2
+  IL_004d:  ldloc.2
+  IL_004e:  ldfld      "System.ValueTuple(Of Integer, Integer).Item1 As Integer"
+  IL_0053:  conv.i8
+  IL_0054:  ldloc.2
+  IL_0055:  ldfld      "System.ValueTuple(Of Integer, Integer).Item2 As Integer"
+  IL_005a:  conv.i8
+  IL_005b:  newobj     "Sub System.ValueTuple(Of Long, Long)..ctor(Long, Long)"
+  IL_0060:  call       "Function C1.op_Implicit((Long, Long)) As C1"
+  IL_0065:  call       "Function C1.op_Implicit(C1) As (c As Byte, d As Byte)"
+  IL_006a:  stloc.3
+  IL_006b:  ldloc.3
+  IL_006c:  ldfld      "System.ValueTuple(Of Byte, Byte).Item1 As Byte"
+  IL_0071:  ldloc.3
+  IL_0072:  ldfld      "System.ValueTuple(Of Byte, Byte).Item2 As Byte"
+  IL_0077:  newobj     "Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)"
+  IL_007c:  newobj     "Sub (Integer, Integer)?..ctor((Integer, Integer))"
+  IL_0081:  box        "(Integer, Integer)?"
+  IL_0086:  call       "Sub System.Console.WriteLine(Object)"
+  IL_008b:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub ImplicitConversions04()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = (1, (1, (1, (1, (1, (1, 1))))))
+        Dim y as C1 = x   
+
+        Dim x2 as (integer, integer) = y
+        System.Console.WriteLine(x2)
+
+        Dim x3 as (integer, (integer, integer)) = y
+        System.Console.WriteLine(x3)
+ 
+        Dim x12 as (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, Integer))))))))))) = y
+        System.Console.WriteLine(x12)
+
+    End Sub
+End Module
+
+Class C1
+    Private x as Byte
+
+    Public Shared Widening Operator CType(arg as (long, C1)) as C1
+        Dim result = new C1()
+        result.x = arg.Item2.x
+        return result
+    End Operator
+
+    Public Shared Widening Operator CType(arg as (long, long)) as C1
+        Dim result = new C1()
+        result.x = CByte(arg.Item2)
+        return result
+    End Operator
+
+    Public Shared Widening Operator CType(arg as C1) as (c As Byte, d as C1)
+        Dim t = arg.x
+        arg.x += 1
+        return (CByte(t), arg)
+    End Operator
+
+    Public Shared Widening Operator CType(arg as C1) as (c As Byte, d as Byte)
+        Dim t1 = arg.x
+        arg.x += 1
+        Dim t2 = arg.x
+        arg.x += 1
+        return (CByte(t1), CByte(t2))
+    End Operator
+End Class
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(1, 2)
+(3, (4, 5))
+(6, (7, (8, (9, (10, (11, (12, (13, (14, (15, (16, 17)))))))))))
+            ]]>)
+
+        End Sub
+
+        <Fact()>
+        Public Sub ExplicitConversions04()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim x = (1, (1, (1, (1, (1, (1, 1))))))
+        Dim y as C1 = x   
+
+        Dim x2 as (integer, integer) = y
+        System.Console.WriteLine(x2)
+
+        Dim x3 as (integer, (integer, integer)) = y
+        System.Console.WriteLine(x3)
+ 
+        Dim x12 as (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, (Integer, Integer))))))))))) = y
+        System.Console.WriteLine(x12)
+
+    End Sub
+End Module
+
+Class C1
+    Private x as Byte
+
+    Public Shared Narrowing Operator CType(arg as (long, C1)) as C1
+        Dim result = new C1()
+        result.x = arg.Item2.x
+        return result
+    End Operator
+
+    Public Shared Narrowing Operator CType(arg as (long, long)) as C1
+        Dim result = new C1()
+        result.x = CByte(arg.Item2)
+        return result
+    End Operator
+
+    Public Shared Narrowing Operator CType(arg as C1) as (c As Byte, d as C1)
+        Dim t = arg.x
+        arg.x += 1
+        return (CByte(t), arg)
+    End Operator
+
+    Public Shared Narrowing Operator CType(arg as C1) as (c As Byte, d as Byte)
+        Dim t1 = arg.x
+        arg.x += 1
+        Dim t2 = arg.x
+        arg.x += 1
+        return (CByte(t1), CByte(t2))
+    End Operator
+End Class
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(1, 2)
+(3, (4, 5))
+(6, (7, (8, (9, (10, (11, (12, (13, (14, (15, (16, 17)))))))))))
+            ]]>)
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -554,6 +554,27 @@ End Module
         End Sub
 
         <Fact()>
+        Public Sub SimpleTupleTargetTyped002a()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x as (Func(Of integer), Func(of String)) = (Function() 42, Function() Nothing)
+        System.Console.WriteLine((x.Item1(), x.Item2()).ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(42, )
+            ]]>)
+        End Sub
+
+        <Fact()>
         Public Sub SimpleTupleTargetTyped003()
 
             Dim verifier = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -494,6 +494,103 @@ BC30269: 'Public Sub Test(x As (Integer, Integer))' has multiple definitions wit
 
         End Sub
 
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped001()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x as (String, String) = (Nothing, Nothing)
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, )
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of String, String) V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldnull
+  IL_0003:  ldnull
+  IL_0004:  call       "Sub System.ValueTuple(Of String, String)..ctor(String, String)"
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  constrained. "System.ValueTuple(Of String, String)"
+  IL_0011:  callvirt   "Function Object.ToString() As String"
+  IL_0016:  call       "Sub System.Console.WriteLine(String)"
+  IL_001b:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped002()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x as (Func(Of integer), Func(of String)) = (Function() 42, Function() "hi")
+        System.Console.WriteLine((x.Item1(), x.Item2()).ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(42, hi)
+            ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub SimpleTupleTargetTyped003()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x = CType((String, String),(Nothing, Nothing))
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, )
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       28 (0x1c)
+  .maxstack  3
+  .locals init (System.ValueTuple(Of String, String) V_0) //x
+  IL_0000:  ldloca.s   V_0
+  IL_0002:  ldnull
+  IL_0003:  ldnull
+  IL_0004:  call       "Sub System.ValueTuple(Of String, String)..ctor(String, String)"
+  IL_0009:  ldloca.s   V_0
+  IL_000b:  constrained. "System.ValueTuple(Of String, String)"
+  IL_0011:  callvirt   "Function Object.ToString() As String"
+  IL_0016:  call       "Sub System.Console.WriteLine(String)"
+  IL_001b:  ret
+}
+]]>)
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -533,6 +533,35 @@ End Module
         End Sub
 
         <Fact()>
+        Public Sub SimpleTupleTargetTyped001Err()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+
+Imports System
+Module C
+
+    Sub Main()
+        Dim x as (A as String, B as String) = (C:=Nothing, D:=Nothing, E:=Nothing)
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30491: Expression does not produce a value.
+        Dim x as (A as String, B as String) = (C:=Nothing, D:=Nothing, E:=Nothing)
+                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</errors>)
+
+
+        End Sub
+
+        <Fact()>
         Public Sub SimpleTupleTargetTyped002()
 
             Dim verifier = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -22240,9 +22240,7 @@ End Class
             Assert.Equal(ImmutableArray.Create(Of Location)(), errTypeSym.Locations)
             Assert.Equal(ImmutableArray.Create(Of SyntaxReference)(), errTypeSym.DeclaringSyntaxReferences)
             Assert.Equal(0, errTypeSym.Arity)
-            Assert.Throws(Of InvalidOperationException)(Sub()
-                                                            Dim tmp = errTypeSym.EnumUnderlyingType
-                                                        End Sub)
+            Assert.Null(errTypeSym.EnumUnderlyingType)
             Assert.Equal("B", errTypeSym.Name)
             Assert.Equal(0, errTypeSym.TypeArguments.Length)
             Assert.Equal(0, errTypeSym.TypeParameters.Length)


### PR DESCRIPTION
Added support for 
- conversions from literals (target typing, TryCast)
- conversions from types (regular assignments, CType, DirectCast)
- overload resolution can tiebreak on tuple Widening/Narrowing conversions between candidate signatures.

Tuple conversions exist between two tuple types of the same cardinality as long as conversions exist for all underlying elements. 
If any of the element conversions are Narrowing conversions, the resulting conversion is NarrowingTuple conversion, otherwise it is WideningTuple conversion.

Tuple conversions are considered Predefined Conversions and thus can stack before and after the operator calls in user defined conversions. 

== not done:
More testing is needed. At least all the applicable C# tests should be ported. Only some "interesting" tests are ported for now.
Semantic info should mostly work, but not tested. (need to add new conversions to the public API)

