### PR TITLE
Fix implement-interface with tuple names attribute

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -61,6 +61,14 @@ index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TupleWithNamesInEvent()
+        {
+            await TestAsync(
+@"interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] event Func<(int a, int b)> Event1; } class Class : [|IInterface|] { } " + s_tupleElementNamesAttribute,
+@"interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] event Func<(int a, int b)> Event1; } class Class : IInterface { public event Func<(int a, int b)> Event1; } " + s_tupleElementNamesAttribute);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public async Task TestMethodWhenClassBracesAreMissing()
         {
             await TestAsync(

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -27,6 +27,39 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface { void Method1 ( ) ; } class Class : IInterface { public void Method1 ( ) { throw new NotImplementedException ( ) ; } } ");
         }
 
+        private static readonly string s_tupleElementNamesAttribute =
+@"namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Event )]
+    public sealed class TupleElementNamesAttribute : Attribute { }
+}
+";
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TupleWithNamesInMethod()
+        {
+            await TestAsync(
+@"interface IInterface { [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Method1 ((int c, string) x); } class Class : [|IInterface|] { } " + s_tupleElementNamesAttribute,
+@"using System; interface IInterface { [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Method1 ((int c, string) x) ; } class Class : IInterface { public (int a, int b)[] Method1 ((int c, string) x) { throw new NotImplementedException ( ) ; } } " + s_tupleElementNamesAttribute);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TupleWithNamesInMethod_Explicitly()
+        {
+            await TestAsync(
+@"interface IInterface { [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Method1 ((int c, string) x); } class Class : [|IInterface|] { } " + s_tupleElementNamesAttribute,
+@"using System; interface IInterface { [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Method1 ((int c, string) x) ; } class Class : IInterface { (int a, int b)[] IInterface.Method1 ((int c, string) x) { throw new NotImplementedException ( ) ; } } " + s_tupleElementNamesAttribute,
+index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TupleWithNamesInProperty()
+        {
+            await TestAsync(
+@"interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Property1 { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] get; [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] set; } } class Class : [|IInterface|] { } " + s_tupleElementNamesAttribute,
+@"using System; interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Property1 { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] get; [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] set; } } class Class : IInterface { public (int a, int b)[] Property1 { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } } } " + s_tupleElementNamesAttribute);
+        }
+
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
         public async Task TestMethodWhenClassBracesAreMissing()
         {

--- a/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/ImplementInterface/ImplementInterfaceTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 }
 ";
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         public async Task TupleWithNamesInMethod()
         {
             await TestAsync(
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 @"using System; interface IInterface { [return: System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Method1 ((int c, string) x) ; } class Class : IInterface { public (int a, int b)[] Method1 ((int c, string) x) { throw new NotImplementedException ( ) ; } } " + s_tupleElementNamesAttribute);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         public async Task TupleWithNamesInMethod_Explicitly()
         {
             await TestAsync(
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.Diagnostics.ImplementIn
 index: 1);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         public async Task TupleWithNamesInProperty()
         {
             await TestAsync(
@@ -60,12 +60,20 @@ index: 1);
 @"using System; interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] (int a, int b)[] Property1 { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] get; [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] set; } } class Class : IInterface { public (int a, int b)[] Property1 { get { throw new NotImplementedException(); } set { throw new NotImplementedException(); } } } " + s_tupleElementNamesAttribute);
         }
 
-        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)]
         public async Task TupleWithNamesInEvent()
         {
             await TestAsync(
 @"interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] event Func<(int a, int b)> Event1; } class Class : [|IInterface|] { } " + s_tupleElementNamesAttribute,
 @"interface IInterface { [System.Runtime.CompilerServices.TupleElementNames(new[] { ""a"", ""b"" })] event Func<(int a, int b)> Event1; } class Class : IInterface { public event Func<(int a, int b)> Event1; } " + s_tupleElementNamesAttribute);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task NoDynamicAttributeInMethod()
+        {
+            await TestAsync(
+@"interface IInterface { [return: System.Runtime.CompilerServices.DynamicAttribute()] object Method1 (); } class Class : [|IInterface|] { } ",
+@"using System; interface IInterface { [return: System.Runtime.CompilerServices.DynamicAttribute()] object Method1 (); } class Class : IInterface { public object Method1 () { throw new NotImplementedException ( ) ; } } ");
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -28,13 +28,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var updatedMethod = method.EnsureNonConflictingNames(
                     this.State.ClassOrStructType, syntaxFacts, cancellationToken);
 
-                updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                    accessibleWithin: this.State.ClassOrStructType,
-                    removeAttributeType: compilation.ComAliasNameAttributeType());
-
-                updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                    accessibleWithin: this.State.ClassOrStructType,
-                    removeAttributeType: compilation.TupleElementNamesAttributeType());
+                updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfTypes(
+                    this.State.ClassOrStructType,
+                    compilation.ComAliasNameAttributeType(), compilation.TupleElementNamesAttributeType());
 
                 return CodeGenerationSymbolFactory.CreateMethodSymbol(
                     updatedMethod,

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
                 updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfTypes(
                     this.State.ClassOrStructType,
-                    compilation.ComAliasNameAttributeType(), compilation.TupleElementNamesAttributeType());
+                    AttributesToRemove(compilation));
 
                 return CodeGenerationSymbolFactory.CreateMethodSymbol(
                     updatedMethod,

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Method.cs
@@ -32,6 +32,10 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                     accessibleWithin: this.State.ClassOrStructType,
                     removeAttributeType: compilation.ComAliasNameAttributeType());
 
+                updatedMethod = updatedMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                    accessibleWithin: this.State.ClassOrStructType,
+                    removeAttributeType: compilation.TupleElementNamesAttributeType());
+
                 return CodeGenerationSymbolFactory.CreateMethodSymbol(
                     updatedMethod,
                     accessibility: accessibility,

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
@@ -27,28 +27,53 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
             {
                 var factory = this.Document.GetLanguageService<SyntaxGenerator>();
                 var comAliasNameAttribute = compilation.ComAliasNameAttributeType();
+                var tupleElementNamesAttribute = compilation.TupleElementNamesAttributeType();
 
-                var getAccessor = property.GetMethod == null
-                    ? null
-                    : CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                        property.GetMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                            accessibleWithin: this.State.ClassOrStructType,
-                            removeAttributeType: comAliasNameAttribute),
-                        attributes: null,
-                        accessibility: accessibility,
-                        explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.GetMethod : null,
-                        statements: GetGetAccessorStatements(compilation, property, generateAbstractly, cancellationToken));
+                IMethodSymbol getAccessor;
+                if (property.GetMethod == null)
+                {
+                    getAccessor = null;
+                }
+                else
+                {
+                    var getMethod = property.GetMethod;
+                    getMethod = getMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                                             accessibleWithin: this.State.ClassOrStructType,
+                                             removeAttributeType: comAliasNameAttribute);
+                    getMethod = getMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                                             accessibleWithin: this.State.ClassOrStructType,
+                                             removeAttributeType: tupleElementNamesAttribute);
 
-                var setAccessor = property.SetMethod == null
-                    ? null
-                    : CodeGenerationSymbolFactory.CreateAccessorSymbol(
-                        property.SetMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                            accessibleWithin: this.State.ClassOrStructType,
-                            removeAttributeType: comAliasNameAttribute),
-                        attributes: null,
-                        accessibility: accessibility,
-                        explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.SetMethod : null,
-                        statements: GetSetAccessorStatements(compilation, property, generateAbstractly, cancellationToken));
+                    getAccessor = CodeGenerationSymbolFactory.CreateAccessorSymbol(
+                                    getMethod,
+                                    attributes: null,
+                                    accessibility: accessibility,
+                                    explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.GetMethod : null,
+                                    statements: GetGetAccessorStatements(compilation, property, generateAbstractly, cancellationToken));
+                }
+
+                IMethodSymbol setAccessor;
+                if (property.SetMethod == null)
+                {
+                    setAccessor = null;
+                }
+                else
+                {
+                    var setMethod = property.SetMethod;
+                    setMethod = setMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                                             accessibleWithin: this.State.ClassOrStructType,
+                                             removeAttributeType: comAliasNameAttribute);
+                    setMethod = setMethod.RemoveInaccessibleAttributesAndAttributesOfType(
+                                             accessibleWithin: this.State.ClassOrStructType,
+                                             removeAttributeType: tupleElementNamesAttribute);
+
+                    setAccessor = CodeGenerationSymbolFactory.CreateAccessorSymbol(
+                                    setMethod,
+                                    attributes: null,
+                                    accessibility: accessibility,
+                                    explicitInterfaceSymbol: useExplicitInterfaceSymbol ? property.SetMethod : null,
+                                    statements: GetSetAccessorStatements(compilation, property, generateAbstractly, cancellationToken));
+                }
 
                 var syntaxFacts = Document.GetLanguageService<ISyntaxFactsService>();
                 var parameterNames = NameGenerator.EnsureUniqueness(

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
@@ -29,8 +29,11 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 var factory = this.Document.GetLanguageService<SyntaxGenerator>();
                 var attributesToRemove = AttributesToRemove(compilation);
 
-                var getAccessor = GenerateGetAccessor(compilation, property, accessibility, generateAbstractly, useExplicitInterfaceSymbol, attributesToRemove, cancellationToken);
-                var setAccessor = GenerateSetAccessor(compilation, property, accessibility, generateAbstractly, useExplicitInterfaceSymbol, attributesToRemove, cancellationToken);
+                var getAccessor = GenerateGetAccessor(compilation, property, accessibility, generateAbstractly,
+                    useExplicitInterfaceSymbol, attributesToRemove, cancellationToken);
+
+                var setAccessor = GenerateSetAccessor(compilation, property, accessibility,
+                    generateAbstractly, useExplicitInterfaceSymbol, attributesToRemove, cancellationToken);
 
                 var syntaxFacts = Document.GetLanguageService<ISyntaxFactsService>();
                 var parameterNames = NameGenerator.EnsureUniqueness(
@@ -53,12 +56,14 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
             /// <summary>
             /// Lists compiler attributes that we want to remove.
-            /// The TupleElementNames attribute is compiler generated and used for naming tuple element names. We never want to place it in source code.
+            /// The TupleElementNames attribute is compiler generated (it is used for naming tuple element names).
+            /// We never want to place it in source code.
             /// Same thing for the Dynamic attribute.
             /// </summary>
             private INamedTypeSymbol[] AttributesToRemove(Compilation compilation)
             {
-                return new[] { compilation.ComAliasNameAttributeType(), compilation.TupleElementNamesAttributeType(), compilation.DynamicAttributeType() };
+                return new[] { compilation.ComAliasNameAttributeType(), compilation.TupleElementNamesAttributeType(),
+                    compilation.DynamicAttributeType() };
             }
 
             private IMethodSymbol GenerateSetAccessor(

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction_Property.cs
@@ -37,12 +37,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 else
                 {
                     var getMethod = property.GetMethod;
-                    getMethod = getMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                                             accessibleWithin: this.State.ClassOrStructType,
-                                             removeAttributeType: comAliasNameAttribute);
-                    getMethod = getMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                                             accessibleWithin: this.State.ClassOrStructType,
-                                             removeAttributeType: tupleElementNamesAttribute);
+                    getMethod = getMethod.RemoveInaccessibleAttributesAndAttributesOfTypes(
+                                             this.State.ClassOrStructType,
+                                             comAliasNameAttribute, tupleElementNamesAttribute);
 
                     getAccessor = CodeGenerationSymbolFactory.CreateAccessorSymbol(
                                     getMethod,
@@ -60,12 +57,9 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                 else
                 {
                     var setMethod = property.SetMethod;
-                    setMethod = setMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                                             accessibleWithin: this.State.ClassOrStructType,
-                                             removeAttributeType: comAliasNameAttribute);
-                    setMethod = setMethod.RemoveInaccessibleAttributesAndAttributesOfType(
-                                             accessibleWithin: this.State.ClassOrStructType,
-                                             removeAttributeType: tupleElementNamesAttribute);
+                    setMethod = setMethod.RemoveInaccessibleAttributesAndAttributesOfTypes(
+                                             this.State.ClassOrStructType,
+                                             comAliasNameAttribute, tupleElementNamesAttribute);
 
                     setAccessor = CodeGenerationSymbolFactory.CreateAccessorSymbol(
                                     setMethod,

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
@@ -143,5 +143,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             return compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.TupleElementNamesAttribute");
         }
-    }
+
+        public static INamedTypeSymbol DynamicAttributeType(this Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.DynamicAttribute");
+        }
+     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICompilationExtensions.cs
@@ -138,5 +138,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         {
             return compilation.GetTypeByMetadataName("System.Diagnostics.CodeAnalysis.SuppressMessageAttribute");
         }
+
+        public static INamedTypeSymbol TupleElementNamesAttributeType(this Compilation compilation)
+        {
+            return compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.TupleElementNamesAttribute");
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -168,13 +168,13 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return updatedMethod.RenameParameters(parameterNames);
         }
 
-        public static IMethodSymbol RemoveInaccessibleAttributesAndAttributesOfType(
-            this IMethodSymbol method, ISymbol accessibleWithin, INamedTypeSymbol removeAttributeType,
-            IList<SyntaxNode> statements = null, IList<SyntaxNode> handlesExpressions = null)
+        public static IMethodSymbol RemoveInaccessibleAttributesAndAttributesOfTypes(
+            this IMethodSymbol method, ISymbol accessibleWithin, params INamedTypeSymbol[] removeAttributeTypes)
         {
             Func<AttributeData, bool> shouldRemoveAttribute = a =>
-                a.AttributeClass.Equals(removeAttributeType) || !a.AttributeClass.IsAccessibleWithin(accessibleWithin);
-            return method.RemoveAttributesCore(shouldRemoveAttribute, statements, handlesExpressions);
+                removeAttributeTypes.Any(attr => attr.Equals(a.AttributeClass)) || !a.AttributeClass.IsAccessibleWithin(accessibleWithin);
+
+            return method.RemoveAttributesCore(shouldRemoveAttribute, statements: null, handlesExpressions: null);
         }
 
         private static IMethodSymbol RemoveAttributesCore(

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IMethodSymbolExtensions.cs
@@ -172,7 +172,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             this IMethodSymbol method, ISymbol accessibleWithin, params INamedTypeSymbol[] removeAttributeTypes)
         {
             Func<AttributeData, bool> shouldRemoveAttribute = a =>
-                removeAttributeTypes.Any(attr => attr.Equals(a.AttributeClass)) || !a.AttributeClass.IsAccessibleWithin(accessibleWithin);
+                removeAttributeTypes.Any(attr => attr != null && attr.Equals(a.AttributeClass)) || !a.AttributeClass.IsAccessibleWithin(accessibleWithin);
 
             return method.RemoveAttributesCore(shouldRemoveAttribute, statements: null, handlesExpressions: null);
         }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -34,15 +35,18 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static IPropertySymbol RemoveAttributeFromParameters(
-            this IPropertySymbol property, INamedTypeSymbol attributeType)
+            this IPropertySymbol property, INamedTypeSymbol[] attributesToRemove)
         {
-            if (attributeType == null)
+            if (attributesToRemove == null)
             {
                 return property;
             }
 
+            Func<AttributeData, bool> shouldRemoveAttribute = a =>
+                attributesToRemove.Where(attr => attr != null).Any(attr => attr.Equals(a.AttributeClass));
+
             var someParameterHasAttribute = property.Parameters
-                .Any(p => p.GetAttributes().Any(a => a.AttributeClass.Equals(attributeType)));
+                .Any(p => p.GetAttributes().Any(shouldRemoveAttribute));
             if (!someParameterHasAttribute)
             {
                 return property;
@@ -58,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 property.Name,
                 property.Parameters.Select(p =>
                     CodeGenerationSymbolFactory.CreateParameterSymbol(
-                        p.GetAttributes().Where(a => !a.AttributeClass.Equals(attributeType)).ToList(),
+                        p.GetAttributes().Where(a => !shouldRemoveAttribute(a)).ToList(),
                         p.RefKind, p.IsParams, p.Type, p.Name, p.IsOptional,
                         p.HasExplicitDefaultValue, p.HasExplicitDefaultValue ? p.ExplicitDefaultValue : null)).ToList(),
                 property.GetMethod,


### PR DESCRIPTION
When an interface with tuple names comes from metadata, the names are carried in an attribute. That attribute should not be printed out by the implement-interface code fix.
In the tests below, I simulate that by putting the `TupleElementNames` attribute directly in source on an interface.

Fixes https://github.com/dotnet/roslyn/issues/12949

@CyrusNajmabadi @dotnet/roslyn-ide for review.
FYI for @dotnet/roslyn-compiler 