### PR TITLE
Revert "Insert traces for cases.."

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.Completion;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Host;
@@ -154,8 +153,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
             if (this.TextView.Selection.Mode == TextSelectionMode.Box)
             {
-                Trace.WriteLine("Box selection, cannot have completion");
-
                 // No completion with multiple selection
                 return false;
             }
@@ -164,8 +161,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             var caret = TextView.GetCaretPoint(SubjectBuffer);
             if (!caret.HasValue)
             {
-                Trace.WriteLine("Caret is not mappable to subject buffer, cannot have completion");
-
                 return false;
             }
 
@@ -211,7 +206,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             Workspace workspace;
             if (!Workspace.TryGetWorkspace(this.SubjectBuffer.AsTextContainer(), out workspace))
             {
-                Trace.WriteLine("Failed to get a workspace, cannot have a completion session.");
                 return null;
             }
 

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_InvokeCompletionList.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Commands;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
@@ -32,7 +31,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             var completionService = this.GetCompletionService();
             if (completionService == null)
             {
-                Trace.WriteLine("Failed to get completion service, cannot have a completion session.");
                 return;
             }
 


### PR DESCRIPTION
Tracing added to help diagnose flaky completion tests is causing UI delays in the product. This change removes the tracing and can easily be reverted to help diagnose flaky tests in the future.