### PR TITLE
reduce allocations

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentPersistentStorage.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/Esent/EsentPersistentStorage.cs
@@ -274,12 +274,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
 
             try
             {
-                id = _nameTableCache.GetOrAdd(value, v =>
-                {
-                    // okay, get one from esent
-                    var uniqueIdValue = fileCheck ? FilePathUtilities.GetRelativePath(Path.GetDirectoryName(SolutionFilePath), v) : v;
-                    return _esentStorage.GetUniqueId(uniqueIdValue);
-                });
+                var uniqueIdValue = fileCheck ? FilePathUtilities.GetRelativePath(Path.GetDirectoryName(SolutionFilePath), value) : value;
+                id = _nameTableCache.GetOrAdd(value, _esentStorage.GetUniqueId(uniqueIdValue));
+
+                return true;
             }
             catch (Exception ex)
             {
@@ -289,8 +287,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Esent
 
                 return false;
             }
-
-            return true;
         }
 
         private static void WriteToStream(Stream inputStream, Stream esentStream, CancellationToken cancellationToken)


### PR DESCRIPTION
@adriansecchia reported this

added quick check before creating lambda.
...

Name                                                                                         Inc %                  Inc
Type <>c__DisplayClass23_0                                                                             7.7     217,515,296
  + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.TryGetUniqueId                       7.7     217,515,296
   + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.TryGetProjectId                     3.8     106,704,224
   + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.TryGetProjectAndDocumentKey         2.0      57,054,144
   + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.ReadStreamAsync                     1.9      53,115,660
   + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.ReadStreamAsync                     0.0         427,600
   + Microsoft.VisualStudio.LanguageServices!EsentPersistentStorage.WriteStreamAsync                    0.0         213,672

217MB allocation for a delegate.

        private bool TryGetUniqueId(string value, bool fileCheck, out int id)
        {
[…]
            try
            {
                id = _nameTableCache.GetOrAdd(value, v =>
                {
                    // okay, get one from esent
                    var uniqueIdValue = fileCheck ? FilePathUtilities.GetRelativePath(Path.GetDirectoryName(SolutionFilePath), v) : v;
                    return _esentStorage.GetUniqueId(uniqueIdValue);
                });
            }

            return true;
        }

Can we make this a private member function and pass that instead of allocating a delegate?
It looks like this guy is a super high call volume function, so removing the allocate will be a significant memory saving.
