### PR TITLE
Make IDkm* stub interfaces internal...

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/IDkmClrFormatter2.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/IDkmClrFormatter2.cs
@@ -6,7 +6,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 
 namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
 {
-    public interface IDkmClrFormatter2
+    internal interface IDkmClrFormatter2
     {
         string GetValueString(DkmClrValue clrValue, DkmClrCustomTypeInfo customTypeInfo, DkmInspectionContext inspectionContext, ReadOnlyCollection<string> formatSpecifiers);
         string GetEditableValueString(DkmClrValue value, DkmInspectionContext inspectionContext, DkmClrCustomTypeInfo customTypeInfo);

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/IDkmClrFullNameProvider.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/IDkmClrFullNameProvider.cs
@@ -7,7 +7,7 @@ using Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation;
 
 namespace Microsoft.VisualStudio.Debugger.ComponentInterfaces
 {
-    public interface IDkmClrFullNameProvider
+    internal interface IDkmClrFullNameProvider
     {
         /// <summary>
         /// Return the type name in a form valid in the language (e.g.: escaping keywords)


### PR DESCRIPTION
These are not intended to be public APIs at this point (they'll eventually
be added to Concord as public APIs).