### PR TITLE
get callstack on codefix crash

### DIFF
--- a/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
+++ b/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
@@ -69,11 +69,11 @@ namespace Microsoft.CodeAnalysis.Editor
                     {
                         base.HandleException(provider, exception);
 
-                        _errorReportingService?.ShowErrorInfoForCodeFix(
-                            codefixName: provider.GetType().Name,
-                            OnEnable: () => { EnableProvider(provider); LogEnableProvider(provider); },
-                            OnEnableAndIgnore: () => { EnableProvider(provider); IgnoreProvider(provider); LogEnableAndIgnoreProvider(provider); },
-                            OnClose: () => LogLeaveDisabled(provider));
+                        _errorReportingService?.ShowErrorInfo(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled,  provider.GetType().Name),
+                            new ErrorReportingUI(WorkspacesResources.Enable, ErrorReportingUI.UIKind.HyperLink, () => LaunchExceptionInfoWindow(exception)),
+                            new ErrorReportingUI(WorkspacesResources.Enable, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),
+                            new ErrorReportingUI(WorkspacesResources.Enable_and_ignore_future_errors, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),
+                            new ErrorReportingUI(String.Empty, ErrorReportingUI.UIKind.Close, () => LogLeaveDisabled(provider)));
                     }
                     else
                     {
@@ -91,6 +91,11 @@ namespace Microsoft.CodeAnalysis.Editor
                 }
 
                 _errorLoggerService?.LogException(provider, exception);
+            }
+
+            private void LaunchExceptionInfoWindow(Exception exception)
+            {
+                throw new NotImplementedException();
             }
 
             private static void LogLeaveDisabled(object provider)

--- a/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
+++ b/src/EditorFeatures/Core/Implementation/EditorLayerExtensionManager.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.Editor
                         base.HandleException(provider, exception);
 
                         _errorReportingService?.ShowErrorInfo(String.Format(WorkspacesResources._0_encountered_an_error_and_has_been_disabled,  provider.GetType().Name),
-                            new ErrorReportingUI(WorkspacesResources.Enable, ErrorReportingUI.UIKind.HyperLink, () => LaunchExceptionInfoWindow(exception)),
+                            new ErrorReportingUI(WorkspacesResources.Show_Stack_Trace, ErrorReportingUI.UIKind.HyperLink, () => ShowDetailedErrorInfo(exception), closeAfterAction: false),
                             new ErrorReportingUI(WorkspacesResources.Enable, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),
                             new ErrorReportingUI(WorkspacesResources.Enable_and_ignore_future_errors, ErrorReportingUI.UIKind.Button, () => { EnableProvider(provider); LogEnableProvider(provider); }),
                             new ErrorReportingUI(String.Empty, ErrorReportingUI.UIKind.Close, () => LogLeaveDisabled(provider)));
@@ -93,9 +93,9 @@ namespace Microsoft.CodeAnalysis.Editor
                 _errorLoggerService?.LogException(provider, exception);
             }
 
-            private void LaunchExceptionInfoWindow(Exception exception)
+            private void ShowDetailedErrorInfo(Exception exception)
             {
-                throw new NotImplementedException();
+                _errorReportingService.ShowDetailedErrorInfo(exception);
             }
 
             private static void LogLeaveDisabled(object provider)

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -8,11 +8,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
     internal class EditorErrorReportingService : IErrorReportingService
     {
-        public void ShowErrorInfoForCodeFix(string codefixName, Action OnEnable, Action OnEnableAndIgnore, Action OnClose)
-        {
-            ShowErrorInfo($"{codefixName} crashed");
-        }
-
         public void ShowErrorInfo(string message, params ErrorReportingUI[] items)
         {
             Logger.Log(FunctionId.Extension_Exception, message);

--- a/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
+++ b/src/EditorFeatures/Core/Implementation/Workspaces/EditorErrorReportingService.cs
@@ -8,6 +8,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Workspaces
 {
     internal class EditorErrorReportingService : IErrorReportingService
     {
+        public void ShowDetailedErrorInfo(Exception exception)
+        {
+            Logger.Log(FunctionId.Extension_Exception, exception.StackTrace);
+        }
+
         public void ShowErrorInfo(string message, params ErrorReportingUI[] items)
         {
             Logger.Log(FunctionId.Extension_Exception, message);

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml
@@ -1,0 +1,35 @@
+﻿<ui:DialogWindow x:Class="Microsoft.VisualStudio.LanguageServices.Implementation.DetailedErrorInfoDialog"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
+             xmlns:local="clr-namespace:Microsoft.VisualStudio.LanguageServices.Implementation"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:ui="clr-namespace:Microsoft.VisualStudio.PlatformUI;assembly=Microsoft.VisualStudio.Shell.14.0"
+             xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             mc:Ignorable="d"
+             ShowInTaskbar="False"
+             WindowStartupLocation="CenterOwner"
+             Background="{DynamicResource {x:Static vs:VsBrushes.ToolboxBackgroundKey}}"
+             Foreground="{DynamicResource {x:Static vs:VsBrushes.ToolboxGradientKey}}"
+             d:DesignHeight="300" d:DesignWidth="300"
+             SizeToContent="Height"
+             MaxWidth="768"
+             MinWidth="300"
+             MinHeight="300">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="38"/>
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Column="0" Grid.Row="0" HorizontalScrollBarVisibility="Auto" Style="{DynamicResource {x:Static vs:VsResourceKeys.ScrollViewerStyleKey}}">
+            <TextBox Name="stackTraceText" IsReadOnly="True"
+                     Background="{DynamicResource {x:Static vs:VsBrushes.ToolboxBackgroundKey}}"
+                     Foreground="{DynamicResource {x:Static vs:VsBrushes.ButtonTextKey}}"/>
+        </ScrollViewer>
+        <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Name="CopyButton" Height="24" Margin="0,0,10,0" Click="CopyMessageToClipBoard" Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
+            <Button Name="CloseButton" Height="24" Width="70" Margin="0,0,10,0" Click="CloseWindow" Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
+        </StackPanel>
+    </Grid>
+</ui:DialogWindow>

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml
@@ -8,6 +8,7 @@
              xmlns:vs="clr-namespace:Microsoft.VisualStudio.Shell;assembly=Microsoft.VisualStudio.Shell.14.0"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              mc:Ignorable="d"
+             x:ClassModifier="internal" 
              ShowInTaskbar="False"
              WindowStartupLocation="CenterOwner"
              Background="{DynamicResource {x:Static vs:VsBrushes.ToolboxBackgroundKey}}"
@@ -22,14 +23,27 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="38"/>
         </Grid.RowDefinitions>
-        <ScrollViewer Grid.Column="0" Grid.Row="0" HorizontalScrollBarVisibility="Auto" Style="{DynamicResource {x:Static vs:VsResourceKeys.ScrollViewerStyleKey}}">
-            <TextBox Name="stackTraceText" IsReadOnly="True"
-                     Background="{DynamicResource {x:Static vs:VsBrushes.ToolboxBackgroundKey}}"
-                     Foreground="{DynamicResource {x:Static vs:VsBrushes.ButtonTextKey}}"/>
+        <ScrollViewer Grid.Column="0" Grid.Row="0"
+                      HorizontalScrollBarVisibility="Auto"
+                      VerticalScrollBarVisibility="Auto"
+                      Style="{DynamicResource {x:Static vs:VsResourceKeys.ScrollViewerStyleKey}}">
+            <TextBox   
+                  Name="stackTraceText"
+                  IsReadOnly="True"
+                  Style="{DynamicResource {x:Static vs:VsResourceKeys.TextBoxStyleKey}}"/>
         </ScrollViewer>
+
         <StackPanel Grid.Row="1" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Name="CopyButton" Height="24" Margin="0,0,10,0" Click="CopyMessageToClipBoard" Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
-            <Button Name="CloseButton" Height="24" Width="70" Margin="0,0,10,0" Click="CloseWindow" Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
+            <Button Name="CopyButton" 
+                    Height="24" 
+                    Margin="0,0,10,0" 
+                    Click="CopyMessageToClipBoard" 
+                    Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
+            <Button Name="CloseButton"
+                    Height="24" Width="70" 
+                    Margin="0,0,10,0"
+                    Click="CloseWindow"
+                    Style="{DynamicResource {x:Static vs:VsResourceKeys.ButtonStyleKey}}"/>
         </StackPanel>
     </Grid>
 </ui:DialogWindow>

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml.cs
@@ -18,14 +18,11 @@ using Microsoft.VisualStudio.Shell;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    /// <summary>
-    /// Interaction logic for UserControl1.xaml
-    /// </summary>
-    public partial class DetailedErrorInfoDialog : DialogWindow
+    internal partial class DetailedErrorInfoDialog : DialogWindow
     {
-        string errorInfo;
+        private readonly string errorInfo;
 
-        internal DetailedErrorInfoDialog(string title,  string errorInfo)
+        internal DetailedErrorInfoDialog(string title, string errorInfo)
         {
             InitializeComponent();
             this.errorInfo = errorInfo;
@@ -33,11 +30,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
             stackTraceText.AppendText(errorInfo);
             this.CopyButton.Content = ServicesVSResources.Copy_to_clipboard;
             this.CloseButton.Content = ServicesVSResources.Close;
+
         }
 
         private void CopyMessageToClipBoard(object sender, RoutedEventArgs e)
         {
-            System.Windows.Clipboard.SetText(errorInfo);
+            try
+            {
+                System.Windows.Clipboard.SetText(errorInfo);
+            }
+            catch (Exception)
+            {
+                // rdpclip.exe not running in a TS session, ignore
+            }
         }
 
         private void CloseWindow(object sender, RoutedEventArgs e)

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/DetailedErrorInfoDialog.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Forms;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+using Microsoft.VisualStudio.PlatformUI;
+using Microsoft.VisualStudio.Shell;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    /// <summary>
+    /// Interaction logic for UserControl1.xaml
+    /// </summary>
+    public partial class DetailedErrorInfoDialog : DialogWindow
+    {
+        string errorInfo;
+
+        internal DetailedErrorInfoDialog(string title,  string errorInfo)
+        {
+            InitializeComponent();
+            this.errorInfo = errorInfo;
+            this.Title = title;
+            stackTraceText.AppendText(errorInfo);
+            this.CopyButton.Content = ServicesVSResources.Copy_to_clipboard;
+            this.CloseButton.Content = ServicesVSResources.Close;
+        }
+
+        private void CopyMessageToClipBoard(object sender, RoutedEventArgs e)
+        {
+            System.Windows.Clipboard.SetText(errorInfo);
+        }
+
+        private void CloseWindow(object sender, RoutedEventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.ExceptionFormatting.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.ExceptionFormatting.cs
@@ -1,0 +1,210 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal partial class VisualStudioErrorReportingService
+    {
+        private const string AsyncMethodPrefix = "async ";
+
+        private static string GetFormattedExceptionStack(Exception exception)
+        {
+            var aggregate = exception as AggregateException;
+            if (aggregate != null)
+            {
+                return GetStackForAggregateException(exception, aggregate);
+            }
+
+            return GetStackForException(exception, false);
+        }
+
+        private static string GetStackForAggregateException(Exception exception, AggregateException aggregate)
+        {
+            var text = GetStackForException(exception, true);
+            for (int i = 0; i < aggregate.InnerExceptions.Count; i++)
+            {
+                text = string.Format(ServicesVSResources._0_1_InnerException_2_3_4_5, text,
+                    Environment.NewLine, i, GetFormattedExceptionStack(aggregate.InnerExceptions[i]), "<---", Environment.NewLine);
+            }
+
+            return text;
+        }
+
+        private static string GetStackForException(Exception exception, bool includeMessageOnly)
+        {
+            var message = exception.Message;
+            var className = exception.GetType().ToString();
+            var stackText = message.Length <= 0
+                ? className
+                : className + " : " + message;
+            var innerException = exception.InnerException;
+            if (innerException != null)
+            {
+                if (includeMessageOnly)
+                {
+                    do
+                    {
+                        stackText += " ---> " + innerException.Message;
+                        innerException = innerException.InnerException;
+                    } while (innerException != null);
+                }
+                else
+                {
+                    stackText += " ---> " + GetFormattedExceptionStack(innerException) + Environment.NewLine +
+                            "   " + ServicesVSResources.End_of_inner_exception_stack;
+                }
+            }
+            
+            return stackText + Environment.NewLine + GetAsyncStackTrace(exception);
+        }
+
+        private static string GetAsyncStackTrace(Exception exception)
+        {
+            var stackTrace = new StackTrace(exception, true);
+
+            var stackFrames = stackTrace.GetFrames();
+            if (stackFrames == null)
+            {
+                return string.Empty;
+            }
+
+            var firstFrame = true;
+            var stringBuilder = new StringBuilder(255);
+
+            foreach (var frame in stackFrames)
+            {
+                var method = frame.GetMethod();
+                if (method == null)
+                {
+                    continue;
+                }
+
+                var declaringType = method.DeclaringType;
+                if (declaringType != null && typeof(INotifyCompletion).IsAssignableFrom(declaringType))
+                {
+                    continue;
+                }
+                if (firstFrame)
+                {
+                    firstFrame = false;
+                }
+                else
+                {
+                    stringBuilder.Append(Environment.NewLine);
+                }
+
+                stringBuilder.AppendFormat("   {0} ", ServicesVSResources.at);
+                var isAsync = FormatMethodName(stringBuilder, declaringType);
+                if (!isAsync)
+                {
+                    stringBuilder.Append(method.Name);
+                    var methodInfo = method as MethodInfo;
+                    if (methodInfo != null && methodInfo.IsGenericMethod)
+                    {
+                        FormatGenericArguments(stringBuilder, methodInfo.GetGenericArguments());
+                    }
+                }
+                else if (declaringType?.IsGenericType == true)
+                {
+                    FormatGenericArguments(stringBuilder, declaringType.GetGenericArguments());
+                }
+
+                stringBuilder.Append("(");
+                if (isAsync)
+                {
+                    stringBuilder.Append(ServicesVSResources.Unknown_parameters);
+                }
+                else
+                {
+                    FormatParameters(stringBuilder, method);
+                }
+
+                stringBuilder.Append(")");
+            }
+
+            return stringBuilder.ToString();
+        }
+
+        private static bool FormatMethodName(StringBuilder stringBuilder, Type declaringType)
+        {
+            if (declaringType == null)
+            {
+                return false;
+            }
+
+            var isAsync = false;
+            var fullName = declaringType.FullName.Replace('+', '.');
+            if (typeof(IAsyncStateMachine).GetTypeInfo().IsAssignableFrom(declaringType))
+            {
+                isAsync = true;
+                stringBuilder.Append(AsyncMethodPrefix);
+                var start = fullName.LastIndexOf('<');
+                var end = fullName.LastIndexOf('>');
+                if (start >= 0 && end >= 0)
+                {
+                    stringBuilder.Append(fullName.Remove(start, 1).Substring(0, end - 1));
+                }
+                else
+                {
+                    stringBuilder.Append(fullName);
+                }
+            }
+            else
+            {
+                stringBuilder.Append(fullName);
+                stringBuilder.Append(".");
+            }
+
+            return isAsync;
+        }
+
+        private static void FormatGenericArguments(StringBuilder stringBuilder, Type[] genericTypeArguments)
+        {
+            if (genericTypeArguments.Length <= 0)
+            {
+                return;
+            }
+
+            stringBuilder.Append("[");
+            var firstTypeParam = true;
+            foreach (var genericArgument in genericTypeArguments)
+            {
+                if (!firstTypeParam)
+                {
+                    stringBuilder.Append(",");
+                }
+                else
+                {
+                    firstTypeParam = false;
+                }
+
+                stringBuilder.Append(genericArgument.Name);
+            }
+
+            stringBuilder.Append("]");
+        }
+
+        private static void FormatParameters(StringBuilder stringBuilder, MethodBase method)
+        {
+            var parameters = method.GetParameters();
+            var firstParam = true;
+            foreach (var t in parameters)
+            {
+                if (!firstParam)
+                {
+                    stringBuilder.Append(", ");
+                }
+                else
+                {
+                    firstParam = false;
+                }
+                var typeName = t.ParameterType?.Name ?? "<UnknownType>";
+
+                stringBuilder.Append(typeName + " " + t.Name);
+            }
+        }
+    }
+}

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -8,14 +8,13 @@ using Microsoft.CodeAnalysis.Extensions;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Imaging;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
-using Microsoft.VisualStudio.PlatformUI;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
-    internal class VisualStudioErrorReportingService : IErrorReportingService
+    internal partial class VisualStudioErrorReportingService : IErrorReportingService
     {
         private readonly static InfoBarButton s_enableItem = new InfoBarButton(ServicesVSResources.Enable);
         private readonly static InfoBarButton s_enableAndIgnoreItem = new InfoBarButton(ServicesVSResources.Enable_and_ignore_future_errors);
@@ -156,44 +155,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public void ShowDetailedErrorInfo(Exception exception)
         {
-            string errorInfo = GetErrorInfoForException(exception);
-
+            string errorInfo = GetFormattedExceptionStack(exception);
             (new DetailedErrorInfoDialog(exception.Message, errorInfo)).ShowModal();
-        }
-
-        private static string GetErrorInfoForException(Exception exception)
-        {
-            string errorInfo = exception.Message + Environment.NewLine + exception.StackTrace;
-
-            var aggregateException = exception as AggregateException;
-            if (aggregateException?.InnerExceptions != null)
-            {
-                foreach (var ex in aggregateException.InnerExceptions)
-                {
-                    errorInfo = AppendExceptionInfo(errorInfo, ex);
-                }
-            }
-            else
-            {
-                if (exception.InnerException != null)
-                {
-                    errorInfo = AppendExceptionInfo(errorInfo, exception.InnerException);
-                }
-            }
-
-            return errorInfo;
-        }
-
-        private static string AppendExceptionInfo(string errorInfo, Exception exception)
-        {
-            errorInfo += Environment.NewLine + exception.Message + Environment.NewLine + exception.StackTrace;
-            while (exception.InnerException != null)
-            {
-                exception = exception.InnerException;
-                errorInfo += Environment.NewLine + exception.Message + Environment.NewLine + exception.StackTrace;
-            }
-
-            return errorInfo;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Workspace/VisualStudioErrorReportingService.cs
@@ -156,15 +156,44 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 
         public void ShowDetailedErrorInfo(Exception exception)
         {
+            string errorInfo = GetErrorInfoForException(exception);
+
+            (new DetailedErrorInfoDialog(exception.Message, errorInfo)).ShowModal();
+        }
+
+        private static string GetErrorInfoForException(Exception exception)
+        {
             string errorInfo = exception.Message + Environment.NewLine + exception.StackTrace;
 
+            var aggregateException = exception as AggregateException;
+            if (aggregateException?.InnerExceptions != null)
+            {
+                foreach (var ex in aggregateException.InnerExceptions)
+                {
+                    errorInfo = AppendExceptionInfo(errorInfo, ex);
+                }
+            }
+            else
+            {
+                if (exception.InnerException != null)
+                {
+                    errorInfo = AppendExceptionInfo(errorInfo, exception.InnerException);
+                }
+            }
+
+            return errorInfo;
+        }
+
+        private static string AppendExceptionInfo(string errorInfo, Exception exception)
+        {
+            errorInfo += Environment.NewLine + exception.Message + Environment.NewLine + exception.StackTrace;
             while (exception.InnerException != null)
             {
                 exception = exception.InnerException;
                 errorInfo += Environment.NewLine + exception.Message + Environment.NewLine + exception.StackTrace;
             }
 
-            (new DetailedErrorInfoDialog(exception.Message, errorInfo)).ShowModal();
+            return errorInfo;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/PublicAPI.Unshipped.txt
+++ b/src/VisualStudio/Core/Def/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-Microsoft.VisualStudio.LanguageServices.Implementation.DetailedErrorInfoDialog
-Microsoft.VisualStudio.LanguageServices.Implementation.DetailedErrorInfoDialog.InitializeComponent() -> void

--- a/src/VisualStudio/Core/Def/PublicAPI.Unshipped.txt
+++ b/src/VisualStudio/Core/Def/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.VisualStudio.LanguageServices.Implementation.DetailedErrorInfoDialog
+Microsoft.VisualStudio.LanguageServices.Implementation.DetailedErrorInfoDialog.InitializeComponent() -> void

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -61,6 +61,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0}{1}---&gt; (Inner Exception #{2}) {3}{4}{5}.
+        /// </summary>
+        internal static string _0_1_InnerException_2_3_4_5 {
+            get {
+                return ResourceManager.GetString("_0_1_InnerException_2_3_4_5", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; encountered an error and has been disabled..
         /// </summary>
         internal static string _0_encountered_an_error_and_has_been_disabled {
@@ -245,6 +254,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to at.
+        /// </summary>
+        internal static string at {
+            get {
+                return ResourceManager.GetString("at", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Base Types.
         /// </summary>
         internal static string Base_Types {
@@ -371,7 +389,7 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copy to Clopboard.
+        ///   Looks up a localized string similar to Copy to Clipboard.
         /// </summary>
         internal static string Copy_to_clipboard {
             get {
@@ -538,6 +556,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Enable_and_ignore_future_errors {
             get {
                 return ResourceManager.GetString("Enable_and_ignore_future_errors", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to --- End of inner exception stack trace ---.
+        /// </summary>
+        internal static string End_of_inner_exception_stack {
+            get {
+                return ResourceManager.GetString("End_of_inner_exception_stack", resourceCulture);
             }
         }
         
@@ -801,6 +828,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Implements_ {
             get {
                 return ResourceManager.GetString("Implements_", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to in {0}:line {1}.
+        /// </summary>
+        internal static string in_0_line_1 {
+            get {
+                return ResourceManager.GetString("in_0_line_1", resourceCulture);
             }
         }
         
@@ -1704,6 +1740,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Uninstalling_0_failed_Additional_information_colon_1 {
             get {
                 return ResourceManager.GetString("Uninstalling_0_failed_Additional_information_colon_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;Unknown Parameters&gt;.
+        /// </summary>
+        internal static string Unknown_parameters {
+            get {
+                return ResourceManager.GetString("Unknown_parameters", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -61,15 +61,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0}{1}---&gt; (Inner Exception #{2}) {3}{4}{5}.
-        /// </summary>
-        internal static string _0_1_InnerException_2_3_4_5 {
-            get {
-                return ResourceManager.GetString("_0_1_InnerException_2_3_4_5", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; encountered an error and has been disabled..
         /// </summary>
         internal static string _0_encountered_an_error_and_has_been_disabled {
@@ -250,15 +241,6 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Assembly {
             get {
                 return ResourceManager.GetString("Assembly", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to at.
-        /// </summary>
-        internal static string at {
-            get {
-                return ResourceManager.GetString("at", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -344,6 +344,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        internal static string Close {
+            get {
+                return ResourceManager.GetString("Close", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Computing remove suppressions fix....
         /// </summary>
         internal static string Computing_remove_suppressions_fix {
@@ -358,6 +367,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Computing_suppressions_fix {
             get {
                 return ResourceManager.GetString("Computing_suppressions_fix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Copy to Clopboard.
+        /// </summary>
+        internal static string Copy_to_clipboard {
+            get {
+                return ResourceManager.GetString("Copy_to_clipboard", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -705,4 +705,19 @@ Additional information: {1}</value>
   <data name="Close" xml:space="preserve">
     <value>Close</value>
   </data>
+  <data name="at" xml:space="preserve">
+    <value>at</value>
+  </data>
+  <data name="End_of_inner_exception_stack" xml:space="preserve">
+    <value>--- End of inner exception stack trace ---</value>
+  </data>
+  <data name="in_0_line_1" xml:space="preserve">
+    <value>in {0}:line {1}</value>
+  </data>
+  <data name="_0_1_InnerException_2_3_4_5" xml:space="preserve">
+    <value>{0}{1}---&gt; (Inner Exception #{2}) {3}{4}{5}</value>
+  </data>
+  <data name="Unknown_parameters" xml:space="preserve">
+    <value>&lt;Unknown Parameters&gt;</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -699,4 +699,10 @@ Additional information: {1}</value>
   <data name="Prefer_predefined_type" xml:space="preserve">
     <value>Prefer predefined type</value>
   </data>
+  <data name="Copy_to_clipboard" xml:space="preserve">
+    <value>Copy to Clopboard</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -700,7 +700,7 @@ Additional information: {1}</value>
     <value>Prefer predefined type</value>
   </data>
   <data name="Copy_to_clipboard" xml:space="preserve">
-    <value>Copy to Clopboard</value>
+    <value>Copy to Clipboard</value>
   </data>
   <data name="Close" xml:space="preserve">
     <value>Close</value>

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -705,17 +705,11 @@ Additional information: {1}</value>
   <data name="Close" xml:space="preserve">
     <value>Close</value>
   </data>
-  <data name="at" xml:space="preserve">
-    <value>at</value>
-  </data>
   <data name="End_of_inner_exception_stack" xml:space="preserve">
     <value>--- End of inner exception stack trace ---</value>
   </data>
   <data name="in_0_line_1" xml:space="preserve">
     <value>in {0}:line {1}</value>
-  </data>
-  <data name="_0_1_InnerException_2_3_4_5" xml:space="preserve">
-    <value>{0}{1}---&gt; (Inner Exception #{2}) {3}{4}{5}</value>
   </data>
   <data name="Unknown_parameters" xml:space="preserve">
     <value>&lt;Unknown Parameters&gt;</value>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -160,6 +160,9 @@
     <Compile Include="Implementation\Watson\Watson.cs" />
     <Compile Include="Implementation\Watson\WatsonErrorReport.cs" />
     <Compile Include="Implementation\Watson\WatsonReporter.cs" />
+    <Compile Include="Implementation\Workspace\DetailedErrorInfoDialog.xaml.cs">
+      <DependentUpon>DetailedErrorInfoDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Implementation\Workspace\Esent\EsentStorage.ProjectDocumentTableAccessor.cs" />
     <Compile Include="Implementation\Workspace\Esent\EsentLogger.cs" />
     <Compile Include="Implementation\Workspace\Esent\EsentStorage.ProjectDocumentTable.cs" />
@@ -713,6 +716,10 @@
     <Page Include="Implementation\GenerateType\GenerateTypeDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Implementation\Workspace\DetailedErrorInfoDialog.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
     </Page>
   </ItemGroup>
   <ItemGroup>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Implementation\Workspace\Esent\EsentStorage.ProjectDocumentTableAccessor.cs" />
     <Compile Include="Implementation\Workspace\Esent\EsentLogger.cs" />
     <Compile Include="Implementation\Workspace\Esent\EsentStorage.ProjectDocumentTable.cs" />
+    <Compile Include="Implementation\Workspace\VisualStudioErrorReportingService.ExceptionFormatting.cs" />
     <Compile Include="Implementation\Workspace\VisualStudioErrorReportingServiceFactory.cs" />
     <Compile Include="Implementation\Workspace\VisualStudioErrorReportingService.cs" />
     <Compile Include="Implementation\Workspace\VisualStudioNavigationOptions.cs" />

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -742,7 +742,6 @@
     <Compile Include="SymbolSearch\SymbolSearchService.PatchService.cs" />
     <None Include="project.json" />
     <PublicAPI Include="PublicAPI.Shipped.txt" />
-    <PublicAPI Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
     <VSCTCompile Include="Commands.vsct">

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -8,7 +8,6 @@ namespace Microsoft.CodeAnalysis.Extensions
 {
     internal interface IErrorReportingService : IWorkspaceService
     {
-        void ShowErrorInfoForCodeFix(string codefixName, Action OnEnable, Action OnEnableAndIgnore, Action OnClose);
         void ShowErrorInfo(string message, params ErrorReportingUI[] items);
     }
 

--- a/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
+++ b/src/Workspaces/Core/Portable/ExtensionManager/IErrorReportingService.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.Extensions
     internal interface IErrorReportingService : IWorkspaceService
     {
         void ShowErrorInfo(string message, params ErrorReportingUI[] items);
+        void ShowDetailedErrorInfo(Exception exception);
     }
 
     internal struct ErrorReportingUI

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -919,6 +919,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Show Stack Trace.
+        /// </summary>
+        internal static string Show_Stack_Trace {
+            get {
+                return ResourceManager.GetString("Show_Stack_Trace", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Solution file not found: &apos;{0}&apos;.
         /// </summary>
         internal static string Solution_file_not_found_colon_0 {

--- a/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.Designer.cs
@@ -62,6 +62,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{0}&apos; encountered an error and has been disabled..
+        /// </summary>
+        internal static string _0_encountered_an_error_and_has_been_disabled {
+            get {
+                return ResourceManager.GetString("_0_encountered_an_error_and_has_been_disabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; is already part of the workspace..
         /// </summary>
         internal static string _0_is_already_part_of_the_workspace {
@@ -527,6 +536,24 @@ namespace Microsoft.CodeAnalysis {
         internal static string Duplicate_source_file_0_in_project_1 {
             get {
                 return ResourceManager.GetString("Duplicate_source_file_0_in_project_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable.
+        /// </summary>
+        internal static string Enable {
+            get {
+                return ResourceManager.GetString("Enable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Enable and ignore future errors.
+        /// </summary>
+        internal static string Enable_and_ignore_future_errors {
+            get {
+                return ResourceManager.GetString("Enable_and_ignore_future_errors", resourceCulture);
             }
         }
         

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -483,4 +483,7 @@
   <data name="_0_encountered_an_error_and_has_been_disabled" xml:space="preserve">
     <value>'{0}' encountered an error and has been disabled.</value>
   </data>
+  <data name="Show_Stack_Trace" xml:space="preserve">
+    <value>Show Stack Trace</value>
+  </data>
 </root>

--- a/src/Workspaces/Core/Portable/WorkspacesResources.resx
+++ b/src/Workspaces/Core/Portable/WorkspacesResources.resx
@@ -474,4 +474,13 @@
   <data name="Options_did_not_come_from_Workspace" xml:space="preserve">
     <value>Options did not come from Workspace</value>
   </data>
+  <data name="Enable" xml:space="preserve">
+    <value>Enable</value>
+  </data>
+  <data name="Enable_and_ignore_future_errors" xml:space="preserve">
+    <value>Enable and ignore future errors</value>
+  </data>
+  <data name="_0_encountered_an_error_and_has_been_disabled" xml:space="preserve">
+    <value>'{0}' encountered an error and has been disabled.</value>
+  </data>
 </root>


### PR DESCRIPTION
If a codefix crashes you'll now see the option to look at the stack trace like so:

![image](https://cloud.githubusercontent.com/assets/9797472/17505697/c961820a-5db7-11e6-88b9-050da79ee6d8.png)

Which will launch this new window:
![image](https://cloud.githubusercontent.com/assets/9797472/17505703/dacdb018-5db7-11e6-98e0-00fb8e2996a5.png)
