### PR TITLE
Fix our MSBuild logic around signing

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -58,35 +58,18 @@
     </Otherwise>
   </Choose>
 
-  <!-- settings for strong name signing -->
-  <PropertyGroup>
-    <ShouldSignBuild Condition="'$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">true</ShouldSignBuild>
-  </PropertyGroup>
-
+  <!-- Settings for strong name signing -->
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">
       <Choose>
-        <!-- Shipping binaries in an "official" build are delay-signed with the MS key; later, the signing
-             system will finish the strong-name signing. -->
+        <!-- Shipping binaries are always public signed.  In the case of an official build $(OfficialBuild) the 
+             binaries will be real signed as a post processing step. -->
         <When Condition="'$(NonShipping)' != 'true'">
-          <Choose>
-              <!-- DelaySign if we're real signing, otherwise public sign -->
-              <When Condition="'$(ShouldSignBuild)' == 'true'">
-                  <PropertyGroup>
-                      <DelaySign>true</DelaySign>
-                  </PropertyGroup>
-              </When>
-              <Otherwise>
-                  <PropertyGroup>
-                      <PublicSign>true</PublicSign>
-                  </PropertyGroup>
-              </Otherwise>
-          </Choose>
-
           <PropertyGroup>
             <AssemblyOriginatorKeyFile>$(VSLToolsPath)\Strong Name Keys\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
             <PublicKey>$(RoslynPublicKey)</PublicKey>
             <PublicKeyToken>31BF3856AD364E35</PublicKeyToken>
+            <PublicSign>true</PublicSign>
           </PropertyGroup>
         </When>
 
@@ -207,7 +190,7 @@
 
   <Target Name="VerifyBuildFlags">
     <Error 
-        Condition="('$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real') AND '$(BuildVersion)' == '42.42.42.42'"
+        Condition="'$(OfficialBuild)' == 'true' AND '$(BuildVersion)' == '42.42.42.42'"
         Text="Must specify a build version in order to real sign a build." />
 
     <Error 

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -16,15 +16,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- We cannot sign an unofficial build, so fail if 'OfficialBuild' is not 'true' but 'SignedBuild' is -->
-    <SignedBuild Condition="'$(RealSignBuild)' == 'true' OR '$(SignType)' == 'real'">true</SignedBuild>
-    <Error Condition="'$(OfficialBuild)' != 'true' AND '$(SignedBuild)' == 'true'">Cannot sign an unofficial build.</Error>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- We should not be signing a build anywhere except for in MicroBuild, which will always specify 'BUILD_BUILDNUMBER' -->
     <BuildNumber Condition="'$(BuildNumber)' == ''">$(BUILD_BUILDNUMBER)</BuildNumber>
-    <Error Condition="'$(BuildNumber)' == '' AND '$(SignedBuild)' == 'true'">A build number must be specified for a signed build.</Error>
+    <Error Condition="'$(BuildNumber)' == '' AND '$(OfficialBuild)' == 'true'">A build number must be specified for a signed build.</Error>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -48,7 +42,7 @@
   </PropertyGroup>
   
   <Choose>
-    <When Condition="'$(OfficialBuild)' == 'true' OR '$(SignedBuild)' == 'true' OR '$(UseShippingAssemblyVersion)' == 'true'">
+    <When Condition="'$(OfficialBuild)' == 'true' OR '$(UseShippingAssemblyVersion)' == 'true'">
       <PropertyGroup>
         <AssemblyVersion>$(RoslynAssemblyVersionBase).0</AssemblyVersion>
         <BuildVersion>$(RoslynFileVersionBase).$(BuildNumberFiveDigitDateStamp)</BuildVersion>


### PR DESCRIPTION
Binaries in Roslyn have only three possible signing states:

1. Public signed with Microsoft controlled keys (shipping binaries)
2. Real signed with a full key in the Roslyn repo (non-shipping binaries)
3. Not signed

Our build targets still had a lot of dead logic around our old methods which included delay signed binaries.  This cleans all of that up and removes some dead variables.