### PR TITLE
Updating Roslyn to consume the Preview4 VSSDK packages.

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -41,6 +41,9 @@ call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev14.project.json"
 echo Restoring packages: Toolsets (Dev15 VS SDK build tools)
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 
+echo Restoring packages: Toolsets (Dev15 VS SDK 'Willow' build tools)
+call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15Willow.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
+
 echo Restoring packages: Roslyn SDK
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\roslynsdk.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -132,13 +132,13 @@
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '15.0'">
       <PropertyGroup>
-        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25201-dev15preview2</VisualStudioBuildToolsNuGetPackagePath>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
       </PropertyGroup>
     </When>
 
     <Otherwise>
       <PropertyGroup>
-        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\14.3.25407</VisualStudioBuildToolsNuGetPackagePath>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\14.3.25420</VisualStudioBuildToolsNuGetPackagePath>
       </PropertyGroup>
     </Otherwise>
   </Choose>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -128,9 +128,23 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+  
+  <!-- This is a really hacky way to detect whether we are on a legacy or a willow based VS install.
+       Basically, we check for a registry key that will only exist in legacy VS installs, and assume
+       we are a willow based installation if our VSVersion is 15.0 and the registry key doesn't exist. -->
+  <PropertyGroup>
+    <VisualStudioInstallDirectoryFromRegistry Condition="'$(OS)' == 'Windows_NT'">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\15.0@InstallDir)</VisualStudioInstallDirectoryFromRegistry>
+    <VisualStudioInstallDirectoryFromRegistry Condition="'$(OS)' == 'Windows_NT' AND '$(VisualStudioInstallDirectoryFromRegistry)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)</VisualStudioInstallDirectoryFromRegistry>
+  </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '15.0'">
+    <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(VisualStudioInstallDirectoryFromRegistry)' != ''">
+      <PropertyGroup>
+        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25201-dev15preview2</VisualStudioBuildToolsNuGetPackagePath>
+      </PropertyGroup>
+    </When>
+    
+    <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(VisualStudioInstallDirectoryFromRegistry)' == ''">
       <PropertyGroup>
         <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
       </PropertyGroup>

--- a/build/ToolsetPackages/dev14.project.json
+++ b/build/ToolsetPackages/dev14.project.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "Microsoft.VSSDK.BuildTools": "14.3.25407"
+        "Microsoft.VSSDK.BuildTools": "14.3.25420"
     },
     "frameworks": {
         "net46": {}

--- a/build/ToolsetPackages/dev15.project.json
+++ b/build/ToolsetPackages/dev15.project.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "Microsoft.VSSDK.BuildTools": "15.0.25201-Dev15Preview2"
+        "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
     },
     "frameworks": {
         "net46": {}

--- a/build/ToolsetPackages/dev15Willow.project.json
+++ b/build/ToolsetPackages/dev15Willow.project.json
@@ -1,6 +1,6 @@
 {
     "dependencies": {
-        "Microsoft.VSSDK.BuildTools": "15.0.25201-dev15preview2"
+        "Microsoft.VSSDK.BuildTools": "15.0.25604-Preview4"
     },
     "frameworks": {
         "net46": {}

--- a/src/EditorFeatures/Next/project.json
+++ b/src/EditorFeatures/Next/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "System.Collections.Immutable": "1.2.0",
-    "Microsoft.VisualStudio.Language.Intellisense": "15.0.25123-Dev15Preview"
+    "Microsoft.VisualStudio.Language.Intellisense": "15.0.25604-Preview4"
   },
   "frameworks": {
     "net46": {}

--- a/src/Tools/RepoUtil/RepoData.json
+++ b/src/Tools/RepoUtil/RepoData.json
@@ -1,10 +1,10 @@
 ﻿{
     "fixedPackages": {
-        "Microsoft.VisualStudio.Language.Intellisense": [ "14.3.25407", "15.0.25123-Dev15Preview" ],
-        "Microsoft.VSSDK.BuildTools": [ "14.3.25407", "15.0.25201-Dev15Preview2" ],
+        "Microsoft.VisualStudio.Language.Intellisense": [ "14.3.25407", "15.0.25604-Preview4" ],
+        "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25604-Preview4" ],
         "System.Reflection.Metadata": "1.0.21",
         "System.Collections.Immutable": "1.1.36",
-		"Microsoft.VisualStudio.ImageCatalog": ["14.3.25407", "15.0.25123-Dev15Preview"]
+        "Microsoft.VisualStudio.ImageCatalog": ["14.3.25407", "15.0.25604-Preview4" ]
     },
 
     "toolsetPackages": [

--- a/src/VisualStudio/Next/project.json
+++ b/src/VisualStudio/Next/project.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "Microsoft.ServiceHub.Client": "0.13.54-alpha-g315dc9a206",
     "StreamJsonRpc": "0.14.3-alpha",
-    "Microsoft.VisualStudio.Shell.15.0-pre": "15.0.25511.2-pre",
-    "Microsoft.VisualStudio.ImageCatalog": "15.0.25123-Dev15Preview",
-    "Microsoft.VisualStudio.Shell.Framework-pre": "15.0.25511-pre",
-	"Microsoft.VisualStudio.Language.Intellisense": "15.0.25123-Dev15Preview",
+    "Microsoft.VisualStudio.Shell.15.0": "15.0.25604-Preview4",
+    "Microsoft.VisualStudio.ImageCatalog": "15.0.25604-Preview4",
+    "Microsoft.VisualStudio.Shell.Framework": "15.0.25604-Preview4",
+    "Microsoft.VisualStudio.Language.Intellisense": "15.0.25604-Preview4",
     "NuGet.VisualStudio": {
       "version": "3.3.0",
       "suppressParent": "all"

--- a/src/VisualStudio/Next/project.json
+++ b/src/VisualStudio/Next/project.json
@@ -10,6 +10,7 @@
       "version": "3.3.0",
       "suppressParent": "all"
     },
+    "Newtonsoft.Json": "8.0.3",
     "System.Collections.Immutable": "1.2.0"
   },
   "frameworks": {

--- a/src/Workspaces/Remote/ServiceHub/project.json
+++ b/src/Workspaces/Remote/ServiceHub/project.json
@@ -1,6 +1,7 @@
 ﻿{
   "dependencies": {
     "StreamJsonRpc": "0.14.3-alpha",
+    "Newtonsoft.Json": "8.0.3",
     "System.Collections.Immutable": "1.2.0"
   },
   "frameworks": {


### PR DESCRIPTION
FYI. @dotnet/roslyn-infrastructure, @mavasani, @jasonmalinowski 

This is required for Roslyn to build ontop of a Willow install.