### PR TITLE
Fix bad casing for argument parsing in RepoUtil.

### DIFF
--- a/src/Tools/RepoUtil/Program.cs
+++ b/src/Tools/RepoUtil/Program.cs
@@ -78,7 +78,7 @@ namespace RepoUtil
                 index++;
                 switch (arg.ToLower())
                 {
-                    case "-sourcesPath":
+                    case "-sourcespath":
                         {
                             if (index < args.Length)
                             {


### PR DESCRIPTION
The -sourcespath can't be used due to a casing bug.