### PR TITLE
Expose the SemanticClassificationViewTagger for all Roslyn languages.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -29,8 +29,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
     /// </summary>
     [Export(typeof(IViewTaggerProvider))]
     [TagType(typeof(IClassificationTag))]
-    [ContentType(ContentTypeNames.CSharpContentType)]
-    [ContentType(ContentTypeNames.VisualBasicContentType)]
+    [ContentType(ContentTypeNames.RoslynContentType)]
     internal partial class SemanticClassificationViewTaggerProvider : AsynchronousViewTaggerProvider<IClassificationTag>
     {
         private readonly ISemanticChangeNotificationService _semanticChangeNotificationService;
@@ -92,14 +91,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             Debug.Assert(context.SpansToTag.IsSingle());
 
             var spanToTag = context.SpansToTag.Single();
-            var document = spanToTag.Document;
 
-            if (document == null)
+            _classificationService = _classificationService ?? 
+                spanToTag.Document?.Project.LanguageServices.GetService<IEditorClassificationService>();
+            if (_classificationService == null)
             {
                 return SpecializedTasks.EmptyTask;
             }
-
-            _classificationService = _classificationService ?? document.Project.LanguageServices.GetService<IEditorClassificationService>();
 
             return SemanticClassificationUtilities.ProduceTagsAsync(context, spanToTag, _classificationService, _typeMap);
         }

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -92,8 +92,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             var spanToTag = context.SpansToTag.Single();
 
-            _classificationService = _classificationService ?? 
-                spanToTag.Document?.Project.LanguageServices.GetService<IEditorClassificationService>();
+            // Attempt to get a classification service which will actually produce the results.
+            // If we can't (because we have no Document, or because the language doesn't support
+            // this service), then bail out immediately.
+            if (_classificationService == null)
+            {
+                var document = spanToTag.Document;
+                _classificationService = document?.Project.LanguageServices.GetService<IEditorClassificationService>();
+            }
+
             if (_classificationService == null)
             {
                 return SpecializedTasks.EmptyTask;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12732