### PR TITLE
Updating the build property from 'VisualStudioInstallDirectoryFromRegistry' to 'IsDev15BeforePreview4'

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -133,21 +133,25 @@
        Basically, we check for a registry key that will only exist in legacy VS installs, and assume
        we are a willow based installation if our VSVersion is 15.0 and the registry key doesn't exist. -->
   <PropertyGroup>
-    <VisualStudioInstallDirectoryFromRegistry Condition="'$(OS)' == 'Windows_NT'">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\15.0@InstallDir)</VisualStudioInstallDirectoryFromRegistry>
-    <VisualStudioInstallDirectoryFromRegistry Condition="'$(OS)' == 'Windows_NT' AND '$(VisualStudioInstallDirectoryFromRegistry)' == ''">$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)</VisualStudioInstallDirectoryFromRegistry>
+    <IsVSBeforeDev15Preview4 Condition="'$(OS)' == 'Windows_NT' AND '$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
+    <IsVSBeforeDev15Preview4 Condition="'$(OS)' == 'Windows_NT' AND '$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(VisualStudioInstallDirectoryFromRegistry)' != ''">
-      <PropertyGroup>
-        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25201-dev15preview2</VisualStudioBuildToolsNuGetPackagePath>
-      </PropertyGroup>
-    </When>
-    
-    <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(VisualStudioInstallDirectoryFromRegistry)' == ''">
-      <PropertyGroup>
-        <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
-      </PropertyGroup>
+    <When Condition="'$(VisualStudioVersion)' == '15.0'">
+      <Choose>
+        <When Condition="'$(IsVSBeforeDev15Preview4)' == 'true'">
+          <PropertyGroup>
+            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25201-dev15preview2</VisualStudioBuildToolsNuGetPackagePath>
+          </PropertyGroup>
+        </When>
+
+        <Otherwise>
+          <PropertyGroup>
+            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
     </When>
 
     <Otherwise>


### PR DESCRIPTION
FYI. @jasonmalinowski 

This cleans up the property name from https://github.com/dotnet/roslyn/pull/13086