### PR TITLE
Fix #12755

### DIFF
--- a/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
+++ b/src/EditorFeatures/CSharpTest/TypeInferrer/TypeInferrerTests.cs
@@ -1850,5 +1850,24 @@ class C
 }";
             await TestAsync(text, "global::System.Collections.Generic.IEnumerable<global::System.Object>", testPosition: false);
         }
+
+        [WorkItem(12755, "https://github.com/dotnet/roslyn/issues/12755")]
+        [Fact, Trait(Traits.Feature, Traits.Features.TypeInferenceService)]
+        public async Task TestObjectCreationBeforeArrayIndexing()
+        {
+            var text =
+@"using System;
+class C
+{
+  void M()
+  {
+        int[] array;
+        C p = new [||]
+        array[4] = 4;
+  }
+}";
+
+            await TestAsync(text, "global::C", testNode: false);
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -702,6 +702,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SpecializedCollections.EmptyEnumerable<ITypeSymbol>();
                 }
 
+                if (previousToken.Value.GetPreviousToken().Kind() == SyntaxKind.EqualsToken)
+                {
+                    // We parsed an array creation but the token before `new` is `=`.
+                    // This could be a case like:
+                    //
+                    // int[] array;
+                    // Program p = new |
+                    // array[4] = 4;
+                    //
+                    // This is similar to the cases described in `InferTypeInObjectCreationExpression`.
+                    // Again, all we have to do is back up to before `new`.
+
+                    return InferTypes(previousToken.Value.SpanStart);
+                }
+
                 var outerTypes = InferTypes(arrayCreationExpression);
                 return outerTypes.Where(o => o is IArrayTypeSymbol);
             }

--- a/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
+++ b/src/Workspaces/CSharp/Portable/LanguageServices/CSharpTypeInferenceService.TypeInferrer.cs
@@ -702,7 +702,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SpecializedCollections.EmptyEnumerable<ITypeSymbol>();
                 }
 
-                if (previousToken.Value.GetPreviousToken().Kind() == SyntaxKind.EqualsToken)
+                if (previousToken.HasValue && previousToken.Value.GetPreviousToken().Kind() == SyntaxKind.EqualsToken)
                 {
                     // We parsed an array creation but the token before `new` is `=`.
                     // This could be a case like:


### PR DESCRIPTION
Tweak C# type inferrer to work in an incomplete object creation expression
followed by array indexing.