### PR TITLE
D-assignment should return a tuple instead of void

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -49,7 +49,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         private BoundDeconstructionAssignmentOperator BindDeconstructionAssignment(CSharpSyntaxNode node, ExpressionSyntax right, ArrayBuilder<DeconstructionVariable> checkedVariables, DiagnosticBag diagnostics, bool isDeclaration, BoundDeconstructValuePlaceholder rhsPlaceholder = null)
         {
-            TypeSymbol returnType = MakeLhsTupleType(checkedVariables, node, Compilation, diagnostics);
+            TypeSymbol returnType = isDeclaration ?
+                GetSpecialType(SpecialType.System_Void, diagnostics, node) :
+                MakeLhsTupleType(checkedVariables, node, Compilation, diagnostics);
 
             // receiver for first Deconstruct step
             var boundRHS = rhsPlaceholder ?? BindValue(right, diagnostics, BindValueKind.RValue);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -385,7 +385,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 typesBuilder.Add(type);
             }
 
-            return TupleTypeSymbol.Create(locationOpt: null, elementTypes: typesBuilder.ToImmutableAndFree(), elementLocations: default(ImmutableArray<Location>), elementNames: default(ImmutableArray<string>), compilation: compilation, diagnostics: diagnostics);
+            return TupleTypeSymbol.Create(locationOpt: null,
+                elementTypes: typesBuilder.ToImmutableAndFree(),
+                elementLocations: default(ImmutableArray<Location>),
+                elementNames: default(ImmutableArray<string>),
+                compilation: compilation,
+                diagnostics: diagnostics,
+                syntax: syntax);
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -358,7 +358,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var outputPlaceholder = new BoundDeconstructValuePlaceholder(node, tuple) { WasCompilerGenerated = true };
 
             BoundExpression construction = new BoundTupleLiteral(node, default(ImmutableArray<string>), constructionInputs.CastArray<BoundExpression>(), tuple);
-            return new BoundDeconstructionConstructionStep(node, construction, constructionInputs, outputPlaceholder);
+            return new BoundDeconstructionConstructionStep(node, construction, outputPlaceholder);
         }
 
         /// <summary>
@@ -473,7 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // each assignment has a placeholder for a receiver and another for the source
             BoundAssignmentOperator op = BindAssignment(receivingVariable.Syntax, outputPlaceholder, inputPlaceholder, diagnostics);
 
-            return new BoundDeconstructionAssignmentStep(node, op, inputPlaceholder, outputPlaceholder);
+            return new BoundDeconstructionAssignmentStep(node, op, outputPlaceholder);
         }
 
         private static ImmutableArray<BoundExpression> FlattenDeconstructVariables(ArrayBuilder<DeconstructionVariable> variables)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -90,9 +90,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     assignmentSteps,
                                     constructionStepsOpt);
 
-            TypeSymbol returnType = (isDeclaration || hasErrors) ?
-                                        GetSpecialType(SpecialType.System_Void, diagnostics, node) :
-                                        constructionStepsOpt.Last().OutputPlaceholder.Type;
+            TypeSymbol returnType = hasErrors ?
+                                        CreateErrorType() :
+                                        isDeclaration ?
+                                            GetSpecialType(SpecialType.System_Void, diagnostics, node) :
+                                            constructionStepsOpt.Last().OutputPlaceholder.Type;
 
             var deconstructions = deconstructionSteps.ToImmutableAndFree();
             var conversions = conversionSteps.ToImmutableAndFree();
@@ -335,10 +337,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            if (constructionStepsOpt != null && !hasErrors)
+            if (constructionStepsOpt != null)
             {
-                var construct = MakeDeconstructionConstructionStep(syntax, diagnostics, constructionInputs.ToImmutableAndFree());
-                constructionStepsOpt.Add(construct);
+                if (hasErrors)
+                {
+                    constructionInputs.Free();
+                }
+                else
+                {
+                    var construct = MakeDeconstructionConstructionStep(syntax, diagnostics, constructionInputs.ToImmutableAndFree());
+                    constructionStepsOpt.Add(construct);
+                }
             }
 
             return !hasErrors;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // receiver for first Deconstruct step
             var boundRHS = rhsPlaceholder ?? BindValue(right, diagnostics, BindValueKind.RValue);
 
-            boundRHS = FixTupleLiteral(checkedVariables, boundRHS, node, right, diagnostics);
+            boundRHS = FixTupleLiteral(checkedVariables, boundRHS, node, diagnostics);
 
             if ((object)boundRHS.Type == null)
             {
@@ -108,7 +108,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             deconstructions, conversions, assignments, constructions, returnType, hasErrors: hasErrors);
         }
 
-        private BoundExpression FixTupleLiteral(ArrayBuilder<DeconstructionVariable> checkedVariables, BoundExpression boundRHS, CSharpSyntaxNode syntax, ExpressionSyntax right, DiagnosticBag diagnostics)
+        private BoundExpression FixTupleLiteral(ArrayBuilder<DeconstructionVariable> checkedVariables, BoundExpression boundRHS, CSharpSyntaxNode syntax, DiagnosticBag diagnostics)
         {
             if (boundRHS.Kind == BoundKind.TupleLiteral)
             {
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if ((object)boundRHS.Type == null)
             {
-                Error(diagnostics, ErrorCode.ERR_DeconstructRequiresExpression, right);
+                Error(diagnostics, ErrorCode.ERR_DeconstructRequiresExpression, boundRHS.Syntax);
             }
 
             return boundRHS;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -47,7 +47,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Deconstruct steps for tuples have no invocation to Deconstruct, but steps for non-tuples do.
         /// The caller is responsible for releasing all the ArrayBuilders in checkedVariables.
         /// </summary>
-        private BoundDeconstructionAssignmentOperator BindDeconstructionAssignment(CSharpSyntaxNode node, ExpressionSyntax right, ArrayBuilder<DeconstructionVariable> checkedVariables, DiagnosticBag diagnostics, bool isDeclaration, BoundDeconstructValuePlaceholder rhsPlaceholder = null)
+        private BoundDeconstructionAssignmentOperator BindDeconstructionAssignment(
+                                                        CSharpSyntaxNode node,
+                                                        ExpressionSyntax right,
+                                                        ArrayBuilder<DeconstructionVariable> checkedVariables,
+                                                        DiagnosticBag diagnostics,
+                                                        bool isDeclaration,
+                                                        BoundDeconstructValuePlaceholder rhsPlaceholder = null)
         {
             // receiver for first Deconstruct step
             var boundRHS = rhsPlaceholder ?? BindValue(right, diagnostics, BindValueKind.RValue);
@@ -316,10 +322,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else
                 {
-                    var conversion = MakeDeconstructionAssignmentStep(variable.Single, valuePlaceholder.Type, valuePlaceholder, syntax, diagnostics);
+                    var conversion = MakeDeconstructionAssignmentStep(variable.Single, valuePlaceholder, syntax, diagnostics);
                     conversionSteps.Add(conversion);
 
-                    var assignment = MakeDeconstructionAssignmentStep(variable.Single, conversion.OutputPlaceholder.Type, conversion.OutputPlaceholder, syntax, diagnostics);
+                    var assignment = MakeDeconstructionAssignmentStep(variable.Single, conversion.OutputPlaceholder, syntax, diagnostics);
                     assignmentSteps.Add(assignment);
 
                     if (constructionInputs != null)
@@ -338,7 +344,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return !hasErrors;
         }
 
-        private BoundDeconstructionConstructionStep MakeDeconstructionConstructionStep(CSharpSyntaxNode node, DiagnosticBag diagnostics, ImmutableArray<BoundDeconstructValuePlaceholder> constructionInputs)
+        private BoundDeconstructionConstructionStep MakeDeconstructionConstructionStep(CSharpSyntaxNode node, DiagnosticBag diagnostics,
+                                                        ImmutableArray<BoundDeconstructValuePlaceholder> constructionInputs)
         {
             var tuple = TupleTypeSymbol.Create(locationOpt: null,
                            elementTypes: constructionInputs.SelectAsArray(e => e.Type),
@@ -418,7 +425,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            return TupleTypeSymbol.Create(locationOpt: null, elementTypes: typesBuilder.ToImmutableAndFree(), elementLocations: default(ImmutableArray<Location>), elementNames: default(ImmutableArray<string>), compilation: compilation, diagnostics: diagnostics);
+            return TupleTypeSymbol.Create(locationOpt: null, elementTypes: typesBuilder.ToImmutableAndFree(), elementLocations: default(ImmutableArray<Location>),
+                                    elementNames: default(ImmutableArray<string>), compilation: compilation, diagnostics: diagnostics);
         }
 
         /// <summary>
@@ -454,10 +462,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Figures out how to assign from sourceType into receivingVariable and bundles the information (leaving holes for the actual source and receiver) into an AssignmentInfo.
+        /// Figures out how to assign from inputPlaceholder into receivingVariable and bundles the information (leaving holes for the actual source and receiver) into an AssignmentInfo.
         /// </summary>
         private BoundDeconstructionAssignmentStep MakeDeconstructionAssignmentStep(
-                                                    BoundExpression receivingVariable, TypeSymbol sourceType, BoundDeconstructValuePlaceholder inputPlaceholder,
+                                                    BoundExpression receivingVariable, BoundDeconstructValuePlaceholder inputPlaceholder,
                                                     CSharpSyntaxNode node, DiagnosticBag diagnostics)
         {
             var outputPlaceholder = new BoundDeconstructValuePlaceholder(receivingVariable.Syntax, receivingVariable.Type) { WasCompilerGenerated = true };
@@ -594,7 +602,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         }
 
-        private BoundBadExpression MissingDeconstruct(BoundExpression receiver, CSharpSyntaxNode syntax, int numParameters, DiagnosticBag diagnostics, out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders, BoundNode childNode)
+        private BoundBadExpression MissingDeconstruct(BoundExpression receiver, CSharpSyntaxNode syntax, int numParameters, DiagnosticBag diagnostics,
+                                    out ImmutableArray<BoundDeconstructValuePlaceholder> outPlaceholders, BoundNode childNode)
         {
             Error(diagnostics, ErrorCode.ERR_MissingDeconstruct, receiver.Syntax, receiver.Type, numParameters);
             outPlaceholders = default(ImmutableArray<BoundDeconstructValuePlaceholder>);
@@ -607,7 +616,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundLocalDeconstructionDeclaration(node, BindDeconstructionDeclaration(node, node.Assignment.VariableComponent, node.Assignment.Value, diagnostics));
         }
 
-        internal BoundDeconstructionAssignmentOperator BindDeconstructionDeclaration(CSharpSyntaxNode node, VariableComponentSyntax declaration, ExpressionSyntax right, DiagnosticBag diagnostics, BoundDeconstructValuePlaceholder rightPlaceholder = null)
+        internal BoundDeconstructionAssignmentOperator BindDeconstructionDeclaration(CSharpSyntaxNode node, VariableComponentSyntax declaration, ExpressionSyntax right,
+                                                        DiagnosticBag diagnostics, BoundDeconstructValuePlaceholder rightPlaceholder = null)
         {
             DeconstructionVariable locals = BindDeconstructionDeclarationLocals(declaration, diagnostics);
             Debug.Assert(locals.HasNestedVariables);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -90,11 +90,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     assignmentSteps,
                                     constructionStepsOpt);
 
-            TypeSymbol returnType = hasErrors ?
-                                        CreateErrorType() :
-                                        isDeclaration ?
+            TypeSymbol returnType = isDeclaration ?
                                             GetSpecialType(SpecialType.System_Void, diagnostics, node) :
-                                            constructionStepsOpt.Last().OutputPlaceholder.Type;
+                                            hasErrors ?
+                                                CreateErrorType() :
+                                                constructionStepsOpt.Last().OutputPlaceholder.Type;
 
             var deconstructions = deconstructionSteps.ToImmutableAndFree();
             var conversions = conversionSteps.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -404,7 +404,7 @@
     <Field Name="Right" Type="BoundExpression"/>
 
     <Field Name="DeconstructSteps" Type="ImmutableArray&lt;BoundDeconstructionDeconstructStep&gt;" Null="NotApplicable" SkipInVisitor="true" />
-
+    <Field Name="ConversionSteps" Type="ImmutableArray&lt;BoundDeconstructionConversionStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
     <Field Name="AssignmentSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
   </Node>
 
@@ -412,6 +412,12 @@
     <Field Name="DeconstructInvocationOpt" Type="BoundExpression" Null="allow"/>
     <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
     <Field Name="OutputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;"/>
+  </Node>
+
+  <Node Name="BoundDeconstructionConversionStep" Base="BoundNode">
+    <Field Name="Conversion" Type="BoundExpression" Null="disallow"/>
+    <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
+    <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 
   <Node Name="BoundDeconstructionAssignmentStep" Base="BoundNode">

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -417,13 +417,11 @@
 
   <Node Name="BoundDeconstructionAssignmentStep" Base="BoundNode">
     <Field Name="Assignment" Type="BoundAssignmentOperator" Null="disallow"/>
-    <Field Name="InputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
     <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 
   <Node Name="BoundDeconstructionConstructionStep" Base="BoundNode">
     <Field Name="Construct" Type="BoundExpression" Null="disallow"/>
-    <Field Name="InputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;"/>
     <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -406,17 +406,24 @@
     <Field Name="DeconstructSteps" Type="ImmutableArray&lt;BoundDeconstructionDeconstructStep&gt;" Null="NotApplicable" SkipInVisitor="true" />
     <Field Name="ConversionSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
     <Field Name="AssignmentSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
+    <Field Name="ConstructionSteps" Type="ImmutableArray&lt;BoundDeconstructionConstructionStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
   </Node>
 
   <Node Name="BoundDeconstructionDeconstructStep" Base="BoundNode">
     <Field Name="DeconstructInvocationOpt" Type="BoundExpression" Null="allow"/>
-    <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
+    <Field Name="InputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
     <Field Name="OutputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;"/>
   </Node>
 
   <Node Name="BoundDeconstructionAssignmentStep" Base="BoundNode">
     <Field Name="Assignment" Type="BoundAssignmentOperator" Null="disallow"/>
-    <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
+    <Field Name="InputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
+    <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
+  </Node>
+
+  <Node Name="BoundDeconstructionConstructionStep" Base="BoundNode">
+    <Field Name="Construct" Type="BoundExpression" Null="disallow"/>
+    <Field Name="InputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;"/>
     <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -404,7 +404,7 @@
     <Field Name="Right" Type="BoundExpression"/>
 
     <Field Name="DeconstructSteps" Type="ImmutableArray&lt;BoundDeconstructionDeconstructStep&gt;" Null="NotApplicable" SkipInVisitor="true" />
-    <Field Name="ConversionSteps" Type="ImmutableArray&lt;BoundDeconstructionConversionStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
+    <Field Name="ConversionSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
     <Field Name="AssignmentSteps" Type="ImmutableArray&lt;BoundDeconstructionAssignmentStep&gt;" Null="NotApplicable" SkipInVisitor="true"/>
   </Node>
 
@@ -412,12 +412,6 @@
     <Field Name="DeconstructInvocationOpt" Type="BoundExpression" Null="allow"/>
     <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
     <Field Name="OutputPlaceholders" Type="ImmutableArray&lt;BoundDeconstructValuePlaceholder&gt;"/>
-  </Node>
-
-  <Node Name="BoundDeconstructionConversionStep" Base="BoundNode">
-    <Field Name="Conversion" Type="BoundExpression" Null="disallow"/>
-    <Field Name="TargetPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
-    <Field Name="OutputPlaceholder" Type="BoundDeconstructValuePlaceholder" Null="disallow"/>
   </Node>
 
   <Node Name="BoundDeconstructionAssignmentStep" Base="BoundNode">

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1743,7 +1743,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                if (!used && ConstructorNotSideEffecting(expression))
+                if (!used && ConstructorNotSideEffecting(expression.Constructor))
                 {
                     // creating nullable has no side-effects, so we will just evaluate the arguments
                     foreach (var arg in expression.Arguments)
@@ -1767,19 +1767,20 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
-        private bool ConstructorNotSideEffecting(BoundObjectCreationExpression expression)
+        private bool ConstructorNotSideEffecting(MethodSymbol constructor)
         {
-            var originalDef = expression.Constructor.OriginalDefinition;
+            var originalDef = constructor.OriginalDefinition;
+            var compilation = _module.Compilation;
 
-            return originalDef == _module.Compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T1__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T2__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T3__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T4__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T5__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T6__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T7__ctor) ||
-                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__ctor);
+            return originalDef == compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T1__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T2__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T3__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T4__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T5__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T6__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T7__ctor) ||
+                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__ctor);
         }
 
         private void EmitAssignmentExpression(BoundAssignmentOperator assignmentOperator, UseKind useKind)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1743,7 +1743,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                if (!used && ConstructorNotSideEffecting(expression.Constructor))
+                if (!used && ConstructorNotSideEffecting(constructor))
                 {
                     // creating nullable has no side-effects, so we will just evaluate the arguments
                     foreach (var arg in expression.Arguments)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1743,11 +1743,13 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
             else
             {
-                if (!used &&
-                    expression.Constructor.OriginalDefinition == _module.Compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor))
+                if (!used && ConstructorNotSideEffecting(expression))
                 {
-                    // creating nullable has no side-effects, so we will just evaluate the arg
-                    EmitExpression(expression.Arguments[0], used: false);
+                    // creating nullable has no side-effects, so we will just evaluate the arguments
+                    foreach (var arg in expression.Arguments)
+                    {
+                        EmitExpression(arg, used: false);
+                    }
                 }
                 else
                 {
@@ -1763,6 +1765,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                     EmitPopIfUnused(used);
                 }
             }
+        }
+
+        private bool ConstructorNotSideEffecting(BoundObjectCreationExpression expression)
+        {
+            var originalDef = expression.Constructor.OriginalDefinition;
+
+            return originalDef == _module.Compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T1__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T2__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T3__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T4__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T5__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T6__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T7__ctor) ||
+                originalDef == _module.Compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__ctor);
         }
 
         private void EmitAssignmentExpression(BoundAssignmentOperator assignmentOperator, UseKind useKind)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -1767,20 +1767,33 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
             }
         }
 
+        /// <summary>
+        /// Recognizes constructors known to not have side-effects (which means they can be skipped unless the constructed object is used)
+        /// </summary>
         private bool ConstructorNotSideEffecting(MethodSymbol constructor)
         {
             var originalDef = constructor.OriginalDefinition;
             var compilation = _module.Compilation;
 
-            return originalDef == compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T1__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T2__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T3__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T4__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T5__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T6__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T7__ctor) ||
-                originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__ctor);
+            if (originalDef == compilation.GetSpecialTypeMember(SpecialMember.System_Nullable_T__ctor))
+            {
+                return true;
+            }
+
+            if (originalDef.ContainingType.Name == TupleTypeSymbol.TupleTypeName &&
+                    (originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T2__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T3__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T4__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T5__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T6__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T7__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_TRest__ctor) ||
+                    originalDef == compilation.GetWellKnownTypeMember(WellKnownMember.System_ValueTuple_T1__ctor)))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         private void EmitAssignmentExpression(BoundAssignmentOperator assignmentOperator, UseKind useKind)
@@ -2729,7 +2742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         private void EmitInstrumentationPayloadRootStore(BoundInstrumentationPayloadRoot node)
         {
             _builder.EmitOpCode(ILOpCode.Stsfld);
-            EmitInstrumentationPayloadRootToken(node);  
+            EmitInstrumentationPayloadRootToken(node);
         }
 
         private void EmitInstrumentationPayloadRootToken(BoundInstrumentationPayloadRoot node)

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1859,10 +1859,10 @@ class C
                 Assert.Equal("(System.String, (System.Int32, System.Int32))", model.GetTypeInfo(literal).ConvertedType.ToTestDisplayString());
                 Assert.Equal(ConversionKind.ImplicitTupleLiteral, model.GetConversion(literal).Kind);
 
-                var nestedLiteral = literal.Arguments[1];
+                var nestedLiteral = literal.Arguments[1].Expression;
                 Assert.Equal(@"(1, 2)", nestedLiteral.ToString());
-                Assert.Null(model.GetTypeInfo(nestedLiteral).Type);
-                Assert.Null(model.GetTypeInfo(nestedLiteral).ConvertedType);
+                Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(nestedLiteral).Type.ToTestDisplayString());
+                Assert.Equal("(System.Int32, System.Int32)", model.GetTypeInfo(nestedLiteral).ConvertedType.ToTestDisplayString());
             };
 
             var comp = CompileAndVerify(source, expectedOutput: " (1, 2)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, sourceSymbolValidator: validator);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -86,25 +86,33 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       40 (0x28)
+  // Code size       48 (0x30)
   .maxstack  3
-  .locals init (string V_0, //y
-                int V_1,
-                string V_2)
+  .locals init (long V_0, //x
+                string V_1, //y
+                int V_2,
+                string V_3,
+                string V_4)
   IL_0000:  newobj     ""C..ctor()""
-  IL_0005:  ldloca.s   V_1
-  IL_0007:  ldloca.s   V_2
+  IL_0005:  ldloca.s   V_2
+  IL_0007:  ldloca.s   V_3
   IL_0009:  call       ""void C.Deconstruct(out int, out string)""
-  IL_000e:  ldloc.1
+  IL_000e:  ldloc.2
   IL_000f:  conv.i8
-  IL_0010:  ldloc.2
-  IL_0011:  stloc.0
-  IL_0012:  box        ""long""
-  IL_0017:  ldstr      "" ""
-  IL_001c:  ldloc.0
-  IL_001d:  call       ""string string.Concat(object, object, object)""
-  IL_0022:  call       ""void System.Console.WriteLine(string)""
-  IL_0027:  ret
+  IL_0010:  ldloc.3
+  IL_0011:  stloc.s    V_4
+  IL_0013:  dup
+  IL_0014:  stloc.0
+  IL_0015:  ldloc.s    V_4
+  IL_0017:  stloc.1
+  IL_0018:  pop
+  IL_0019:  ldloc.0
+  IL_001a:  box        ""long""
+  IL_001f:  ldstr      "" ""
+  IL_0024:  ldloc.1
+  IL_0025:  call       ""string string.Concat(object, object, object)""
+  IL_002a:  call       ""void System.Console.WriteLine(string)""
+  IL_002f:  ret
 }");
         }
 
@@ -246,8 +254,8 @@ class D2
 @"getHolderforX
 getHolderforY
 Constructor1
-Constructor2
 Conversion1
+Constructor2
 Conversion2
 setX
 setY
@@ -738,71 +746,82 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size      141 (0x8d)
+  // Code size      152 (0x98)
   .maxstack  10
-  .locals init (long V_0, //x
-                int V_1) //y
+  .locals init (int V_0, //y
+                long V_1,
+                long V_2,
+                long V_3,
+                long V_4,
+                long V_5,
+                long V_6,
+                long V_7,
+                long V_8,
+                long V_9,
+                int V_10)
   IL_0000:  ldc.i4.1
-  IL_0001:  ldc.i4.1
+  IL_0001:  conv.i8
   IL_0002:  ldc.i4.1
-  IL_0003:  ldc.i4.1
+  IL_0003:  conv.i8
   IL_0004:  ldc.i4.1
-  IL_0005:  ldc.i4.1
+  IL_0005:  conv.i8
   IL_0006:  ldc.i4.1
-  IL_0007:  ldc.i4.1
-  IL_0008:  ldc.i4.4
-  IL_0009:  ldc.i4.2
-  IL_000a:  newobj     ""System.ValueTuple<int, int, int>..ctor(int, int, int)""
-  IL_000f:  newobj     ""System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>..ctor(int, int, int, int, int, int, int, (int, int, int))""
-  IL_0014:  dup
-  IL_0015:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item1""
-  IL_001a:  conv.i8
-  IL_001b:  stloc.0
-  IL_001c:  dup
-  IL_001d:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item2""
-  IL_0022:  conv.i8
-  IL_0023:  stloc.0
+  IL_0007:  conv.i8
+  IL_0008:  ldc.i4.1
+  IL_0009:  conv.i8
+  IL_000a:  ldc.i4.1
+  IL_000b:  conv.i8
+  IL_000c:  ldc.i4.1
+  IL_000d:  conv.i8
+  IL_000e:  ldc.i4.1
+  IL_000f:  conv.i8
+  IL_0010:  ldc.i4.4
+  IL_0011:  conv.i8
+  IL_0012:  ldc.i4.2
+  IL_0013:  newobj     ""System.ValueTuple<long, long, int>..ctor(long, long, int)""
+  IL_0018:  newobj     ""System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>..ctor(long, long, long, long, long, long, long, (long, long, int))""
+  IL_001d:  dup
+  IL_001e:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item1""
+  IL_0023:  stloc.1
   IL_0024:  dup
-  IL_0025:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item3""
-  IL_002a:  conv.i8
-  IL_002b:  stloc.0
-  IL_002c:  dup
-  IL_002d:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item4""
-  IL_0032:  conv.i8
-  IL_0033:  stloc.0
-  IL_0034:  dup
-  IL_0035:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item5""
-  IL_003a:  conv.i8
-  IL_003b:  stloc.0
-  IL_003c:  dup
-  IL_003d:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item6""
-  IL_0042:  conv.i8
-  IL_0043:  stloc.0
-  IL_0044:  dup
-  IL_0045:  ldfld      ""int System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Item7""
-  IL_004a:  conv.i8
-  IL_004b:  stloc.0
-  IL_004c:  dup
-  IL_004d:  ldfld      ""(int, int, int) System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Rest""
-  IL_0052:  ldfld      ""int System.ValueTuple<int, int, int>.Item1""
-  IL_0057:  conv.i8
-  IL_0058:  stloc.0
-  IL_0059:  dup
-  IL_005a:  ldfld      ""(int, int, int) System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Rest""
-  IL_005f:  ldfld      ""int System.ValueTuple<int, int, int>.Item2""
-  IL_0064:  conv.i8
-  IL_0065:  stloc.0
-  IL_0066:  ldfld      ""(int, int, int) System.ValueTuple<int, int, int, int, int, int, int, (int, int, int)>.Rest""
-  IL_006b:  ldfld      ""int System.ValueTuple<int, int, int>.Item3""
-  IL_0070:  stloc.1
-  IL_0071:  ldloc.0
-  IL_0072:  box        ""long""
-  IL_0077:  ldstr      "" ""
-  IL_007c:  ldloc.1
-  IL_007d:  box        ""int""
-  IL_0082:  call       ""string string.Concat(object, object, object)""
-  IL_0087:  call       ""void System.Console.WriteLine(string)""
-  IL_008c:  ret
+  IL_0025:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item2""
+  IL_002a:  stloc.2
+  IL_002b:  dup
+  IL_002c:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item3""
+  IL_0031:  stloc.3
+  IL_0032:  dup
+  IL_0033:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item4""
+  IL_0038:  stloc.s    V_4
+  IL_003a:  dup
+  IL_003b:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item5""
+  IL_0040:  stloc.s    V_5
+  IL_0042:  dup
+  IL_0043:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item6""
+  IL_0048:  stloc.s    V_6
+  IL_004a:  dup
+  IL_004b:  ldfld      ""long System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Item7""
+  IL_0050:  stloc.s    V_7
+  IL_0052:  dup
+  IL_0053:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_0058:  ldfld      ""long System.ValueTuple<long, long, int>.Item1""
+  IL_005d:  stloc.s    V_8
+  IL_005f:  dup
+  IL_0060:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_0065:  ldfld      ""long System.ValueTuple<long, long, int>.Item2""
+  IL_006a:  stloc.s    V_9
+  IL_006c:  ldfld      ""(long, long, int) System.ValueTuple<long, long, long, long, long, long, long, (long, long, int)>.Rest""
+  IL_0071:  ldfld      ""int System.ValueTuple<long, long, int>.Item3""
+  IL_0076:  stloc.s    V_10
+  IL_0078:  ldloc.s    V_9
+  IL_007a:  ldloc.s    V_10
+  IL_007c:  stloc.0
+  IL_007d:  box        ""long""
+  IL_0082:  ldstr      "" ""
+  IL_0087:  ldloc.0
+  IL_0088:  box        ""int""
+  IL_008d:  call       ""string string.Concat(object, object, object)""
+  IL_0092:  call       ""void System.Console.WriteLine(string)""
+  IL_0097:  ret
 }
 ");
         }
@@ -825,7 +844,38 @@ class C
 ";
 
             var comp = CompileAndVerify(source, expectedOutput: "9 10", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
-            comp.VerifyDiagnostics();
+            comp.VerifyDiagnostics(
+                // (9,43): warning CS8123: The tuple element name 'a' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "a: 1").WithArguments("a").WithLocation(9, 43),
+                // (9,49): warning CS8123: The tuple element name 'b' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "b: 2").WithArguments("b").WithLocation(9, 49),
+                // (9,55): warning CS8123: The tuple element name 'c' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "c: 3").WithArguments("c").WithLocation(9, 55),
+                // (9,61): warning CS8123: The tuple element name 'd' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "d: 4").WithArguments("d").WithLocation(9, 61),
+                // (9,67): warning CS8123: The tuple element name 'e' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "e: 5").WithArguments("e").WithLocation(9, 67),
+                // (9,73): warning CS8123: The tuple element name 'f' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "f: 6").WithArguments("f").WithLocation(9, 73),
+                // (9,79): warning CS8123: The tuple element name 'g' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "g: 7").WithArguments("g").WithLocation(9, 79),
+                // (9,85): warning CS8123: The tuple element name 'h' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "h: 8").WithArguments("h").WithLocation(9, 85),
+                // (9,91): warning CS8123: The tuple element name 'i' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "i: 9").WithArguments("i").WithLocation(9, 91),
+                // (9,97): warning CS8123: The tuple element name 'j' is ignored because a different name is specified by the assignment target.
+                //         (x, x, x, x, x, x, x, x, x, y) = (a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10);
+                Diagnostic(ErrorCode.WRN_TupleLiteralNameMismatch, "j: 10").WithArguments("j").WithLocation(9, 97)
+                );
         }
 
         [Fact]
@@ -870,10 +920,12 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main", @"
 {
-  // Code size       48 (0x30)
+  // Code size       52 (0x34)
   .maxstack  3
   .locals init (string V_0, //x
-                string V_1) //y
+                string V_1, //y
+                string V_2,
+                string V_3)
   IL_0000:  ldstr      ""goodbye""
   IL_0005:  stloc.0
   IL_0006:  ldnull
@@ -881,15 +933,19 @@ class C
   IL_000c:  newobj     ""System.ValueTuple<string, string>..ctor(string, string)""
   IL_0011:  dup
   IL_0012:  ldfld      ""string System.ValueTuple<string, string>.Item1""
-  IL_0017:  stloc.0
+  IL_0017:  stloc.2
   IL_0018:  ldfld      ""string System.ValueTuple<string, string>.Item2""
-  IL_001d:  stloc.1
-  IL_001e:  ldstr      ""{0}{1}""
-  IL_0023:  ldloc.0
-  IL_0024:  ldloc.1
-  IL_0025:  call       ""string string.Format(string, object, object)""
-  IL_002a:  call       ""void System.Console.WriteLine(string)""
-  IL_002f:  ret
+  IL_001d:  stloc.3
+  IL_001e:  ldloc.2
+  IL_001f:  stloc.0
+  IL_0020:  ldloc.3
+  IL_0021:  stloc.1
+  IL_0022:  ldstr      ""{0}{1}""
+  IL_0027:  ldloc.0
+  IL_0028:  ldloc.1
+  IL_0029:  call       ""string string.Format(string, object, object)""
+  IL_002e:  call       ""void System.Console.WriteLine(string)""
+  IL_0033:  ret
 }
 ");
         }
@@ -932,7 +988,6 @@ class C
   IL_0011:  pop
   IL_0012:  ret
 }");
-            // TODO: should not emit ctor
         }
 
         [Fact]
@@ -1061,18 +1116,25 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Swap", @"
 {
-  // Code size       37 (0x25)
+  // Code size       41 (0x29)
   .maxstack  2
+  .locals init (int V_0,
+                int V_1)
   IL_0000:  ldsfld     ""int C.y""
   IL_0005:  ldsfld     ""int C.x""
   IL_000a:  newobj     ""System.ValueTuple<int, int>..ctor(int, int)""
   IL_000f:  dup
   IL_0010:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_0015:  stsfld     ""int C.x""
-  IL_001a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_001f:  stsfld     ""int C.y""
-  IL_0024:  ret
+  IL_0015:  stloc.0
+  IL_0016:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_001b:  stloc.1
+  IL_001c:  ldloc.0
+  IL_001d:  stsfld     ""int C.x""
+  IL_0022:  ldloc.1
+  IL_0023:  stsfld     ""int C.y""
+  IL_0028:  ret
 }
+
 ");
         }
 
@@ -2278,43 +2340,46 @@ class C
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       70 (0x46)
+  // Code size       72 (0x48)
   .maxstack  2
   .locals init (System.Collections.Generic.IEnumerator<(int, int)> V_0,
                 int V_1, //x1
-                int V_2) //x2
+                int V_2, //x2
+                int V_3)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<(int, int)> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<(int, int)> System.Collections.Generic.IEnumerable<(int, int)>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_0031
+    IL_000b:  br.s       IL_0033
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""(int, int) System.Collections.Generic.IEnumerator<(int, int)>.Current.get""
     IL_0013:  dup
     IL_0014:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-    IL_0019:  stloc.1
+    IL_0019:  stloc.3
     IL_001a:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-    IL_001f:  stloc.2
-    IL_0020:  ldloc.1
-    IL_0021:  box        ""int""
-    IL_0026:  ldloc.2
-    IL_0027:  box        ""int""
-    IL_002c:  call       ""void C.Print(object, object)""
-    IL_0031:  ldloc.0
-    IL_0032:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_0037:  brtrue.s   IL_000d
-    IL_0039:  leave.s    IL_0045
+    IL_001f:  ldloc.3
+    IL_0020:  stloc.1
+    IL_0021:  stloc.2
+    IL_0022:  ldloc.1
+    IL_0023:  box        ""int""
+    IL_0028:  ldloc.2
+    IL_0029:  box        ""int""
+    IL_002e:  call       ""void C.Print(object, object)""
+    IL_0033:  ldloc.0
+    IL_0034:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_0039:  brtrue.s   IL_000d
+    IL_003b:  leave.s    IL_0047
   }
   finally
   {
-    IL_003b:  ldloc.0
-    IL_003c:  brfalse.s  IL_0044
-    IL_003e:  ldloc.0
-    IL_003f:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_0044:  endfinally
+    IL_003d:  ldloc.0
+    IL_003e:  brfalse.s  IL_0046
+    IL_0040:  ldloc.0
+    IL_0041:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0046:  endfinally
   }
-  IL_0045:  ret
+  IL_0047:  ret
 }
 ");
         }
@@ -2363,57 +2428,60 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       91 (0x5b)
+  // Code size       95 (0x5f)
   .maxstack  4
   .locals init ((int, int)[] V_0,
                 int V_1,
                 int V_2, //x1
-                int V_3) //x2
+                int V_3, //x2
+                int V_4)
   IL_0000:  call       ""(int, int)[] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_0054
+  IL_0008:  br.s       IL_0058
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  ldelem     ""System.ValueTuple<int, int>""
   IL_0011:  dup
   IL_0012:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_0017:  stloc.2
-  IL_0018:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_001d:  stloc.3
-  IL_001e:  ldc.i4.4
-  IL_001f:  newarr     ""object""
-  IL_0024:  dup
-  IL_0025:  ldc.i4.0
-  IL_0026:  ldloc.2
-  IL_0027:  box        ""int""
-  IL_002c:  stelem.ref
-  IL_002d:  dup
-  IL_002e:  ldc.i4.1
-  IL_002f:  ldstr      "" ""
-  IL_0034:  stelem.ref
-  IL_0035:  dup
-  IL_0036:  ldc.i4.2
-  IL_0037:  ldloc.3
-  IL_0038:  box        ""int""
-  IL_003d:  stelem.ref
-  IL_003e:  dup
-  IL_003f:  ldc.i4.3
-  IL_0040:  ldstr      "" - ""
-  IL_0045:  stelem.ref
-  IL_0046:  call       ""string string.Concat(params object[])""
-  IL_004b:  call       ""void System.Console.Write(string)""
-  IL_0050:  ldloc.1
-  IL_0051:  ldc.i4.1
-  IL_0052:  add
-  IL_0053:  stloc.1
+  IL_0017:  stloc.s    V_4
+  IL_0019:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+  IL_001e:  ldloc.s    V_4
+  IL_0020:  stloc.2
+  IL_0021:  stloc.3
+  IL_0022:  ldc.i4.4
+  IL_0023:  newarr     ""object""
+  IL_0028:  dup
+  IL_0029:  ldc.i4.0
+  IL_002a:  ldloc.2
+  IL_002b:  box        ""int""
+  IL_0030:  stelem.ref
+  IL_0031:  dup
+  IL_0032:  ldc.i4.1
+  IL_0033:  ldstr      "" ""
+  IL_0038:  stelem.ref
+  IL_0039:  dup
+  IL_003a:  ldc.i4.2
+  IL_003b:  ldloc.3
+  IL_003c:  box        ""int""
+  IL_0041:  stelem.ref
+  IL_0042:  dup
+  IL_0043:  ldc.i4.3
+  IL_0044:  ldstr      "" - ""
+  IL_0049:  stelem.ref
+  IL_004a:  call       ""string string.Concat(params object[])""
+  IL_004f:  call       ""void System.Console.Write(string)""
   IL_0054:  ldloc.1
-  IL_0055:  ldloc.0
-  IL_0056:  ldlen
-  IL_0057:  conv.i4
-  IL_0058:  blt.s      IL_000a
-  IL_005a:  ret
+  IL_0055:  ldc.i4.1
+  IL_0056:  add
+  IL_0057:  stloc.1
+  IL_0058:  ldloc.1
+  IL_0059:  ldloc.0
+  IL_005a:  ldlen
+  IL_005b:  conv.i4
+  IL_005c:  blt.s      IL_000a
+  IL_005e:  ret
 }");
         }
 
@@ -2460,7 +2528,7 @@ class C
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size      106 (0x6a)
+  // Code size      110 (0x6e)
   .maxstack  3
   .locals init ((int, int)[,] V_0,
                 int V_1,
@@ -2468,7 +2536,8 @@ class C
                 int V_3,
                 int V_4,
                 int V_5, //x1
-                int V_6) //x2
+                int V_6, //x2
+                int V_7)
   IL_0000:  call       ""(int, int)[,] C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldloc.0
@@ -2483,41 +2552,43 @@ class C
   IL_0017:  ldc.i4.0
   IL_0018:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_001d:  stloc.3
-  IL_001e:  br.s       IL_0065
+  IL_001e:  br.s       IL_0069
   IL_0020:  ldloc.0
   IL_0021:  ldc.i4.1
   IL_0022:  callvirt   ""int System.Array.GetLowerBound(int)""
   IL_0027:  stloc.s    V_4
-  IL_0029:  br.s       IL_005c
+  IL_0029:  br.s       IL_0060
   IL_002b:  ldloc.0
   IL_002c:  ldloc.3
   IL_002d:  ldloc.s    V_4
   IL_002f:  call       ""(int, int)[*,*].Get""
   IL_0034:  dup
   IL_0035:  ldfld      ""int System.ValueTuple<int, int>.Item1""
-  IL_003a:  stloc.s    V_5
+  IL_003a:  stloc.s    V_7
   IL_003c:  ldfld      ""int System.ValueTuple<int, int>.Item2""
-  IL_0041:  stloc.s    V_6
-  IL_0043:  ldloc.s    V_5
-  IL_0045:  box        ""int""
-  IL_004a:  ldloc.s    V_6
-  IL_004c:  box        ""int""
-  IL_0051:  call       ""void C.Print(object, object)""
-  IL_0056:  ldloc.s    V_4
-  IL_0058:  ldc.i4.1
-  IL_0059:  add
-  IL_005a:  stloc.s    V_4
-  IL_005c:  ldloc.s    V_4
-  IL_005e:  ldloc.2
-  IL_005f:  ble.s      IL_002b
-  IL_0061:  ldloc.3
-  IL_0062:  ldc.i4.1
-  IL_0063:  add
-  IL_0064:  stloc.3
+  IL_0041:  ldloc.s    V_7
+  IL_0043:  stloc.s    V_5
+  IL_0045:  stloc.s    V_6
+  IL_0047:  ldloc.s    V_5
+  IL_0049:  box        ""int""
+  IL_004e:  ldloc.s    V_6
+  IL_0050:  box        ""int""
+  IL_0055:  call       ""void C.Print(object, object)""
+  IL_005a:  ldloc.s    V_4
+  IL_005c:  ldc.i4.1
+  IL_005d:  add
+  IL_005e:  stloc.s    V_4
+  IL_0060:  ldloc.s    V_4
+  IL_0062:  ldloc.2
+  IL_0063:  ble.s      IL_002b
   IL_0065:  ldloc.3
-  IL_0066:  ldloc.1
-  IL_0067:  ble.s      IL_0020
-  IL_0069:  ret
+  IL_0066:  ldc.i4.1
+  IL_0067:  add
+  IL_0068:  stloc.3
+  IL_0069:  ldloc.3
+  IL_006a:  ldloc.1
+  IL_006b:  ble.s      IL_0020
+  IL_006d:  ret
 }");
         }
 
@@ -2571,18 +2642,19 @@ static class Extension
             comp.VerifyDiagnostics();
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       60 (0x3c)
+  // Code size       64 (0x40)
   .maxstack  3
   .locals init (string V_0,
                 int V_1,
                 int V_2, //x2
                 int V_3,
-                int V_4)
+                int V_4,
+                int V_5)
   IL_0000:  call       ""string C.M()""
   IL_0005:  stloc.0
   IL_0006:  ldc.i4.0
   IL_0007:  stloc.1
-  IL_0008:  br.s       IL_0032
+  IL_0008:  br.s       IL_0036
   IL_000a:  ldloc.0
   IL_000b:  ldloc.1
   IL_000c:  callvirt   ""char string.this[int].get""
@@ -2591,20 +2663,22 @@ static class Extension
   IL_0015:  call       ""void Extension.Deconstruct(char, out int, out int)""
   IL_001a:  ldloc.3
   IL_001b:  ldloc.s    V_4
-  IL_001d:  stloc.2
-  IL_001e:  box        ""int""
-  IL_0023:  ldloc.2
-  IL_0024:  box        ""int""
-  IL_0029:  call       ""void C.Print(object, object)""
-  IL_002e:  ldloc.1
-  IL_002f:  ldc.i4.1
-  IL_0030:  add
-  IL_0031:  stloc.1
+  IL_001d:  stloc.s    V_5
+  IL_001f:  ldloc.s    V_5
+  IL_0021:  stloc.2
+  IL_0022:  box        ""int""
+  IL_0027:  ldloc.2
+  IL_0028:  box        ""int""
+  IL_002d:  call       ""void C.Print(object, object)""
   IL_0032:  ldloc.1
-  IL_0033:  ldloc.0
-  IL_0034:  callvirt   ""int string.Length.get""
-  IL_0039:  blt.s      IL_000a
-  IL_003b:  ret
+  IL_0033:  ldc.i4.1
+  IL_0034:  add
+  IL_0035:  stloc.1
+  IL_0036:  ldloc.1
+  IL_0037:  ldloc.0
+  IL_0038:  callvirt   ""int string.Length.get""
+  IL_003d:  blt.s      IL_000a
+  IL_003f:  ret
 }");
         }
 
@@ -2791,7 +2865,7 @@ Deconstructing (5, 6)
 
             comp.VerifyIL("C.Main",
 @"{
-  // Code size       90 (0x5a)
+  // Code size       98 (0x62)
   .maxstack  3
   .locals init (System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> V_0,
                 int V_1, //x2
@@ -2799,13 +2873,15 @@ Deconstructing (5, 6)
                 int V_3,
                 Pair<int, int> V_4,
                 int V_5,
-                int V_6)
+                int V_6,
+                int V_7,
+                int V_8)
   IL_0000:  call       ""System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>> C.M()""
   IL_0005:  callvirt   ""System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>> System.Collections.Generic.IEnumerable<Pair<int, Pair<int, int>>>.GetEnumerator()""
   IL_000a:  stloc.0
   .try
   {
-    IL_000b:  br.s       IL_0045
+    IL_000b:  br.s       IL_004d
     IL_000d:  ldloc.0
     IL_000e:  callvirt   ""Pair<int, Pair<int, int>> System.Collections.Generic.IEnumerator<Pair<int, Pair<int, int>>>.Current.get""
     IL_0013:  ldloca.s   V_3
@@ -2818,29 +2894,33 @@ Deconstructing (5, 6)
     IL_0027:  ldloc.3
     IL_0028:  conv.i8
     IL_0029:  ldloc.s    V_5
-    IL_002b:  stloc.1
-    IL_002c:  ldloc.s    V_6
-    IL_002e:  stloc.2
-    IL_002f:  box        ""long""
-    IL_0034:  ldloc.1
-    IL_0035:  box        ""int""
-    IL_003a:  ldloc.2
-    IL_003b:  box        ""int""
-    IL_0040:  call       ""void C.Print(object, object, object)""
-    IL_0045:  ldloc.0
-    IL_0046:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
-    IL_004b:  brtrue.s   IL_000d
-    IL_004d:  leave.s    IL_0059
+    IL_002b:  stloc.s    V_7
+    IL_002d:  ldloc.s    V_6
+    IL_002f:  stloc.s    V_8
+    IL_0031:  ldloc.s    V_7
+    IL_0033:  stloc.1
+    IL_0034:  ldloc.s    V_8
+    IL_0036:  stloc.2
+    IL_0037:  box        ""long""
+    IL_003c:  ldloc.1
+    IL_003d:  box        ""int""
+    IL_0042:  ldloc.2
+    IL_0043:  box        ""int""
+    IL_0048:  call       ""void C.Print(object, object, object)""
+    IL_004d:  ldloc.0
+    IL_004e:  callvirt   ""bool System.Collections.IEnumerator.MoveNext()""
+    IL_0053:  brtrue.s   IL_000d
+    IL_0055:  leave.s    IL_0061
   }
   finally
   {
-    IL_004f:  ldloc.0
-    IL_0050:  brfalse.s  IL_0058
-    IL_0052:  ldloc.0
-    IL_0053:  callvirt   ""void System.IDisposable.Dispose()""
-    IL_0058:  endfinally
+    IL_0057:  ldloc.0
+    IL_0058:  brfalse.s  IL_0060
+    IL_005a:  ldloc.0
+    IL_005b:  callvirt   ""void System.IDisposable.Dispose()""
+    IL_0060:  endfinally
   }
-  IL_0059:  ret
+  IL_0061:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1039,6 +1039,25 @@ class C
         }
 
         [Fact]
+        public void ValueTupleReturnIsEmittedIfUsedInLambda()
+        {
+            string source = @"
+class C
+{
+    static void F(System.Action a) { }
+    static void F<T>(System.Func<T> f) { System.Console.Write(f().ToString()); }
+    static void Main()
+    {
+        int x, y;
+        F(() => (x, y) = (1, 2));
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "(1, 2)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void AssigningIntoProperties()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -201,8 +201,8 @@ getHolderforY
 getDeconstructReceiver
 Deconstruct
 Conversion1
-setX
 Conversion2
+setX
 setY
 ";
             var comp = CompileAndVerify(source, expectedOutput: expected);

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -1070,6 +1070,32 @@ class C
         }
 
         [Fact]
+        public void NestedAssignmentTypeIsValueTuple()
+        {
+            string source = @"
+class C
+{
+    public static void Main()
+    {
+        long x1; string x2; int x3;
+
+        var y = ((x1, x2), x3) = (new C(), 3);
+
+        System.Console.Write($""{y.ToString()}"");
+    }
+
+    public void Deconstruct(out int a, out string b)
+    {
+        a = 1;
+        b = ""hello"";
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "((1, hello), 3)", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
         public void AssignmentReturnsLongValueTuple()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -1104,6 +1104,33 @@ class C
         }
 
         [Fact]
+        public void DeconstructWithoutValueTupleLibrary()
+        {
+            string source = @"
+class C
+{
+    public static void Main()
+    {
+        long x;
+        var y = (x, x) = new C();
+        System.Console.Write(y.ToString());
+    }
+
+    public void Deconstruct(out int x1, out int x2)
+    {
+        x1 = x2 = 1;
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.VerifyDiagnostics(
+                // (7,17): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         var y = (x, x) = new C();
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(x, x) = new C()").WithArguments("System.ValueTuple`2").WithLocation(7, 17)
+                );
+        }
+
+        [Fact]
         public void NestedTypelessTupleAssignment2()
         {
             string source = @"


### PR DESCRIPTION
With this change, `var t = (x, y) = (1, 2);` is now allowed and `t` is a tuple.
This works with long tuples and nested deconstruction as well.

In the process, I had to include the fix for the evaluation order. The new order is:
1. Evaluate all the LHS variables for side-effects
2. Evaluate all the RHS elements (with conversions for tuple literals) 
      - If the RHS is a tuple literal (even if it has a natural type), it gets a type by conversion to a "merged tuple type"
3. Do all deconstructions
4. Apply Conversions
5. Assign converted values to LHS variables
6. Produce a tuple with the converted values (that construction of `ValueTuple` is not emitted unless it is consumed, as we require the construction of `ValueTuple` to be side-effect-free)

As a result of this change, you need to reference the ValueTuple library whenever using deconstructions.

Also, you can see that more locals are created to store the outputs of conversions at step (4). I think we should be able to optimize in some more cases.

Fixes https://github.com/dotnet/roslyn/issues/12635 (return type) and https://github.com/dotnet/roslyn/issues/12400 (evaluation order).

FYI for @MadsTorgersen regarding evaluation order.