### PR TITLE
Add parsing of NuGet.Config files to RepoUtil and other work.

### DIFF
--- a/src/Tools/RepoUtil/ConflictingPackagesException.cs
+++ b/src/Tools/RepoUtil/ConflictingPackagesException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace RepoUtil
+{
+    internal class ConflictingPackagesException : Exception
+    {
+        public ConflictingPackagesException(List<NuGetPackageConflict> conflictingPackages) :
+            base("Creation failed because of conflicting package versions.")
+        {
+            ConflictingPackages = conflictingPackages.ToImmutableArray();
+        }
+
+        public ImmutableArray<NuGetPackageConflict> ConflictingPackages { get; }
+    }
+}

--- a/src/Tools/RepoUtil/ConsumesCommand.cs
+++ b/src/Tools/RepoUtil/ConsumesCommand.cs
@@ -31,10 +31,21 @@ namespace RepoUtil
         private JObject GoCore()
         {
             var obj = new JObject();
+            obj.Add(GetNuGetFeeds());
             obj.Add(GetFixedPackages());
             obj.Add(GetBuildPackages());
             obj.Add(GetToolsetPackages());
             return obj;
+        }
+
+        private JProperty GetNuGetFeeds()
+        {
+            var obj = new JObject();
+            foreach (var nugetFeed in _repoData.NuGetFeeds)
+            {
+                obj.Add(GetProperty(nugetFeed));
+            }
+            return new JProperty("nugetFeeds", obj);
         }
 
         private JProperty GetFixedPackages()
@@ -66,6 +77,11 @@ namespace RepoUtil
             }
 
             return new JProperty(name, obj);
+        }
+
+        private static JProperty GetProperty(NuGetFeed feed)
+        {
+            return new JProperty(feed.Name, feed.Url);
         }
 
         private static JProperty GetProperty(NuGetPackage package)

--- a/src/Tools/RepoUtil/NuGetConfigUtil.cs
+++ b/src/Tools/RepoUtil/NuGetConfigUtil.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Xml.Linq;
+
+namespace RepoUtil
+{
+    internal static class NuGetConfigUtil
+    {
+        internal static List<NuGetFeed> GetNuGetFeeds(string nugetConfigFile)
+        {
+            var nugetConfig = XElement.Load(nugetConfigFile);
+            var nugetFeeds =
+                from el in nugetConfig.Descendants("packageSources").Descendants("add")
+                select new NuGetFeed(el.Attribute("key").Value, new Uri(el.Attribute("value").Value));
+
+            return nugetFeeds.ToList();
+        }
+
+        internal static IEnumerable<string> GetNuGetConfigFiles(string sourcesPath)
+        {
+            return Directory.EnumerateFiles(sourcesPath, "nuget*config", SearchOption.AllDirectories);
+        }
+    }
+}

--- a/src/Tools/RepoUtil/NuGetFeed.cs
+++ b/src/Tools/RepoUtil/NuGetFeed.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace RepoUtil
+{
+    internal struct NuGetFeed : IEquatable<NuGetFeed>
+    {
+        internal string Name { get; }
+        internal Uri Url { get; }
+
+        internal NuGetFeed(string name, Uri url)
+        {
+            Name = name;
+            Url = url;
+        }
+
+        public static bool operator ==(NuGetFeed left, NuGetFeed right) =>
+            StringComparer.OrdinalIgnoreCase.Equals(left.Name, right.Name) &&
+            left.Url == right.Url;
+        public static bool operator !=(NuGetFeed left, NuGetFeed right) => !(left == right);
+        public override bool Equals(object obj) => obj is NuGetFeed && Equals((NuGetFeed)obj);
+        public override int GetHashCode() => Name?.GetHashCode() ?? 0;
+        public override string ToString() => $"{Name}-{Url}";
+        public bool Equals(NuGetFeed other) => this == other;
+    }
+}

--- a/src/Tools/RepoUtil/Program.cs
+++ b/src/Tools/RepoUtil/Program.cs
@@ -21,7 +21,29 @@ namespace RepoUtil
 
         internal static int Main(string[] args)
         {
-            return Run(args) ? 0 : 1;
+            int result = 1;
+            try
+            {
+                if (Run(args))
+                    result = 0;
+            }
+            catch (ConflictingPackagesException ex)
+            {
+                Console.WriteLine(ex.Message);
+                foreach (var package in ex.ConflictingPackages)
+                {
+                    Console.WriteLine(package.PackageName);
+                    Console.WriteLine($"\t{package.Conflict.NuGetPackage.Version} - {package.Conflict.FileName}");
+                    Console.WriteLine($"\t{package.Original.NuGetPackage.Version} - {package.Original.FileName}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Something unexpected happened.");
+                Console.WriteLine(ex.ToString());
+            }
+
+            return result;
         }
 
         private static bool Run(string[] args)

--- a/src/Tools/RepoUtil/RepoConfig.cs
+++ b/src/Tools/RepoUtil/RepoConfig.cs
@@ -41,18 +41,21 @@ namespace RepoUtil
         internal ImmutableArray<NuGetPackage> FixedPackages { get; }
         internal ImmutableArray<string> ToolsetPackages { get; }
         internal ImmutableArray<Regex> NuSpecExcludes { get; }
+        internal ImmutableArray<Regex> ProjectJsonExcludes { get; }
         internal GenerateData? MSBuildGenerateData { get; }
 
         internal RepoConfig(
             IEnumerable<NuGetPackage> fixedPackages, 
             IEnumerable<string> toolsetPackages, 
             IEnumerable<Regex> nuspecExcludes,
+            IEnumerable<Regex> projectJsonExcludes,
             GenerateData? msbuildGenerateData)
         {
             Debug.Assert(toolsetPackages.Distinct().Count() == toolsetPackages.Count());
             MSBuildGenerateData = msbuildGenerateData;
             FixedPackages = fixedPackages.OrderBy(x => x.Name).ToImmutableArray();
             NuSpecExcludes = nuspecExcludes.ToImmutableArray();
+            ProjectJsonExcludes = projectJsonExcludes.ToImmutableArray();
             ToolsetPackages = toolsetPackages.OrderBy(x => x).ToImmutableArray();
 
             var map = new Dictionary<string, List<string>>();
@@ -110,10 +113,18 @@ namespace RepoUtil
                 nuspecExcludes.AddRange(((JArray)nuspecExcludesProp.Value).Values<string>().Select(x => new Regex(x)));
             }
 
+            var projectJsonExcludes = new List<Regex>();
+            var projectJsonExcludesProp = obj.Property("projectJsonExcludes");
+            if (projectJsonExcludesProp != null)
+            {
+                projectJsonExcludes.AddRange(((JArray)projectJsonExcludesProp.Value).Values<string>().Select(x => new Regex(x)));
+            }
+
             return new RepoConfig(
                 fixedPackagesList,
                 toolsetPackages,
                 nuspecExcludes,
+                projectJsonExcludes,
                 msbuildGenerateData);
         }
 

--- a/src/Tools/RepoUtil/RepoUtil.csproj
+++ b/src/Tools/RepoUtil/RepoUtil.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChangeCommand.cs" />
+    <Compile Include="ConflictingPackagesException.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="ConsumesCommand.cs" />
     <Compile Include="FileName.cs" />
@@ -48,6 +49,8 @@
     <Compile Include="GenerateUtil.cs" />
     <Compile Include="ICommand.cs" />
     <Compile Include="JsonTypes.cs" />
+    <Compile Include="NuGetConfigUtil.cs" />
+    <Compile Include="NuGetFeed.cs" />
     <Compile Include="NuGetPackage.cs" />
     <Compile Include="NuGetPackageChange.cs" />
     <Compile Include="NuGetPackageSource.cs" />


### PR DESCRIPTION
The RepoUtil tool will now include NuGet feed information in the output
for the 'consumes' command.
Added a mechanism for excluding project.json files from being included.
Package conflicts will no longer result in an unhandled exception, instead
it will output a list of the conflicts.