### PR TITLE
fail fast if the anonymous type display service could not be found

### DIFF
--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
     internal partial class CSharpSymbolDisplayService : AbstractSymbolDisplayService
     {
         public CSharpSymbolDisplayService(HostLanguageServices provider)
-            : base(provider.GetService<IAnonymousTypeDisplayService>())
+            : base(provider.GetRequiredService<IAnonymousTypeDisplayService>())
         {
         }
 


### PR DESCRIPTION
Investigating internal bug 221007 led to a `NullReferenceException` [here](https://github.com/dotnet/roslyn/blob/master/src/Features/Core/Portable/LanguageServices/SymbolDisplayService/AbstractSymbolDisplayService.AnonymousTypes.cs#L46) which could only be caused by the `_anonymousTypeDisplayService` field.  This can be traced back to [here](https://github.com/dotnet/roslyn/blob/master/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.cs#L13).  The existing dump files didn't contain enough information to diagnose this (infact, even `!dso` failed.)

As to why this service couldn't be resolved, I currently don't know (I'm open to suggestions) but my thought is that we can force the generation of more crash dumps by failing earlier in the process.
