### PR TITLE
Don't run the IteratorRewriter on BaseMethodWrapperSymbols (#12676)

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/MethodToClassRewriter.cs
@@ -721,6 +721,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 AddSynthesizedAttribute(ref attributes, this.DeclaringCompilation.TrySynthesizeAttribute(WellKnownMember.System_Diagnostics_DebuggerHiddenAttribute__ctor));
             }
+
+            internal override TypeSymbol IteratorElementType
+            {
+                get
+                {
+                    // BaseMethodWrapperSymbol should not be rewritten by the IteratorRewriter
+                    return null;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This is inserting commit https://github.com/dotnet/roslyn/commit/89be9817421125b2b69ff93ebbb640e396c78a90 (from PR https://github.com/dotnet/roslyn/pull/12676) back into preview 4.