### PR TITLE
move newtonsoft.Json version back to 6.0.6

### DIFF
--- a/src/VisualStudio/Setup.Next/project.json
+++ b/src/VisualStudio/Setup.Next/project.json
@@ -1,7 +1,7 @@
 ﻿{
   "dependencies": {
     "StreamJsonRpc": "0.14.3-alpha",
-    "Newtonsoft.Json": "8.0.3",
+    "Newtonsoft.Json": "6.0.6",
     "RoslynDependencies.Microsoft.VisualStudio.CallHierarchy.Package.Definitions": {
         "version": "14.3.25407",
         "suppressParent": "all"


### PR DESCRIPTION
this NewtonSoft.Json is for service hub client/JsonRpc library we use in service hub and its dependency is on 6.0.6.

the lib version we are using is version shipped with preview 3. we will move newer version when we move to preview 4.

