### PR TITLE
Fix flow analysis of foreach statements

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2088,8 +2088,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // foreach ( var v in node.Expression ) { node.Body; node.ContinueLabel: } node.BreakLabel:
             VisitRvalue(node.Expression);
-            var breakState = this.State.Clone();
             LoopHead(node);
+            var breakState = this.State.Clone();
             VisitForEachIterationVariable(node);
             VisitStatement(node.Body);
             ResolveContinues(node.ContinueLabel);


### PR DESCRIPTION
`LoopHead` needs to be called before getting `breakState` to ensure that it is merged with the state from the end of the body of a `foreach` loop. Otherwise, the effect of the body of a `foreach` loop will be ignored -- the state after the loop will be the intersection of the state at any explicit `break` statements and the state after the expression is evaluated. I'm not sure if this actually matters for any current users of `PreciseAbstractFlowPass`, but it might for future ones.