### PR TITLE
Preserve trivia when converting a property to a method.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/ReplacePropertyWithMethods/ReplacePropertyWithMethodsTests.cs
@@ -294,6 +294,23 @@ class D
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
+        public async Task TestComputedPropWithTrailingTriviaAfterArrow()
+        {
+            await TestAsync(
+@"class C
+{
+    public int [||]Prop => /* return 42 */ 42;
+}",
+@"class C
+{
+    public int GetProp()
+    {
+        return /* return 42 */ 42;
+    }
+}", compareTokens: false);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsReplacePropertyWithMethods)]
         public async Task TestAbstractProperty()
         {
             await TestAsync(

--- a/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
+++ b/src/Features/CSharp/Portable/ReplacePropertyWithMethods/CSharpReplacePropertyWithMethodsService.cs
@@ -132,8 +132,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ReplacePropertyWithMethods
 
             if (propertyDeclaration.ExpressionBody != null)
             {
-                var returnStatement = SyntaxFactory.ReturnStatement(propertyDeclaration.ExpressionBody.Expression)
-                                                   .WithSemicolonToken(propertyDeclaration.SemicolonToken);
+                var returnKeyword = SyntaxFactory.Token(SyntaxKind.ReturnKeyword)
+                                                 .WithTrailingTrivia(propertyDeclaration.ExpressionBody.ArrowToken.TrailingTrivia);
+
+                var returnStatement = SyntaxFactory.ReturnStatement(
+                    returnKeyword, 
+                    propertyDeclaration.ExpressionBody.Expression,
+                    propertyDeclaration.SemicolonToken);
                 statements.Add(returnStatement);
             }
             else


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/12143