### PR TITLE
Add code from CodeLens in VS

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -161,6 +161,7 @@
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameType.cs" />
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameFile.cs" />
     <Compile Include="CodeActions\ReplacePropertyWithMethods\ReplacePropertyWithMethodsTests.cs" />
+    <Compile Include="CodeLens\CSharpCodeLensTests.cs" />
     <Compile Include="Completion\CompletionServiceTests.cs" />
     <Compile Include="Diagnostics\AddUsing\AddUsingTests_NuGet.cs" />
     <Compile Include="Diagnostics\GenerateMethod\GenerateConversionTests.cs" />

--- a/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeLens/CSharpCodeLensTests.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CodeLens;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeLens
+{
+    public class CSharpCodeLensTests
+    {
+        private CodeLensReferenceService _referenceService;
+
+        private async Task<TestWorkspace> SetupWorkspaceAsync(string content)
+        {
+            var workspace = await TestWorkspace.CreateCSharpAsync(content);
+            _referenceService = new CodeLensReferenceService();
+            return workspace;
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        public async Task TestCount()
+        {
+            using (var workspace = await SetupWorkspaceAsync(@"
+class A
+{
+    void B()
+    {
+        C();
+    }
+
+    void C()
+    {
+        D();
+    }
+
+    void D()
+    {
+        C();
+    }
+}"))
+            {
+                var solution = workspace.CurrentSolution;
+                var documentId = workspace.Documents.First().Id;
+                var document = solution.GetDocument(documentId);
+                var syntaxNode = await document.GetSyntaxRootAsync();
+                var iterator = syntaxNode.ChildNodes().First().ChildNodes().GetEnumerator();
+                iterator.MoveNext();
+
+                var result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.True(result.HasValue);
+                Assert.Equal(0, result.Value.Count);
+                Assert.False(result.Value.IsCapped);
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.True(result.HasValue);
+                Assert.Equal(2, result.Value.Count);
+                Assert.False(result.Value.IsCapped);
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.True(result.HasValue);
+                Assert.Equal(1, result.Value.Count);
+                Assert.False(result.Value.IsCapped);
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        public async Task TestCapping()
+        {
+            using (var workspace = await SetupWorkspaceAsync(@"
+class A
+{
+    void B()
+    {
+        C();
+    }
+
+    void C()
+    {
+        D();
+    }
+
+    void D()
+    {
+        C();
+    }
+}"))
+            {
+                var solution = workspace.CurrentSolution;
+                var documentId = workspace.Documents.First().Id;
+                var document = solution.GetDocument(documentId);
+                var syntaxNode = await document.GetSyntaxRootAsync();
+                var iterator = syntaxNode.ChildNodes().First().ChildNodes().GetEnumerator();
+                iterator.MoveNext();
+
+                var result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None, 1);
+                Assert.True(result.HasValue);
+                Assert.Equal(0, result.Value.Count);
+                Assert.False(result.Value.IsCapped);
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None, 1);
+                Assert.True(result.HasValue);
+                Assert.Equal(1, result.Value.Count);
+                Assert.True(result.Value.IsCapped);
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None, 1);
+                Assert.True(result.HasValue);
+                Assert.Equal(1, result.Value.Count);
+                Assert.False(result.Value.IsCapped);
+            }
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeLens)]
+        public async Task TestDisplay()
+        {
+            using (var workspace = await SetupWorkspaceAsync(@"
+class A
+{
+    void B()
+    {
+        C();
+    }
+
+    void C()
+    {
+        D();
+    }
+
+    void D()
+    {
+        C();
+    }
+}"))
+            {
+                var solution = workspace.CurrentSolution;
+                var documentId = workspace.Documents.First().Id;
+                var document = solution.GetDocument(documentId);
+                var syntaxNode = await document.GetSyntaxRootAsync();
+                var iterator = syntaxNode.ChildNodes().First().ChildNodes().GetEnumerator();
+                iterator.MoveNext();
+
+                var result =
+                    await
+                        _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.Equal(0, result.Count());
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.Equal(2, result.Count());
+
+                iterator.MoveNext();
+                result =
+                    await
+                        _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current,
+                            CancellationToken.None);
+                Assert.Equal(1, result.Count());
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/TestUtilities/Traits.cs
+++ b/src/EditorFeatures/TestUtilities/Traits.cs
@@ -84,6 +84,7 @@ namespace Roslyn.Test.Utilities
             public const string CodeActionsUseExplicitType = "CodeActions.UseExplicitType";
             public const string CodeGeneration = nameof(CodeGeneration);
             public const string CodeGenerationSortDeclarations = "CodeGeneration.SortDeclarations";
+            public const string CodeLens = nameof(CodeLens);
             public const string CodeModel = nameof(CodeModel);
             public const string CodeModelEvents = "CodeModel.Events";
             public const string CodeModelMethodXml = "CodeModel.MethodXml";

--- a/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
+++ b/src/EditorFeatures/VisualBasicTest/BasicEditorServicesTest.vbproj
@@ -142,6 +142,7 @@
     <Compile Include="CodeActions\MoveType\MoveTypeTests.RenameFile.vb" />
     <Compile Include="CodeActions\Preview\PreviewTests.vb" />
     <Compile Include="CodeActions\ReplacePropertyWithMethods\ReplacePropertyWithMethodsTests.vb" />
+    <Compile Include="CodeLens\VisualBasicCodeLensTests.vb" />
     <Compile Include="Completion\CompletionServiceTests.vb" />
     <Compile Include="Diagnostics\AddImport\AddImportTests_NuGet.vb" />
     <Compile Include="Diagnostics\ImplementAbstractClass\ImplementAbstractClassTests_FixAllTests.vb" />

--- a/src/EditorFeatures/VisualBasicTest/CodeLens/VisualBasicCodeLensTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeLens/VisualBasicCodeLensTests.vb
@@ -1,0 +1,137 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Threading
+Imports Microsoft.CodeAnalysis.CodeLens
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+
+Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.UnitTests.CodeLens
+    Public Class VisualBasicCodeLensTests
+        Private _referenceService As CodeLensReferenceService
+
+        Private Async Function SetupWorkspaceAsync(content As String) As Task(Of TestWorkspace)
+            Dim workspace = Await TestWorkspace.CreateVisualBasicAsync(content)
+            _referenceService = New CodeLensReferenceService()
+            Return workspace
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeLens)>
+        Public Async Function TestCount() As Task
+            Using workspace = Await SetupWorkspaceAsync("" + vbCrLf +
+"Class A" + vbCrLf +
+"    Sub B()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub C()" + vbCrLf +
+"        D()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub D()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"End Class")
+                Dim solution = workspace.CurrentSolution
+                Dim documentId = workspace.Documents.First().Id
+                Dim document = solution.GetDocument(documentId)
+                Dim syntaxNode = Await document.GetSyntaxRootAsync()
+                Dim iterator = syntaxNode.ChildNodes().First().ChildNodes().Skip(1).GetEnumerator()
+                iterator.MoveNext()
+
+                Dim result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.True(result.HasValue)
+                Assert.Equal(0, result.Value.Count)
+                Assert.False(result.Value.IsCapped)
+
+                iterator.MoveNext()
+                result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.True(result.HasValue)
+                Assert.Equal(2, result.Value.Count)
+                Assert.False(result.Value.IsCapped)
+
+                iterator.MoveNext()
+                result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.True(result.HasValue)
+                Assert.Equal(1, result.Value.Count)
+                Assert.False(result.Value.IsCapped)
+            End Using
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeLens)>
+        Public Async Function TestCapping() As Task
+            Using workspace = Await SetupWorkspaceAsync("" + vbCrLf +
+"Class A" + vbCrLf +
+"    Sub B()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub C()" + vbCrLf +
+"        D()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub D()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"End Class")
+                Dim solution = workspace.CurrentSolution
+                Dim documentId = workspace.Documents.First().Id
+                Dim document = solution.GetDocument(documentId)
+                Dim syntaxNode = Await document.GetSyntaxRootAsync()
+                Dim iterator = syntaxNode.ChildNodes().First().ChildNodes().Skip(1).GetEnumerator()
+                iterator.MoveNext()
+
+                Dim result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.True(result.HasValue)
+                Assert.Equal(0, result.Value.Count)
+                Assert.False(result.Value.IsCapped)
+
+                iterator.MoveNext()
+                result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None, 1)
+                Assert.True(result.HasValue)
+                Assert.Equal(1, result.Value.Count)
+                Assert.True(result.Value.IsCapped)
+
+                iterator.MoveNext()
+                result = Await _referenceService.GetReferenceCountAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None, 1)
+                Assert.True(result.HasValue)
+                Assert.Equal(1, result.Value.Count)
+                Assert.False(result.Value.IsCapped)
+            End Using
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeLens)>
+        Public Async Function TestDisplay() As Task
+            Using workspace = Await SetupWorkspaceAsync("" + vbCrLf +
+"Class A" + vbCrLf +
+"    Sub B()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub C()" + vbCrLf +
+"        D()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"" + vbCrLf +
+"    Sub D()" + vbCrLf +
+"        C()" + vbCrLf +
+"    End Sub" + vbCrLf +
+"End Class")
+                Dim solution = workspace.CurrentSolution
+                Dim documentId = workspace.Documents.First().Id
+                Dim document = solution.GetDocument(documentId)
+                Dim syntaxNode = Await document.GetSyntaxRootAsync()
+                Dim iterator = syntaxNode.ChildNodes().First().ChildNodes().Skip(1).GetEnumerator()
+                iterator.MoveNext()
+
+                Dim result = Await _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.Equal(0, result.Count())
+
+                iterator.MoveNext()
+                result = Await _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.Equal(2, result.Count())
+
+                iterator.MoveNext()
+                result = Await _referenceService.FindReferenceLocationsAsync(solution, documentId, iterator.Current.ChildNodes().First(), CancellationToken.None)
+                Assert.Equal(1, result.Count())
+            End Using
+        End Function
+    End Class
+End Namespace

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -92,6 +92,7 @@
     <Compile Include="CodeFixes\Suppression\CSharpSuppressionCodeFixProvider.cs" />
     <Compile Include="CodeFixes\TypeStyle\UseExplicitTypeCodeFixProvider.cs" />
     <Compile Include="CodeFixes\TypeStyle\UseImplicitTypeCodeFixProvider.cs" />
+    <Compile Include="CodeLens\DisplayInfoCSharpServices.cs" />
     <Compile Include="CodeRefactorings\ConvertToInterpolatedString\ConvertToInterpolatedStringRefactoringProvider.cs" />
     <Compile Include="CodeRefactorings\EncapsulateField\EncapsulateFieldCodeRefactoringProvider.cs" />
     <Compile Include="CodeRefactorings\ExtractInterface\ExtractInterfaceCodeRefactoringProvider.cs" />

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -947,6 +947,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (Unknown).
+        /// </summary>
+        internal static string unknown_value {
+            get {
+                return ResourceManager.GetString("unknown_value", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Use explicit type.
         /// </summary>
         internal static string Use_explicit_type {

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -464,4 +464,7 @@
   <data name="struct_name" xml:space="preserve">
     <value>&lt;struct name&gt;</value>
   </data>
+  <data name="unknown_value" xml:space="preserve">
+    <value>(Unknown)</value>
+  </data>
 </root>

--- a/src/Features/CSharp/Portable/CodeLens/DisplayInfoCSharpServices.cs
+++ b/src/Features/CSharp/Portable/CodeLens/DisplayInfoCSharpServices.cs
@@ -1,0 +1,348 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.CodeLens;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Host.Mef;
+
+namespace Microsoft.CodeAnalysis.CSharp.Diagnostics
+{
+    [ExportLanguageService(typeof(IDisplayInfoLanguageServices), LanguageNames.CSharp), Shared]
+    internal sealed class DisplayInfoCSharpServices : IDisplayInfoLanguageServices
+    {
+        private const SymbolDisplayMiscellaneousOptions MiscOptions =
+            SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers |
+            SymbolDisplayMiscellaneousOptions.UseSpecialTypes |
+            SymbolDisplayMiscellaneousOptions.UseAsterisksInMultiDimensionalArrays |
+            SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName;
+
+        private const SymbolDisplayMemberOptions MemberOptions =
+            SymbolDisplayMemberOptions.IncludeParameters | SymbolDisplayMemberOptions.IncludeContainingType;
+
+        // Matches default ToDisplayString
+        private static readonly SymbolDisplayFormat DefaultFormat = new SymbolDisplayFormat(
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.OmittedAsContaining,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                propertyStyle: SymbolDisplayPropertyStyle.NameOnly,
+                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                memberOptions: MemberOptions,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeParamsRefOut | SymbolDisplayParameterOptions.IncludeType,
+                miscellaneousOptions: MiscOptions);
+
+        // Matches default ToDisplayString except removing global namspace and namespaces
+        private static readonly SymbolDisplayFormat ShortFormat = new SymbolDisplayFormat(
+                globalNamespaceStyle: SymbolDisplayGlobalNamespaceStyle.Omitted,
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+                propertyStyle: SymbolDisplayPropertyStyle.NameOnly,
+                genericsOptions: SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                memberOptions: MemberOptions,
+                parameterOptions: SymbolDisplayParameterOptions.IncludeParamsRefOut | SymbolDisplayParameterOptions.IncludeType,
+                miscellaneousOptions: MiscOptions);
+
+        /// <summary>
+        /// Indicates if the given node is a declaration of some kind of symbol. 
+        /// For example a class for a method declaration.
+        /// </summary>
+        public bool IsDeclaration(SyntaxNode node)
+        {
+            return IsTypeOrNamespaceDeclaration(node) || IsMemberDeclaration(node);
+        }
+
+        /// <summary>
+        /// Indicates if the given node is a namespace import.
+        /// </summary>
+        public bool IsDirectiveOrImport(SyntaxNode node)
+        {
+            if (node.IsKind(SyntaxKind.UsingDirective) ||
+                node.IsKind(SyntaxKind.ExternAliasDirective))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Indicates if the given node is an assembly level attribute "[assembly: MyAttribute]"
+        /// </summary>
+        public bool IsGlobalAttribute(SyntaxNode node)
+        {
+            if (node.IsKind(SyntaxKind.Attribute) &&
+                node.Parent.IsKind(SyntaxKind.AttributeList))
+            {
+                var attributeListNode = (AttributeListSyntax)node.Parent;
+                if (attributeListNode.Target != null)
+                {
+                    return attributeListNode.Target.Identifier.IsKind(SyntaxKind.AssemblyKeyword);
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Indicates if given node is DocumentationCommentTriviaSyntax
+        /// </summary>
+        public bool IsDocumentationComment(SyntaxNode node)
+        {
+            return node.IsKind(SyntaxKind.SingleLineDocumentationCommentTrivia) ||
+                   node.IsKind(SyntaxKind.MultiLineDocumentationCommentTrivia);
+        }
+
+        /// <summary>
+        /// Returns the node that should be displayed
+        /// </summary>
+        public SyntaxNode GetDisplayNode(SyntaxNode node)
+        {
+            while (true)
+            {
+                switch (node.Kind())
+                {
+                    // LocalDeclarations do not have symbols themselves, you need a variable declarator
+                    case SyntaxKind.LocalDeclarationStatement:
+                        var localDeclarationNode = (LocalDeclarationStatementSyntax) node;
+                        node = localDeclarationNode.Declaration.Variables.First();
+                        continue;
+
+                        // Field and event declarations do not have symbols themselves, you need a variable declarator
+                    case SyntaxKind.FieldDeclaration:
+                    case SyntaxKind.EventFieldDeclaration:
+                        var fieldNode = (BaseFieldDeclarationSyntax) node;
+                        node = fieldNode.Declaration.Variables.First();
+                        continue;
+
+                        // Variable is a field without access modifier. Parent is FieldDeclaration
+                    case SyntaxKind.VariableDeclaration:
+                        node = node.Parent;
+                        continue;
+
+                        // Built in types   
+                    case SyntaxKind.PredefinedType:
+                        node = node.Parent;
+                        continue;
+
+                    case SyntaxKind.MultiLineDocumentationCommentTrivia:
+                    case SyntaxKind.SingleLineDocumentationCommentTrivia:
+                        // For DocumentationCommentTrivia node, node.Parent is null. Obtain parent through ParentTrivia.Token
+                        if (node.IsStructuredTrivia)
+                        {
+                            var structuredTriviaSyntax = (StructuredTriviaSyntax) node;
+                            node = structuredTriviaSyntax.ParentTrivia.Token.Parent;
+                            continue;
+                        }
+                        return null;
+
+                    default:
+                        return node;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the DisplayName for the given node.
+        /// </summary>
+        public string GetDisplayName(
+            SemanticModel semanticModel,
+            SyntaxNode node,
+            DisplayFormat displayFormat)
+        {
+            if (node == null)
+            {
+                return CSharpFeaturesResources.unknown_value;
+            }
+
+            SymbolDisplayFormat symbolDisplayFormat = DefaultFormat;
+            if (displayFormat == DisplayFormat.Short)
+            {
+                symbolDisplayFormat = ShortFormat;
+            }
+
+            string displayName;
+            string enclosingScopeString;
+
+            int lastDotBeforeSpaceIndex;
+
+            ISymbol symbol;
+
+            if (IsGlobalAttribute(node))
+            {
+                return "assembly: " + node;
+            }
+
+            // Don't discriminate between getters and setters for indexers
+            if (node.Parent != null && node.Parent.IsKind(SyntaxKind.AccessorList) &&
+                node.Parent.Parent.IsKind(SyntaxKind.IndexerDeclaration))
+            {
+                return GetDisplayName(semanticModel, node.Parent.Parent, displayFormat);
+            }
+
+            switch (node.Kind())
+            {
+                case SyntaxKind.ConstructorDeclaration:
+                    // The constructor's name will be the name of the class, not ctor like we want
+                    symbol = semanticModel.GetDeclaredSymbol(node);
+                    displayName = symbol.ToDisplayString(symbolDisplayFormat);
+                    var openParenIndex = displayName.IndexOf('(');
+                    int lastDotBeforeOpenParenIndex = displayName.LastIndexOf('.', openParenIndex, openParenIndex);
+
+                    var constructorName = symbol.IsStatic ? "cctor" : "ctor";
+
+                    displayName = displayName.Substring(0, lastDotBeforeOpenParenIndex + 1) +
+                                         constructorName +
+                                         displayName.Substring(openParenIndex);
+                    break;
+
+                case SyntaxKind.IndexerDeclaration:
+                    // The name will be "namespace.class.this[type] - we want "namespace.class[type] Indexer"
+                    symbol = semanticModel.GetDeclaredSymbol(node);
+                    displayName = symbol.ToDisplayString(symbolDisplayFormat);
+                    int openBracketIndex = displayName.IndexOf('[');
+                    var lastDotBeforeOpenBracketIndex = displayName.LastIndexOf('.', openBracketIndex, openBracketIndex);
+
+                    displayName = displayName.Substring(0, lastDotBeforeOpenBracketIndex) +
+                                         displayName.Substring(openBracketIndex) +
+                                         " Indexer";
+                    break;
+
+                case SyntaxKind.OperatorDeclaration:
+                    // The name will be "namespace.class.operator +(type)" - we want namespace.class.+(type) Operator
+                    symbol = semanticModel.GetDeclaredSymbol(node);
+                    displayName = symbol.ToDisplayString(symbolDisplayFormat);
+                    int spaceIndex = displayName.IndexOf(' ');
+                    lastDotBeforeSpaceIndex = displayName.LastIndexOf('.', spaceIndex, spaceIndex);
+
+                    displayName = displayName.Substring(0, lastDotBeforeSpaceIndex + 1) +
+                                         displayName.Substring(spaceIndex + 1) +
+                                         " Operator";
+                    break;
+
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    // The name will be "namespace.class.operator +(type)" - we want namespace.class.+(type) Operator
+                    symbol = semanticModel.GetDeclaredSymbol(node);
+                    displayName = symbol.ToDisplayString(symbolDisplayFormat);
+                    int firstSpaceIndex = displayName.IndexOf(' ');
+                    int secondSpaceIndex = displayName.IndexOf(' ', firstSpaceIndex + 1);
+                    lastDotBeforeSpaceIndex = displayName.LastIndexOf('.', firstSpaceIndex, firstSpaceIndex);
+
+                    displayName = displayName.Substring(0, lastDotBeforeSpaceIndex + 1) +
+                                         displayName.Substring(secondSpaceIndex + 1) +
+                                         " Operator";
+                    break;
+
+                case SyntaxKind.UsingDirective:
+                    // We want to see usings formatted as simply "Using", prefaced by the namespace they are in
+                    enclosingScopeString = GetEnclosingScopeString(node, semanticModel, symbolDisplayFormat);
+                    displayName = string.IsNullOrEmpty(enclosingScopeString) ? "Using" : enclosingScopeString + " Using";
+                    break;
+
+                case SyntaxKind.ExternAliasDirective:
+                    // We want to see aliases formatted as "Alias", prefaced by their enclosing scope, if any
+                    enclosingScopeString = GetEnclosingScopeString(node, semanticModel, symbolDisplayFormat);
+                    displayName = string.IsNullOrEmpty(enclosingScopeString) ? "Alias" : enclosingScopeString + " Alias";
+                    break;
+
+                default:
+                    displayName = GetSymbolDisplayString(node, semanticModel, symbolDisplayFormat);
+                    break;
+            }
+
+            return displayName;
+        }
+
+        private static bool IsTypeOrNamespaceDeclaration(SyntaxNode node)
+        {
+            // From the C# language spec:
+            // type-declaration:
+            //     class-declaration
+            //     struct-declaration
+            //     interface-declaration
+            //     enum-declaration
+            //     delegate-declaration
+            switch (node.Kind())
+            {
+                case SyntaxKind.NamespaceDeclaration:
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.StructDeclaration:
+                case SyntaxKind.InterfaceDeclaration:
+                case SyntaxKind.EnumDeclaration:
+                case SyntaxKind.DelegateDeclaration:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static bool IsMemberDeclaration(SyntaxNode node)
+        {
+            // From the C# language spec:
+            // class-member-declaration:
+            //    constant-declaration
+            //    field-declaration
+            //    method-declaration
+            //    property-declaration
+            //    event-declaration
+            //    indexer-declaration
+            //    operator-declaration
+            //    constructor-declaration
+            //    destructor-declaration
+            //    static-constructor-declaration
+            //    type-declaration
+            switch (node.Kind())
+            {
+                // Because fields declarations can define multiple symbols "public int a, b;" 
+                // We want to get the VariableDeclarator node inside the field declaration to print out the symbol for the name.
+                case SyntaxKind.VariableDeclarator:
+                    return node.Parent.Parent.IsKind(SyntaxKind.FieldDeclaration) ||
+                           node.Parent.Parent.IsKind(SyntaxKind.EventFieldDeclaration);
+
+                case SyntaxKind.FieldDeclaration:
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.PropertyDeclaration:
+                case SyntaxKind.GetAccessorDeclaration:
+                case SyntaxKind.SetAccessorDeclaration:
+                case SyntaxKind.EventDeclaration:
+                case SyntaxKind.EventFieldDeclaration:
+                case SyntaxKind.AddAccessorDeclaration:
+                case SyntaxKind.RemoveAccessorDeclaration:
+                case SyntaxKind.IndexerDeclaration:
+                case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.DestructorDeclaration:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+
+        private static string GetEnclosingScopeString(SyntaxNode node, SemanticModel semanticModel, SymbolDisplayFormat symbolDisplayFormat)
+        {
+            SyntaxNode scopeNode = node;
+            while (scopeNode != null && !IsTypeOrNamespaceDeclaration(scopeNode))
+            {
+                scopeNode = scopeNode.Parent;
+            }
+
+            if (scopeNode == null)
+            {
+                return null;
+            }
+
+            ISymbol scopeSymbol = semanticModel.GetDeclaredSymbol(scopeNode);
+            return scopeSymbol.ToDisplayString(symbolDisplayFormat);
+        }
+
+        private static string GetSymbolDisplayString(SyntaxNode node, SemanticModel semanticModel, SymbolDisplayFormat symbolDisplayFormat)
+        {
+            if (node == null)
+            {
+                return CSharpFeaturesResources.unknown_value;
+            }
+
+            ISymbol symbol = semanticModel.GetDeclaredSymbol(node);
+            return symbol != null ? symbol.ToDisplayString(symbolDisplayFormat) : CSharpFeaturesResources.unknown_value;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    /// <summary>
+    /// Tracks incremental progress of a find references search, we use this to
+    /// count the number of references up until a certain cap is reached and cancel the search
+    /// or until the search completes, if such a cap is not reached.
+    /// </summary>
+    /// <remarks>
+    /// All public methods of this type could be called from multiple threads.
+    /// </remarks>
+    internal sealed class CodeLensFindReferencesProgress : IFindReferencesProgress
+    {
+        private readonly object _gate = new object();
+
+        /// <summary>
+        /// this token is linked to an aggregate token that is passed to the Find References
+        /// operation, this is used solely to trigger the cancellation of an in progress
+        /// find references operation, when the references count hits a given cap.
+        /// </summary>
+        private readonly CancellationTokenSource _cancellationTokenSource;
+        private readonly SyntaxNode _queriedNode;
+        private readonly ISymbol _queriedSymbol;
+        private readonly ConcurrentSet<ISymbol> _foundDefinitions = new ConcurrentSet<ISymbol>();
+
+        /// <remarks>
+        /// _referencesCount is read and written from multiple threads.
+        /// so all read and write should be through a lock around _gate.
+        /// </remarks>
+        private int _referencesCount;
+
+        /// <remarks>
+        /// If the cap is 0, then there is no cap.
+        /// </remarks>
+        public int SearchCap { get; }
+
+        public CodeLensFindReferencesProgress(
+            ISymbol queriedDefinition,
+            SyntaxNode queriedNode,
+            CancellationTokenSource cancellationTokenSource,
+            int searchCap)
+        {
+            _queriedSymbol = queriedDefinition;
+            _queriedNode = queriedNode;
+            _cancellationTokenSource = cancellationTokenSource;
+
+            SearchCap = searchCap;
+        }
+
+        public bool SearchCapReached
+        {
+            get
+            {
+                if (SearchCap == 0)
+                {
+                    return false;
+                }
+
+                lock (_gate)
+                {
+                    return _referencesCount > SearchCap;
+                }
+            }
+        }
+
+        public int ReferencesCount
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    return _referencesCount;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Returns partial symbol locations whose node does not match the given syntaxNode
+        /// </summary>
+        /// <param name="symbol">Symbol whose locations are queried</param>
+        /// <param name="syntaxNode">Syntax node to compare against to exclude location - actual location being queried</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Partial locations</returns>
+        private static IEnumerable<Location> GetPartialLocations(ISymbol symbol, SyntaxNode syntaxNode, CancellationToken cancellationToken)
+        {
+            // Returns nodes from source not equal to actual location
+            IEnumerable<SyntaxNode> syntaxNodes = from syntaxReference in symbol.DeclaringSyntaxReferences
+                                                  let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
+                                                  where !(syntaxNode.Span == candidateSyntaxNode.Span &&
+                                                          syntaxNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath, StringComparison.OrdinalIgnoreCase))
+                                                  select candidateSyntaxNode;
+
+            // This matches the definition locations to syntax references, ignores metadata locations
+            IEnumerable<Location> partialLocations = from currentSyntaxNode in syntaxNodes
+                                                     from sourceLocation in symbol.Locations
+                                                     where !sourceLocation.IsInMetadata
+                                                           && currentSyntaxNode.SyntaxTree.Equals(sourceLocation.SourceTree)
+                                                           && currentSyntaxNode.Span.Contains(sourceLocation.SourceSpan)
+                                                     select sourceLocation;
+
+            return partialLocations;
+        }
+
+        /// <remarks>
+        /// This method will not be called concurrently with any other progress method.
+        /// Hence, locks are not necessary.
+        /// </remarks>
+        public void OnCompleted()
+        {
+            // If we didn't hit the cap, we are in the most common case of *not widely cascaded* items.
+            // Essentially, the search count we display should be accurate, so,
+            // we have to add the count of definitions we've encountered plus account for cases like partial definitions.
+            if (SearchCapReached || !_foundDefinitions.Any())
+            {
+                return;
+            }
+
+            // Add all definitions, except the one that we queried on.
+            // Note: there can be more than 1 queried definition in case of linked files.
+            var queriedDefinitions = _foundDefinitions.Where(IsQueriedDefinition);
+            var definitions = _foundDefinitions.Except(queriedDefinitions);
+            var definitionLocations = definitions.Select(def => def.Locations);
+            _referencesCount += definitionLocations.Count();
+
+            // Add all partial declaration locations.
+            foreach (var queriedDefinition in queriedDefinitions)
+            {
+                var additionalSyntaxLocations = GetPartialLocations(queriedDefinition, _queriedNode, _cancellationTokenSource.Token);
+                _referencesCount += additionalSyntaxLocations.Count();
+            }
+        }
+
+        private bool IsQueriedDefinition(ISymbol symbol)
+        {
+            return symbol.Locations.Intersect(
+                   _queriedSymbol.Locations, LocationComparer.Instance).Any();
+        }
+
+        public void OnDefinitionFound(ISymbol symbol)
+        {
+            if (FilteringHelpers.FilterDeclaration(symbol))
+            {
+                _foundDefinitions.Add(symbol);
+            }
+        }
+
+        public void OnFindInDocumentCompleted(Document document)
+        {
+        }
+
+        public void OnFindInDocumentStarted(Document document)
+        {
+        }
+
+        public void OnReferenceFound(ISymbol symbol, ReferenceLocation location)
+        {
+            if (!FilteringHelpers.FilterReference(_queriedSymbol, symbol, location))
+            {
+                return;
+            }
+
+            lock (_gate)
+            {
+                _referencesCount++;
+
+                if (SearchCapReached)
+                {
+                    _cancellationTokenSource.Cancel();
+                }
+            }
+        }
+
+        public void OnStarted()
+        {
+        }
+
+        public void ReportProgress(int current, int maximum)
+        {
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/CodeLenseReferenceService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLenseReferenceService.cs
@@ -1,0 +1,269 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    [ExportWorkspaceService(typeof(ICodeLensReferencesService)), Shared]
+    internal sealed class CodeLensReferenceService : ICodeLensReferencesService
+    {
+        public async Task<ReferenceCount?> GetReferenceCountAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, CancellationToken cancellationToken,
+            int maxSearchResults = 0)
+        {
+            if (solution == null || documentId == null || syntaxNode == null)
+            {
+                return null;
+            }
+
+            var document = solution.GetDocument(documentId);
+            if (document == null)
+            {
+                return null;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (semanticModel == null)
+            {
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var symbol = semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken);
+            if (symbol == null)
+            {
+                return null;
+            }
+
+            using (var cappingCancellationTokenSource = new CancellationTokenSource())
+            {
+                var aggregateCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
+                    cappingCancellationTokenSource.Token, cancellationToken);
+
+                var progress = new CodeLensFindReferencesProgress(
+                    symbol, syntaxNode, cappingCancellationTokenSource, maxSearchResults);
+
+                try
+                {
+                    await
+                        SymbolFinder.FindReferencesAsync(symbol, solution, progress, null,
+                            aggregateCancellationTokenSource.Token).ConfigureAwait(false);
+
+                    return
+                        new ReferenceCount(
+                            progress.SearchCap > 0
+                                ? Math.Min(progress.ReferencesCount, progress.SearchCap)
+                                : progress.ReferencesCount, progress.SearchCapReached);
+                }
+                catch (OperationCanceledException)
+                {
+                    if (progress.SearchCapReached)
+                    {
+                        // search was cancelled, and it was cancelled by us because a cap was reached.
+                        return new ReferenceCount(progress.SearchCap, true);
+                    }
+
+                    // search was cancelled, but not because of cap.
+                    // this always throws.
+                    cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                throw ExceptionUtilities.Unreachable;
+            }
+        }
+
+        private static bool IsQueriedDefinition(ReferencedSymbol reference, ISymbol queriedDefinition)
+        {
+            return reference.Definition.Locations.Intersect(
+                queriedDefinition.Locations, LocationComparer.Instance).Any();
+        }
+
+        private static async Task<IEnumerable<Tuple<ReferencedSymbol, bool>>> GetReferences(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+
+            // Exclude the following kind of symbols:
+            //  (a) Implicitly declared symbols (such as implicit fields backing properties)
+            //  (b) Symbols that can't be referenced by name (such as property getters and setters).
+            //  (c) Metadata only symbols, i.e. symbols with no location in source.
+            IEnumerable<ReferencedSymbol> filteredReferences = from reference in references
+                                                               let symbolDef = reference.Definition
+                                                               where FilteringHelpers.FilterReference(symbolDef, reference)
+                                                               select reference;
+
+            return filteredReferences.Select(reference => Tuple.Create(reference, IsQueriedDefinition(reference, symbol)));
+        }
+
+        private static async Task<Tuple<SyntaxNode, IEnumerable<Tuple<ReferencedSymbol, bool>>>> FindReferencesAsync(Solution solution, Document document, SyntaxNode syntaxNode, SemanticModel semanticModel, CancellationToken cancellationToken)
+        {
+            var symbol = semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken);
+            if (symbol == null)
+            {
+                return null;
+            }
+
+            var references = await SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+
+            // Exclude the following kind of symbols:
+            //  (a) Implicitly declared symbols (such as implicit fields backing properties)
+            //  (b) Symbols that can't be referenced by name (such as property getters and setters).
+            //  (c) Metadata only symbols, i.e. symbols with no location in source.
+            IEnumerable<ReferencedSymbol> filteredReferences = from reference in references
+                                                               let symbolDef = reference.Definition
+                                                               where FilteringHelpers.FilterReference(symbolDef, reference)
+                                                               select reference;
+
+            var allReferences =
+                filteredReferences.Select(reference => Tuple.Create(reference, IsQueriedDefinition(reference, symbol)));
+
+            // Search through all other projects to see if we can a matching symbol in other projects
+            foreach (var additionalProject in document.Project.Solution.Projects)
+            {
+                if (additionalProject == document.Project)
+                {
+                    continue;
+                }
+
+                var additionalDocument = additionalProject.Documents.FirstOrDefault(d => document.FilePath.Equals(d.FilePath, StringComparison.OrdinalIgnoreCase));
+                if (additionalDocument == null)
+                {
+                    continue;
+                }
+
+                var additionalSemanticModel = await additionalDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+                var token = (await additionalSemanticModel.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false)).FindToken(syntaxNode.Span.Start);
+                var node = token.Parent.AncestorsAndSelf().FirstOrDefault(n => n.Span == syntaxNode.Span);
+
+                if (node == null)
+                {
+                    continue;
+                }
+
+                var additionalSymbol = additionalSemanticModel.GetDeclaredSymbol(node, cancellationToken);
+
+                // Sanity check that the symbol is the same
+                if (additionalSymbol != null && additionalSymbol.Kind == symbol.Kind && additionalSymbol.Name == symbol.Name)
+                {
+                    allReferences = allReferences.Concat(await GetReferences(additionalSymbol, solution, cancellationToken).ConfigureAwait(false));
+                }
+            }
+
+            return Tuple.Create(syntaxNode, allReferences);
+        }
+
+        /// <summary>
+        /// Returns partial symbol locations whose node does not match the given syntaxNode
+        /// </summary>
+        /// <param name="symbol">Symbol whose locations are queried</param>
+        /// <param name="syntaxNode">Syntax node to compare against to exclude location - actual location being queried</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Partial locations</returns>
+        private static IEnumerable<Location> GetPartialLocations(ISymbol symbol, SyntaxNode syntaxNode, CancellationToken cancellationToken)
+        {
+            // Returns nodes from source not equal to actual location
+            IEnumerable<SyntaxNode> syntaxNodes = from syntaxReference in symbol.DeclaringSyntaxReferences
+                                                  let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
+                                                  where !(syntaxNode.Span == candidateSyntaxNode.Span &&
+                                                          syntaxNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath, StringComparison.OrdinalIgnoreCase))
+                                                  select candidateSyntaxNode;
+
+            // This matches the definition locations to syntax references, ignores metadata locations
+            IEnumerable<Location> partialLocations = from currentSyntaxNode in syntaxNodes
+                                                     from sourceLocation in symbol.Locations
+                                                     where !sourceLocation.IsInMetadata
+                                                           && currentSyntaxNode.SyntaxTree.Equals(sourceLocation.SourceTree)
+                                                           && currentSyntaxNode.Span.Contains(sourceLocation.SourceSpan)
+                                                     select sourceLocation;
+
+            return partialLocations;
+        }
+
+        private static IEnumerable<Location> ExtractLocations(Tuple<SyntaxNode, IEnumerable<Tuple<ReferencedSymbol, bool>>> referenceInfo, CancellationToken cancellationToken)
+        {
+            SyntaxNode definitionSyntaxNode = referenceInfo.Item1;
+            IEnumerable<Tuple<ReferencedSymbol, bool>> referencingSymbols = referenceInfo.Item2;
+
+            // Take reference locations from all definitions
+            IEnumerable<Location> referenceLocations = from referencedSymbol in referencingSymbols
+                                                       from location in referencedSymbol.Item1.Locations
+                                                       select location.Location;
+
+            // Exclude the definition we queried for - base references should be 0
+            IEnumerable<ISymbol> definitions = from referencedSymbol in referencingSymbols
+                                               where !referencedSymbol.Item2    // Item2 indicates if this was the queried symbol definition
+                                               select referencedSymbol.Item1.Definition;
+
+            IEnumerable<Location> definitionLocations = definitions.SelectMany(def => def.Locations);
+
+            // Partial types can have more than one declaring syntax references.
+            // Add remote locations for all the syntax references except the queried syntax node.
+            // To query for the partial locations, filter definition locations that occur in source whose span is part of
+            // span of any syntax node from Definition.DeclaringSyntaxReferences except for the queried syntax node.
+            IEnumerable<Location> additionalSyntaxLocations = from referencedSymbol in referencingSymbols
+                                                              let symbolReference = referencedSymbol.Item1
+                                                              let isQueriedDefinition = referencedSymbol.Item2
+                                                              where isQueriedDefinition
+                                                              from partialLocation in GetPartialLocations(symbolReference.Definition, definitionSyntaxNode, cancellationToken)
+                                                              select partialLocation;
+
+            return referenceLocations.Concat(definitionLocations).Concat(additionalSyntaxLocations);
+        }
+
+        private static IEnumerable<Location> FilterLocations(IEnumerable<Location> locations)
+        {
+            // Exclude references from metadata
+            IEnumerable<Location> sourceLocations = from location in locations
+                                                    where location.Kind != LocationKind.MetadataFile && location.Kind != LocationKind.None
+                                                    select location;
+
+            // Strip out duplicate locations
+            IEnumerable<Location> uniqueLocations = sourceLocations.Distinct(LocationComparer.Instance);
+
+            return uniqueLocations;
+        }
+
+        public async Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, CancellationToken cancellationToken)
+        {
+            if (solution == null || documentId == null || syntaxNode == null)
+            {
+                return null;
+            }
+
+            var document = solution.GetDocument(documentId);
+            if (document == null)
+            {
+                return null;
+            }
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            if (semanticModel == null)
+            {
+                return null;
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Tuple<SyntaxNode, IEnumerable<Tuple<ReferencedSymbol, bool>>> referencingSymbols =
+                await FindReferencesAsync(solution, document, syntaxNode, semanticModel, cancellationToken).ConfigureAwait(false);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            IEnumerable<Location> locations = ExtractLocations(referencingSymbols, cancellationToken);
+            IEnumerable<Location> filteredLocations = FilterLocations(locations);
+            return
+                filteredLocations.Select(
+                    location =>
+                        new ReferenceLocationDescriptor(solution, location, DisplayInfoProvider.GetDisplayInfoOfEnclosingSymbol(document, semanticModel,
+                            location.SourceSpan.Start)));
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/DisplayFormat.cs
+++ b/src/Features/Core/Portable/CodeLens/DisplayFormat.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    /// <summary>
+    /// Defines the display name format type for 
+    /// </summary>
+    internal enum DisplayFormat
+    {
+        /// <summary>
+        ///  Fully qualified name
+        /// </summary>
+        Long,
+
+        /// <summary>
+        /// Abbreviated name
+        /// </summary>
+        Short
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/DisplayInfo.cs
+++ b/src/Features/Core/Portable/CodeLens/DisplayInfo.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal sealed class DisplayInfo
+    {
+        public DisplayInfo(string longName,
+                           string language,
+                           Glyph? glyph,
+                           string referenceLineText,
+                           int referenceStart,
+                           int referenceLength,
+                           string beforeReferenceText1,
+                           string beforeReferenceText2,
+                           string afterReferenceText1,
+                           string afterReferenceText2)
+        {
+            LongName = longName;
+            Language = language;
+            Glyph = glyph;
+            ReferenceLineText = referenceLineText;
+            ReferenceStart = referenceStart;
+            ReferenceLength = referenceLength;
+            BeforeReferenceText1 = beforeReferenceText1;
+            BeforeReferenceText2 = beforeReferenceText2;
+            AfterReferenceText1 = afterReferenceText1;
+            AfterReferenceText2 = afterReferenceText2;
+        }
+
+        /// <summary>
+        /// Fully qualified name of the symbol containing the reference location
+        /// </summary>
+        public string LongName { get; private set; }
+
+        /// <summary>
+        /// Language of the reference location
+        /// </summary>
+        public string Language { get; private set; }
+
+        /// <summary>
+        /// The kind of symbol containing the reference location (such as type, method, property, etc.)
+        /// </summary>
+        public Glyph? Glyph { get; private set; }
+
+        /// <summary>
+        /// the full line of source that contained the reference
+        /// </summary>
+        public string ReferenceLineText { get; private set; }
+
+        /// <summary>
+        /// the beginning of the span within reference text that was the use of the reference
+        /// </summary>
+        public int ReferenceStart { get; private set; }
+
+        /// <summary>
+        /// the length of the span of the reference
+        /// </summary>
+        public int ReferenceLength { get; private set; }
+
+        /// <summary>
+        /// Text above the line with the reference
+        /// </summary>
+        public string BeforeReferenceText1 { get; private set; }
+
+        /// <summary>
+        /// Text above the line with the reference
+        /// </summary>
+        public string BeforeReferenceText2 { get; private set; }
+
+        /// <summary>
+        /// Text below the line with the reference
+        /// </summary>
+        public string AfterReferenceText1 { get; private set; }
+
+        /// <summary>
+        /// Text below the line with the reference
+        /// </summary>
+        public string AfterReferenceText2 { get; private set; }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/DisplayInfoProvider.cs
+++ b/src/Features/Core/Portable/CodeLens/DisplayInfoProvider.cs
@@ -1,0 +1,346 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Shared.Extensions;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal static class DisplayInfoProvider
+    {
+        private static bool IsValueParameter(ISymbol symbol)
+        {
+            if (symbol is IParameterSymbol)
+            {
+                var method = symbol.ContainingSymbol as IMethodSymbol;
+                if (method != null)
+                {
+                    if (method.MethodKind == MethodKind.EventAdd ||
+                        method.MethodKind == MethodKind.EventRemove ||
+                        method.MethodKind == MethodKind.PropertySet)
+                    {
+                        return symbol.Name == "value";
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static Glyph? GetGlyph(ISymbol symbol)
+        {
+            while (true)
+            {
+                if (symbol == null)
+                {
+                    return null;
+                }
+
+                Glyph publicIcon;
+
+                switch (symbol.Kind)
+                {
+                    case SymbolKind.Alias:
+                        symbol = ((IAliasSymbol)symbol).Target;
+                        continue;
+
+                    case SymbolKind.Assembly:
+                        return Glyph.Assembly;
+
+                    case SymbolKind.ArrayType:
+                        symbol = ((IArrayTypeSymbol)symbol).ElementType;
+                        continue;
+
+                    case SymbolKind.DynamicType:
+                        return Glyph.ClassPublic;
+
+                    case SymbolKind.Event:
+                        publicIcon = Glyph.EventPublic;
+                        break;
+
+                    case SymbolKind.Field:
+                        var containingType = symbol.ContainingType;
+                        if (containingType != null && containingType.TypeKind == TypeKind.Enum)
+                        {
+                            return Glyph.EnumMember;
+                        }
+
+                        publicIcon = ((IFieldSymbol)symbol).IsConst ? Glyph.ConstantPublic : Glyph.FieldPublic;
+                        break;
+
+                    case SymbolKind.Label:
+                        return Glyph.Label;
+
+                    case SymbolKind.Local:
+                        return Glyph.Local;
+
+                    case SymbolKind.NamedType:
+                    case SymbolKind.ErrorType:
+                        {
+                            switch (((INamedTypeSymbol)symbol).TypeKind)
+                            {
+                                case TypeKind.Class:
+                                    publicIcon = Glyph.ClassPublic;
+                                    break;
+
+                                case TypeKind.Delegate:
+                                    publicIcon = Glyph.DelegatePublic;
+                                    break;
+
+                                case TypeKind.Enum:
+                                    publicIcon = Glyph.EnumPublic;
+                                    break;
+
+                                case TypeKind.Interface:
+                                    publicIcon = Glyph.InterfacePublic;
+                                    break;
+
+                                case TypeKind.Module:
+                                    publicIcon = Glyph.ModulePublic;
+                                    break;
+
+                                case TypeKind.Struct:
+                                    publicIcon = Glyph.StructurePublic;
+                                    break;
+
+                                case TypeKind.Error:
+                                    return Glyph.Error;
+
+                                default:
+                                    return Glyph.Error;
+                            }
+
+                            break;
+                        }
+
+                    case SymbolKind.Method:
+                        {
+                            var methodSymbol = (IMethodSymbol)symbol;
+
+                            if (methodSymbol.MethodKind == MethodKind.UserDefinedOperator || methodSymbol.MethodKind == MethodKind.Conversion)
+                            {
+                                return Glyph.Operator;
+                            }
+                            if (methodSymbol.IsExtensionMethod || methodSymbol.MethodKind == MethodKind.ReducedExtension)
+                            {
+                                publicIcon = Glyph.ExtensionMethodPublic;
+                            }
+                            else if (methodSymbol.MethodKind == MethodKind.PropertyGet || methodSymbol.MethodKind == MethodKind.PropertySet)
+                            {
+                                publicIcon = Glyph.PropertyPublic;
+                            }
+                            else
+                            {
+                                publicIcon = Glyph.MethodPublic;
+                            }
+                        }
+
+                        break;
+
+                    case SymbolKind.Namespace:
+                        return Glyph.Namespace;
+
+                    case SymbolKind.NetModule:
+                        return Glyph.Assembly;
+
+                    case SymbolKind.Parameter:
+                        return IsValueParameter(symbol) ? Glyph.Keyword : Glyph.Parameter;
+
+                    case SymbolKind.PointerType:
+                        symbol = ((IPointerTypeSymbol)symbol).PointedAtType;
+                        continue;
+
+                    case SymbolKind.Property:
+                        {
+                            var propertySymbol = (IPropertySymbol)symbol;
+
+                            publicIcon = propertySymbol.IsWithEvents ? Glyph.FieldPublic : Glyph.PropertyPublic;
+                        }
+
+                        break;
+
+                    case SymbolKind.RangeVariable:
+                        return Glyph.RangeVariable;
+
+                    case SymbolKind.TypeParameter:
+                        return Glyph.TypeParameter;
+
+                    default:
+                        return Glyph.Error;
+                }
+
+                switch (symbol.DeclaredAccessibility)
+                {
+                    case Accessibility.Private:
+                        publicIcon += Glyph.ClassPrivate - Glyph.ClassPublic;
+                        break;
+
+                    case Accessibility.Protected:
+                    case Accessibility.ProtectedAndInternal:
+                    case Accessibility.ProtectedOrInternal:
+                        publicIcon += Glyph.ClassProtected - Glyph.ClassPublic;
+                        break;
+
+                    case Accessibility.Internal:
+                        publicIcon += Glyph.ClassInternal - Glyph.ClassPublic;
+                        break;
+                }
+
+                return publicIcon;
+            }
+        }
+
+        public static DisplayInfo GetDisplayInfoOfEnclosingSymbol(
+            Document document,
+            SemanticModel semanticModel,
+            int position)
+        {
+            IDisplayInfoLanguageServices langServices = document.GetLanguageService<IDisplayInfoLanguageServices>();
+            if (langServices == null)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Unsupported language '{0}'", semanticModel.Language), nameof(semanticModel));
+            }
+
+            SyntaxNode node = GetEnclosingCodeElementNode(document, position, langServices);
+            string longName = langServices.GetDisplayName(semanticModel, node, DisplayFormat.Long);
+            // while we have all these things, also grab the actual line of code for the reference
+            Tuple<string, string, string, string, string, TextSpan> result = GetReferenceText(document, position);
+            string referenceText = result.Item1;
+            string lineBeforeReferenceText1 = result.Item2;
+            string lineBeforeReferenceText2 = result.Item3;
+            string lineAfterReferenceText1 = result.Item4;
+            string lineAfterReferenceText2 = result.Item5;
+            TextSpan referenceSpan = result.Item6;
+
+            ISymbol symbol = semanticModel.GetDeclaredSymbol(node);
+            var glyph = GetGlyph(symbol);
+
+            return new DisplayInfo(longName,
+                                   semanticModel.Language,
+                                   glyph,
+                                   referenceText,
+                                   referenceSpan.Start,
+                                   referenceSpan.Length,
+                                   lineBeforeReferenceText1,
+                                   lineBeforeReferenceText2,
+                                   lineAfterReferenceText1,
+                                   lineAfterReferenceText2);
+        }
+
+        /// <summary>
+        /// given a document and the position of a reference, return the line of code (leading + trailing space trimmed) that referenced the reference.
+        /// also returns as an out param the exact span of text that is the reference within the line of code (can be used for highlighting)
+        /// </summary>
+        /// <param name="document">the document containing the reference</param>
+        /// <param name="position">the position of the reference</param>
+        /// <returns>tuple of the the full line of code that used the reference, and the span of text that is the reference in the returned line of code</returns>
+        private static Tuple<string, string, string, string, string, TextSpan> GetReferenceText(Document document, int position)
+        {
+            SyntaxToken token = FindTokenAtPosition(document, position);
+
+            // get the full line of source text on the line that contains this position
+            Task<SourceText> docText = document.GetTextAsync();
+            SourceText text = docText.Result;
+            // get the actual span of text for the line containing reference
+            TextLine textLine = text.Lines.GetLineFromPosition(position);
+            // turn the span from document relative to line relative
+            int spanStart = token.Span.Start - textLine.Span.Start;
+            string line = textLine.ToString();
+
+            string beforeLine1 = string.Empty;
+            if (textLine.LineNumber > 0)
+            {
+                TextLine beforeTextLine = text.Lines[textLine.LineNumber - 1];
+                beforeLine1 = beforeTextLine.ToString();
+            }
+
+            string beforeLine2 = string.Empty;
+            if (textLine.LineNumber - 1 > 0)
+            {
+                TextLine beforeTextLine = text.Lines[textLine.LineNumber - 2];
+                beforeLine2 = beforeTextLine.ToString();
+            }
+
+            string afterLine1 = string.Empty;
+            if (textLine.LineNumber < text.Lines.Count - 1)
+            {
+                TextLine afterTextLine = text.Lines[textLine.LineNumber + 1];
+                afterLine1 = afterTextLine.ToString();
+            }
+
+            string afterLine2 = string.Empty;
+            if (textLine.LineNumber + 1 < text.Lines.Count - 1)
+            {
+                TextLine afterTextLine = text.Lines[textLine.LineNumber + 2];
+                afterLine2 = afterTextLine.ToString();
+            }
+
+            return new Tuple<string, string, string, string, string, TextSpan>(line.TrimEnd(),
+                                                               beforeLine1.TrimEnd(),
+                                                               beforeLine2.TrimEnd(),
+                                                               afterLine1.TrimEnd(),
+                                                               afterLine2.TrimEnd(),
+                                                               new TextSpan(spanStart, token.Span.Length));
+        }
+
+        /// <summary>
+        /// find the token at a given postion in the document
+        /// </summary>
+        /// <param name="document">the document containing the reference</param>
+        /// <param name="position">the position of the reference</param>
+        /// <returns>the syntax token at the specified location</returns>
+        private static SyntaxToken FindTokenAtPosition(Document document, int position)
+        {
+            Task<SyntaxNode> taskGetSyntaxRoot = document.GetSyntaxRootAsync();
+            SyntaxNode root = taskGetSyntaxRoot.Result;
+
+            // IncludeTrivia when searching for token as roslyn returns locations from xml documentation as well
+            SyntaxToken token;
+            try
+            {
+                token = root.FindToken(position, true);
+            }
+            catch (ArgumentOutOfRangeException e)
+            {
+                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Could not find position '{0}' in document: {1}", position, document.FilePath), e);
+            }
+
+            return token;
+        }
+
+        private static SyntaxNode GetEnclosingCodeElementNode(Document document, int position, IDisplayInfoLanguageServices langServices)
+        {
+            SyntaxToken token = FindTokenAtPosition(document, position);
+
+            SyntaxNode node = token.Parent;
+            while (node != null)
+            {
+                if (langServices.IsDocumentationComment(node))
+                {
+                    IStructuredTriviaSyntax structuredTriviaSyntax = (IStructuredTriviaSyntax)node;
+                    SyntaxTrivia parentTrivia = structuredTriviaSyntax.ParentTrivia;
+                    node = parentTrivia.Token.Parent;
+                }
+                else if (langServices.IsDeclaration(node) ||
+                         langServices.IsDirectiveOrImport(node) ||
+                         langServices.IsGlobalAttribute(node))
+                {
+                    break;
+                }
+                else
+                {
+                    node = node.Parent;
+                }
+            }
+
+            if (node == null)
+            {
+                node = token.Parent;
+            }
+
+            return langServices.GetDisplayNode(node);
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/FilteringHelpers.cs
+++ b/src/Features/Core/Portable/CodeLens/FilteringHelpers.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.CodeAnalysis.FindSymbols;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal sealed class FilteringHelpers
+    {
+        /// <summary>
+        /// Exclude the following kind of symbols:
+        ///  1. Implicitly declared symbols (such as implicit fields backing properties)
+        ///  2. Symbols that can't be referenced by name (such as property getters and setters).
+        ///  3. Metadata only symbols, i.e. symbols with no location in source.
+        /// </summary>
+        /// <remarks>
+        /// This is consumed by the streaming find refs progress counting implementation which does not
+        /// store the intermediate results from find refs.
+        /// </remarks>
+        public static bool FilterReference(ISymbol queriedSymbol, ISymbol definition, ReferenceLocation reference)
+        {
+            return FilterImplicitDefinition(definition) &&
+                   FilterImplicitReference(queriedSymbol, definition) &&
+                   (definition.Locations.Any(loc => loc.IsInSource)
+                    || reference.Location.IsInSource);
+        }
+
+        /// <remarks>
+        /// This is consumed by the native find refs count implementation that does a full find refs search
+        /// and counts the number of locations. This does not need to filter implicit references as it eventually strips
+        /// out all duplicate locations.
+        /// </remarks>
+        public static bool FilterReference(ISymbol definition, ReferencedSymbol reference)
+        {
+            return FilterImplicitDefinition(definition) &&
+                   (definition.Locations.Any(loc => loc.IsInSource)
+                    || reference.Locations.Any(loc => loc.Location.IsInSource));
+        }
+
+        public static bool FilterDeclaration(ISymbol definition)
+        {
+            return FilterImplicitDefinition(definition) &&
+                   definition.Locations.Any(loc => loc.IsInSource);
+        }
+
+        private static bool FilterImplicitDefinition(ISymbol symbol)
+        {
+            return !symbol.IsImplicitlyDeclared && !IsAccessor(symbol);
+        }
+
+        /// <remarks>
+        /// FindRefs treats a constructor invocation as a reference to the constructor symbol and to the named type symbol that defines it.
+        /// While we need to count the cascaded symbol definition from the named type to its constructor, we should not double count the
+        /// reference location for the invocation while computing references count for the named type symbol. 
+        /// </remarks>
+        private static bool FilterImplicitReference(ISymbol queriedSymbol, ISymbol definition)
+        {
+            return !(queriedSymbol.Kind == SymbolKind.NamedType && (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor);
+        }
+
+        ///<remarks>
+        /// This method explicity checks if the given reference symbol is an accessor for the queried symbol.
+        /// </remarks>
+        private static bool IsAccessor(ISymbol referencedSymbol)
+        {
+            var methodSymbol = referencedSymbol as IMethodSymbol;
+            return methodSymbol?.AssociatedSymbol != null;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/ICodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/ICodeLensReferencesService.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal interface ICodeLensReferencesService : IWorkspaceService
+    {
+        /// <summary>
+        /// Given a document and syntax node, returns the number of locations where the located node is referenced.
+        /// <para>
+        ///     Optionally, the service supports capping the reference count to a value specified by <paramref name="maxSearchResults"/>
+        ///     if <paramref name="maxSearchResults"/> is greater than 0.
+        /// </para>
+        /// </summary>
+        Task<ReferenceCount?> GetReferenceCountAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, CancellationToken cancellationToken, int maxSearchResults = 0);
+
+        /// <summary>
+        /// Given a document and syntax node, returns a collection of locations where the located node is referenced.
+        /// </summary>
+        Task<IEnumerable<ReferenceLocationDescriptor>> FindReferenceLocationsAsync(Solution solution, DocumentId documentId, SyntaxNode syntaxNode, CancellationToken cancellationToken);
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/IDisplayInfoLanguageServices.cs
+++ b/src/Features/Core/Portable/CodeLens/IDisplayInfoLanguageServices.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Host;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal interface IDisplayInfoLanguageServices : ILanguageService
+    {
+        /// <summary>
+        /// Indicates if the given node is a declaration of some kind of symbol. 
+        /// For example a class for a method declaration.
+        /// </summary>
+        bool IsDeclaration(SyntaxNode node);
+
+        /// <summary>
+        /// Indicates if the given node is a namespace import.
+        /// </summary>
+        bool IsDirectiveOrImport(SyntaxNode node);
+
+        /// <summary>
+        /// Indicates if the given node is an assembly level attribute "[assembly: MyAttribute]"
+        /// </summary>
+        bool IsGlobalAttribute(SyntaxNode node);
+
+        /// <summary>
+        /// Indicates if given node is DocumentationCommentTriviaSyntax
+        /// </summary>
+        bool IsDocumentationComment(SyntaxNode node);
+
+        /// <summary>
+        /// Gets the node used for display info
+        /// </summary>
+        SyntaxNode GetDisplayNode(SyntaxNode node);
+
+        /// <summary>
+        /// Gets the DisplayName for the given node for given display format
+        /// </summary>
+        string GetDisplayName(SemanticModel semanticModel, SyntaxNode node, DisplayFormat displayFormat);
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/LocationComparer.cs
+++ b/src/Features/Core/Portable/CodeLens/LocationComparer.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    internal sealed class LocationComparer : IEqualityComparer<Location>
+    {
+        public static LocationComparer Instance { get; } = new LocationComparer();
+
+        public bool Equals(Location x, Location y)
+        {
+            if (x != null && x.IsInSource && y != null && y.IsInSource)
+            {
+                return x.SourceSpan.Equals(y.SourceSpan) &&
+                       x.SourceTree.FilePath.Equals(y.SourceTree.FilePath, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return object.Equals(x, y);
+        }
+
+        public int GetHashCode(Location obj)
+        {
+            if (obj != null && obj.IsInSource)
+            {
+                return obj.SourceSpan.GetHashCode() ^
+                   StringComparer.OrdinalIgnoreCase.GetHashCode(obj.SourceTree.FilePath);
+            }
+            return obj?.GetHashCode() ?? 0;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/ReferenceCount.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceCount.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    /// <summary>
+    /// Represents the result of a FindReferences Count operation.
+    /// </summary>
+    internal struct ReferenceCount
+    {
+        /// <summary>
+        /// Represents the number of references to a given symbol.
+        /// </summary>
+        public int Count { get; }
+
+        /// <summary>
+        /// Represents if the count is capped by a certain maximum.
+        /// </summary>
+        public bool IsCapped { get; }
+
+        public ReferenceCount(int count, bool isCapped)
+        {
+            Count = count;
+            IsCapped = isCapped;
+        }
+    }
+}

--- a/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis.CodeLens
+{
+    /// <summary>
+    /// Holds information required to display and navigate to individual references
+    /// </summary>
+    internal sealed class ReferenceLocationDescriptor
+    {
+        public int LineNumber { get; }
+
+        public int ColumnNumber { get; }
+
+        public DocumentId Document { get; }
+
+        public string Language { get; }
+
+        public string LongDescription { get; }
+
+        public Glyph? Glyph { get; }
+
+        public string ReferenceLineText { get; }
+
+        public int ReferenceStart { get; }
+
+        public int ReferenceLength { get; }
+
+        public string BeforeReferenceText1 { get; }
+
+        public string BeforeReferenceText2 { get; }
+
+        public string AfterReferenceText1 { get; }
+
+        public string AfterReferenceText2 { get; }
+
+        public ReferenceLocationDescriptor(Solution solution, Location location, DisplayInfo displayInfo)
+        {
+            Language = displayInfo.Language;
+            LongDescription = displayInfo.LongName;
+            Glyph = displayInfo.Glyph;
+            LinePosition sourceText = location.GetLineSpan().StartLinePosition;
+            LineNumber = sourceText.Line;
+            ColumnNumber = sourceText.Character;
+            // We want to keep track of the location's document if it comes from a file in your solution.
+            var document = solution.GetDocument(location.SourceTree);
+            Document = document?.Id;
+            ReferenceLineText = displayInfo.ReferenceLineText;
+            ReferenceStart = displayInfo.ReferenceStart;
+            ReferenceLength = displayInfo.ReferenceLength;
+            BeforeReferenceText1 = displayInfo.BeforeReferenceText1;
+            BeforeReferenceText2 = displayInfo.BeforeReferenceText2;
+            AfterReferenceText1 = displayInfo.AfterReferenceText1;
+            AfterReferenceText2 = displayInfo.AfterReferenceText2;
+        }
+    }
+}

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -146,6 +146,17 @@
     <Compile Include="CodeFixes\Suppression\ExportSuppressionFixProviderAttribute.cs" />
     <Compile Include="CodeFixes\Suppression\WrapperCodeFixProvider.cs" />
     <Compile Include="CodeFixes\Suppression\AbstractSuppressionCodeFixProvider.cs" />
+    <Compile Include="CodeLens\CodeLenseReferenceService.cs" />
+    <Compile Include="CodeLens\CodeLensFindReferenceProgress.cs" />
+    <Compile Include="CodeLens\DisplayFormat.cs" />
+    <Compile Include="CodeLens\DisplayInfo.cs" />
+    <Compile Include="CodeLens\DisplayInfoProvider.cs" />
+    <Compile Include="CodeLens\FilteringHelpers.cs" />
+    <Compile Include="CodeLens\ICodeLensReferencesService.cs" />
+    <Compile Include="CodeLens\IDisplayInfoLanguageServices.cs" />
+    <Compile Include="CodeLens\LocationComparer.cs" />
+    <Compile Include="CodeLens\ReferenceCount.cs" />
+    <Compile Include="CodeLens\ReferenceLocationDescriptor.cs" />
     <Compile Include="CodeRefactorings\CodeRefactoringContextExtensions.cs" />
     <Compile Include="CodeRefactorings\CodeRefactoring.cs" />
     <Compile Include="CodeRefactorings\CodeRefactoringService.cs" />

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -126,6 +126,7 @@
     <Compile Include="CodeFixes\SimplifyTypeNames\SimplifyTypeNamesCodeFixProvider.vb" />
     <Compile Include="CodeFixes\Spellcheck\VisualBasicSpellCheckCodeFixProvider.vb" />
     <Compile Include="CodeFixes\Suppression\VisualBasicSuppressionCodeFixProvider.vb" />
+    <Compile Include="CodeLens\DisplayInfoVisualBasicServices.vb" />
     <Compile Include="CodeRefactorings\ConvertToInterpolatedString\ConvertToInterpolatedStringRefactoringProvider.vb" />
     <Compile Include="CodeRefactorings\EncapsulateField\EncapsulateFieldRefactoringProvider.vb" />
     <Compile Include="CodeRefactorings\ExtractInterface\ExtractInterfaceCodeRefactoringProvider.vb" />

--- a/src/Features/VisualBasic/Portable/CodeLens/DisplayInfoVisualBasicServices.vb
+++ b/src/Features/VisualBasic/Portable/CodeLens/DisplayInfoVisualBasicServices.vb
@@ -1,0 +1,275 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+Imports System.Composition
+Imports System.Globalization
+Imports Microsoft.CodeAnalysis.CodeLens
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.CodeLens
+    <ExportLanguageService(GetType(IDisplayInfoLanguageServices), LanguageNames.VisualBasic), [Shared]>
+    Friend NotInheritable Class DisplayInfoVisualBasicServices
+        Implements IDisplayInfoLanguageServices
+
+        Private Shared ReadOnly DefaultDisplayFormatVB As SymbolDisplayFormat = New SymbolDisplayFormat(
+                SymbolDisplayGlobalNamespaceStyle.Omitted,                                  ' Don't prepend VB namespaces with "Global."
+                SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,    ' Show fully qualified names
+                SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                SymbolDisplayMemberOptions.IncludeContainingType Or SymbolDisplayMemberOptions.IncludeParameters,
+                SymbolDisplayDelegateStyle.NameOnly,
+                SymbolDisplayExtensionMethodStyle.StaticMethod,
+                SymbolDisplayParameterOptions.IncludeType,
+                SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+                SymbolDisplayLocalOptions.IncludeType,
+                SymbolDisplayKindOptions.None,
+                SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers Or SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
+
+        Private Shared ReadOnly ShortDisplayFormatVB As SymbolDisplayFormat = New SymbolDisplayFormat(
+                SymbolDisplayGlobalNamespaceStyle.Omitted,
+                SymbolDisplayTypeQualificationStyle.NameAndContainingTypes,
+                SymbolDisplayGenericsOptions.IncludeTypeParameters,
+                SymbolDisplayMemberOptions.IncludeContainingType Or SymbolDisplayMemberOptions.IncludeParameters,
+                SymbolDisplayDelegateStyle.NameOnly,
+                SymbolDisplayExtensionMethodStyle.StaticMethod,
+                SymbolDisplayParameterOptions.IncludeType,
+                SymbolDisplayPropertyStyle.ShowReadWriteDescriptor,
+                SymbolDisplayLocalOptions.IncludeType,
+                SymbolDisplayKindOptions.None,
+                SymbolDisplayMiscellaneousOptions.EscapeKeywordIdentifiers Or SymbolDisplayMiscellaneousOptions.UseSpecialTypes)
+
+        ''' <summary>
+        ''' Indicates if the given node Is a declaration of some kind of symbol. 
+        ''' For example a class for a sub declaration.
+        ''' </summary>
+        Public Function IsDeclaration(node As SyntaxNode) As Boolean Implements IDisplayInfoLanguageServices.IsDeclaration
+            ' From the Visual Basic language spec:
+            ' NamespaceMemberDeclaration  :=
+            '    NamespaceDeclaration  |
+            '    TypeDeclaration
+            ' TypeDeclaration  ::=
+            '    ModuleDeclaration  |
+            '    NonModuleDeclaration
+            ' NonModuleDeclaration  ::=
+            '    EnumDeclaration  |
+            '    StructureDeclaration  |
+            '    InterfaceDeclaration  |
+            '    ClassDeclaration  |
+            '    DelegateDeclaration
+            ' ClassMemberDeclaration  ::=
+            '    NonModuleDeclaration  |
+            '    EventMemberDeclaration  |
+            '    VariableMemberDeclaration  |
+            '    ConstantMemberDeclaration  |
+            '    MethodMemberDeclaration  |
+            '    PropertyMemberDeclaration  |
+            '    ConstructorMemberDeclaration  |
+            '    OperatorDeclaration
+            Select Case node.Kind()
+                ' Because fields declarations can define multiple symbols "Public a, b As Integer" 
+                ' We want to get the VariableDeclarator node inside the field declaration to print out the symbol for the name.
+                Case SyntaxKind.VariableDeclarator
+                    If (node.Parent.IsKind(SyntaxKind.FieldDeclaration)) Then
+                        Return True
+                    End If
+                    Return False
+
+                Case SyntaxKind.NamespaceStatement
+                Case SyntaxKind.NamespaceBlock
+                Case SyntaxKind.ModuleStatement
+                Case SyntaxKind.ModuleBlock
+                Case SyntaxKind.EnumStatement
+                Case SyntaxKind.EnumBlock
+                Case SyntaxKind.StructureStatement
+                Case SyntaxKind.StructureBlock
+                Case SyntaxKind.InterfaceStatement
+                Case SyntaxKind.InterfaceBlock
+                Case SyntaxKind.ClassStatement
+                Case SyntaxKind.ClassBlock
+                Case SyntaxKind.DelegateFunctionStatement
+                Case SyntaxKind.DelegateSubStatement
+                Case SyntaxKind.EventStatement
+                Case SyntaxKind.EventBlock
+                Case SyntaxKind.AddHandlerAccessorBlock
+                Case SyntaxKind.RemoveHandlerAccessorBlock
+                Case SyntaxKind.FieldDeclaration
+                Case SyntaxKind.SubStatement
+                Case SyntaxKind.SubBlock
+                Case SyntaxKind.FunctionStatement
+                Case SyntaxKind.FunctionBlock
+                Case SyntaxKind.PropertyStatement
+                Case SyntaxKind.PropertyBlock
+                Case SyntaxKind.GetAccessorBlock
+                Case SyntaxKind.SetAccessorBlock
+                Case SyntaxKind.SubNewStatement
+                Case SyntaxKind.ConstructorBlock
+                Case SyntaxKind.OperatorStatement
+                Case SyntaxKind.OperatorBlock
+                    Return True
+            End Select
+
+            Return False
+        End Function
+
+        ''' <summary>
+        ''' Indicates if the given node Is a namespace import.
+        ''' </summary>
+        Public Function IsDirectiveOrImport(node As SyntaxNode) As Boolean Implements IDisplayInfoLanguageServices.IsDirectiveOrImport
+            Return node.IsKind(SyntaxKind.ImportsStatement)
+        End Function
+
+        ''' <summary>
+        ''' Indicates if the given node Is an assembly level attribute "[assembly: MyAttribute]"
+        ''' </summary>
+        Public Function IsGlobalAttribute(node As SyntaxNode) As Boolean Implements IDisplayInfoLanguageServices.IsGlobalAttribute
+            If node.IsKind(SyntaxKind.Attribute) Then
+                Dim attributeNode = CType(node, AttributeSyntax)
+                If attributeNode.Target IsNot Nothing Then
+                    Return attributeNode.Target.AttributeModifier.IsKind(SyntaxKind.AssemblyKeyword)
+                End If
+            End If
+
+            Return False
+        End Function
+
+        ''' <summary>
+        ''' Indicates if given node Is DocumentationCommentTriviaSyntax
+        ''' </summary>
+        Public Function IsDocumentationComment(node As SyntaxNode) As Boolean Implements IDisplayInfoLanguageServices.IsDocumentationComment
+            Return node.IsKind(SyntaxKind.DocumentationCommentTrivia)
+        End Function
+
+        ''' <summary>
+        ''' Returns the node that should be displayed
+        ''' </summary>
+        Public Function GetDisplayNode(node As SyntaxNode) As SyntaxNode Implements IDisplayInfoLanguageServices.GetDisplayNode
+            Select Case node.Kind()
+                ' A variable declarator can contain multiple symbols, for example "Private field2, field3 As Integer"
+                ' In that case default to the first field name.
+                Case SyntaxKind.VariableDeclarator
+                    Dim variableNode = CType(node, VariableDeclaratorSyntax)
+                    Return GetDisplayNode(variableNode.Names.First())
+
+                ' A field declaration (global variable) can contain multiple symbols, for example "Private field2, field3 As Integer"
+                ' In that case default to the first field name.
+                Case SyntaxKind.FieldDeclaration
+                    Dim fieldNode = CType(node, FieldDeclarationSyntax)
+                    Return GetDisplayNode(fieldNode.Declarators.First())
+
+                Case SyntaxKind.PredefinedType
+                    Return GetDisplayNode(node.Parent)
+
+                Case SyntaxKind.DocumentationCommentTrivia
+                    If node.IsStructuredTrivia Then
+                        Dim structuredTriviaSyntax = CType(node, StructuredTriviaSyntax)
+                        Return GetDisplayNode(structuredTriviaSyntax.ParentTrivia.Token.Parent)
+                    Else
+                        Return node
+                    End If
+            End Select
+
+            Return node
+        End Function
+
+        Private Shared Function SymbolToDisplayString(symbolDisplayFormat As SymbolDisplayFormat, symbol As ISymbol) As String
+            If symbol Is Nothing Then
+                Return VBFeaturesResources.Unknown_value
+            End If
+
+            Dim symbolName As String = symbol.ToDisplayString(symbolDisplayFormat)
+
+            ' surounding a idenitfier in square brackets allows you to use a keyword as an identifer
+            symbolName = symbolName.Replace("[", String.Empty).Replace("]", String.Empty)
+            Return symbolName
+        End Function
+
+        Private Shared Function FormatPropertyAccessor(node As SyntaxNode, symbolName As String) As String
+            Dim symbolNameWithNoParams As String = RemoveParameters(symbolName)
+            If node.IsKind(SyntaxKind.GetAccessorBlock) Then
+                symbolName = String.Format(CultureInfo.CurrentCulture, VBFeaturesResources.Property_getter_name, symbolNameWithNoParams)
+            Else
+                Debug.Assert(node.IsKind(SyntaxKind.SetAccessorBlock))
+
+                symbolName = String.Format(CultureInfo.CurrentCulture, VBFeaturesResources.Property_setter_name, symbolNameWithNoParams)
+            End If
+
+            Return symbolName
+        End Function
+
+        Private Shared Function FormatEventHandler(node As SyntaxNode, symbolName As String) As String
+            ' symbol name looks Like this at this point : Namespace.Class.Event(EventHandler)
+            Dim symbolNameWithNoParams As String = RemoveParameters(symbolName)
+            If node.IsKind(SyntaxKind.AddHandlerAccessorBlock) Then
+                symbolName = String.Format(CultureInfo.CurrentCulture, VBFeaturesResources.Event_add_handler_name, symbolNameWithNoParams)
+            Else
+                Debug.Assert(node.IsKind(SyntaxKind.RemoveHandlerAccessorBlock))
+
+                symbolName = String.Format(CultureInfo.CurrentCulture, VBFeaturesResources.Event_remove_handler_name, symbolNameWithNoParams)
+            End If
+
+            Return symbolName
+        End Function
+
+        Private Shared Function IsAccessorForDefaultProperty(symbol As ISymbol) As Boolean
+            Dim methodSymbol = TryCast(symbol, IMethodSymbol) ' its really a SourcePropertyAccessorSymbol but it Is Not accessible 
+            If methodSymbol IsNot Nothing Then
+                Dim propertySymbol = TryCast(methodSymbol.AssociatedSymbol, IPropertySymbol)
+                If propertySymbol IsNot Nothing Then
+                    ' Applying the default modifier to a property allows it to be used Like a C# indexer
+                    Return propertySymbol.IsDefault()
+                End If
+            End If
+
+            Return False
+        End Function
+
+        Private Shared Function RemoveParameters(symbolName As String) As String
+            Dim openParenIndex As Integer = symbolName.IndexOf("("c)
+            Dim symbolNameWithNoParams As String = symbolName.Substring(0, openParenIndex)
+            Return symbolNameWithNoParams
+        End Function
+
+        ''' <summary>
+        ''' Gets the DisplayName for the given node.
+        ''' </summary>
+        Public Function GetDisplayName(semanticModel As SemanticModel, node As SyntaxNode, displayFormat As DisplayFormat) As String Implements IDisplayInfoLanguageServices.GetDisplayName
+            Dim symbolDisplayFormat As SymbolDisplayFormat = DefaultDisplayFormatVB
+            If displayFormat = DisplayFormat.Short Then
+                symbolDisplayFormat = ShortDisplayFormatVB
+            End If
+
+            If IsGlobalAttribute(node) Then
+                Return node.ToString()
+            End If
+
+            Dim symbol As ISymbol = semanticModel.GetDeclaredSymbol(node)
+            Dim symbolName As String = Nothing
+
+            Select Case node.Kind()
+                Case SyntaxKind.GetAccessorBlock
+                Case SyntaxKind.SetAccessorBlock
+                    ' Indexer properties should Not include get And set
+                    symbol = semanticModel.GetDeclaredSymbol(node)
+                    If IsAccessorForDefaultProperty(symbol) AndAlso node.Parent.IsKind(SyntaxKind.PropertyBlock) Then
+                        Return GetDisplayName(semanticModel, node.Parent, displayFormat)
+                    Else
+                        ' Append "get" Or "set" to property accessors
+                        symbolName = SymbolToDisplayString(symbolDisplayFormat, symbol)
+                        symbolName = FormatPropertyAccessor(node, symbolName)
+                    End If
+
+                Case SyntaxKind.AddHandlerAccessorBlock
+                Case SyntaxKind.RemoveHandlerAccessorBlock
+                    ' Append "add" Or "remove" to event handlers
+                    symbolName = SymbolToDisplayString(symbolDisplayFormat, symbol)
+                    symbolName = FormatEventHandler(node, symbolName)
+
+                Case SyntaxKind.ImportsStatement
+                    symbolName = "Imports"
+
+                Case Else
+                    symbolName = SymbolToDisplayString(symbolDisplayFormat, symbol)
+            End Select
+
+            Return symbolName
+        End Function
+    End Class
+End Namespace

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.Designer.vb
@@ -869,6 +869,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to {0}.add.
+        '''</summary>
+        Friend ReadOnly Property Event_add_handler_name() As String
+            Get
+                Return ResourceManager.GetString("Event_add_handler_name", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to {0}.remove.
+        '''</summary>
+        Friend ReadOnly Property Event_remove_handler_name() As String
+            Get
+                Return ResourceManager.GetString("Event_remove_handler_name", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Exits a Do loop and transfers execution immediately to the statement following the Loop statement..
         '''</summary>
         Friend ReadOnly Property Exits_a_Do_loop_and_transfers_execution_immediately_to_the_statement_following_the_Loop_statement() As String
@@ -1856,6 +1874,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         Friend ReadOnly Property property_accessor() As String
             Get
                 Return ResourceManager.GetString("property_accessor", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to {0}.get.
+        '''</summary>
+        Friend ReadOnly Property Property_getter_name() As String
+            Get
+                Return ResourceManager.GetString("Property_getter_name", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to {0}.set.
+        '''</summary>
+        Friend ReadOnly Property Property_setter_name() As String
+            Get
+                Return ResourceManager.GetString("Property_setter_name", resourceCulture)
             End Get
         End Property
         
@@ -3159,6 +3195,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.VBFeaturesResources
         Friend ReadOnly Property type_parameters() As String
             Get
                 Return ResourceManager.GetString("type_parameters", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to (Unknown).
+        '''</summary>
+        Friend ReadOnly Property Unknown_value() As String
+            Get
+                Return ResourceManager.GetString("Unknown_value", resourceCulture)
             End Get
         End Property
         

--- a/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
+++ b/src/Features/VisualBasic/Portable/VBFeaturesResources.resx
@@ -1219,4 +1219,23 @@ Sub(&lt;parameterList&gt;) &lt;statement&gt;</value>
   <data name="Type_a_name_here_to_declare_a_partial_structure" xml:space="preserve">
     <value>Type a name here to declare a partial structure.</value>
   </data>
+  <data name="Event_add_handler_name" xml:space="preserve">
+    <value>{0}.add</value>
+    <comment>The name of an event add handler where "{0}" is the event name.</comment>
+  </data>
+  <data name="Event_remove_handler_name" xml:space="preserve">
+    <value>{0}.remove</value>
+    <comment>The name of an event remove handler where "{0}" is the event name.</comment>
+  </data>
+  <data name="Property_getter_name" xml:space="preserve">
+    <value>{0}.get</value>
+    <comment>The name of a property getter like "public int MyProperty { get; }" where "{0}" is the property name</comment>
+  </data>
+  <data name="Property_setter_name" xml:space="preserve">
+    <value>{0}.set</value>
+    <comment>The name of a property setter like "public int MyProperty { set; }" where "{0}" is the property name</comment>
+  </data>
+  <data name="Unknown_value" xml:space="preserve">
+    <value>(Unknown)</value>
+  </data>
 </root>


### PR DESCRIPTION
This moves the code that backs the references indicator of CodeLens from Visual Studio into Roslyn. It isn't hooked up to anything until CodeLens is moved over to the interface in Visual Studio, but this enables that. The bulk of the code is a straight copy of the original code, so I created only simple tests to make sure the interface works, I didn't exercise the whole feature (sadly, there were no tests at this level in the original code).

This is currently just a local service, the next (relatively simple) step is to add an out of process interface.

@CyrusNajmabadi I know some of this might overlap some of the Find References code, let me know if anything can be removed and use existing code, or if anything looks hinky.
@srivatsn @heejaechang 