### PR TITLE
Walk converted tuples in flow analysis

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -2314,6 +2314,14 @@ EnteredRegion:
         End Function
 
         Public Overrides Function VisitTupleLiteral(node As BoundTupleLiteral) As BoundNode
+            Return VisitTupleExpression(node)
+        End Function
+
+        Public Overrides Function VisitConvertedTupleLiteral(node As BoundConvertedTupleLiteral) As BoundNode
+            Return VisitTupleExpression(node)
+        End Function
+
+        Private Function VisitTupleExpression(node As BoundTupleExpression) As BoundNode
             For Each argument In node.Arguments
                 VisitRvalue(argument)
             Next


### PR DESCRIPTION
We were walking literals, but did not walk converted (targettyped) ones.