### PR TITLE
Avoid importing MS.Net.Compilers.props unless $(BuildingProject) is true

### DIFF
--- a/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
+++ b/build/NuGetAdditionalFiles/Microsoft.Net.Compilers.props
@@ -7,7 +7,7 @@
        not be used and the compiler exe at the ToolPath, if set, will be executed, otherwise
        the executable in the MSBuild install path will be executed. -->
 
-  <Target Name="ValidateMSBuildToolsVersion">
+  <Target Name="ValidateMSBuildToolsVersion" Condition="'$(BuildingProject)' == 'true'">
     <Error Text="Microsoft.Net.Compilers is only supported on MSBuild v14.0 and above"
            Condition="'$(MSBuildToolsVersion)' == '2.0'
                    OR '$(MSBuildToolsVersion)' == '3.5'

--- a/build/Targets/Microsoft.Net.Compilers.props
+++ b/build/Targets/Microsoft.Net.Compilers.props
@@ -7,7 +7,7 @@
        not be used and the compiler exe at the ToolPath, if set, will be executed, otherwise
        the executable in the MSBuild install path will be executed. -->
 
-  <Target Name="ValidateMSBuildToolsVersion">
+  <Target Name="ValidateMSBuildToolsVersion" Condition="'$(BuildingProject)' == 'true'">
     <Error Text="Microsoft.Net.Compilers is only supported on MSBuild v14.0 and above"
            Condition="'$(MSBuildToolsVersion)' == '2.0'
                    OR '$(MSBuildToolsVersion)' == '3.5'


### PR DESCRIPTION
Otherwise the MSbuildToolVersion check in MS.Net.Compilers.props would run during NuGet restore. I ran into this problem on machine with only willow installation that `nuget restore` will always pick up msbuild `4.0` even though `15.0` is in the path.

@mavasani @jasonmalinowski @dotnet/roslyn-infrastructure 

