### PR TITLE
Implemented abstract methods must always be public.

### DIFF
--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.vb
@@ -1,6 +1,5 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Option Strict Off
 Imports Microsoft.CodeAnalysis.CodeFixes
 Imports Microsoft.CodeAnalysis.Diagnostics
 Imports Microsoft.CodeAnalysis.VisualBasic.CodeFixes.ImplementInterface
@@ -2175,6 +2174,32 @@ End Class", compareTokens:=False)
             Await TestAsync(
 NewLines("Imports System \n Imports System.Collections.Generic \n Class Program(Of T) \n Implements [|IList(Of Object)|] \n Private Shared innerList As List(Of Object) = New List(Of Object) \n End Class"),
 NewLines("Imports System \n Imports System.Collections \n Imports System.Collections.Generic \n Class Program(Of T) \n Implements IList(Of Object) \n Private Shared innerList As List(Of Object) = New List(Of Object) \n Public ReadOnly Property Count As Integer Implements ICollection(Of Object).Count \n Get \n Return DirectCast(innerList, IList(Of Object)).Count \n End Get \n End Property \n Public ReadOnly Property IsReadOnly As Boolean Implements ICollection(Of Object).IsReadOnly \n Get \n Return DirectCast(innerList, IList(Of Object)).IsReadOnly \n End Get \n End Property \n Default Public Property Item(index As Integer) As Object Implements IList(Of Object).Item \n Get \n Return DirectCast(innerList, IList(Of Object))(index) \n End Get \n Set(value As Object) \n DirectCast(innerList, IList(Of Object))(index) = value \n End Set \n End Property \n Public Sub Add(item As Object) Implements ICollection(Of Object).Add \n DirectCast(innerList, IList(Of Object)).Add(item) \n End Sub \n Public Sub Clear() Implements ICollection(Of Object).Clear \n DirectCast(innerList, IList(Of Object)).Clear() \n End Sub \n Public Sub CopyTo(array() As Object, arrayIndex As Integer) Implements ICollection(Of Object).CopyTo \n DirectCast(innerList, IList(Of Object)).CopyTo(array, arrayIndex) \n End Sub \n Public Sub Insert(index As Integer, item As Object) Implements IList(Of Object).Insert \n DirectCast(innerList, IList(Of Object)).Insert(index, item) \n End Sub \n Public Sub RemoveAt(index As Integer) Implements IList(Of Object).RemoveAt \n DirectCast(innerList, IList(Of Object)).RemoveAt(index) \n End Sub \n Public Function Contains(item As Object) As Boolean Implements ICollection(Of Object).Contains \n Return DirectCast(innerList, IList(Of Object)).Contains(item) \n End Function \n Public Function GetEnumerator() As IEnumerator(Of Object) Implements IEnumerable(Of Object).GetEnumerator \n Return DirectCast(innerList, IList(Of Object)).GetEnumerator() \n End Function \n Public Function IndexOf(item As Object) As Integer Implements IList(Of Object).IndexOf \n Return DirectCast(innerList, IList(Of Object)).IndexOf(item) \n End Function \n Public Function Remove(item As Object) As Boolean Implements ICollection(Of Object).Remove \n Return DirectCast(innerList, IList(Of Object)).Remove(item) \n End Function \n Private Function IEnumerable_GetEnumerator() As IEnumerator Implements IEnumerable.GetEnumerator \n Return DirectCast(innerList, IList(Of Object)).GetEnumerator() \n End Function \n End Class"),
+index:=1)
+        End Function
+
+        <WorkItem(11444, "https://github.com/dotnet/roslyn/issues/11444")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        Public Async Function TestAbstractConflictingMethod() As Task
+            Await TestAsync(
+"Friend Interface IFace
+    Sub M()
+End Interface
+
+Public MustInherit Class C
+    Implements [|IFace|]
+
+    Public MustOverride Sub M()
+End Class",
+"Friend Interface IFace
+    Sub M()
+End Interface
+
+Public MustInherit Class C
+    Implements IFace
+
+    Public MustOverride Sub IFace_M() Implements IFace.M
+    Public MustOverride Sub M()
+End Class",
 index:=1)
         End Function
     End Class

--- a/src/Features/CSharp/Portable/CodeFixes/ImplementInterface/ImplementInterfaceCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/CodeFixes/ImplementInterface/ImplementInterfaceCodeFixProvider.cs
@@ -21,9 +21,9 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeFixes.ImplementInterface
         private readonly Func<TypeSyntax, bool> _interfaceName = n => n.Parent is BaseTypeSyntax && n.Parent.Parent is BaseListSyntax && ((BaseTypeSyntax)n.Parent).Type == n;
         private readonly Func<IEnumerable<CodeAction>, bool> _codeActionAvailable = actions => actions != null && actions.Any();
 
-        internal const string CS0535 = nameof(CS0535); // 'Program' does not implement interface member 'System.Collections.IEnumerable.GetEnumerator()'
-        internal const string CS0737 = nameof(CS0737); // 'Class' does not implement interface member 'IInterface.M()'. 'Class.M()' cannot implement an interface member because it is not public.
-        internal const string CS0738 = nameof(CS0738); // 'C' does not implement interface member 'I.Method1()'. 'B.Method1()' cannot implement 'I.Method1()' because it does not have the matching return type of 'void'.
+        private const string CS0535 = nameof(CS0535); // 'Program' does not implement interface member 'System.Collections.IEnumerable.GetEnumerator()'
+        private const string CS0737 = nameof(CS0737); // 'Class' does not implement interface member 'IInterface.M()'. 'Class.M()' cannot implement an interface member because it is not public.
+        private const string CS0738 = nameof(CS0738); // 'C' does not implement interface member 'I.Method1()'. 'B.Method1()' cannot implement 'I.Method1()' because it does not have the matching return type of 'void'.
 
         public sealed override ImmutableArray<string> FixableDiagnosticIds
         {

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -369,7 +369,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var modifiers = new DeclarationModifiers(isAbstract: generateAbstractly, isNew: addNew, isUnsafe: addUnsafe);
 
                 var useExplicitInterfaceSymbol = generateInvisibly || !Service.CanImplementImplicitly;
-                var accessibility = member.Name == memberName ? Accessibility.Public : Accessibility.Private;
+                var accessibility = member.Name == memberName || generateAbstractly
+                    ? Accessibility.Public 
+                    : Accessibility.Private;
 
                 if (member.Kind == SymbolKind.Method)
                 {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/11444