### PR TITLE
For new switch semantics, we rely on subsumption checking to

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder_BindPatternSwitch.cs
@@ -127,7 +127,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                             node, boundSwitchExpression, boundSwitchExpression.Type, caseLabelSyntax.Value, node.HasErrors, diagnostics, out wasExpression, wasSwitchCase: true);
                         bool hasErrors = pattern.HasErrors;
                         var constantValue = pattern.ConstantValue;
-                        if (!hasErrors && (object)constantValue != null && this.FindMatchingSwitchCaseLabel(constantValue, caseLabelSyntax) != label)
+                        if (!hasErrors &&
+                            (object)constantValue != null &&
+                            pattern.Value.Type == SwitchGoverningType &&
+                            this.FindMatchingSwitchCaseLabel(constantValue, caseLabelSyntax) != label)
                         {
                             diagnostics.Add(ErrorCode.ERR_DuplicateCaseLabel, node.Location, pattern.ConstantValue.GetValueToDisplay() ?? label.Name);
                             hasErrors = true;
@@ -142,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         bool hasErrors = pattern.HasErrors;
                         if (defaultLabel != null)
                         {
-                            diagnostics.Add(ErrorCode.ERR_DuplicateCaseLabel, node.Location, "default");
+                            diagnostics.Add(ErrorCode.ERR_DuplicateCaseLabel, node.Location, label.Name);
                             hasErrors = true;
                         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -1163,5 +1163,62 @@ NaN";
             var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
         }
 
+        [Fact, WorkItem(12573, "https://github.com/dotnet/roslyn/issues/12573")]
+        public void EnumAndUnderlyingType()
+        {
+            var source =
+@"using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        M(0);
+        M(0L);
+        M((byte)0);
+        M(EnumA.ValueA);
+        M(2);
+    }
+
+    public static void M(object value)
+    {
+        switch (value)
+        {
+            case 0:
+                Console.WriteLine(""0"");
+                break;
+            case 0L:
+                Console.WriteLine(""0L"");
+                break;
+            case (byte)0:
+                Console.WriteLine(""(byte)0"");
+                break;
+            case EnumA.ValueA:
+                Console.WriteLine(""EnumA.ValueA"");
+                break;
+            default:
+                Console.WriteLine(""Default"");
+                break;
+        }
+    }
+}
+
+public enum EnumA
+{
+    ValueA,
+    ValueB,
+    ValueC
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            var expectedOutput =
+@"0
+0L
+(byte)0
+EnumA.ValueA
+Default";
+            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -359,14 +359,14 @@ public class TestClass
     }
 }";
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
-                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
                 //             default:            //CS0152
                 Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(15, 13)
                 );
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
-                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default'
+                // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
                 //             default:            //CS0152
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default").WithLocation(15, 13)
+                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "default:").WithArguments("default:").WithLocation(15, 13)
                 );
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (15,13): error CS0152: The switch statement contains multiple cases with the label value 'default:'
@@ -1135,9 +1135,9 @@ class C
                 // (9,17): error CS7036: There is no argument given that corresponds to the required formal parameter 'o' of 'C.M(object)'
                 //                 M();
                 Diagnostic(ErrorCode.ERR_NoCorrespondingArgument, "M").WithArguments("o", "C.M(object)").WithLocation(9, 17),
-                // (12,13): error CS0152: The switch statement contains multiple cases with the label value '0'
+                // (12,13): error CS8120: The switch case has already been handled by a previous case.
                 //             case 0:
-                Diagnostic(ErrorCode.ERR_DuplicateCaseLabel, "case 0:").WithArguments("0").WithLocation(12, 13)
+                Diagnostic(ErrorCode.ERR_PatternIsSubsumed, "case 0:").WithLocation(12, 13)
                 );
         }
 


### PR DESCRIPTION
diagnose duplicate cases. Also, modify one of the diagnostics in
the new switch binder to be identical to that produced by the C#6
switch binder.

Fixes #12573 
@AlekseyTs @agocke Please review
@dotnet/roslyn-compiler Additional eyes most welcome.
