### PR TITLE
Implement definite assignment analysis for tuples

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -705,12 +705,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return slot;
         }
 
-        // Descends through Rest fields of a tuple is "symbol" is an extended field
-        // As a result the "symbol" will be adjusted to be the field of the innermost tuple
-        // and a corresponding containingSlot is returned.
-        // Return value -1 indicates a failure which could happen for the following reasons
-        // a) Rest field does not exist, which could happen in rare error scenarios involving broken ValueTuple types
-        // b) Rest is not tracked already and forceSlotsToExist is false (otherwise we create slots on demand)
+        /// <summary>
+        /// Descends through Rest fields of a tuple if "symbol" is an extended field
+        /// As a result the "symbol" will be adjusted to be the field of the innermost tuple
+        /// and a corresponding containingSlot is returned.
+        /// Return value -1 indicates a failure which could happen for the following reasons
+        /// a) Rest field does not exist, which could happen in rare error scenarios involving broken ValueTuple types
+        /// b) Rest is not tracked already and forceSlotsToExist is false (otherwise we create slots on demand)
+        /// </summary>
         private int DescendThroughTupleRestFields(ref Symbol symbol, int containingSlot, bool forceContainingSlotsToExist)
         {
             var fieldSymbol = symbol as TupleFieldSymbol;
@@ -718,7 +720,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 TypeSymbol containingType = ((TupleTypeSymbol)symbol.ContainingType).UnderlyingNamedType;
 
-                // for tuple fields the varible indentifier represents the underlying field
+                // for tuple fields the variable identifier represents the underlying field
                 symbol = fieldSymbol.TupleUnderlyingField;
 
                 // descend through Rest fields

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
@@ -118,8 +118,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if ((object)field != null)
                 {
-                    var actualFiledType = field.Type;
-                    if (!IsEmptyStructType(actualFiledType, typesWithMembersOfThisType))
+                    var actualFieldType = field.Type;
+                    if (!IsEmptyStructType(actualFieldType, typesWithMembersOfThisType))
                     {
                         return false;
                     }
@@ -166,15 +166,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (member.Kind)
                 {
                     case SymbolKind.Field:
+                        var field = (FieldSymbol)member;
+
                         // Do not report virtual tuple fields.
                         // They are additional aliases to the fields of the underlying struct or nested extensions.
                         // and as such are already accounted for via the nonvirtual fields.
-                        if (member is TupleVirtualElementFieldSymbol)
+                        if (field.IsVirtualTupleField)
                         {
                             return null;
                         }
 
-                        var field = (FieldSymbol)member;
                         return (field.IsFixed || ShouldIgnoreStructField(field, field.Type)) ? null : field.AsMember(type);
 
                     case SymbolKind.Event:

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
@@ -166,6 +166,14 @@ namespace Microsoft.CodeAnalysis.CSharp
                 switch (member.Kind)
                 {
                     case SymbolKind.Field:
+                        // Do not report virtual tuple fields.
+                        // They are additional aliases to the fields of the underlying struct or nested extensions.
+                        // and as such are already accounted for via the nonvirtual fields.
+                        if (field is TupleVirtualElementFieldSymbol)
+                        {
+                            return null;
+                        }
+
                         var field = (FieldSymbol)member;
                         return (field.IsFixed || ShouldIgnoreStructField(field, field.Type)) ? null : field.AsMember(type);
 

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/EmptyStructTypeCache.cs
@@ -169,7 +169,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         // Do not report virtual tuple fields.
                         // They are additional aliases to the fields of the underlying struct or nested extensions.
                         // and as such are already accounted for via the nonvirtual fields.
-                        if (field is TupleVirtualElementFieldSymbol)
+                        if (member is TupleVirtualElementFieldSymbol)
                         {
                             return null;
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -385,6 +385,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
+        /// Returns Ture when field symbol is not mapped directly to a field in the underlying tuple struct.
+        /// </summary>
+        internal virtual bool IsVirtualTupleField
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// If this is a field of a tuple type, return corresponding underlying field from the
         /// tuple underlying type. Otherwise, null. In case of a malformed underlying type
         /// the corresponding underlying field might be missing, return null in this case too.

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -385,7 +385,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Returns Ture when field symbol is not mapped directly to a field in the underlying tuple struct.
+        /// Returns True when field symbol is not mapped directly to a field in the underlying tuple struct.
         /// </summary>
         internal virtual bool IsVirtualTupleField
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected readonly TupleTypeSymbol _containingTuple;
 
         /// <summary>
-        /// If this field represents a tuple element (including the name match), 
+        /// If this field represents a tuple element, 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this field represents a tuple element (including the name match), 
+        /// If this field represents a tuple element, 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>i
@@ -103,22 +103,27 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override sealed int GetHashCode()
         {
-            return Hash.Combine(_containingTuple.GetHashCode(), _tupleFieldId.GetHashCode());
+            return Hash.Combine(
+                Hash.Combine(_containingTuple.GetHashCode(), _tupleFieldId.GetHashCode()),
+                this.Name.GetHashCode());
         }
 
         public override sealed bool Equals(object obj)
         {
-            return Equals(obj as TupleFieldSymbol);
-        }
+            var other = obj as TupleFieldSymbol;
 
-        public bool Equals(TupleFieldSymbol other)
-        {
             if ((object)other == this)
             {
                 return true;
             }
 
-            return (object)other != null && _tupleFieldId == other._tupleFieldId && _containingTuple == other._containingTuple;
+            // note we have to compare both index and name because 
+            // in nameless tuple there could be fields that differ only by index
+            // and in named tupoles there could be fields that differ only by name
+            return (object)other != null && 
+                _tupleFieldId == other.TupleElementIndex && 
+                _containingTuple == other._containingTuple &&
+                this.Name == other.Name;
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -239,5 +239,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return null;
             }
         }
+
+        internal override bool IsVirtualTupleField
+        {
+            get
+            {
+                return true;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal const int RestPosition = 8; // The Rest field is in 8th position
         internal const string TupleTypeName = "ValueTuple";
+        internal const string RestFieldName = "Rest";
 
         private TupleTypeSymbol(Location locationOpt, NamedTypeSymbol underlyingType, ImmutableArray<Location> elementLocations, ImmutableArray<string> elementNames, ImmutableArray<TypeSymbol> elementTypes)
             : this(locationOpt == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create(locationOpt),
@@ -813,21 +814,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     if (namesOfVirtualFields[tupleFieldIndex] != defaultName)
                                     {
                                         // The name given doesn't match default name Item8, etc.
-                                        members.Add(new TupleRenamedElementFieldSymbol(this, fieldSymbol, defaultName, -members.Count - 1, null));
+                                        // Add a field with default name and make it virtual since we are not at the top level
+                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, defaultName, -members.Count - 1, null));
                                     }
 
                                     // Add a field with the given name
                                     var location = _elementLocations.IsDefault ? null : _elementLocations[tupleFieldIndex];
+                                    members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex],
+                                                        tupleFieldIndex, location));
 
-                                    if (field.Name == namesOfVirtualFields[tupleFieldIndex])
-                                    {
-                                        members.Add(new TupleElementFieldSymbol(this, fieldSymbol, tupleFieldIndex, location));
-                                    }
-                                    else
-                                    {
-                                        members.Add(new TupleRenamedElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex],
-                                                                                                tupleFieldIndex, location));
-                                    }
                                 }
                                 else if (field.Name == namesOfVirtualFields[tupleFieldIndex])
                                 {
@@ -842,7 +837,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     // Add a field with the given name
                                     if (namesOfVirtualFields[tupleFieldIndex] != null)
                                     {
-                                        members.Add(new TupleRenamedElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex], tupleFieldIndex,
+                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, namesOfVirtualFields[tupleFieldIndex], tupleFieldIndex,
                                                                                                 _elementLocations.IsDefault ? null : _elementLocations[tupleFieldIndex]));
                                     }
                                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -556,6 +556,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return 0;
             }
 
+            return MatchesCanonicalElementName(name);
+        }
+
+        /// <summary>
+        /// Returns 3 for "Item3".
+        /// Returns -1 otherwise.
+        /// </summary>
+        private static int MatchesCanonicalElementName(string name)
+        {
             if (name.StartsWith("Item", StringComparison.Ordinal))
             {
                 string tail = name.Substring(4);
@@ -724,13 +733,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     continue;
                 }
 
-                int index = (member as TupleFieldSymbol)?.TupleElementIndex ??
-                            ((TupleErrorFieldSymbol)member).TupleElementIndex;
+                var field = (FieldSymbol)member;
+                var index = field.TupleElementIndex;
 
-                if (index >= 0)
+                if (index >= 0 && index == MatchesCanonicalElementName(field.Name) - 1)
                 {
                     Debug.Assert((object)builder[index] == null);
-                    builder[index] = (FieldSymbol)member;
+                    builder[index] = field;
                 }
             }
 
@@ -815,7 +824,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     {
                                         // The name given doesn't match default name Item8, etc.
                                         // Add a field with default name and make it virtual since we are not at the top level
-                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, defaultName, -members.Count - 1, null));
+                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, defaultName, tupleFieldIndex, null));
                                     }
 
                                     // Add a field with the given name
@@ -832,7 +841,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 else
                                 {
                                     // Add a field with default name
-                                    members.Add(new TupleFieldSymbol(this, fieldSymbol, -members.Count - 1));
+                                    members.Add(new TupleFieldSymbol(this, fieldSymbol, tupleFieldIndex));
 
                                     // Add a field with the given name
                                     if (namesOfVirtualFields[tupleFieldIndex] != null)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -8632,7 +8632,7 @@ class C
 
             Assert.IsType<TupleElementFieldSymbol>(m1Item1);
             Assert.IsType<TupleFieldSymbol>(m2Item1);
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m2a2);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m2a2);
 
             Assert.True(m1Item1.IsTupleField);
             Assert.Same(m1Item1, m1Item1.OriginalDefinition);
@@ -8879,7 +8879,7 @@ class C
 
             var m3Item8 = (FieldSymbol)m3Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m3Item8);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m3Item8);
 
             Assert.True(m3Item8.IsTupleField);
             Assert.Same(m3Item8, m3Item8.OriginalDefinition);
@@ -9073,7 +9073,7 @@ class C
 
             var m4Item8 = (FieldSymbol)m4Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m4Item8);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m4Item8);
 
             Assert.True(m4Item8.IsTupleField);
             Assert.Same(m4Item8, m4Item8.OriginalDefinition);
@@ -9092,7 +9092,7 @@ class C
 
             var m4h4 = (FieldSymbol)m4Tuple.GetMembers("h4").Single();
 
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m4h4);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m4h4);
 
             Assert.True(m4h4.IsTupleField);
             Assert.Same(m4h4, m4h4.OriginalDefinition);
@@ -9321,7 +9321,7 @@ class C
 
             var m5Item8 = (FieldSymbol)m5Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m5Item8);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m5Item8);
 
             Assert.True(m5Item8.IsTupleField);
             Assert.Same(m5Item8, m5Item8.OriginalDefinition);
@@ -9691,7 +9691,7 @@ class C
 
             var m8Item8 = (FieldSymbol)m8Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m8Item8);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m8Item8);
 
             Assert.True(m8Item8.IsTupleField);
             Assert.Same(m8Item8, m8Item8.OriginalDefinition);
@@ -9711,7 +9711,7 @@ class C
 
             var m8Item1 = (FieldSymbol)m8Tuple.GetMembers("Item1").Last();
 
-            Assert.IsType<TupleElementFieldSymbol>(m8Item1);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m8Item1);
 
             Assert.True(m8Item1.IsTupleField);
             Assert.Same(m8Item1, m8Item1.OriginalDefinition);
@@ -9892,7 +9892,7 @@ class C
 
             Assert.IsType<TupleElementFieldSymbol>(m1Item1);
             Assert.IsType<TupleFieldSymbol>(m2Item1);
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m2a2);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m2a2);
 
             Assert.True(m1Item1.IsTupleField);
             Assert.Same(m1Item1, m1Item1.OriginalDefinition);
@@ -10228,7 +10228,7 @@ partial class C
 
             Assert.IsType<TupleElementFieldSymbol>(m10Item1);
             Assert.IsType<TupleFieldSymbol>(m102Item20);
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m102a);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m102a);
 
             Assert.Equal("System.ObsoleteAttribute", m10Item1.GetAttributes().Single().ToString());
             Assert.Equal("System.ObsoleteAttribute", m102Item20.GetAttributes().Single().ToString());
@@ -10242,7 +10242,7 @@ partial class C
             Assert.IsType<TupleElementFieldSymbol>(m10Item2);
             Assert.IsType<TupleFieldSymbol>(m102Item2);
             Assert.IsType<TupleFieldSymbol>(m102Item21);
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m102b);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m102b);
 
             Assert.Equal(20, m10Item2.TypeLayoutOffset);
             Assert.Equal(20, m102Item2.TypeLayoutOffset);
@@ -10256,8 +10256,8 @@ partial class C
             var m103Item2 = (FieldSymbol)m103Tuple.GetMembers("Item2").Last();
             var m103Item9 = (FieldSymbol)m103Tuple.GetMembers("Item9").Single();
 
-            Assert.IsType<TupleElementFieldSymbol>(m103Item2);
-            Assert.IsType<TupleRenamedElementFieldSymbol>(m103Item9);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m103Item2);
+            Assert.IsType<TupleVirtualElementFieldSymbol>(m103Item9);
             Assert.Null(m103Item2.TypeLayoutOffset);
             Assert.Equal(20, m103Item2.TupleUnderlyingField.TypeLayoutOffset);
             Assert.Null(m103Item9.TypeLayoutOffset);
@@ -14007,6 +14007,7 @@ class C
             var comp = CreateCompilationWithMscorlib(source,
                 references: s_valueTupleRefs,
                 parseOptions: TestOptions.Regular, assemblyName: "ImplicitConversions06Err");
+
             comp.VerifyEmitDiagnostics(
                 // (8,16): error CS0030: Cannot convert type '(int, (int, (int, (int, (int, (int, int))))))' to 'C.C1'
                 //         C1 y = (C1)x;   
@@ -16563,6 +16564,837 @@ public class C
 
             var x2 = nodes.OfType<VariableDeclaratorSyntax>().Skip(1).First();
             Assert.Equal("<anonymous type: (System.Int32 c, System.Int32) Tuple> x2", model.GetDeclaredSymbol(x2).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void DefiniteAssignment001()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string A, string B) ss;
+
+            ss.A = ""q"";
+            ss.Item2 = ""w"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, w)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment002()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string A, string B) ss;
+
+            ss.A = ""q"";
+            ss.B = ""q"";
+            ss.Item1 = ""w"";
+            ss.Item2 = ""w"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(w, w)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment003()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string A, (string B, string C) D) ss;
+
+            ss.A = ""q"";
+            ss.D.B = ""w"";
+            ss.D.C = ""e"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, (w, e))
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment004()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            ss.I8 = ""q"";
+            ss.I9 = ""q"";
+            ss.I10 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q, q, q, q, q, q, q, q)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment005()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.Item1 = ""q"";
+            ss.Item2 = ""q"";
+            ss.Item3 = ""q"";
+            ss.Item4 = ""q"";
+            ss.Item5 = ""q"";
+            ss.Item6 = ""q"";
+            ss.Item7 = ""q"";
+            ss.Item8 = ""q"";
+            ss.Item9 = ""q"";
+            ss.Item10 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q, q, q, q, q, q, q, q)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment006()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.Item1 = ""q"";
+            ss.I2 = ""q"";
+            ss.Item3 = ""q"";
+            ss.I4 = ""q"";
+            ss.Item5 = ""q"";
+            ss.I6 = ""q"";
+            ss.Item7 = ""q"";
+            ss.I8 = ""q"";
+            ss.Item9 = ""q"";
+            ss.I10 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q, q, q, q, q, q, q, q)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment007()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.Item1 = ""q"";
+            ss.I2 = ""q"";
+            ss.Item3 = ""q"";
+            ss.I4 = ""q"";
+            ss.Item5 = ""q"";
+            ss.I6 = ""q"";
+            ss.Item7 = ""q"";
+            ss.I8 = ""q"";
+            ss.Item9 = ""q"";
+            ss.I10 = ""q"";
+
+            System.Console.WriteLine(ss.Rest);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment008()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.I8 = ""q"";
+            ss.Item9 = ""q"";
+            ss.I10 = ""q"";
+
+            System.Console.WriteLine(ss.Rest);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q)
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment009()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            Assign(out ss.Rest);
+
+            System.Console.WriteLine(ss);
+        }
+
+        static void Assign<T>(out T v)
+        {
+            v = default(T);
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"
+(q, q, q, q, q, q, q, , , )
+");
+        }
+
+        [Fact]
+        public void DefiniteAssignment010()
+        {
+            var source = @"
+using System;
+class C
+{
+        static void Main(string[] args)
+        {
+            (string I1, 
+             string I2, 
+             string I3, 
+             string I4, 
+             string I5, 
+             string I6, 
+             string I7, 
+             string I8, 
+             string I9, 
+             string I10) ss;
+
+            Assign(out ss.Rest, (""q"", ""w"", ""e""));
+
+            System.Console.WriteLine(ss.I9);
+        }
+
+        static void Assign<T>(out T r, T v)
+        {
+            r = v;
+        }
+    }
+";
+
+            var comp = CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"w");
+        }
+
+        [Fact]
+        public void DefiniteAssignment011()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        if (1.ToString() == 2.ToString())
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+        else if (1.ToString() == 3.ToString())
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            // ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+        else 
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            // ss.I7 = ""q"";
+            ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss); // should fail
+        }
+    }
+}
+
+namespace System
+{
+    public struct ValueTuple<T1>
+    {
+        public T1 Item1;
+
+        public ValueTuple(T1 item1)
+        {
+            this.Item1 = item1;
+        }
+    }
+
+    public struct ValueTuple<T1, T2>
+    {
+        public T1 Item1;
+        public T2 Item2;
+
+        public ValueTuple(T1 item1, T2 item2)
+        {
+            this.Item1 = item1;
+            this.Item2 = item2;
+        }
+    }
+
+    public struct ValueTuple<T1, T2, T3, T4, T5, T6, T7, TRest>
+    {
+        public T1 Item1;
+        public T2 Item2;
+        public T3 Item3;
+        public T4 Item4;
+        public T5 Item5;
+        public T6 Item6;
+        public T7 Item7;
+        // public TRest Rest;     oops, Rest is missing
+
+        public ValueTuple(T1 item1, T2 item2, T3 item3, T4 item4, T5 item5, T6 item6, T7 item7, TRest rest)
+        {
+            Item1 = item1;
+            Item2 = item2;
+            Item3 = item3;
+            Item4 = item4;
+            Item5 = item5;
+            Item6 = item6;
+            Item7 = item7;
+            // Rest = rest;   
+        }
+    }
+}
+";
+
+            var comp = CreateCompilationWithMscorlib(source,
+                parseOptions: TestOptions.Regular);
+
+            comp.VerifyDiagnostics(
+                // (71,38): error CS0165: Use of unassigned local variable 'ss'
+                //             System.Console.WriteLine(ss); // should fail
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "ss").WithArguments("ss").WithLocation(71, 38),
+                // (2,1): hidden CS8019: Unnecessary using directive.
+                // using System;
+                Diagnostic(ErrorCode.HDN_UnusedUsingDirective, "using System;").WithLocation(2, 1)
+            );
+        }
+
+        [Fact]
+        public void DefiniteAssignment012()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        if (1.ToString() == 2.ToString())
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss);
+        }
+        else if (1.ToString() == 3.ToString())
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            ss.I7 = ""q"";
+            // ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss); // should fail1
+        }
+        else 
+        {
+            (string I1, 
+                string I2, 
+                string I3, 
+                string I4, 
+                string I5, 
+                string I6, 
+                string I7, 
+                string I8) ss;
+
+            ss.I1 = ""q"";
+            ss.I2 = ""q"";
+            ss.I3 = ""q"";
+            ss.I4 = ""q"";
+            ss.I5 = ""q"";
+            ss.I6 = ""q"";
+            // ss.I7 = ""q"";
+            ss.I8 = ""q"";
+
+            System.Console.WriteLine(ss); // should fail2
+        }
+    }
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib(source,
+                references: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular);
+
+            comp.VerifyEmitDiagnostics(
+                // (49,38): error CS0165: Use of unassigned local variable 'ss'
+                //             System.Console.WriteLine(ss); // should fail1
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "ss").WithArguments("ss").WithLocation(49, 38),
+                // (71,38): error CS0165: Use of unassigned local variable 'ss'
+                //             System.Console.WriteLine(ss); // should fail2
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "ss").WithArguments("ss").WithLocation(71, 38)
+            );
+        }
+
+
+        [Fact]
+        public void DefiniteAssignment013()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        (string I1, 
+            string I2, 
+            string I3, 
+            string I4, 
+            string I5, 
+            string I6, 
+            string I7, 
+            string I8) ss;
+
+        ss.I1 = ""q"";
+        ss.I2 = ""q"";
+        ss.I3 = ""q"";
+        ss.I4 = ""q"";
+        ss.I5 = ""q"";
+        ss.I6 = ""q"";
+        ss.I7 = ""q"";
+
+        ss.Item1 = ""q"";
+        ss.Item2 = ""q"";
+        ss.Item3 = ""q"";
+        ss.Item4 = ""q"";
+        ss.Item5 = ""q"";
+        ss.Item6 = ""q"";
+        ss.Item7 = ""q"";
+
+        System.Console.WriteLine(ss.Rest);
+    }
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib(source,
+                references: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular);
+
+            comp.VerifyEmitDiagnostics(
+                // (32,34): error CS0170: Use of possibly unassigned field 'Rest'
+                //         System.Console.WriteLine(ss.Rest);
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "ss.Rest").WithArguments("Rest").WithLocation(32, 34)
+            );
+        }
+
+        [Fact]
+        public void DefiniteAssignment014()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main(string[] args)
+    {
+        (string I1, 
+            string I2, 
+            string I3, 
+            string I4, 
+            string I5, 
+            string I6, 
+            string I7, 
+            string I8) ss;
+
+        ss.I1 = ""q"";
+        ss.Item2 = ""aa"";
+
+        System.Console.WriteLine(ss.Item1);
+        System.Console.WriteLine(ss.I2);
+
+        System.Console.WriteLine(ss.I3);
+       
+    }
+}
+
+";
+
+            var comp = CreateCompilationWithMscorlib(source,
+                references: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular);
+
+            comp.VerifyEmitDiagnostics(
+                // (22,34): error CS0170: Use of possibly unassigned field 'I3'
+                //         System.Console.WriteLine(ss.I3);
+                Diagnostic(ErrorCode.ERR_UseDefViolationField, "ss.I3").WithArguments("I3").WithLocation(22, 34)
+            );
+        }
+
+        [Fact]
+        public void DefiniteAssignment015()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+class C
+{
+        static void Main(string[] args)
+        {
+            var v = Test().Result;
+        }
+
+        static async Task<long> Test()
+        {
+            (long a, int b) v1;
+            (byte x, int y) v2;
+
+            v1.a = 5;  
+
+            v2.x = 5;   // no need to persist across await since it is unused after it.
+            System.Console.WriteLine(v2.Item1);
+
+            await Task.Yield();
+
+            // this is assigned and persisted across await
+            return v1.Item1;            
+        }
+    }
+" + trivial2uple;
+
+            var verifier = CompileAndVerify(source, additionalRefs: new[] { MscorlibRef_v46 }, expectedOutput: @"5", options: TestOptions.ReleaseExe);
+
+            // NOTE: !!! There should be NO IL local for  " (long a, int b) v1 " , it should be captured instead
+            // NOTE: !!! There should be an IL local for  " (byte x, int y) v2 " , it should not be captured 
+            verifier.VerifyIL("C.<Test>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      201 (0xc9)
+  .maxstack  3
+  .locals init (int V_0,
+                long V_1,
+                System.ValueTuple<byte, int> V_2, //v2
+                System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_3,
+                System.Runtime.CompilerServices.YieldAwaitable V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<Test>d__1.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldloc.0
+    IL_0008:  brfalse.s  IL_0062
+    IL_000a:  ldarg.0
+    IL_000b:  ldflda     ""(long a, int b) C.<Test>d__1.<v1>5__1""
+    IL_0010:  ldc.i4.5
+    IL_0011:  conv.i8
+    IL_0012:  stfld      ""long System.ValueTuple<long, int>.Item1""
+    IL_0017:  ldloca.s   V_2
+    IL_0019:  ldc.i4.5
+    IL_001a:  stfld      ""byte System.ValueTuple<byte, int>.Item1""
+    IL_001f:  ldloc.2
+    IL_0020:  ldfld      ""byte System.ValueTuple<byte, int>.Item1""
+    IL_0025:  call       ""void System.Console.WriteLine(int)""
+    IL_002a:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_002f:  stloc.s    V_4
+    IL_0031:  ldloca.s   V_4
+    IL_0033:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0038:  stloc.3
+    IL_0039:  ldloca.s   V_3
+    IL_003b:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_0040:  brtrue.s   IL_007e
+    IL_0042:  ldarg.0
+    IL_0043:  ldc.i4.0
+    IL_0044:  dup
+    IL_0045:  stloc.0
+    IL_0046:  stfld      ""int C.<Test>d__1.<>1__state""
+    IL_004b:  ldarg.0
+    IL_004c:  ldloc.3
+    IL_004d:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1.<>u__1""
+    IL_0052:  ldarg.0
+    IL_0053:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
+    IL_0058:  ldloca.s   V_3
+    IL_005a:  ldarg.0
+    IL_005b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<Test>d__1>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<Test>d__1)""
+    IL_0060:  leave.s    IL_00c8
+    IL_0062:  ldarg.0
+    IL_0063:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1.<>u__1""
+    IL_0068:  stloc.3
+    IL_0069:  ldarg.0
+    IL_006a:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<Test>d__1.<>u__1""
+    IL_006f:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0075:  ldarg.0
+    IL_0076:  ldc.i4.m1
+    IL_0077:  dup
+    IL_0078:  stloc.0
+    IL_0079:  stfld      ""int C.<Test>d__1.<>1__state""
+    IL_007e:  ldloca.s   V_3
+    IL_0080:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0085:  ldloca.s   V_3
+    IL_0087:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_008d:  ldarg.0
+    IL_008e:  ldflda     ""(long a, int b) C.<Test>d__1.<v1>5__1""
+    IL_0093:  ldfld      ""long System.ValueTuple<long, int>.Item1""
+    IL_0098:  stloc.1
+    IL_0099:  leave.s    IL_00b4
+  }
+  catch System.Exception
+  {
+    IL_009b:  stloc.s    V_5
+    IL_009d:  ldarg.0
+    IL_009e:  ldc.i4.s   -2
+    IL_00a0:  stfld      ""int C.<Test>d__1.<>1__state""
+    IL_00a5:  ldarg.0
+    IL_00a6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
+    IL_00ab:  ldloc.s    V_5
+    IL_00ad:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetException(System.Exception)""
+    IL_00b2:  leave.s    IL_00c8
+  }
+  IL_00b4:  ldarg.0
+  IL_00b5:  ldc.i4.s   -2
+  IL_00b7:  stfld      ""int C.<Test>d__1.<>1__state""
+  IL_00bc:  ldarg.0
+  IL_00bd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long> C.<Test>d__1.<>t__builder""
+  IL_00c2:  ldloc.1
+  IL_00c3:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<long>.SetResult(long)""
+  IL_00c8:  ret
+}
+");
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16615,9 +16615,7 @@ class C
 
             var comp = CompileAndVerify(source,
                 additionalRefs: s_valueTupleRefs,
-                parseOptions: TestOptions.Regular, expectedOutput: @"
-(w, w)
-");
+                parseOptions: TestOptions.Regular, expectedOutput: @"(w, w)");
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -8630,9 +8630,9 @@ class C
             var m2Item1 = (FieldSymbol)m2Tuple.GetMembers()[0];
             var m2a2 = (FieldSymbol)m2Tuple.GetMembers()[1];
 
-            Assert.IsType<TupleElementFieldSymbol>(m1Item1);
-            Assert.IsType<TupleFieldSymbol>(m2Item1);
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m2a2);
+            AssertNonvirtualTupleElementField(m1Item1);
+            AssertNonvirtualTupleElementField(m2Item1);
+            AssertVirtualTupleElementField(m2a2);
 
             Assert.True(m1Item1.IsTupleField);
             Assert.Same(m1Item1, m1Item1.OriginalDefinition);
@@ -8879,7 +8879,7 @@ class C
 
             var m3Item8 = (FieldSymbol)m3Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m3Item8);
+            AssertVirtualTupleElementField(m3Item8);
 
             Assert.True(m3Item8.IsTupleField);
             Assert.Same(m3Item8, m3Item8.OriginalDefinition);
@@ -9073,7 +9073,7 @@ class C
 
             var m4Item8 = (FieldSymbol)m4Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m4Item8);
+            AssertVirtualTupleElementField(m4Item8);
 
             Assert.True(m4Item8.IsTupleField);
             Assert.Same(m4Item8, m4Item8.OriginalDefinition);
@@ -9092,7 +9092,7 @@ class C
 
             var m4h4 = (FieldSymbol)m4Tuple.GetMembers("h4").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m4h4);
+            AssertVirtualTupleElementField(m4h4);
 
             Assert.True(m4h4.IsTupleField);
             Assert.Same(m4h4, m4h4.OriginalDefinition);
@@ -9321,7 +9321,7 @@ class C
 
             var m5Item8 = (FieldSymbol)m5Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m5Item8);
+            AssertVirtualTupleElementField(m5Item8);
 
             Assert.True(m5Item8.IsTupleField);
             Assert.Same(m5Item8, m5Item8.OriginalDefinition);
@@ -9691,7 +9691,7 @@ class C
 
             var m8Item8 = (FieldSymbol)m8Tuple.GetMembers("Item8").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m8Item8);
+            AssertVirtualTupleElementField(m8Item8);
 
             Assert.True(m8Item8.IsTupleField);
             Assert.Same(m8Item8, m8Item8.OriginalDefinition);
@@ -9711,7 +9711,7 @@ class C
 
             var m8Item1 = (FieldSymbol)m8Tuple.GetMembers("Item1").Last();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m8Item1);
+            AssertVirtualTupleElementField(m8Item1);
 
             Assert.True(m8Item1.IsTupleField);
             Assert.Same(m8Item1, m8Item1.OriginalDefinition);
@@ -9890,9 +9890,9 @@ class C
             var m2Item1 = (FieldSymbol)m2Tuple.GetMembers()[0];
             var m2a2 = (FieldSymbol)m2Tuple.GetMembers()[1];
 
-            Assert.IsType<TupleElementFieldSymbol>(m1Item1);
-            Assert.IsType<TupleFieldSymbol>(m2Item1);
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m2a2);
+            AssertNonvirtualTupleElementField(m1Item1);
+            AssertNonvirtualTupleElementField(m2Item1);
+            AssertVirtualTupleElementField(m2a2);
 
             Assert.True(m1Item1.IsTupleField);
             Assert.Same(m1Item1, m1Item1.OriginalDefinition);
@@ -10226,9 +10226,9 @@ partial class C
             var m102Item20 = (FieldSymbol)m102Tuple.GetMembers("Item20").Single();
             var m102a = (FieldSymbol)m102Tuple.GetMembers("a").Single();
 
-            Assert.IsType<TupleElementFieldSymbol>(m10Item1);
-            Assert.IsType<TupleFieldSymbol>(m102Item20);
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m102a);
+            AssertNonvirtualTupleElementField(m10Item1);
+            AssertTupleNonElementField(m102Item20);
+            AssertVirtualTupleElementField(m102a);
 
             Assert.Equal("System.ObsoleteAttribute", m10Item1.GetAttributes().Single().ToString());
             Assert.Equal("System.ObsoleteAttribute", m102Item20.GetAttributes().Single().ToString());
@@ -10239,10 +10239,10 @@ partial class C
             var m102Item2 = (FieldSymbol)m102Tuple.GetMembers("Item2").Single();
             var m102b = (FieldSymbol)m102Tuple.GetMembers("b").Single();
 
-            Assert.IsType<TupleElementFieldSymbol>(m10Item2);
-            Assert.IsType<TupleFieldSymbol>(m102Item2);
-            Assert.IsType<TupleFieldSymbol>(m102Item21);
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m102b);
+            AssertNonvirtualTupleElementField(m10Item2);
+            AssertNonvirtualTupleElementField(m102Item2);
+            AssertTupleNonElementField(m102Item21);
+            AssertVirtualTupleElementField(m102b);
 
             Assert.Equal(20, m10Item2.TypeLayoutOffset);
             Assert.Equal(20, m102Item2.TypeLayoutOffset);
@@ -10256,8 +10256,8 @@ partial class C
             var m103Item2 = (FieldSymbol)m103Tuple.GetMembers("Item2").Last();
             var m103Item9 = (FieldSymbol)m103Tuple.GetMembers("Item9").Single();
 
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m103Item2);
-            Assert.IsType<TupleVirtualElementFieldSymbol>(m103Item9);
+            AssertVirtualTupleElementField(m103Item2);
+            AssertVirtualTupleElementField(m103Item9);
             Assert.Null(m103Item2.TypeLayoutOffset);
             Assert.Equal(20, m103Item2.TupleUnderlyingField.TypeLayoutOffset);
             Assert.Null(m103Item9.TypeLayoutOffset);
@@ -10294,6 +10294,36 @@ partial class C
 
             var m10E2 = m10Tuple.GetMember<EventSymbol>("E2");
             Assert.Equal("System.ObsoleteAttribute", m10E2.GetAttributes().Single().ToString());
+        }
+
+        private void AssertTupleNonElementField(FieldSymbol sym)
+        {
+            Assert.True(sym.IsTupleField);
+            Assert.False(sym.IsVirtualTupleField);
+
+            //it is not an element so index must be negative
+            Assert.True(sym.TupleElementIndex < 0);
+        }
+
+        private void AssertVirtualTupleElementField(FieldSymbol sym)
+        {
+            Assert.True(sym.IsTupleField);
+            Assert.True(sym.IsVirtualTupleField);
+
+            //it is an element so must have nonnegative index
+            Assert.True(sym.TupleElementIndex >= 0);
+        }
+
+        private void AssertNonvirtualTupleElementField(FieldSymbol sym)
+        {
+            Assert.True(sym.IsTupleField);
+            Assert.False(sym.IsVirtualTupleField);
+
+            //it is an element so must have nonnegative index
+            Assert.True(sym.TupleElementIndex >= 0);
+
+            //if it was 8th or after, it would be virtual
+            Assert.True(sym.TupleElementIndex < TupleTypeSymbol.RestPosition - 1);
         }
 
         [Fact]


### PR DESCRIPTION
When recording assignments of tuple fields, associate tracking slots with underlying field symbols. This way the element assignment to a tuple field and to a corresponding "ItemX" field would be tracked equivalently.

When checking whether a tuple is definitely assigned, only look at nonvirtual fields - fields that map directly to the actual fields in the top level ValueTuple.

Fixes C# portion of https://github.com/dotnet/roslyn/issues/13046