### PR TITLE
Pass along the new completion list span if a provider overrides the default one.

### DIFF
--- a/src/Features/Core/Portable/Completion/CompletionTags.cs
+++ b/src/Features/Core/Portable/Completion/CompletionTags.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-
 namespace Microsoft.CodeAnalysis.Completion
 {
     /// <summary>


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12919