### PR TITLE
Remove unnecessary extra_unix_args.rsp file

### DIFF
--- a/build/unix/extra_unix_args.rsp
+++ b/build/unix/extra_unix_args.rsp
@@ -1,1 +1,0 @@
-/publicsign 


### PR DESCRIPTION
The toolset compiler supports publicsign, so this is
unnecessary now. Fixes #7756.

/cc @jaredpar @dotnet/roslyn-compiler 

Simple fix, please review.