### PR TITLE
Fix a couple of official build issues

### DIFF
--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioTelemetry/Microsoft.CodeAnalysis.VisualStudio.Telemetry.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioTelemetry/Microsoft.CodeAnalysis.VisualStudio.Telemetry.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.VisualStudio.Telemetry
         version=$(Version)
-        vs.package.chip=neutral
         vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=28354cb8-c808-4138-bfce-33aa846bbd51

--- a/src/Setup/SetupStep2.proj
+++ b/src/Setup/SetupStep2.proj
@@ -5,9 +5,6 @@
 
   <Target Name="Build">
 
-    <!-- Build the Roslyn NuGet packages -->
-    <MSBuild Projects="..\Nuget\NuGet.proj" />
-
     <!-- Build CoreXT packages for insertion into DevDiv (order of the following actions matters) -->
     <MSBuild Projects="DevDivPackages\Dependencies.proj" />
     <MSBuild Projects="DevDivInsertionFiles\DevDivInsertionFiles.sln" />

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -24,7 +24,6 @@
     <MSBuild Projects="$(ProjectDir)src\Dependencies\Dependencies.sln" BuildInParallel="true" />
     <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep1.proj" />
 
-    <!-- TODO: pass arguments -->
     <Exec Command="$(ProjectDir)Binaries\$(Configuration)\SignRoslyn\SignRoslyn.exe $(SignRoslynArgs) -binariesPath &quot;$(BinariesPath)&quot;" WorkingDirectory="$(ProjectDir)" />
 
     <MSBuild Projects="$(ProjectDir)src\NuGet\NuGet.proj" />


### PR DESCRIPTION
Fixes

1. Fixes warning about neutral chip in the telemetry SWIX project.
2. Only build NuGet.proj once.  Previously built from Build.proj and SetupStep2.proj