### PR TITLE
Move SnapshotJsonRpcClient up

### DIFF
--- a/src/VisualStudio/Next/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Next/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -7,7 +7,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.ErrorReporting;
 using Microsoft.CodeAnalysis.Execution;
-using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.VisualStudio.LanguageServices.Implementation.Remote;
 using Roslyn.Utilities;
 

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSnapshot.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSnapshot.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Execution;
-using Microsoft.CodeAnalysis.Remote;
 using Roslyn.Utilities;
-using StreamJsonRpc;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
@@ -17,9 +15,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     {
         private class JsonRpcSession : Session
         {
-            // communication channel related to snapshot information
-            private readonly SnapshotJsonRpcClient _snapshotClient;
-
             // communication channel related to service information
             private readonly ServiceJsonRpcClient _serviceClient;
 
@@ -28,13 +23,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             public JsonRpcSession(
                 ChecksumScope snapshot,
-                Stream snapshotStream,
                 object callbackTarget,
                 Stream serviceStream,
                 CancellationToken cancellationToken) :
                 base(snapshot, cancellationToken)
             {
-                _snapshotClient = new SnapshotJsonRpcClient(this, snapshotStream);
                 _serviceClient = new ServiceJsonRpcClient(serviceStream, callbackTarget);
 
                 // dispose session when cancellation has raised
@@ -74,9 +67,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // dispose cancellation registration
                 _cancellationRegistration.Dispose();
 
-                // dispose service and snapshot channels
+                // dispose service channels
                 _serviceClient.Dispose();
-                _snapshotClient.Dispose();
             }
 
             /// <summary>
@@ -95,75 +87,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
 
                 protected override object GetCallbackTarget() => _callbackTarget;
-            }
-
-            /// <summary>
-            /// Communication channel between remote host client and remote host.
-            /// 
-            /// this is framework's back channel to talk to remote host
-            /// 
-            /// for example, this will be used to deliver missing assets in remote host.
-            /// 
-            /// each remote host client will have its own back channel so that it can work isolated
-            /// with other clients.
-            /// </summary>
-            private class SnapshotJsonRpcClient : JsonRpcClient
-            {
-                private readonly JsonRpcSession _owner;
-                private readonly CancellationTokenSource _source;
-
-                public SnapshotJsonRpcClient(JsonRpcSession owner, Stream stream) :
-                    base(stream)
-                {
-                    _owner = owner;
-                    _source = new CancellationTokenSource();
-                }
-
-                private ChecksumScope ChecksumScope => _owner.ChecksumScope;
-
-                protected override object GetCallbackTarget() => this;
-
-                /// <summary>
-                /// this is callback from remote host side to get asset associated with checksum from VS.
-                /// </summary>
-                public async Task RequestAssetAsync(int serviceId, byte[] checksum, string streamName)
-                {
-                    try
-                    {
-                        var service = ChecksumScope.Workspace.Services.GetRequiredService<ISolutionChecksumService>();
-
-                        using (var stream = await DirectStream.GetAsync(streamName, _source.Token).ConfigureAwait(false))
-                        {
-                            using (var writer = new ObjectWriter(stream))
-                            {
-                                writer.WriteInt32(serviceId);
-                                writer.WriteArray(checksum);
-
-                                var checksumObject = service.GetChecksumObject(new Checksum(checksum), _source.Token);
-                                writer.WriteString(checksumObject.Kind);
-
-                                await checksumObject.WriteToAsync(writer, _source.Token).ConfigureAwait(false);
-                            }
-
-                            await stream.FlushAsync(_source.Token).ConfigureAwait(false);
-                        }
-                    }
-                    catch (IOException)
-                    {
-                        // remote host side is cancelled (client stream connection is closed)
-                        // can happen if pinned solution scope is disposed
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // rpc connection is closed. 
-                        // can happen if pinned solution scope is disposed
-                    }
-                }
-
-                protected override void OnDisconnected(object sender, JsonRpcDisconnectedEventArgs e)
-                {
-                    _source.Cancel();
-                }
             }
         }
     }

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.SnapshotJsonRpcClient.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.SnapshotJsonRpcClient.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Execution;
+using Microsoft.CodeAnalysis.Remote;
+using Roslyn.Utilities;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.LanguageServices.Remote
+{
+    internal partial class ServiceHubRemoteHostClient
+    {
+        /// <summary>
+        /// Communication channel between remote host client and remote host.
+        /// 
+        /// this is framework's back channel to talk to remote host
+        /// 
+        /// for example, this will be used to deliver missing assets in remote host.
+        /// 
+        /// each remote host client will have its own back channel so that it can work isolated
+        /// with other clients.
+        /// </summary>
+        private class SnapshotJsonRpcClient : JsonRpcClient
+        {
+            private readonly ISolutionChecksumService _checksumService;
+            private readonly CancellationTokenSource _source;
+
+            public SnapshotJsonRpcClient(ISolutionChecksumService checksumService, Stream stream) :
+                base(stream)
+            {
+                _checksumService = checksumService;
+                _source = new CancellationTokenSource();
+            }
+
+            protected override object GetCallbackTarget() => this;
+
+            /// <summary>
+            /// this is callback from remote host side to get asset associated with checksum from VS.
+            /// </summary>
+            public async Task RequestAssetAsync(int serviceId, byte[] checksum, string streamName)
+            {
+                try
+                {
+                    using (var stream = await DirectStream.GetAsync(streamName, _source.Token).ConfigureAwait(false))
+                    {
+                        using (var writer = new ObjectWriter(stream))
+                        {
+                            writer.WriteInt32(serviceId);
+                            writer.WriteArray(checksum);
+
+                            var checksumObject = _checksumService.GetChecksumObject(new Checksum(checksum), _source.Token);
+                            writer.WriteString(checksumObject.Kind);
+
+                            await checksumObject.WriteToAsync(writer, _source.Token).ConfigureAwait(false);
+                        }
+
+                        await stream.FlushAsync(_source.Token).ConfigureAwait(false);
+                    }
+                }
+                catch (IOException)
+                {
+                    // remote host side is cancelled (client stream connection is closed)
+                    // can happen if pinned solution scope is disposed
+                }
+                catch (OperationCanceledException)
+                {
+                    // rpc connection is closed. 
+                    // can happen if pinned solution scope is disposed
+                }
+            }
+
+            protected override void OnDisconnected(object sender, JsonRpcDisconnectedEventArgs e)
+            {
+                _source.Cancel();
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -17,15 +17,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     internal partial class ServiceHubRemoteHostClient : RemoteHostClient
     {
         private readonly HubClient _hubClient;
-        private readonly Stream _stream;
+        private readonly Stream _remoteHostStream;
         private readonly JsonRpc _rpc;
+        // communication channel related to snapshot information
+        private readonly SnapshotJsonRpcClient _snapshotClient;
 
         public static async Task<ServiceHubRemoteHostClient> CreateAsync(Workspace workspace, CancellationToken cancellationToken)
         {
-            var primary = new HubClient("RoslynPrimaryHubClient");
-            var remoteHostStream = await primary.RequestServiceAsync(WellKnownServiceHubServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
+            var hubClient = new HubClient("RoslynPrimaryHubClient");
+            var remoteHostStream = await hubClient.RequestServiceAsync(WellKnownServiceHubServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
 
-            var instance = new ServiceHubRemoteHostClient(workspace, primary, remoteHostStream);
+            // get stream from service hub to communicate snapshot/asset related information
+            // this is the back channel the system uses to move data between VS and remote host
+            var snapshotStream = await hubClient.RequestServiceAsync(WellKnownServiceHubServices.ServiceHubSnapshotService, cancellationToken).ConfigureAwait(false);
+
+            var instance = new ServiceHubRemoteHostClient(workspace, hubClient, remoteHostStream, snapshotStream);
 
             // make sure connection is done right
             var current = $"VS ({Process.GetCurrentProcess().Id})";
@@ -40,29 +46,27 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             return instance;
         }
 
-        private ServiceHubRemoteHostClient(Workspace workspace, HubClient hubClient, Stream stream) :
+        private ServiceHubRemoteHostClient(Workspace workspace, HubClient hubClient, Stream remoteHostStream, Stream snapshotStream) :
             base(workspace)
         {
             _hubClient = hubClient;
-            _stream = stream;
+            _remoteHostStream = remoteHostStream;
 
-            _rpc = JsonRpc.Attach(stream, target: this);
+            _rpc = JsonRpc.Attach(remoteHostStream, target: this);
 
             // handle disconnected situation
             _rpc.Disconnected += OnRpcDisconnected;
+
+            _snapshotClient = new SnapshotJsonRpcClient(workspace.Services.GetRequiredService<ISolutionChecksumService>(), snapshotStream);
         }
 
         protected override async Task<Session> CreateCodeAnalysisServiceSessionAsync(ChecksumScope snapshot, object callbackTarget, CancellationToken cancellationToken)
         {
-            // get stream from service hub to communicate snapshot/asset related information
-            // this is the back channel the system uses to move data between VS and remote host
-            var snapshotStream = await _hubClient.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false);
-
             // get stream from service hub to communicate service specific information
             // this is what consumer actually use to communicate information
             var serviceStream = await _hubClient.RequestServiceAsync(WellKnownServiceHubServices.CodeAnalysisService, cancellationToken).ConfigureAwait(false);
 
-            return new JsonRpcSession(snapshot, snapshotStream, callbackTarget, serviceStream, cancellationToken);
+            return new JsonRpcSession(snapshot, callbackTarget, serviceStream, cancellationToken);
         }
 
         protected override void OnConnected()
@@ -72,7 +76,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         protected override void OnDisconnected()
         {
             _rpc.Dispose();
-            _stream.Dispose();
+            _remoteHostStream.Dispose();
+            _snapshotClient.Dispose();
         }
 
         private void OnRpcDisconnected(object sender, JsonRpcDisconnectedEventArgs e)

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             // get stream from service hub to communicate snapshot/asset related information
             // this is the back channel the system uses to move data between VS and remote host
-            var snapshotStream = await hubClient.RequestServiceAsync(WellKnownServiceHubServices.ServiceHubSnapshotService, cancellationToken).ConfigureAwait(false);
+            var snapshotStream = await hubClient.RequestServiceAsync(WellKnownServiceHubServices.SnapshotService, cancellationToken).ConfigureAwait(false);
 
             var instance = new ServiceHubRemoteHostClient(workspace, hubClient, remoteHostStream, snapshotStream);
 

--- a/src/VisualStudio/Next/ServicesVisualStudio.Next.csproj
+++ b/src/VisualStudio/Next/ServicesVisualStudio.Next.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Remote\RemoteHostClientServiceFactory.cs" />
     <Compile Include="Remote\JsonRpcClient.cs" />
     <Compile Include="Remote\RemoteHostOptions.cs" />
+    <Compile Include="Remote\ServiceHubRemoteHostClient.SnapshotJsonRpcClient.cs" />
     <Compile Include="Remote\ServiceHubRemoteHostClient.JsonRpcSnapshot.cs" />
     <Compile Include="Remote\ServiceHubRemoteHostClient.cs" />
   </ItemGroup>


### PR DESCRIPTION
@heejaechang If I read things correctly, we don't need to create a new snapshot client service for each session -- since the service is per-workspace, we can just create it once for a RemoteHostClient and have it be shared among all Sessions. Does that sound correct?