### PR TITLE
Method Type Inference in VB

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1224,12 +1224,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As ConversionKind = ConversionKind.WideningTuple
 
             For i As Integer = 0 To arguments.Length - 1
+                Dim argument = arguments(i)
                 Dim targetElementType = targetElementTypes(i)
-                If targetElementType.IsErrorType Then
+
+                If argument.HasErrors OrElse targetElementType.IsErrorType Then
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
-                Dim argument = arguments(i)
                 Dim elementConversion = ClassifyConversion(argument, targetElementType, binder, useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then
@@ -3507,13 +3508,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As ConversionKind = ConversionKind.WideningTuple
 
             For i As Integer = 0 To sourceElementTypes.Length - 1
+                Dim argumentType = sourceElementTypes(i)
                 Dim targetType = targetElementTypes(i)
 
-                If targetType.IsErrorType Then
+                If argumentType.IsErrorType OrElse targetType.IsErrorType Then
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
-                Dim argumentType = sourceElementTypes(i)
                 Dim elementConversion = ClassifyConversion(argumentType, targetType, useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1224,8 +1224,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As ConversionKind = ConversionKind.WideningTuple
 
             For i As Integer = 0 To arguments.Length - 1
+                Dim targetElementType = targetElementTypes(i)
+                If targetElementType.IsErrorType Then
+                    Return Nothing 'ConversionKind.NoConversion
+                End If
+
                 Dim argument = arguments(i)
-                Dim elementConversion = ClassifyConversion(argument, targetElementTypes(i), binder, useSiteDiagnostics).Key
+                Dim elementConversion = ClassifyConversion(argument, targetElementType, binder, useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then
                     Return Nothing 'ConversionKind.NoConversion
@@ -3502,8 +3507,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim result As ConversionKind = ConversionKind.WideningTuple
 
             For i As Integer = 0 To sourceElementTypes.Length - 1
+                Dim targetType = targetElementTypes(i)
+
+                If targetType.IsErrorType Then
+                    Return Nothing 'ConversionKind.NoConversion
+                End If
+
                 Dim argumentType = sourceElementTypes(i)
-                Dim elementConversion = ClassifyConversion(argumentType, targetElementTypes(i), useSiteDiagnostics).Key
+                Dim elementConversion = ClassifyConversion(argumentType, targetType, useSiteDiagnostics).Key
 
                 If NoConversion(elementConversion) Then
                     Return Nothing 'ConversionKind.NoConversion

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -1131,20 +1131,18 @@ HandleAsAGeneralExpression:
                 Debug.Assert(argNode.Expression.Kind = BoundKind.TupleLiteral)
 
                 Dim tupleLiteral = DirectCast(argNode.Expression, BoundTupleLiteral)
-
-                ' If literal has type, just infer from that type
-                If tupleLiteral.Type IsNot Nothing Then
-                    AddTypeToGraph(argNode, isOutgoingEdge:=True)
-                    Return
-                End If
-
                 Dim tupleArguments = tupleLiteral.Arguments
+
                 If parameterType.IsTupleOrCompatibleWithTupleOfCardinality(tupleArguments.Length) Then
                     Dim parameterElementTypes = parameterType.GetElementTypesOfTupleOrCompatible
                     For i As Integer = 0 To tupleArguments.Length - 1
                         RegisterArgument(tupleArguments(i), parameterElementTypes(i), argNode.Parameter)
                     Next
+
+                    Return
                 End If
+
+                AddTypeToGraph(argNode, isOutgoingEdge:=True)
             End Sub
 
             Private Sub AddAddressOfToGraph(argNode As ArgumentNode, binder As Binder)

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -1040,6 +1040,8 @@ HandleAsAGeneralExpression:
                         AddLambdaToGraph(argNode, argument.GetBinderFromLambda())
                     Case BoundKind.AddressOfOperator
                         AddAddressOfToGraph(argNode, DirectCast(argument, BoundAddressOfOperator).Binder)
+                    Case BoundKind.TupleLiteral
+                        AddTupleLiteralToGraph(argNode)
                     Case Else
                         AddTypeToGraph(argNode, isOutgoingEdge:=True)
                 End Select
@@ -1099,15 +1101,50 @@ HandleAsAGeneralExpression:
 
                         Dim possiblyGenericType = DirectCast(parameterType, NamedTypeSymbol)
 
-                        Do
-                            For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
-                                AddTypeToGraph(typeArgument, argNode, isOutgoingEdge, haveSeenTypeParameters)
+                        Dim elementTypes As ImmutableArray(Of TypeSymbol) = Nothing
+                        If possiblyGenericType.TryGetElementTypesIfTupleOrCompatible(elementTypes) Then
+                            For Each elementType In elementTypes
+                                AddTypeToGraph(elementType, argNode, isOutgoingEdge, haveSeenTypeParameters)
                             Next
+                        Else
 
-                            possiblyGenericType = possiblyGenericType.ContainingType
-                        Loop While possiblyGenericType IsNot Nothing
+                            Do
+                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                                    AddTypeToGraph(typeArgument, argNode, isOutgoingEdge, haveSeenTypeParameters)
+                                Next
+
+                                possiblyGenericType = possiblyGenericType.ContainingType
+                            Loop While possiblyGenericType IsNot Nothing
+                        End If
                 End Select
 
+            End Sub
+
+            Private Sub AddTupleLiteralToGraph(argNode As ArgumentNode)
+                AddTupleLiteralToGraph(argNode.ParameterType, argNode)
+            End Sub
+
+            Private Sub AddTupleLiteralToGraph(
+                parameterType As TypeSymbol,
+                argNode As ArgumentNode
+            )
+                Debug.Assert(argNode.Expression.Kind = BoundKind.TupleLiteral)
+
+                Dim tupleLiteral = DirectCast(argNode.Expression, BoundTupleLiteral)
+
+                ' If literal has type, just infer from that type
+                If tupleLiteral.Type IsNot Nothing Then
+                    AddTypeToGraph(argNode, isOutgoingEdge:=True)
+                    Return
+                End If
+
+                Dim tupleArguments = tupleLiteral.Arguments
+                If parameterType.IsTupleOrCompatibleWithTupleOfCardinality(tupleArguments.Length) Then
+                    Dim parameterElementTypes = parameterType.GetElementTypesOfTupleOrCompatible
+                    For i As Integer = 0 To tupleArguments.Length - 1
+                        RegisterArgument(tupleArguments(i), parameterElementTypes(i), argNode.Parameter)
+                    Next
+                End If
             End Sub
 
             Private Sub AddAddressOfToGraph(argNode As ArgumentNode, binder As Binder)
@@ -1291,16 +1328,24 @@ HandleAsAGeneralExpression:
 
                         Dim possiblyGenericType = DirectCast(parameterType, NamedTypeSymbol)
 
-                        Do
-                            For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
-                                If RefersToGenericParameterToInferArgumentFor(typeArgument) Then
+                        Dim elementTypes As ImmutableArray(Of TypeSymbol) = Nothing
+                        If possiblyGenericType.TryGetElementTypesIfTupleOrCompatible(elementTypes) Then
+                            For Each elementType In elementTypes
+                                If RefersToGenericParameterToInferArgumentFor(elementType) Then
                                     Return True
                                 End If
                             Next
+                        Else
+                            Do
+                                For Each typeArgument In possiblyGenericType.TypeArgumentsWithDefinitionUseSiteDiagnostics(Me.UseSiteDiagnostics)
+                                    If RefersToGenericParameterToInferArgumentFor(typeArgument) Then
+                                        Return True
+                                    End If
+                                Next
 
-                            possiblyGenericType = possiblyGenericType.ContainingType
-                        Loop While possiblyGenericType IsNot Nothing
-
+                                possiblyGenericType = possiblyGenericType.ContainingType
+                            Loop While possiblyGenericType IsNot Nothing
+                        End If
                 End Select
 
                 Return False
@@ -1346,6 +1391,7 @@ HandleAsAGeneralExpression:
                 '   -- If P is G(Of T) and A is G(Of X), then infer X for T
                 '   -- If P is Array Of T, and A is Array Of X, then infer X for T
                 '   -- If P is ByRef T, then infer A for T
+                '   -- If P is (T, T) and A is (X, X), then infer X for T
 
                 If parameterType.IsTypeParameter() Then
 
@@ -1357,6 +1403,39 @@ HandleAsAGeneralExpression:
                         param,
                         False,
                         inferenceRestrictions)
+                    Return True
+                End If
+
+
+                Dim parameterElementTypes As ImmutableArray(Of TypeSymbol) = Nothing
+                If parameterType.TryGetElementTypesIfTupleOrCompatible(parameterElementTypes) Then
+
+                    Dim argumentElementTypes As ImmutableArray(Of TypeSymbol) = Nothing
+                    If Not argumentType.TryGetElementTypesIfTupleOrCompatible(argumentElementTypes) OrElse
+                            parameterElementTypes.Length <> argumentElementTypes.Length Then
+                        Return False
+                    End If
+
+                    For typeArgumentIndex As Integer = 0 To parameterElementTypes.Length - 1
+
+                        Dim parameterElementType = parameterElementTypes(typeArgumentIndex)
+                        Dim argumentElementType = argumentElementTypes(typeArgumentIndex)
+
+                        ' propagate restrictions to the elements
+                        If Not InferTypeArgumentsFromArgument(
+                                        argumentLocation,
+                                        argumentElementType,
+                                        argumentTypeByAssumption,
+                                        parameterElementType,
+                                        param,
+                                        digThroughToBasesAndImplements,
+                                        inferenceRestrictions
+                          ) Then
+                            Return False
+                        End If
+                    Next
+
+                    Return True
 
                 ElseIf parameterType.Kind = SymbolKind.NamedType Then
                     ' e.g. handle foo(of T)(x as Bar(Of T)) We need to dig into Bar(Of T)
@@ -1424,7 +1503,7 @@ HandleAsAGeneralExpression:
                                             Case VarianceKind.In
 
                                                 paramInferenceRestrictions = Conversions.InvertConversionRequirement(
-                                                    Conversions.StrengthenConversionRequirementToReference(inferenceRestrictions))
+                                                Conversions.StrengthenConversionRequirementToReference(inferenceRestrictions))
 
                                             Case VarianceKind.Out
 
@@ -1446,14 +1525,14 @@ HandleAsAGeneralExpression:
                                         End If
 
                                         If Not InferTypeArgumentsFromArgument(
-                                                                            argumentLocation,
-                                                                            argumentTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
-                                                                            argumentTypeByAssumption,
-                                                                            parameterTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
-                                                                            param,
-                                                                            _DigThroughToBasesAndImplements,
-                                                                            paramInferenceRestrictions
-                                                                      ) Then
+                                                                        argumentLocation,
+                                                                        argumentTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
+                                                                        argumentTypeByAssumption,
+                                                                        parameterTypeAsNamedType.TypeArgumentWithDefinitionUseSiteDiagnostics(typeArgumentIndex, Me.UseSiteDiagnostics),
+                                                                        param,
+                                                                        _DigThroughToBasesAndImplements,
+                                                                        paramInferenceRestrictions
+                                                                  ) Then
                                             ' TODO: Would it make sense to continue through other type arguments even if inference failed for 
                                             '       the current one?
                                             Return False
@@ -1479,13 +1558,13 @@ HandleAsAGeneralExpression:
 
                             ' lwischik: ??? what do array elements have to do with nullables?
                             Return InferTypeArgumentsFromArgument(
-                                    argumentLocation,
-                                    argumentType,
-                                    argumentTypeByAssumption,
-                                    parameterTypeAsNamedType.GetNullableUnderlyingType(),
-                                    param,
-                                    digThroughToBasesAndImplements,
-                                    Conversions.CombineConversionRequirements(inferenceRestrictions, RequiredConversion.ArrayElement))
+                                argumentLocation,
+                                argumentType,
+                                argumentTypeByAssumption,
+                                parameterTypeAsNamedType.GetNullableUnderlyingType(),
+                                param,
+                                digThroughToBasesAndImplements,
+                                Conversions.CombineConversionRequirements(inferenceRestrictions, RequiredConversion.ArrayElement))
 
                         End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1252,7 +1252,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' Should this be optimized for perf (caching for VT<0> to VT<7>, etc.)?
             If (Not IsUnboundGenericType AndAlso
                 ContainingSymbol?.Kind = SymbolKind.Namespace AndAlso
-                ContainingNamespace.ContainingNamespace?.IsGlobalNamespace = True AndAlso
+                ContainingNamespace?.ContainingNamespace?.IsGlobalNamespace = True AndAlso
                 Name = TupleTypeSymbol.TupleTypeName AndAlso
                 ContainingNamespace.Name = MetadataHelpers.SystemString) Then
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -319,7 +319,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._locations = locations
         End Sub
 
-        Friend Shared Function Create(locationOpt As Location, elementTypes As ImmutableArray(Of TypeSymbol), elementLocations As ImmutableArray(Of Location), elementNames As ImmutableArray(Of String), compilation As VisualBasicCompilation, Optional syntax As VisualBasicSyntaxNode = Nothing, Optional diagnostics As DiagnosticBag = Nothing) As NamedTypeSymbol
+        Friend Shared Function Create(locationOpt As Location, elementTypes As ImmutableArray(Of TypeSymbol), elementLocations As ImmutableArray(Of Location), elementNames As ImmutableArray(Of String), compilation As VisualBasicCompilation, Optional syntax As VisualBasicSyntaxNode = Nothing, Optional diagnostics As DiagnosticBag = Nothing) As TupleTypeSymbol
             Debug.Assert(elementNames.IsDefault OrElse elementTypes.Length = elementNames.Length)
             Dim length As Integer = elementTypes.Length
 
@@ -866,9 +866,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Me._underlyingType.GetAttributes()
         End Function
 
-        ' PROTOTYPE: where is this used?
-        '            should we ignore names
-        '            do we need to be case-insensitive when we compare names
         Public Overrides Function Equals(obj As Object) As Boolean
             Dim otherTuple = TryCast(obj, TupleTypeSymbol)
             If otherTuple Is Nothing Then
@@ -883,11 +880,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim myNames = Me.TupleElementNames
             Dim otherNames = otherTuple.TupleElementNames
 
-            If myNames.IsDefaultOrEmpty Then
-                Return otherNames.IsDefaultOrEmpty
+            If myNames.IsDefault Then
+                Return otherNames.IsDefault
             End If
 
-            If otherNames.IsDefaultOrEmpty Then
+            If otherNames.IsDefault Then
                 Return False
             End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -891,7 +891,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return False
             End If
 
-            Return myNames.SequenceEqual(otherNames)
+            Debug.Assert(myNames.Length = otherNames.Length)
+
+            For i As Integer = 0 To myNames.Length - 1
+                If Not IdentifierComparison.Equals(myNames(i), otherNames(i)) Then
+                    Return False
+                End If
+            Next
+
+            Return True
         End Function
 
         Public Overrides Function GetHashCode() As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/TypeSymbolExtensions.vb
@@ -61,7 +61,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         <Extension()>
-        Public Function TryGetElementTypesIfTupleOrCompatible(type As TypeSymbol, <Out> elementTypes As ImmutableArray(Of TypeSymbol)) As Boolean
+        Public Function TryGetElementTypesIfTupleOrCompatible(type As TypeSymbol, <Out> ByRef elementTypes As ImmutableArray(Of TypeSymbol)) As Boolean
             If type.IsTupleType Then
                 elementTypes = DirectCast(type, TupleTypeSymbol).TupleElementTypes
                 Return True

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -1864,6 +1864,42 @@ System.String
 Imports System
 Module C
     Sub Main()
+        System.Console.WriteLine(Test((new Object(),"q")))
+        System.Console.WriteLine(Test1((new Object(),"q")))
+    End Sub
+
+    Function Test(of T)(x as (T, T)) as (T, T)
+        Console.WriteLine(Gettype(T))
+        
+        return x
+    End Function
+
+    Function Test1(of T)(x as T) as T
+        Console.WriteLine(Gettype(T))
+        
+        return x
+    End Function
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+System.Object
+(System.Object, q)
+System.ValueTuple`2[System.Object,System.String]
+(System.Object, q)
+            ]]>)
+
+        End Sub
+
+        <Fact()>
+        Public Sub MethodTypeInference004Err()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+
+Imports System
+Module C
+    Sub Main()
         Dim q = "q"
         Dim a as object = "a"
 
@@ -1881,14 +1917,15 @@ Module C
         return x
     End Function
 End Module
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
 
-    </file>
-</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
-System.Object
-(a, a)
-q
-a
-            ]]>)
+            comp.AssertTheseDiagnostics(
+<errors>
+BC36651: Data type(s) of the type parameter(s) in method 'Public Function Test(Of T)(ByRef x As (T, T)) As (T, T)' cannot be inferred from these arguments because more than one type is possible. Specifying the data type(s) explicitly might correct this error.
+        System.Console.WriteLine(Test((q, a)))
+                                 ~~~~
+</errors>)
 
         End Sub
 


### PR DESCRIPTION
The idea is that when ```(int, long)``` is passed to ```(T, U)```, we can infer T=int, U=long.

The situation is generally more complex though since tuples have Narrowing and Widening conversions as long as underlying types allow that. For example, in the example above, if target is ```(T, T)``` the inference will be T=long

The implementation roughly follows the same strategy as in C#. However it is plugged into a substantially different and more complex framework of type inference in VB.

Includes some fixes from the conversions PR feedback.