### PR TITLE
Add handling for tuple types in various remaining scenarios

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/ClsComplianceChecker.cs
@@ -180,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (DoNotVisit(symbol)) return;
 
-            System.Diagnostics.Debug.Assert(!symbol.IsImplicitClass);
+            Debug.Assert(!symbol.IsImplicitClass);
 
             Compliance compliance = GetDeclaredOrInheritedCompliance(symbol);
 
@@ -988,6 +988,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!IsTrue(GetDeclaredOrInheritedCompliance(type.OriginalDefinition)))
             {
                 return false;
+            }
+
+            if (type.IsTupleType)
+            {
+                return IsCompliantType(type.TupleUnderlyingType, context);
             }
 
             foreach (TypeSymbol typeArg in type.TypeArgumentsNoUseSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -490,6 +490,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                     var typeMap = new TypeMap(otherTypeParameters, otherTypeArguments, allowAlpha: true);
                     return typeMap.SubstituteNamedType(otherDef);
                 }
+                else if (sourceType.IsTupleType)
+                {
+                    var otherDef = (NamedTypeSymbol)this.Visit(originalDef.TupleUnderlyingType);
+                    if ((object)otherDef == null)
+                    {
+                        return null;
+                    }
+
+                    return TupleTypeSymbol.Create(otherDef, sourceType.TupleElementNames);
+                }
 
                 Debug.Assert(sourceType.IsDefinition);
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -492,8 +492,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 }
                 else if (sourceType.IsTupleType)
                 {
-                    var otherDef = (NamedTypeSymbol)this.Visit(originalDef.TupleUnderlyingType);
-                    if ((object)otherDef == null || !otherDef.IsTupleOrCompatibleWithTupleOfCardinality(originalDef.TupleElementTypes.Length))
+                    var otherDef = (NamedTypeSymbol)this.Visit(sourceType.TupleUnderlyingType);
+                    if ((object)otherDef == null || !otherDef.IsTupleOrCompatibleWithTupleOfCardinality(sourceType.TupleElementTypes.Length))
                     {
                         return null;
                     }
@@ -705,7 +705,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 return _comparer.Equals(method.ReturnType, other.ReturnType) &&
                     method.Parameters.SequenceEqual(other.Parameters, AreParametersEqual) &&
-                    method.TypeArguments.SequenceEqual(other.TypeArguments, AreTypesEqual);
+                    method.TypeParameters.SequenceEqual(other.TypeParameters, AreTypesEqual);
             }
 
             private static MethodSymbol SubstituteTypeParameters(MethodSymbol method)

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -728,11 +728,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // TODO: Test with overloads (from PE base class?) that have modifiers.
                 Debug.Assert(!type.HasTypeArgumentsCustomModifiers);
                 Debug.Assert(!other.HasTypeArgumentsCustomModifiers);
-
-                if (type.IsTupleType)
-                {
-                    return other.IsTupleType && type.TupleElementTypes.SequenceEqual(other.TupleElementTypes, AreTypesEqual);
-                }
+                Debug.Assert(!type.IsTupleType);
+                Debug.Assert(!other.IsTupleType);
 
                 return type.TypeArgumentsNoUseSiteDiagnostics.SequenceEqual(other.TypeArgumentsNoUseSiteDiagnostics, AreTypesEqual);
             }

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -718,6 +718,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // TODO: Test with overloads (from PE base class?) that have modifiers.
                 Debug.Assert(!type.HasTypeArgumentsCustomModifiers);
                 Debug.Assert(!other.HasTypeArgumentsCustomModifiers);
+
+                if (type.IsTupleType)
+                {
+                    if (!other.IsTupleType)
+                    {
+                        return false;
+                    }
+
+                    type.TupleElementTypes.SequenceEqual(other.TupleElementTypes, AreTypesEqual);
+                }
+
                 return type.TypeArgumentsNoUseSiteDiagnostics.SequenceEqual(other.TypeArgumentsNoUseSiteDiagnostics, AreTypesEqual);
             }
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -493,7 +493,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 else if (sourceType.IsTupleType)
                 {
                     var otherDef = (NamedTypeSymbol)this.Visit(originalDef.TupleUnderlyingType);
-                    if ((object)otherDef == null)
+                    if ((object)otherDef == null || !otherDef.IsTupleOrCompatibleWithTupleOfCardinality(originalDef.TupleElementTypes.Length))
                     {
                         return null;
                     }
@@ -728,6 +728,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
                 // TODO: Test with overloads (from PE base class?) that have modifiers.
                 Debug.Assert(!type.HasTypeArgumentsCustomModifiers);
                 Debug.Assert(!other.HasTypeArgumentsCustomModifiers);
+
+                // Tuple types should be unwrapped to their underlying type before getting here (see MatchSymbols.VisitNamedType)
                 Debug.Assert(!type.IsTupleType);
                 Debug.Assert(!other.IsTupleType);
 

--- a/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/EditAndContinue/CSharpSymbolMatcher.cs
@@ -731,12 +731,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
 
                 if (type.IsTupleType)
                 {
-                    if (!other.IsTupleType)
-                    {
-                        return false;
-                    }
-
-                    type.TupleElementTypes.SequenceEqual(other.TupleElementTypes, AreTypesEqual);
+                    return other.IsTupleType && type.TupleElementTypes.SequenceEqual(other.TupleElementTypes, AreTypesEqual);
                 }
 
                 return type.TypeArgumentsNoUseSiteDiagnostics.SequenceEqual(other.TypeArgumentsNoUseSiteDiagnostics, AreTypesEqual);

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -230,6 +230,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                     do
                     {
+                        if (namedType.IsTupleType)
+                        {
+                            namedType = namedType.TupleUnderlyingType;
+                        }
+
                         var arguments = namedType.TypeArgumentsNoUseSiteDiagnostics;
                         int count = arguments.Length;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -212,7 +212,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 case SymbolKind.ErrorType:
                     goto case SymbolKind.NamedType;
                 case SymbolKind.NamedType:
-
                     var namedType = (NamedTypeSymbol)symbol;
                     AssemblySymbol containingAssembly = symbol.OriginalDefinition.ContainingAssembly;
                     int i;
@@ -230,10 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                     do
                     {
-                        if (namedType.IsTupleType)
-                        {
-                            namedType = namedType.TupleUnderlyingType;
-                        }
+                        Debug.Assert(!namedType.IsTupleType);
 
                         var arguments = namedType.TypeArgumentsNoUseSiteDiagnostics;
                         int count = arguments.Length;

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/MetadataDecoder.cs
@@ -229,7 +229,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
 
                     do
                     {
-                        Debug.Assert(!namedType.IsTupleType);
+                        if (namedType.IsTupleType)
+                        {
+                            return IsOrClosedOverATypeFromAssemblies(namedType.TupleUnderlyingType, assemblies);
+                        }
 
                         var arguments = namedType.TypeArgumentsNoUseSiteDiagnostics;
                         int count = arguments.Length;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -635,6 +635,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                     case SymbolKind.NamedType:
 
                         var namedType = (NamedTypeSymbol)symbol;
+                        if (namedType.IsTupleType)
+                        {
+                            namedType = namedType.TupleUnderlyingType;
+                        }
 
                         if ((object)symbol.OriginalDefinition.ContainingModule == (object)_retargetingModule.UnderlyingModule &&
                             namedType.IsExplicitDefinitionOfNoPiaLocalType)

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -428,7 +428,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
             {
                 if (type.IsTupleType)
                 {
-                    return ((TupleTypeSymbol)type).WithUnderlyingType(Retarget(type.TupleUnderlyingType, options));
+                    var newUnderlyingType = Retarget(type.TupleUnderlyingType, options);
+                    if (newUnderlyingType.IsErrorType())
+                    {
+                        return newUnderlyingType;
+                    }
+                    else
+                    {
+                        return ((TupleTypeSymbol)type).WithUnderlyingType(newUnderlyingType);
+                    }
                 }
 
                 NamedTypeSymbol originalDefinition = type.OriginalDefinition;

--- a/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.cs
@@ -429,13 +429,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Retargeting
                 if (type.IsTupleType)
                 {
                     var newUnderlyingType = Retarget(type.TupleUnderlyingType, options);
-                    if (newUnderlyingType.IsErrorType())
+                    if (newUnderlyingType.IsTupleOrCompatibleWithTupleOfCardinality(type.TupleElementTypes.Length))
                     {
-                        return newUnderlyingType;
+                        return ((TupleTypeSymbol)type).WithUnderlyingType(newUnderlyingType);
                     }
                     else
                     {
-                        return ((TupleTypeSymbol)type).WithUnderlyingType(newUnderlyingType);
+                        return newUnderlyingType;
                     }
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -89,6 +89,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             NamedTypeSymbol underlyingType = GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics);
 
+            if (((SourceModuleSymbol)compilation.SourceModule).AnyReferencedAssembliesAreLinked)
+            {
+                // Complain about unembeddable types from linked assemblies.
+                Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(underlyingType, syntax, diagnostics);
+            }
+
             return Create(underlyingType, elementNames, locationOpt, elementLocations);
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeUnification.cs
@@ -287,9 +287,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                         NamedTypeSymbol namedType = (NamedTypeSymbol)type;
                         while ((object)namedType != null)
                         {
-                            foreach (TypeSymbol typeArg in namedType.TypeArgumentsNoUseSiteDiagnostics)
+                            ImmutableArray<TypeSymbol> typeParts = namedType.IsTupleType ? namedType.TupleElementTypes : namedType.TypeArgumentsNoUseSiteDiagnostics;
+                            foreach (TypeSymbol typePart in typeParts)
                             {
-                                if (Contains(typeArg, typeParam))
+                                if (Contains(typePart, typeParam))
                                 {
                                     return true;
                                 }

--- a/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Utilities/TypeSymbolExtensions.cs
@@ -41,6 +41,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
                     {
+                        if (type.IsTupleType)
+                        {
+                            return type.TupleUnderlyingType.CustomModifierCount();
+                        }
+
                         bool isDefinition = type.IsDefinition;
 
                         if (!isDefinition)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16164,6 +16164,23 @@ public class C3 : I0<int>, I0<int> { }
                 // public class C1 : I0<(int a, int b)>, I0<(int notA, int notB)> { }
                 Diagnostic(ErrorCode.ERR_DuplicateInterfaceWithTupleNamesInBaseList, "C1").WithArguments("I0<(int notA, int notB)>", "I0<(int a, int b)>", "C1").WithLocation(3, 14)
                 );
+
+            var tree = comp.SyntaxTrees.First();
+            var model = comp.GetSemanticModel(tree);
+            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+            var c1 = nodes.OfType<ClassDeclarationSyntax>().First();
+            Assert.Equal(2, model.GetDeclaredSymbol(c1).AllInterfaces.Count());
+            Assert.Equal("I0<(System.Int32 a, System.Int32 b)>", model.GetDeclaredSymbol(c1).AllInterfaces[0].ToTestDisplayString());
+            Assert.Equal("I0<(System.Int32 notA, System.Int32 notB)>", model.GetDeclaredSymbol(c1).AllInterfaces[1].ToTestDisplayString());
+
+            var c2 = nodes.OfType<ClassDeclarationSyntax>().Skip(1).First();
+            Assert.Equal(1, model.GetDeclaredSymbol(c2).AllInterfaces.Count());
+            Assert.Equal("I0<(System.Int32 a, System.Int32 b)>", model.GetDeclaredSymbol(c2).AllInterfaces[0].ToTestDisplayString());
+
+            var c3 = nodes.OfType<ClassDeclarationSyntax>().Skip(2).First();
+            Assert.Equal(1, model.GetDeclaredSymbol(c3).AllInterfaces.Count());
+            Assert.Equal("I0<System.Int32>", model.GetDeclaredSymbol(c3).AllInterfaces[0].ToTestDisplayString());
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16394,6 +16394,18 @@ public class Derived : Base<(int a, int b)>
         }
 
         [Fact]
+        public void InterfaceUnification2()
+        {
+            var source = @"
+public interface I0<T1> { }
+public class Derived<T> : I0<Derived<(T, T)>>, I0<T> { }
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics();
+            // Didn't run out of memory in trying to substitute T with Derived<(T, T)> in a loop
+        }
+
+        [Fact]
         public void AmbiguousExtensionMethodWithDifferentTupleNames()
         {
             var source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17454,5 +17454,19 @@ public struct S
                 Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("S.field", "(S, S)").WithLocation(4, 19)
                 );
         }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13088")]
+        public void AssignNullWithMissingValueTuple()
+        {
+            var source = @"
+public struct S
+{
+    (int, int) t = null;
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.VerifyDiagnostics(); // crashes
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17564,9 +17564,6 @@ public class B
                 Diagnostic(ErrorCode.ERR_NoTypeDef, "A.M").WithArguments("System.ValueTuple<,>", "System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51").WithLocation(4, 24)
                 );
 
-            var tree = comp.SyntaxTrees.First();
-            var model = comp.GetSemanticModel(tree);
-            var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
             var methodM = comp.GetMember<MethodSymbol>("A.M");
 
             Assert.Equal("(System.Int32, System.Int32)", methodM.ReturnType.ToTestDisplayString());

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17436,5 +17436,23 @@ class C
 }
 ");
         }
+
+        [Fact]
+        public void StructInStruct()
+        {
+            var source = @"
+public struct S
+{
+    public (S, S) field;
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (4,19): error CS0523: Struct member 'S.field' of type '(S, S)' causes a cycle in the struct layout
+                //     public (S, S) field;
+                Diagnostic(ErrorCode.ERR_StructLayoutCycle, "field").WithArguments("S.field", "(S, S)").WithLocation(4, 19)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1403,9 +1403,7 @@ public class C
                                 new MetadataReference[] { },
                                 null);
 
-            var assembly1 = assemblies1[0];
-            var c1 = assembly1.GlobalNamespace.GetTypeMembers("C").Single();
-            Assert.Equal(SymbolKind.ErrorType, c1.GetMembers("Test1").OfType<MethodSymbol>().Single().ReturnType.Kind);
+            Assert.Equal(SymbolKind.ErrorType, assemblies1[0].GlobalNamespace.GetMember<MethodSymbol>("C.Test1").ReturnType.Kind);
 
             var assemblies2 = MetadataTestHelpers.GetSymbolsForReferences(
                                 new CSharpCompilation[] { },
@@ -1413,9 +1411,7 @@ public class C
                                 new MetadataReference[] { comp.ToMetadataReference() },
                                 null);
 
-            var assembly2 = assemblies2[0];
-            var c2 = assembly2.GlobalNamespace.GetTypeMembers("C").Single();
-            Assert.Equal(SymbolKind.ErrorType, c2.GetMembers("Test1").OfType<MethodSymbol>().Single().ReturnType.Kind);
+            Assert.Equal(SymbolKind.ErrorType, assemblies2[0].GlobalNamespace.GetMember<MethodSymbol>("C.Test1").ReturnType.Kind);
         }
 
         [ClrOnlyFact]
@@ -1452,9 +1448,7 @@ public class C
                                 new MetadataReference[] { },
                                 null);
 
-            var assembly1 = assemblies1[0];
-            var c1 = assembly1.GlobalNamespace.GetTypeMembers("C").Single();
-            Assert.Equal(SymbolKind.ErrorType, c1.GetMembers("Test1").OfType<MethodSymbol>().Single().ReturnType.Kind);
+            Assert.Equal(SymbolKind.ErrorType, assemblies1[0].GlobalNamespace.GetMember<MethodSymbol>("C.Test1").ReturnType.Kind);
 
             var assemblies2 = MetadataTestHelpers.GetSymbolsForReferences(
                                 new CSharpCompilation[] { },
@@ -1462,9 +1456,7 @@ public class C
                                 new MetadataReference[] { comp.ToMetadataReference() },
                                 null);
 
-            var assembly2 = assemblies2[0];
-            var c2 = assembly1.GlobalNamespace.GetTypeMembers("C").Single();
-            Assert.Equal(SymbolKind.ErrorType, c2.GetMembers("Test1").OfType<MethodSymbol>().Single().ReturnType.Kind);
+            Assert.Equal(SymbolKind.ErrorType, assemblies2[0].GlobalNamespace.GetMember<MethodSymbol>("C.Test1").ReturnType.Kind);
         }
 
         [ClrOnlyFact]

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.Cascading.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/ReorderParametersTests.Cascading.cs
@@ -40,6 +40,36 @@ class C : I
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
+        public async Task ReorderParameters_Cascade_ToImplementedMethod_WithTuples()
+        {
+            var markup = @"
+interface I
+{
+    void M((int, int) x, (string a, string b) y);
+}
+
+class C : I
+{
+    $$public void M((int, int) x, (string a, string b) y)
+    { }
+}";
+            var permutation = new[] { 1, 0 };
+            var updatedCode = @"
+interface I
+{
+    void M((string a, string b) y, (int, int) x);
+}
+
+class C : I
+{
+    public void M((string a, string b) y, (int, int) x)
+    { }
+}";
+
+            await TestChangeSignatureViaCommandAsync(LanguageNames.CSharp, markup, updatedSignature: permutation, expectedUpdatedInvocationDocumentCode: updatedCode);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)]
         public async Task ReorderParameters_Cascade_ToImplementingMethod()
         {
             var markup = @"

--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.cs
@@ -105,6 +105,15 @@ index: 2);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
+        public async Task TestFixAll_WithTuples()
+        {
+            await TestAsync(
+@"class C : [||]B { public C((bool, bool) x) { } } class B { internal B((int, int) x) { } protected B((string, string) x) { } public B((bool, bool) x) { } }",
+@"class C : B { public C((bool, bool) x) { } protected C((string, string) x) : base(x) { } internal C((int, int) x) : base(x) { } } class B { internal B((int, int) x) { } protected B((string, string) x) { } public B((bool, bool) x) { } }",
+index: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)]
         public async Task TestMissing1()
         {
             await TestMissingAsync(

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -336,6 +336,18 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
             {
                 Debug.Assert(GetTypeKind(x) == GetTypeKind(y));
 
+                if (x.IsTupleType)
+                {
+                    if (y.IsTupleType)
+                    {
+                        return HandleNamedTypesWorker(x.TupleUnderlyingType, y.TupleUnderlyingType, equivalentTypesWithDifferingAssemblies);
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+
                 if (x.IsDefinition != y.IsDefinition ||
                     IsConstructedFromSelf(x) != IsConstructedFromSelf(y) ||
                     x.Arity != y.Arity ||

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -338,14 +338,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                 if (x.IsTupleType)
                 {
-                    if (y.IsTupleType)
-                    {
-                        return HandleNamedTypesWorker(x.TupleUnderlyingType, y.TupleUnderlyingType, equivalentTypesWithDifferingAssemblies);
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    return y.IsTupleType && HandleNamedTypesWorker(x.TupleUnderlyingType, y.TupleUnderlyingType, equivalentTypesWithDifferingAssemblies);
                 }
 
                 if (x.IsDefinition != y.IsDefinition ||

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs
@@ -338,7 +338,7 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
                 if (x.IsTupleType)
                 {
-                    return y.IsTupleType && HandleNamedTypesWorker(x.TupleUnderlyingType, y.TupleUnderlyingType, equivalentTypesWithDifferingAssemblies);
+                    return y.IsTupleType && TypeArgumentsAreEquivalent(x.TupleElementTypes, y.TupleElementTypes, equivalentTypesWithDifferingAssemblies);
                 }
 
                 if (x.IsDefinition != y.IsDefinition ||

--- a/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
+++ b/src/Workspaces/Core/Portable/Shared/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs
@@ -172,6 +172,11 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
 
             private int CombineNamedTypeHashCode(INamedTypeSymbol x, int currentHash)
             {
+                if (x.IsTupleType)
+                {
+                    return CombineHashCodes(x.TupleElementTypes, currentHash, _symbolAggregator);
+                }
+
                 // If we want object and dynamic to be the same, and this is 'object', then return
                 // the same hash we do for 'dynamic'.
                 currentHash =


### PR DESCRIPTION
A scrub of the source for handling of `SymbolKind.ArrayType` without a corresponding handling of `SymbolKind.NamedType` checking for `IsTupleType` yielded the methods listed below.

1. [SymbolEquivalenceComparer.CombineNamedTypeHashCode](http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Utilities/SymbolEquivalenceComparer.GetHashCodeVisitor.cs,ded250b32f3d4cd6) (tested by `ReorderParameters_Cascade_ToImplementedMethod_WithTuples`)
2. [SymbolEquivalenceComparer.NamedTypesAreEquivalent](http://source.roslyn.io/#Microsoft.CodeAnalysis.Workspaces/Shared/Utilities/SymbolEquivalenceComparer.EquivalenceVisitor.cs,8b8169c8f6b57564) (tested by `TestFixAll_WithTuples`)
3. [TypeSymbolExtensions.CustomModifierCount](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Utilities/TypeSymbolExtensions.cs,f01c69143cc4d767) (covered by `TupleWithCustomModifiersInOverride`, but I didn't find how to make the change observable)
5. [TypeUnification.Contains](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/TypeUnification.cs,7ae7f3c164ae2fa5) (out-of-memory exception, tested by `InterfaceUnification2`)
8. [RetargetingModuleSymbol.IsOrClosedOverAnExplicitLocalType](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Retargeting/RetargetingSymbolTranslator.cs,9920b12c8e672224) (tested by new tests in `NoPia.cs`)
10. [CSharpSymbolMatcher.AreNamedTypesEqual](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Emitter/EditAndContinue/CSharpSymbolMatcher.cs,b7b11994ce611b33) (was crashing, tested by `ModifyMethod_WithTuples`)
9. [MetadataDecoder.IsOrClosedOverATypeFromAssemblies](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Metadata/PE/MetadataDecoder.cs,0be3913cb6640076) (cannot be reached with a tuple type)
11. [ClsComplianceChecker.VisitNamedType](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Compiler/ClsComplianceChecker.cs,8f39cb7610a940bc) (tested by `TupleDefersClsComplianceToUnderlyingType`)
12. [AccessCheck.IsNamedTypeAccessible](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Binder/Semantics/AccessCheck.cs,b064be367929ef3d) (cannot reach, left as-is, added baseline test `AccessCheckLooksInsideTuples`)
6. [SymbolDistinguisher.UnwrapSymbol](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/SymbolDistinguisher.cs,7077976658f578a9) (I think this should be left as-is)
7. [Symbol.CanBeReferencedByName](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/Symbol.cs,866231257786fd53) (can be left as-is because `TupleTypeSymbol.Name` is empty, which is not a valid identifier)
4. [VarianceSafety.IsVarianceUnsafe ](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Symbols/VarianceSafety.cs,1418e432eed62ada) (left as-is which I think is appropriate because `ValueTuple` is a struct and we'll enforce that)