### PR TITLE
Correct spacing on nullable tuple type

### DIFF
--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -324,6 +324,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
 
+            // nullable
+            if (currentToken.Kind() == SyntaxKind.QuestionToken &&
+                currentToken.Parent.Kind() == SyntaxKind.NullableType)
+            {
+                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+            }
+
             // ( * or ) * or [ * or ] * or . * or -> *
             switch (previousToken.Kind())
             {
@@ -335,11 +342,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                 case SyntaxKind.CloseParenToken:
                 case SyntaxKind.CloseBracketToken:
-                    if (previousToken.Parent.Kind() == SyntaxKind.TupleType)
-                    {
-                        break;
-                    }
-
                     int space = (previousToken.Kind() == currentToken.Kind()) ? 0 : 1;
                     return CreateAdjustSpacesOperation(space, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }
@@ -359,13 +361,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
             // ! *
             if (previousToken.Kind() == SyntaxKind.ExclamationToken)
-            {
-                return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
-            }
-
-            // nullable
-            if (currentToken.Kind() == SyntaxKind.QuestionToken &&
-                currentToken.Parent.Kind() == SyntaxKind.NullableType)
             {
                 return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -335,6 +335,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
                 case SyntaxKind.CloseParenToken:
                 case SyntaxKind.CloseBracketToken:
+                    if (previousToken.Parent.Kind() == SyntaxKind.TupleType)
+                    {
+                        break;
+                    }
+
                     int space = (previousToken.Kind() == currentToken.Kind()) ? 0 : 1;
                     return CreateAdjustSpacesOperation(space, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
             }

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -4443,6 +4443,28 @@ var(x,y)=(1,2);
 
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SpacingInNullableTuple()
+        {
+            var code = @"class Class5
+{
+    void bar()
+    {
+        (int, string) ? x = (1, ""hello"");
+    }
+}";
+            var expectedCode = @"class Class5
+{
+    void bar()
+    {
+        (int, string)? x = (1, ""hello"");
+    }
+}";
+
+            await AssertFormatAsync(expectedCode, code);
+        }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Formatting)]
         public async Task SpacingInNestedDeconstruction()
         {
             var code = @"class Class5{


### PR DESCRIPTION
The formatter current prefers `(int, string) ? t;` over `(int, string)? t;`.
This is because the rule for formatting parenthesis comes before the rule for handling nullable type. I'm switching the order around to give priority to the rule for nullable type, which is more specific.

Fixes https://github.com/dotnet/roslyn/issues/11988
@CyrusNajmabadi @dotnet/roslyn-ide for review.
FYI for @gafter @dotnet/roslyn-compiler 