### PR TITLE
Fix for issue #12544 

### DIFF
--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -363,7 +363,7 @@ class D
 class BaseAttribute : System.Attribute
 {
     public virtual int foo { get; set; }
-    public int bar { get; set; }
+    public bool bar { get; set; }
 }
 class DerivedAttribute : BaseAttribute
 {
@@ -379,7 +379,6 @@ class D
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
             expectedOrderedItems.Add(new SignatureHelpTestItem($"DerivedAttribute({CSharpFeaturesResources.Properties}: [bar = int], [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
 
-            // TODO: Bug 12319: Enable tests for script when this is fixed.
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
         }
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -355,17 +355,21 @@ class D
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp),Trait("a","b")]
-        public async Task TestAttributeWithOverriddenProperty()
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        [WorkItem(12544, "https://github.com/dotnet/roslyn/issues/12544")]
+        public async Task TestAttributeWithOverriddenAndNewProperties()
         {
             var markup = @"
 class BaseAttribute : System.Attribute
 {
     public virtual int foo { get; set; }
+    public int bar { get; set; }
 }
 class DerivedAttribute : BaseAttribute
 {
     public override int foo { get; set; }
+    public new int bar { get; set; }
+
 }
 [[|Derived($$|])]
 class D
@@ -373,7 +377,7 @@ class D
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
-            expectedOrderedItems.Add(new SignatureHelpTestItem($"DerivedAttribute({CSharpFeaturesResources.Properties}: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"DerivedAttribute({CSharpFeaturesResources.Properties}: [bar = int], [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
 
             // TODO: Bug 12319: Enable tests for script when this is fixed.
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/AttributeSignatureHelpProviderTests.cs
@@ -355,6 +355,31 @@ class D
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
         }
 
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp),Trait("a","b")]
+        public async Task TestAttributeWithOverriddenProperty()
+        {
+            var markup = @"
+class BaseAttribute : System.Attribute
+{
+    public virtual int foo { get; set; }
+}
+class DerivedAttribute : BaseAttribute
+{
+    public override int foo { get; set; }
+}
+[[|Derived($$|])]
+class D
+{
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem($"DerivedAttribute({CSharpFeaturesResources.Properties}: [foo = int])", string.Empty, string.Empty, currentParameterIndex: 0));
+
+            // TODO: Bug 12319: Enable tests for script when this is fixed.
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: false);
+        }
+
+
         [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
         public async Task TestAttributeWithInvalidPropertyStatic()
         {

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
@@ -198,7 +198,7 @@ End Class
 Class BaseAttribute
     Inherits System.Attribute
     Public Overridable Property Name As String
-    Public Property Name2 As Int16
+    Public Property NAMe2 As Int16
 End Class
 
 Class DerivedAttribute

--- a/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/SignatureHelp/AttributeSignatureHelpProviderTests.vb
@@ -191,6 +191,38 @@ End Class
             Await VerifyCurrentParameterNameAsync(markupWithPosition:=markup, expectedParameterName:="y")
         End Function
 
+        <WorkItem(12544, "https://github.com/dotnet/roslyn/issues/12544")>
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestAttributePropertiesIncludingOverloadedAndOverriddenProperties() As Task
+            Dim markup = <Text><![CDATA[
+Class BaseAttribute
+    Inherits System.Attribute
+    Public Overridable Property Name As String
+    Public Property Name2 As Int16
+End Class
+
+Class DerivedAttribute
+    Inherits BaseAttribute
+    Public Overrides Property Name As String
+    Public Overloads Property Name2 As Int32
+End Class
+
+
+<Derived($$)>
+Class D
+
+End Class
+]]></Text>.Value
+
+            Dim expectedOrderedItems As New List(Of SignatureHelpTestItem)()
+            expectedOrderedItems.Add(New SignatureHelpTestItem("DerivedAttribute(Properties: [Name:=String], [Name2:=Int32])",
+                                                               String.Empty,
+                                                               String.Empty,
+                                                               currentParameterIndex:=0))
+            Await TestAsync(markupWithPositionAndOptSpan:=markup, expectedOrderedItemsOrNull:=expectedOrderedItems)
+
+        End Function
+
         <WorkItem(1094379, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1094379")>
         <Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
         Public Async Function TestAttributeSigHelpWithNoArgumentList() As Task

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -374,7 +374,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ISymbol within)
         {
             var systemAttributeType = compilation.AttributeType();
-            var propertyNames = new HashSet<string>(StringComparer.Ordinal);
+            
+            var propertyNames = new HashSet<string>(
+                compilation.IsCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
             foreach (var type in attributeSymbol.GetBaseTypesAndThis())
             {
                 if (type.Equals(systemAttributeType))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -374,8 +374,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ISymbol within)
         {
             var systemAttributeType = compilation.AttributeType();
-            
-            HashSet<string> propertyNames = new HashSet<string>(StringComparer.Ordinal);
+            var propertyNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (var type in attributeSymbol.GetBaseTypesAndThis())
             {
                 if (type.Equals(systemAttributeType))

--- a/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/INamedTypeSymbolExtensions.cs
@@ -374,7 +374,8 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             ISymbol within)
         {
             var systemAttributeType = compilation.AttributeType();
-
+            
+            HashSet<string> propertyNames = new HashSet<string>(StringComparer.Ordinal);
             foreach (var type in attributeSymbol.GetBaseTypesAndThis())
             {
                 if (type.Equals(systemAttributeType))
@@ -385,8 +386,9 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 foreach (var member in type.GetMembers())
                 {
                     var namedParameter = IsAttributeNamedParameter(member, within ?? compilation.Assembly);
-                    if (namedParameter != null)
+                    if (namedParameter != null && !propertyNames.Contains(namedParameter.Name))
                     {
+                        propertyNames.Add(namedParameter.Name);
                         yield return namedParameter;
                     }
                 }


### PR DESCRIPTION
Created a fix for the issue and added a test for it. This fix will solve a similar issue in VB as it was shared code that the change was made in. It avoids listing overridden and replaced by `new` attribute members.
