### PR TITLE
Allocate less when converting symbols into syntax.

### DIFF
--- a/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ITypeSymbolExtensions.TypeSyntaxGeneratorVisitor.cs
@@ -17,6 +17,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
         {
             private readonly bool _nameOnly;
 
+            private static TypeSyntaxGeneratorVisitor NameOnlyInstance = new TypeSyntaxGeneratorVisitor(nameOnly: true);
+            private static TypeSyntaxGeneratorVisitor NotNameOnlyInstance = new TypeSyntaxGeneratorVisitor(nameOnly: false);
+
             private TypeSyntaxGeneratorVisitor(bool nameOnly)
             {
                 _nameOnly = nameOnly;
@@ -24,7 +27,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
 
             public static TypeSyntaxGeneratorVisitor Create(bool nameOnly = false)
             {
-                return new TypeSyntaxGeneratorVisitor(nameOnly);
+                return nameOnly ? NameOnlyInstance : NotNameOnlyInstance;
             }
 
             public override TypeSyntax DefaultVisit(ISymbol node)

--- a/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/ExpressionSyntaxGeneratorVisitor.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Sub
 
         Public Overrides Function DefaultVisit(symbol As ISymbol) As ExpressionSyntax
-            Return symbol.Accept(New TypeSyntaxGeneratorVisitor(_addGlobal))
+            Return symbol.Accept(TypeSyntaxGeneratorVisitor.Create(_addGlobal))
         End Function
 
         Private Function AddInformationTo(Of TExpressionSyntax As ExpressionSyntax)(expression As TExpressionSyntax, symbol As ISymbol) As TExpressionSyntax
@@ -34,7 +34,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
         End Function
 
         Public Overrides Function VisitNamedType(symbol As INamedTypeSymbol) As ExpressionSyntax
-            Dim typeSyntax = New TypeSyntaxGeneratorVisitor(_addGlobal).CreateSimpleTypeSyntax(symbol)
+            Dim typeSyntax = TypeSyntaxGeneratorVisitor.Create(_addGlobal).CreateSimpleTypeSyntax(symbol)
             If Not (TypeOf typeSyntax Is SimpleNameSyntax) Then
                 Return typeSyntax
             End If

--- a/src/Workspaces/VisualBasic/Portable/Extensions/INamespaceOrTypeSymbolExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/INamespaceOrTypeSymbolExtensions.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
     Friend Module INamespaceOrTypeSymbolExtensions
         <Extension>
         Public Function GenerateTypeSyntax(symbol As INamespaceOrTypeSymbol, Optional addGlobal As Boolean = True) As TypeSyntax
-            Return symbol.Accept(New TypeSyntaxGeneratorVisitor(addGlobal)).WithAdditionalAnnotations(Simplifier.Annotation)
+            Return symbol.Accept(TypeSyntaxGeneratorVisitor.Create(addGlobal)).WithAdditionalAnnotations(Simplifier.Annotation)
         End Function
 
         <Extension>

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -17,9 +17,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
         Private ReadOnly _addGlobal As Boolean
 
-        Public Sub New(addGlobal As Boolean)
+        Private Shared ReadOnly AddGlobalInstance As TypeSyntaxGeneratorVisitor = New TypeSyntaxGeneratorVisitor(addGlobal:=True)
+        Private Shared ReadOnly NotAddGlobalInstance As TypeSyntaxGeneratorVisitor = New TypeSyntaxGeneratorVisitor(addGlobal:=False)
+
+        Private Sub New(addGlobal As Boolean)
             Me._addGlobal = addGlobal
         End Sub
+
+        Public Shared Function Create(addGlobal As Boolean) As TypeSyntaxGeneratorVisitor
+            Return If(addGlobal, AddGlobalInstance, NotAddGlobalInstance)
+        End Function
 
         Public Overrides Function DefaultVisit(node As ISymbol) As TypeSyntax
             Throw New NotImplementedException()


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12980