### PR TITLE
crash right away when we don't get mandatory analyzers from VS.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -21,6 +21,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
     [Export(typeof(IWorkspaceDiagnosticAnalyzerProviderService))]
     internal partial class VisualStudioWorkspaceDiagnosticAnalyzerProviderService : IWorkspaceDiagnosticAnalyzerProviderService
     {
+        public const string MicrosoftCodeAnalysisCSharp = "Microsoft.CodeAnalysis.CSharp.dll";
+        public const string MicrosoftCodeAnalysisVisualBasic = "Microsoft.CodeAnalysis.VisualBasic.dll";
+
         private const string AnalyzerContentTypeName = "Microsoft.VisualStudio.Analyzer";
 
         private readonly ImmutableArray<HostDiagnosticAnalyzerPackage> _hostDiagnosticAnalyzerInfo;
@@ -124,8 +127,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
         {
             foreach (var package in packages)
             {
-                if (package.Assemblies.Any(a => a?.EndsWith("Microsoft.CodeAnalysis.CSharp.dll", StringComparison.OrdinalIgnoreCase) == true) &&
-                    package.Assemblies.Any(a => a?.EndsWith("Microsoft.CodeAnalysis.VisualBasic.dll", StringComparison.OrdinalIgnoreCase) == true))
+                if (package.Assemblies.Any(a => a?.EndsWith(MicrosoftCodeAnalysisCSharp, StringComparison.OrdinalIgnoreCase) == true) &&
+                    package.Assemblies.Any(a => a?.EndsWith(MicrosoftCodeAnalysisVisualBasic, StringComparison.OrdinalIgnoreCase) == true))
                 {
                     return;
                 }

--- a/src/VisualStudio/Core/Test/Diagnostics/MockExtensionManager.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/MockExtensionManager.vb
@@ -5,6 +5,7 @@ Imports System.Globalization
 Imports System.IO
 Imports System.Xml
 Imports Microsoft.CodeAnalysis
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 Imports Moq
 Imports Roslyn.Utilities
 
@@ -30,19 +31,22 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             For Each location In _locations
                 Dim installedExtensionMock As New Mock(Of IMockInstalledExtension)(MockBehavior.Strict)
 
-                Dim contentMock = New MockContent(_contentType, location)
                 installedExtensionMock.SetupGet(Function(m) m.Content).Returns(
-                    SpecializedCollections.SingletonEnumerable(Of MockContent)(contentMock))
+                    New MockContent() {
+                        New MockContent(_contentType, location),
+                        New MockContent(_contentType, VisualStudioWorkspaceDiagnosticAnalyzerProviderService.MicrosoftCodeAnalysisCSharp),
+                        New MockContent(_contentType, VisualStudioWorkspaceDiagnosticAnalyzerProviderService.MicrosoftCodeAnalysisVisualBasic)
+                    })
 
-                installedExtensionMock.Setup(Function(m) m.GetContentLocation(contentMock)).Returns(Function()
-                                                                                                        If contentMock.RelativePath.IndexOf("$RootFolder$") >= 0 Then
-                                                                                                            Return contentMock.RelativePath.Replace("$RootFolder$", "ResolvedRootFolder")
-                                                                                                        ElseIf contentMock.RelativePath.IndexOf("$ShellFolder$") >= 0 Then
-                                                                                                            Return contentMock.RelativePath.Replace("$ShellFolder$", "ResolvedShellFolder")
-                                                                                                        Else
-                                                                                                            Return Path.Combine("\InstallPath", contentMock.RelativePath)
-                                                                                                        End If
-                                                                                                    End Function)
+                installedExtensionMock.Setup(Function(m) m.GetContentLocation(It.IsAny(Of MockContent))).Returns(Function(content As MockContent)
+                                                                                                                     If content.RelativePath.IndexOf("$RootFolder$") >= 0 Then
+                                                                                                                         Return content.RelativePath.Replace("$RootFolder$", "ResolvedRootFolder")
+                                                                                                                     ElseIf content.RelativePath.IndexOf("$ShellFolder$") >= 0 Then
+                                                                                                                         Return content.RelativePath.Replace("$ShellFolder$", "ResolvedShellFolder")
+                                                                                                                     Else
+                                                                                                                         Return Path.Combine("\InstallPath", content.RelativePath)
+                                                                                                                     End If
+                                                                                                                 End Function)
 
                 Dim headerMock As New Mock(Of IMockHeader)(MockBehavior.Strict)
                 headerMock.SetupGet(Function(h) h.LocalizedName).Returns("Vsix")

--- a/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
+++ b/src/VisualStudio/Core/Test/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderServiceTests.vb
@@ -18,15 +18,15 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.Diagnostics
             Assert.Equal(packages.Count(), 3)
 
             Assert.Equal(packages(0).Name, "Vsix")
-            Assert.Equal(packages(0).Assemblies.Length, 1)
+            Assert.Equal(packages(0).Assemblies.Length, 3)
             Assert.Equal(packages(0).Assemblies(0), "ResolvedRootFolder\test\test.dll")
 
             Assert.Equal(packages(1).Name, "Vsix")
-            Assert.Equal(packages(1).Assemblies.Length, 1)
+            Assert.Equal(packages(1).Assemblies.Length, 3)
             Assert.Equal(packages(1).Assemblies(0), "ResolvedShellFolder\test\test.dll")
 
             Assert.Equal(packages(2).Name, "Vsix")
-            Assert.Equal(packages(2).Assemblies.Length, 1)
+            Assert.Equal(packages(2).Assemblies.Length, 3)
             Assert.Equal(packages(2).Assemblies(0), "\InstallPath\test\test.dll")
         End Sub
 


### PR DESCRIPTION
if we let this one pass, roslyn will crash at some point since our code assumes that compiler analyzer always exist. and at that point, it is too late to figure out why those are missing.