### PR TITLE
Abort completion commit when buffer is unmapped

### DIFF
--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/CommonDiagnosticComparer.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/CommonDiagnosticComparer.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal sealed class CommonDiagnosticComparer : IEqualityComparer<Diagnostic>
+    {
+        internal static readonly CommonDiagnosticComparer Instance = new CommonDiagnosticComparer();
+
+        private CommonDiagnosticComparer()
+        {
+        }
+
+        public bool Equals(Diagnostic x, Diagnostic y)
+        {
+            if (object.ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return x.Location == y.Location && x.Id == y.Id;
+        }
+
+        public int GetHashCode(Diagnostic obj)
+        {
+            if (object.ReferenceEquals(obj, null))
+            {
+                return 0;
+            }
+
+            return Hash.Combine(obj.Location, obj.Id.GetHashCode());
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/CommonMessageProvider.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/CommonMessageProvider.cs
@@ -1,0 +1,222 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Abstracts the ability to classify and load messages for error codes. Allows the error
+    /// infrastructure to be reused between C# and VB.
+    /// </summary>
+    internal abstract class CommonMessageProvider
+    {
+        /// <summary>
+        /// Given an error code, get the severity (warning or error) of the code.
+        /// </summary>
+        public abstract DiagnosticSeverity GetSeverity(int code);
+
+        /// <summary>
+        /// Load the message for the given error code. If the message contains
+        /// "fill-in" placeholders, those should be expressed in standard string.Format notation
+        /// and be in the string.
+        /// </summary>
+        public abstract string LoadMessage(int code, CultureInfo language);
+
+        /// <summary>
+        /// Get an optional localizable title for the given diagnostic code.
+        /// </summary>
+        public abstract LocalizableString GetTitle(int code);
+
+        /// <summary>
+        /// Get an optional localizable description for the given diagnostic code.
+        /// </summary>
+        public abstract LocalizableString GetDescription(int code);
+
+        /// <summary>
+        /// Get a localizable message format string for the given diagnostic code.
+        /// </summary>
+        public abstract LocalizableString GetMessageFormat(int code);
+
+        /// <summary>
+        /// Get an optional help link for the given diagnostic code.
+        /// </summary>
+        public abstract string GetHelpLink(int code);
+
+        /// <summary>
+        /// Get the diagnostic category for the given diagnostic code.
+        /// Default category is <see cref="Diagnostic.CompilerDiagnosticCategory"/>.
+        /// </summary>
+        public abstract string GetCategory(int code);
+
+        /// <summary>
+        /// Get the text prefix (e.g., "CS" for C#) used on error messages.
+        /// </summary>
+        public abstract string CodePrefix { get; }
+
+        /// <summary>
+        /// Get the warning level for warnings (e.g., 1 through 4 for C#). VB does not have warning
+        /// levels and always uses 1. Errors should return 0.
+        /// </summary>
+        public abstract int GetWarningLevel(int code);
+
+        /// <summary>
+        /// Type that defines error codes. For testing purposes only.
+        /// </summary>
+        public abstract Type ErrorCodeType { get; }
+
+        /// <summary>
+        /// Create a simple language specific diagnostic for given error code.
+        /// </summary>
+        public Diagnostic CreateDiagnostic(int code, Location location)
+        {
+            return CreateDiagnostic(code, location, SpecializedCollections.EmptyObjects);
+        }
+
+        /// <summary>
+        /// Create a simple language specific diagnostic for given error code.
+        /// </summary>
+        public abstract Diagnostic CreateDiagnostic(int code, Location location, params object[] args);
+
+        /// <summary>
+        /// Given a message identifier (e.g., CS0219), severity, warning as error and a culture, 
+        /// get the entire prefix (e.g., "error CS0219: Warning as Error:" for C# or "error BC42024:" for VB) used on error messages.
+        /// </summary>
+        public abstract string GetMessagePrefix(string id, DiagnosticSeverity severity, bool isWarningAsError, CultureInfo culture);
+
+        /// <summary>
+        /// Convert given symbol to string representation.
+        /// </summary>
+        public abstract string GetErrorDisplayString(ISymbol symbol);
+
+        /// <summary>
+        /// Given an error code (like 1234) return the identifier (CS1234 or BC1234).
+        /// </summary>
+        public string GetIdForErrorCode(int errorCode)
+        {
+            return CodePrefix + errorCode.ToString("0000");
+        }
+
+        /// <summary>
+        /// Produces the filtering action for the diagnostic based on the options passed in.
+        /// </summary>
+        /// <returns>
+        /// A new <see cref="DiagnosticInfo"/> with new effective severity based on the options or null if the
+        /// diagnostic has been suppressed.
+        /// </returns>
+        public abstract ReportDiagnostic GetDiagnosticReport(DiagnosticInfo diagnosticInfo, CompilationOptions options);
+
+        /// <summary>
+        /// Filter a <see cref="DiagnosticInfo"/> based on the compilation options so that /nowarn and /warnaserror etc. take effect.options
+        /// </summary>
+        /// <returns>A <see cref="DiagnosticInfo"/> with effective severity based on option or null if suppressed.</returns>
+        public DiagnosticInfo FilterDiagnosticInfo(DiagnosticInfo diagnosticInfo, CompilationOptions options)
+        {
+            var report = this.GetDiagnosticReport(diagnosticInfo, options);
+            switch (report)
+            {
+                case ReportDiagnostic.Error:
+                    return diagnosticInfo.GetInstanceWithSeverity(DiagnosticSeverity.Error);
+                case ReportDiagnostic.Warn:
+                    return diagnosticInfo.GetInstanceWithSeverity(DiagnosticSeverity.Warning);
+                case ReportDiagnostic.Info:
+                    return diagnosticInfo.GetInstanceWithSeverity(DiagnosticSeverity.Info);
+                case ReportDiagnostic.Hidden:
+                    return diagnosticInfo.GetInstanceWithSeverity(DiagnosticSeverity.Hidden);
+                case ReportDiagnostic.Suppress:
+                    return null;
+                default:
+                    return diagnosticInfo;
+            }
+        }
+
+        // Common error messages 
+
+        public abstract int ERR_FailedToCreateTempFile { get; }
+
+        // command line:
+        public abstract int ERR_ExpectedSingleScript { get; }
+        public abstract int ERR_OpenResponseFile { get; }
+        public abstract int ERR_InvalidPathMap { get; }
+        public abstract int FTL_InputFileNameTooLong { get; }
+        public abstract int ERR_FileNotFound { get; }
+        public abstract int ERR_NoSourceFile { get; }
+        public abstract int ERR_CantOpenFileWrite { get; }
+        public abstract int ERR_OutputWriteFailed { get; }
+        public abstract int WRN_NoConfigNotOnCommandLine { get; }
+        public abstract int ERR_BinaryFile { get; }
+        public abstract int WRN_UnableToLoadAnalyzer { get; }
+        public abstract int INF_UnableToLoadSomeTypesInAnalyzer { get; }
+        public abstract int WRN_AnalyzerCannotBeCreated { get; }
+        public abstract int WRN_NoAnalyzerInAssembly { get; }
+        public abstract int ERR_CantReadRulesetFile { get; }
+        public abstract int ERR_CompileCancelled { get; }
+
+        // compilation options:
+        public abstract int ERR_BadCompilationOptionValue { get; }
+        public abstract int ERR_MutuallyExclusiveOptions { get; }
+
+        // emit options:
+        public abstract int ERR_InvalidDebugInformationFormat { get; }
+        public abstract int ERR_InvalidFileAlignment { get; }
+        public abstract int ERR_InvalidSubsystemVersion { get; }
+        public abstract int ERR_InvalidOutputName { get; }
+
+        // reference manager:
+        public abstract int ERR_MetadataFileNotAssembly { get; }
+        public abstract int ERR_MetadataFileNotModule { get; }
+        public abstract int ERR_InvalidAssemblyMetadata { get; }
+        public abstract int ERR_InvalidModuleMetadata { get; }
+        public abstract int ERR_ErrorOpeningAssemblyFile { get; }
+        public abstract int ERR_ErrorOpeningModuleFile { get; }
+        public abstract int ERR_MetadataFileNotFound { get; }
+        public abstract int ERR_MetadataReferencesNotSupported { get; }
+        public abstract int ERR_LinkedNetmoduleMetadataMustProvideFullPEImage { get; }
+
+        public abstract void ReportDuplicateMetadataReferenceStrong(DiagnosticBag diagnostics, Location location, MetadataReference reference, AssemblyIdentity identity, MetadataReference equivalentReference, AssemblyIdentity equivalentIdentity);
+        public abstract void ReportDuplicateMetadataReferenceWeak(DiagnosticBag diagnostics, Location location, MetadataReference reference, AssemblyIdentity identity, MetadataReference equivalentReference, AssemblyIdentity equivalentIdentity);
+
+        // signing:
+        public abstract int ERR_PublicKeyFileFailure { get; }
+        public abstract int ERR_PublicKeyContainerFailure { get; }
+        public abstract int ERR_OptionMustBeAbsolutePath { get; }
+
+        // resources:
+        public abstract int ERR_CantReadResource { get; }
+        public abstract int ERR_CantOpenWin32Resource { get; }
+        public abstract int ERR_CantOpenWin32Manifest { get; }
+        public abstract int ERR_CantOpenWin32Icon { get; }
+        public abstract int ERR_BadWin32Resource { get; }
+        public abstract int ERR_ErrorBuildingWin32Resource { get; }
+        public abstract int ERR_ResourceNotUnique { get; }
+        public abstract int ERR_ResourceFileNameNotUnique { get; }
+        public abstract int ERR_ResourceInModule { get; }
+
+        // pseudo-custom attributes:
+        public abstract int ERR_PermissionSetAttributeFileReadError { get; }
+
+        // PDB writing:
+        public abstract int WRN_PdbUsingNameTooLong { get; }
+        public abstract int WRN_PdbLocalNameTooLong { get; }
+        public abstract int ERR_PdbWritingFailed { get; }
+
+        // PE writing:
+        public abstract int ERR_MetadataNameTooLong { get; }
+        public abstract int ERR_EncReferenceToAddedMember { get; }
+        public abstract int ERR_TooManyUserStrings { get; }
+        public abstract int ERR_PeWritingFailure { get; }
+        public abstract int ERR_ModuleEmitFailure { get; }
+        public abstract int ERR_EncUpdateFailedMissingAttribute { get; }
+
+        public abstract void ReportInvalidAttributeArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, AttributeData attribute);
+        public abstract void ReportInvalidNamedArgument(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex, ITypeSymbol attributeClass, string parameterName);
+        public abstract void ReportParameterNotValidForType(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int namedArgumentIndex);
+
+        public abstract void ReportMarshalUnmanagedTypeNotValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
+        public abstract void ReportMarshalUnmanagedTypeOnlyValidForFields(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, int parameterIndex, string unmanagedTypeName, AttributeData attribute);
+
+        public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName);
+        public abstract void ReportAttributeParameterRequired(DiagnosticBag diagnostics, SyntaxNode attributeSyntax, string parameterName1, string parameterName2);
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/Diagnostic.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/Diagnostic.cs
@@ -1,0 +1,508 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a diagnostic, such as a compiler error or a warning, along with the location where it occurred.
+    /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    public abstract partial class Diagnostic : IEquatable<Diagnostic>, IFormattable
+    {
+        internal const string CompilerDiagnosticCategory = "Compiler";
+
+        /// <summary>
+        /// Highest valid warning level for non-error diagnostics.
+        /// </summary>
+        internal const int HighestValidWarningLevel = 4;
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance.
+        /// </summary>
+        /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="messageArgs">Arguments to the message of the diagnostic</param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            DiagnosticDescriptor descriptor,
+            Location location,
+            params object[] messageArgs)
+        {
+            return Create(descriptor, location, null, null, messageArgs);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance.
+        /// </summary>
+        /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="properties">
+        /// An optional set of name-value pairs by means of which the analyzer that creates the diagnostic
+        /// can convey more detailed information to the fixer. If null, <see cref="Properties"/> will return
+        /// <see cref="ImmutableDictionary{TKey, TValue}.Empty"/>.
+        /// </param>
+        /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            DiagnosticDescriptor descriptor,
+            Location location,
+            ImmutableDictionary<string, string> properties,
+            params object[] messageArgs)
+        {
+            return Create(descriptor, location, null, properties, messageArgs);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance.
+        /// </summary>
+        /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="additionalLocations">
+        /// An optional set of additional locations related to the diagnostic.
+        /// Typically, these are locations of other items referenced in the message.
+        /// If null, <see cref="AdditionalLocations"/> will return an empty list.
+        /// </param>
+        /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            DiagnosticDescriptor descriptor,
+            Location location,
+            IEnumerable<Location> additionalLocations,
+            params object[] messageArgs)
+        {
+            return Create(descriptor, location, additionalLocations, properties: null, messageArgs: messageArgs);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance.
+        /// </summary>
+        /// <param name="descriptor">A <see cref="DiagnosticDescriptor"/> describing the diagnostic.</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="additionalLocations">
+        /// An optional set of additional locations related to the diagnostic.
+        /// Typically, these are locations of other items referenced in the message.
+        /// If null, <see cref="AdditionalLocations"/> will return an empty list.
+        /// </param>
+        /// <param name="properties">
+        /// An optional set of name-value pairs by means of which the analyzer that creates the diagnostic
+        /// can convey more detailed information to the fixer. If null, <see cref="Properties"/> will return
+        /// <see cref="ImmutableDictionary{TKey, TValue}.Empty"/>.
+        /// </param>
+        /// <param name="messageArgs">Arguments to the message of the diagnostic.</param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            DiagnosticDescriptor descriptor,
+            Location location,
+            IEnumerable<Location> additionalLocations,
+            ImmutableDictionary<string, string> properties,
+            params object[] messageArgs)
+        {
+            if (descriptor == null)
+            {
+                throw new ArgumentNullException(nameof(descriptor));
+            }
+
+            var warningLevel = GetDefaultWarningLevel(descriptor.DefaultSeverity);
+            return SimpleDiagnostic.Create(
+                descriptor,
+                severity: descriptor.DefaultSeverity,
+                warningLevel: warningLevel,
+                location: location ?? Location.None,
+                additionalLocations: additionalLocations,
+                messageArgs: messageArgs,
+                properties: properties);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance which is localizable.
+        /// </summary>
+        /// <param name="id">An identifier for the diagnostic. For diagnostics generated by the compiler, this will be a numeric code with a prefix such as "CS1001".</param>
+        /// <param name="category">The category of the diagnostic. For diagnostics generated by the compiler, the category will be "Compiler".</param>
+        /// <param name="message">The diagnostic message text.</param>
+        /// <param name="severity">The diagnostic's effective severity.</param>
+        /// <param name="defaultSeverity">The diagnostic's default severity.</param>
+        /// <param name="isEnabledByDefault">True if the diagnostic is enabled by default</param>
+        /// <param name="warningLevel">The warning level, between 1 and 4 if severity is <see cref="DiagnosticSeverity.Warning"/>; otherwise 0.</param>
+        /// <param name="title">An optional short localizable title describing the diagnostic.</param>
+        /// <param name="description">An optional longer localizable description for the diagnostic.</param>
+        /// <param name="helpLink">An optional hyperlink that provides more detailed information regarding the diagnostic.</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="additionalLocations">
+        /// An optional set of additional locations related to the diagnostic.
+        /// Typically, these are locations of other items referenced in the message.
+        /// If null, <see cref="AdditionalLocations"/> will return an empty list.
+        /// </param>
+        /// <param name="customTags">
+        /// An optional set of custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.
+        /// If null, <see cref="CustomTags"/> will return an empty list.
+        /// </param>
+        /// <param name="properties">
+        /// An optional set of name-value pairs by means of which the analyzer that creates the diagnostic
+        /// can convey more detailed information to the fixer. If null, <see cref="Properties"/> will return
+        /// <see cref="ImmutableDictionary{TKey, TValue}.Empty"/>.
+        /// </param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            string id,
+            string category,
+            LocalizableString message,
+            DiagnosticSeverity severity,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            int warningLevel,
+            LocalizableString title = null,
+            LocalizableString description = null,
+            string helpLink = null,
+            Location location = null,
+            IEnumerable<Location> additionalLocations = null,
+            IEnumerable<string> customTags = null,
+            ImmutableDictionary<string, string> properties = null)
+        {
+            return Create(id, category, message, severity, defaultSeverity, isEnabledByDefault, warningLevel, false,
+                title, description, helpLink, location, additionalLocations, customTags, properties);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Diagnostic"/> instance which is localizable.
+        /// </summary>
+        /// <param name="id">An identifier for the diagnostic. For diagnostics generated by the compiler, this will be a numeric code with a prefix such as "CS1001".</param>
+        /// <param name="category">The category of the diagnostic. For diagnostics generated by the compiler, the category will be "Compiler".</param>
+        /// <param name="message">The diagnostic message text.</param>
+        /// <param name="severity">The diagnostic's effective severity.</param>
+        /// <param name="defaultSeverity">The diagnostic's default severity.</param>
+        /// <param name="isEnabledByDefault">True if the diagnostic is enabled by default</param>
+        /// <param name="warningLevel">The warning level, between 1 and 4 if severity is <see cref="DiagnosticSeverity.Warning"/>; otherwise 0.</param>
+        /// <param name="isSuppressed">Flag indicating whether the diagnostic is suppressed by a source suppression.</param>
+        /// <param name="title">An optional short localizable title describing the diagnostic.</param>
+        /// <param name="description">An optional longer localizable description for the diagnostic.</param>
+        /// <param name="helpLink">An optional hyperlink that provides more detailed information regarding the diagnostic.</param>
+        /// <param name="location">An optional primary location of the diagnostic. If null, <see cref="Location"/> will return <see cref="Location.None"/>.</param>
+        /// <param name="additionalLocations">
+        /// An optional set of additional locations related to the diagnostic.
+        /// Typically, these are locations of other items referenced in the message.
+        /// If null, <see cref="AdditionalLocations"/> will return an empty list.
+        /// </param>
+        /// <param name="customTags">
+        /// An optional set of custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.
+        /// If null, <see cref="CustomTags"/> will return an empty list.
+        /// </param>
+        /// <param name="properties">
+        /// An optional set of name-value pairs by means of which the analyzer that creates the diagnostic
+        /// can convey more detailed information to the fixer. If null, <see cref="Properties"/> will return
+        /// <see cref="ImmutableDictionary{TKey, TValue}.Empty"/>.
+        /// </param>
+        /// <returns>The <see cref="Diagnostic"/> instance.</returns>
+        public static Diagnostic Create(
+            string id,
+            string category,
+            LocalizableString message,
+            DiagnosticSeverity severity,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            int warningLevel,
+            bool isSuppressed,
+            LocalizableString title = null,
+            LocalizableString description = null,
+            string helpLink = null,
+            Location location = null,
+            IEnumerable<Location> additionalLocations = null,
+            IEnumerable<string> customTags = null,
+            ImmutableDictionary<string, string> properties = null)
+        {
+            if (id == null)
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (category == null)
+            {
+                throw new ArgumentNullException(nameof(category));
+            }
+
+            if (message == null)
+            {
+                throw new ArgumentNullException(nameof(message));
+            }
+
+            return SimpleDiagnostic.Create(id, title ?? string.Empty, category, message, description ?? string.Empty, helpLink ?? string.Empty,
+                severity, defaultSeverity, isEnabledByDefault, warningLevel, location ?? Location.None, additionalLocations, customTags, properties, isSuppressed);
+        }
+
+        internal static Diagnostic Create(CommonMessageProvider messageProvider, int errorCode)
+        {
+            return Create(new DiagnosticInfo(messageProvider, errorCode));
+        }
+
+        internal static Diagnostic Create(CommonMessageProvider messageProvider, int errorCode, params object[] arguments)
+        {
+            return Create(new DiagnosticInfo(messageProvider, errorCode, arguments));
+        }
+
+        internal static Diagnostic Create(DiagnosticInfo info)
+        {
+            return new DiagnosticWithInfo(info, Location.None);
+        }
+
+        /// <summary>
+        /// Gets the diagnostic descriptor, which provides a description about a <see cref="Diagnostic"/>.
+        /// </summary>
+        public abstract DiagnosticDescriptor Descriptor { get; }
+
+        /// <summary>
+        /// Gets the diagnostic identifier. For diagnostics generated by the compiler, this will be a numeric code with a prefix such as "CS1001".
+        /// </summary>
+        public abstract string Id { get; }
+
+        /// <summary>
+        /// Gets the category of diagnostic. For diagnostics generated by the compiler, the category will be "Compiler".
+        /// </summary>
+        internal virtual string Category { get { return this.Descriptor.Category; } }
+
+        /// <summary>
+        /// Get the culture specific text of the message.
+        /// </summary>
+        public abstract string GetMessage(IFormatProvider formatProvider = null);
+
+        /// <summary>
+        /// Gets the default <see cref="DiagnosticSeverity"/> of the diagnostic's <see cref="DiagnosticDescriptor"/>.
+        /// </summary>
+        /// <remarks>
+        /// To get the effective severity of the diagnostic, use <see cref="Severity"/>.
+        /// </remarks>
+        public virtual DiagnosticSeverity DefaultSeverity { get { return this.Descriptor.DefaultSeverity; } }
+
+        /// <summary>
+        /// Gets the effective <see cref="DiagnosticSeverity"/> of the diagnostic.
+        /// </summary>
+        /// <remarks>
+        /// To get the default severity of diagnostic's <see cref="DiagnosticDescriptor"/>, use <see cref="DefaultSeverity"/>.
+        /// To determine if this is a warning treated as an error, use <see cref="IsWarningAsError"/>.
+        /// </remarks>
+        public abstract DiagnosticSeverity Severity { get; }
+
+        /// <summary>
+        /// Gets the warning level. This is 0 for diagnostics with severity <see cref="DiagnosticSeverity.Error"/>,
+        /// otherwise an integer between 1 and 4.
+        /// </summary>
+        public abstract int WarningLevel { get; }
+
+        /// <summary>
+        /// Returns true if the diagnostic has a source suppression, i.e. an attribute or a pragma suppression.
+        /// </summary>
+        public abstract bool IsSuppressed { get; }
+
+        /// <summary>
+        /// Gets the <see cref="SuppressionInfo"/> for suppressed diagnostics, i.e. <see cref="IsSuppressed"/> = true.
+        /// Otherwise, returns null.
+        /// </summary>
+        public SuppressionInfo GetSuppressionInfo(Compilation compilation)
+        {
+            if (!IsSuppressed)
+            {
+                return null;
+            }
+
+            AttributeData attribute;
+            var suppressMessageState = new SuppressMessageAttributeState(compilation);
+            if (!suppressMessageState.IsDiagnosticSuppressed(this, out attribute))
+            {
+                attribute = null;
+            }
+
+            return new SuppressionInfo(this.Id, attribute);
+        }
+
+        /// <summary>
+        /// Returns true if this diagnostic is enabled by default by the author of the diagnostic.
+        /// </summary>
+        internal virtual bool IsEnabledByDefault { get { return this.Descriptor.IsEnabledByDefault; } }
+
+        /// <summary>
+        /// Returns true if this is a warning treated as an error; otherwise false.
+        /// </summary>
+        /// <remarks>
+        /// True implies <see cref="DefaultSeverity"/> = <see cref="DiagnosticSeverity.Warning"/>
+        /// and <see cref="Severity"/> = <see cref="DiagnosticSeverity.Error"/>.
+        /// </remarks>
+        public bool IsWarningAsError
+        {
+            get
+            {
+                return this.DefaultSeverity == DiagnosticSeverity.Warning &&
+                    this.Severity == DiagnosticSeverity.Error;
+            }
+        }
+
+        /// <summary>
+        /// Gets the primary location of the diagnostic, or <see cref="Location.None"/> if no primary location.
+        /// </summary>
+        public abstract Location Location { get; }
+
+        /// <summary>
+        /// Gets an array of additional locations related to the diagnostic.
+        /// Typically these are the locations of other items referenced in the message.
+        /// </summary>
+        public abstract IReadOnlyList<Location> AdditionalLocations { get; }
+
+        /// <summary>
+        /// Gets custom tags for the diagnostic.
+        /// </summary>
+        internal virtual IReadOnlyList<string> CustomTags { get { return (IReadOnlyList<string>)this.Descriptor.CustomTags; } }
+
+        /// <summary>
+        /// Gets property bag for the diagnostic. it will return <see cref="ImmutableDictionary{TKey, TValue}.Empty"/> if there is no entry.
+        /// This can be used to put diagnostic specific information you want to pass around. for example, to corresponding fixer.
+        /// </summary>
+        public virtual ImmutableDictionary<string, string> Properties { get { return ImmutableDictionary<string, string>.Empty; } }
+
+        string IFormattable.ToString(string ignored, IFormatProvider formatProvider)
+        {
+            return DiagnosticFormatter.Instance.Format(this, formatProvider);
+        }
+
+        public override string ToString()
+        {
+            return DiagnosticFormatter.Instance.Format(this, CultureInfo.CurrentUICulture);
+        }
+
+        public abstract override bool Equals(object obj);
+
+        public abstract override int GetHashCode();
+
+        public abstract bool Equals(Diagnostic obj);
+
+        private string GetDebuggerDisplay()
+        {
+            switch (this.Severity)
+            {
+                case InternalDiagnosticSeverity.Unknown:
+                    // If we called ToString before the diagnostic was resolved,
+                    // we would risk infinite recursion (e.g. if we were still computing
+                    // member lists).
+                    return "Unresolved diagnostic at " + this.Location;
+
+                case InternalDiagnosticSeverity.Void:
+                    // If we called ToString on a void diagnostic, the MessageProvider
+                    // would complain about the code.
+                    return "Void diagnostic at " + this.Location;
+
+                default:
+                    return ToString();
+            }
+        }
+
+        /// <summary>
+        /// Create a new instance of this diagnostic with the Location property changed.
+        /// </summary>
+        internal abstract Diagnostic WithLocation(Location location);
+
+        /// <summary>
+        /// Create a new instance of this diagnostic with the Severity property changed.
+        /// </summary>
+        internal abstract Diagnostic WithSeverity(DiagnosticSeverity severity);
+
+        /// <summary>
+        /// Create a new instance of this diagnostic with the suppression info changed.
+        /// </summary>
+        internal abstract Diagnostic WithIsSuppressed(bool isSuppressed);
+
+        // compatibility
+        internal virtual int Code { get { return 0; } }
+
+        internal virtual IReadOnlyList<object> Arguments
+        {
+            get { return SpecializedCollections.EmptyReadOnlyList<object>(); }
+        }
+
+        /// <summary>
+        /// Returns true if the diagnostic location (or any additional location) is within the given tree and intersects with the filterSpanWithinTree, if non-null.
+        /// </summary>
+        internal bool HasIntersectingLocation(SyntaxTree tree, TextSpan? filterSpanWithinTree = null)
+        {
+            var locations = this.GetDiagnosticLocationsWithinTree(tree);
+
+            foreach (var location in locations)
+            {
+                if (!filterSpanWithinTree.HasValue || filterSpanWithinTree.Value.IntersectsWith(location.SourceSpan))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private IEnumerable<Location> GetDiagnosticLocationsWithinTree(SyntaxTree tree)
+        {
+            if (this.Location.SourceTree == tree)
+            {
+                yield return this.Location;
+            }
+
+            if (this.AdditionalLocations != null)
+            {
+                foreach (var additionalLocation in this.AdditionalLocations)
+                {
+                    if (additionalLocation.SourceTree == tree)
+                    {
+                        yield return additionalLocation;
+                    }
+                }
+            }
+        }
+
+        internal Diagnostic WithReportDiagnostic(ReportDiagnostic reportAction)
+        {
+            switch (reportAction)
+            {
+                case ReportDiagnostic.Suppress:
+                    // Suppressed diagnostic.
+                    return null;
+                case ReportDiagnostic.Error:
+                    return this.WithSeverity(DiagnosticSeverity.Error);
+                case ReportDiagnostic.Default:
+                    return this;
+                case ReportDiagnostic.Warn:
+                    return this.WithSeverity(DiagnosticSeverity.Warning);
+                case ReportDiagnostic.Info:
+                    return this.WithSeverity(DiagnosticSeverity.Info);
+                case ReportDiagnostic.Hidden:
+                    return this.WithSeverity(DiagnosticSeverity.Hidden);
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(reportAction);
+            }
+        }
+
+        internal static int GetDefaultWarningLevel(DiagnosticSeverity severity)
+        {
+            switch (severity)
+            {
+                case DiagnosticSeverity.Error:
+                    return 0;
+
+                case DiagnosticSeverity.Warning:
+                    return 1;
+
+                default:
+                    return HighestValidWarningLevel;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if a diagnostic is not configurable, i.e. cannot be suppressed or filtered or have its severity changed.
+        /// For example, compiler errors are always non-configurable.
+        /// </summary>
+        internal virtual bool IsNotConfigurable()
+        {
+            return AnalyzerManager.HasNotConfigurableTag(this.CustomTags);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticBag.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticBag.cs
@@ -1,0 +1,366 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a mutable bag of diagnostics. You can add diagnostics to the bag,
+    /// and also get all the diagnostics out of the bag (the bag implements
+    /// IEnumerable&lt;Diagnostics&gt;. Once added, diagnostics cannot be removed, and no ordering
+    /// is guaranteed.
+    /// 
+    /// It is ok to Add diagnostics to the same bag concurrently on multiple threads.
+    /// It is NOT ok to Add concurrently with Clear or Free operations.
+    /// </summary>
+    /// <remarks>The bag is optimized to be efficient when containing zero errors.</remarks>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    [DebuggerTypeProxy(typeof(DebuggerProxy))]
+    internal class DiagnosticBag
+    {
+        // The lazyBag field is populated lazily -- the first time an error is added.
+        private ConcurrentQueue<Diagnostic> _lazyBag;
+
+        /// <summary>
+        /// Return true if the bag is completely empty - not even containing void diagnostics.
+        /// </summary>
+        /// <remarks>
+        /// This exists for short-circuiting purposes. Use <see cref="System.Linq.Enumerable.Any{T}(IEnumerable{T})"/>
+        /// to get a resolved Tuple(Of NamedTypeSymbol, ImmutableArray(Of Diagnostic)) (i.e. empty after eliminating void diagnostics).
+        /// </remarks>
+        public bool IsEmptyWithoutResolution
+        {
+            get
+            {
+                // It should be safe to access this here, since we normally have a collect phase and
+                // then a report phase, and we shouldn't be called during the "report" phase. We
+                // also never remove diagnostics, so the worst that happens is that we don't return
+                // an element that is added a split second after this is called.
+                ConcurrentQueue<Diagnostic> bag = _lazyBag;
+                return bag == null || bag.IsEmpty;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if the bag has any diagnostics with Severity=Error. Does not consider warnings or informationals.
+        /// </summary>
+        /// <remarks>
+        /// Resolves any lazy diagnostics in the bag.
+        /// 
+        /// Generally, this should only be called by the creator (modulo pooling) of the bag (i.e. don't use bags to communicate -
+        /// if you need more info, pass more info).
+        /// </remarks>
+        public bool HasAnyErrors()
+        {
+            if (IsEmptyWithoutResolution)
+            {
+                return false;
+            }
+
+            foreach (Diagnostic diagnostic in Bag)
+            {
+                if (diagnostic.Severity == DiagnosticSeverity.Error)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns true if the bag has any non-lazy diagnostics with Severity=Error.
+        /// </summary>
+        /// <remarks>
+        /// Does not resolve any lazy diagnostics in the bag.
+        /// 
+        /// Generally, this should only be called by the creator (modulo pooling) of the bag (i.e. don't use bags to communicate -
+        /// if you need more info, pass more info).
+        /// </remarks>
+        internal bool HasAnyResolvedErrors()
+        {
+            if (IsEmptyWithoutResolution)
+            {
+                return false;
+            }
+
+            foreach (Diagnostic diagnostic in Bag)
+            {
+                if ((diagnostic as DiagnosticWithInfo)?.HasLazyInfo != true && diagnostic.Severity == DiagnosticSeverity.Error)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Add a diagnostic to the bag.
+        /// </summary>
+        public void Add(Diagnostic diag)
+        {
+            ConcurrentQueue<Diagnostic> bag = this.Bag;
+            bag.Enqueue(diag);
+        }
+
+        /// <summary>
+        /// Add multiple diagnostics to the bag.
+        /// </summary>
+        public void AddRange<T>(ImmutableArray<T> diagnostics) where T : Diagnostic
+        {
+            if (!diagnostics.IsDefaultOrEmpty)
+            {
+                ConcurrentQueue<Diagnostic> bag = this.Bag;
+                for (int i = 0; i < diagnostics.Length; i++)
+                {
+                    bag.Enqueue(diagnostics[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Add multiple diagnostics to the bag.
+        /// </summary>
+        public void AddRange(IEnumerable<Diagnostic> diagnostics)
+        {
+            foreach (Diagnostic diagnostic in diagnostics)
+            {
+                this.Bag.Enqueue(diagnostic);
+            }
+        }
+
+        /// <summary>
+        /// Add another DiagnosticBag to the bag.
+        /// </summary>
+        public void AddRange(DiagnosticBag bag)
+        {
+            if (!bag.IsEmptyWithoutResolution)
+            {
+                AddRange(bag.Bag);
+            }
+        }
+
+        /// <summary>
+        /// Add another DiagnosticBag to the bag and free the argument.
+        /// </summary>
+        public void AddRangeAndFree(DiagnosticBag bag)
+        {
+            AddRange(bag);
+            bag.Free();
+        }
+
+        /// <summary>
+        /// Seal the bag so no further errors can be added, while clearing it and returning the old set of errors.
+        /// Return the bag to the pool.
+        /// </summary>
+        public ImmutableArray<TDiagnostic> ToReadOnlyAndFree<TDiagnostic>() where TDiagnostic : Diagnostic
+        {
+            ConcurrentQueue<Diagnostic> oldBag = _lazyBag;
+            Free();
+
+            return ToReadOnlyCore<TDiagnostic>(oldBag);
+        }
+
+        public ImmutableArray<Diagnostic> ToReadOnlyAndFree()
+        {
+            return ToReadOnlyAndFree<Diagnostic>();
+        }
+
+        public ImmutableArray<TDiagnostic> ToReadOnly<TDiagnostic>() where TDiagnostic : Diagnostic
+        {
+            ConcurrentQueue<Diagnostic> oldBag = _lazyBag;
+            return ToReadOnlyCore<TDiagnostic>(oldBag);
+        }
+
+        public ImmutableArray<Diagnostic> ToReadOnly()
+        {
+            return ToReadOnly<Diagnostic>();
+        }
+
+        private static ImmutableArray<TDiagnostic> ToReadOnlyCore<TDiagnostic>(ConcurrentQueue<Diagnostic> oldBag) where TDiagnostic : Diagnostic
+        {
+            if (oldBag == null)
+            {
+                return ImmutableArray<TDiagnostic>.Empty;
+            }
+
+            ArrayBuilder<TDiagnostic> builder = ArrayBuilder<TDiagnostic>.GetInstance();
+
+            foreach (TDiagnostic diagnostic in oldBag) // Cast should be safe since all diagnostics should be from same language.
+            {
+                if (diagnostic.Severity != InternalDiagnosticSeverity.Void)
+                {
+                    Debug.Assert(diagnostic.Severity != InternalDiagnosticSeverity.Unknown); //Info access should have forced resolution.
+                    builder.Add(diagnostic);
+                }
+            }
+
+            return builder.ToImmutableAndFree();
+        }
+
+
+        /// <remarks>
+        /// Generally, this should only be called by the creator (modulo pooling) of the bag (i.e. don't use bags to communicate -
+        /// if you need more info, pass more info).
+        /// </remarks>
+        public IEnumerable<Diagnostic> AsEnumerable()
+        {
+            ConcurrentQueue<Diagnostic> bag = this.Bag;
+
+            bool foundVoid = false;
+
+            foreach (Diagnostic diagnostic in bag)
+            {
+                if (diagnostic.Severity == InternalDiagnosticSeverity.Void)
+                {
+                    foundVoid = true;
+                    break;
+                }
+            }
+
+            return foundVoid
+                ? AsEnumerableFiltered()
+                : bag;
+        }
+
+        /// <remarks>
+        /// Using an iterator to avoid copying the list.  If perf is a problem,
+        /// create an explicit enumerator type.
+        /// </remarks>
+        private IEnumerable<Diagnostic> AsEnumerableFiltered()
+        {
+            foreach (Diagnostic diagnostic in this.Bag)
+            {
+                if (diagnostic.Severity != InternalDiagnosticSeverity.Void)
+                {
+                    Debug.Assert(diagnostic.Severity != InternalDiagnosticSeverity.Unknown); //Info access should have forced resolution.
+                    yield return diagnostic;
+                }
+            }
+        }
+
+        internal IEnumerable<Diagnostic> AsEnumerableWithoutResolution()
+        {
+            // PERF: don't make a defensive copy - callers are internal and won't modify the bag.
+            return _lazyBag ?? SpecializedCollections.EmptyEnumerable<Diagnostic>();
+        }
+
+        public override string ToString()
+        {
+            if (this.IsEmptyWithoutResolution)
+            {
+                // TODO(cyrusn): do we need to localize this?
+                return "<no errors>";
+            }
+            else
+            {
+                StringBuilder builder = new StringBuilder();
+                foreach (Diagnostic diag in Bag) // NOTE: don't force resolution
+                {
+                    builder.AppendLine(diag.ToString());
+                }
+                return builder.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Get the underlying concurrent storage, creating it on demand if needed.
+        /// NOTE: Concurrent Adding to the bag is supported, but concurrent Clearing is not.
+        ///       If one thread adds to the bug while another clears it, the scenario is 
+        ///       broken and we cannot do anything about it here.
+        /// </summary>
+        private ConcurrentQueue<Diagnostic> Bag
+        {
+            get
+            {
+                ConcurrentQueue<Diagnostic> bag = _lazyBag;
+                if (bag != null)
+                {
+                    return bag;
+                }
+
+                ConcurrentQueue<Diagnostic> newBag = new ConcurrentQueue<Diagnostic>();
+                return Interlocked.CompareExchange(ref _lazyBag, newBag, null) ?? newBag;
+            }
+        }
+
+        // clears the bag.
+        /// NOTE: Concurrent Adding to the bag is supported, but concurrent Clearing is not.
+        ///       If one thread adds to the bug while another clears it, the scenario is 
+        ///       broken and we cannot do anything about it here.
+        internal void Clear()
+        {
+            ConcurrentQueue<Diagnostic> bag = _lazyBag;
+            if (bag != null)
+            {
+                _lazyBag = null;
+            }
+        }
+
+        #region "Poolable"
+
+        internal static DiagnosticBag GetInstance()
+        {
+            DiagnosticBag bag = s_poolInstance.Allocate();
+            return bag;
+        }
+
+        internal void Free()
+        {
+            Clear();
+            s_poolInstance.Free(this);
+        }
+
+        private static readonly ObjectPool<DiagnosticBag> s_poolInstance = CreatePool(128);
+        private static ObjectPool<DiagnosticBag> CreatePool(int size)
+        {
+            return new ObjectPool<DiagnosticBag>(() => new DiagnosticBag(), size);
+        }
+
+        #endregion
+
+        #region Debugger View
+
+        internal sealed class DebuggerProxy
+        {
+            private readonly DiagnosticBag _bag;
+
+            public DebuggerProxy(DiagnosticBag bag)
+            {
+                _bag = bag;
+            }
+
+            [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+            public object[] Diagnostics
+            {
+                get
+                {
+                    ConcurrentQueue<Diagnostic> lazyBag = _bag._lazyBag;
+                    if (lazyBag != null)
+                    {
+                        return lazyBag.ToArray();
+                    }
+                    else
+                    {
+                        return SpecializedCollections.EmptyObjects;
+                    }
+                }
+            }
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            return "Count = " + (_lazyBag?.Count ?? 0);
+        }
+        #endregion
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticDescriptor.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticDescriptor.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Provides a description about a <see cref="Diagnostic"/>
+    /// </summary>
+    public sealed class DiagnosticDescriptor : IEquatable<DiagnosticDescriptor>
+    {
+        /// <summary>
+        /// An unique identifier for the diagnostic.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// A short localizable title describing the diagnostic.
+        /// </summary>
+        public LocalizableString Title { get; }
+
+        /// <summary>
+        /// An optional longer localizable description for the diagnostic.
+        /// </summary>
+        public LocalizableString Description { get; }
+
+        /// <summary>
+        /// An optional hyperlink that provides more detailed information regarding the diagnostic.
+        /// </summary>
+        public string HelpLinkUri { get; }
+
+        /// <summary>
+        /// A localizable format message string, which can be passed as the first argument to <see cref="String.Format(string, object[])"/> when creating the diagnostic message with this descriptor.
+        /// </summary>
+        /// <returns></returns>
+        public LocalizableString MessageFormat { get; }
+
+        /// <summary>
+        /// The category of the diagnostic (like Design, Naming etc.)
+        /// </summary>
+        public string Category { get; }
+
+        /// <summary>
+        /// The default severity of the diagnostic.
+        /// </summary>
+        public DiagnosticSeverity DefaultSeverity { get; }
+
+        /// <summary>
+        /// Returns true if the diagnostic is enabled by default.
+        /// </summary>
+        public bool IsEnabledByDefault { get; }
+
+        /// <summary>
+        /// Custom tags for the diagnostic.
+        /// </summary>
+        public IEnumerable<string> CustomTags { get; }
+
+        /// <summary>
+        /// Create a DiagnosticDescriptor, which provides description about a <see cref="Diagnostic"/>.
+        /// NOTE: For localizable <paramref name="title"/>, <paramref name="description"/> and/or <paramref name="messageFormat"/>,
+        /// use constructor overload <see cref="DiagnosticDescriptor(string, LocalizableString, LocalizableString, string, DiagnosticSeverity, bool, LocalizableString, string, string[])"/>.
+        /// </summary>
+        /// <param name="id">A unique identifier for the diagnostic. For example, code analysis diagnostic ID "CA1001".</param>
+        /// <param name="title">A short title describing the diagnostic. For example, for CA1001: "Types that own disposable fields should be disposable".</param>
+        /// <param name="messageFormat">A format message string, which can be passed as the first argument to <see cref="String.Format(string, object[])"/> when creating the diagnostic message with this descriptor.
+        /// For example, for CA1001: "Implement IDisposable on '{0}' because it creates members of the following IDisposable types: '{1}'."</param>
+        /// <param name="category">The category of the diagnostic (like Design, Naming etc.). For example, for CA1001: "Microsoft.Design".</param>
+        /// <param name="defaultSeverity">Default severity of the diagnostic.</param>
+        /// <param name="isEnabledByDefault">True if the diagnostic is enabled by default.</param>
+        /// <param name="description">An optional longer description of the diagnostic.</param>
+        /// <param name="helpLinkUri">An optional hyperlink that provides a more detailed description regarding the diagnostic.</param>
+        /// <param name="customTags">Optional custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.</param>
+        public DiagnosticDescriptor(
+            string id,
+            string title,
+            string messageFormat,
+            string category,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            string description = null,
+            string helpLinkUri = null,
+            params string[] customTags)
+            : this(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLinkUri, customTags.AsImmutableOrEmpty())
+        {
+        }
+
+        /// <summary>
+        /// Create a DiagnosticDescriptor, which provides description about a <see cref="Diagnostic"/>.
+        /// </summary>
+        /// <param name="id">A unique identifier for the diagnostic. For example, code analysis diagnostic ID "CA1001".</param>
+        /// <param name="title">A short localizable title describing the diagnostic. For example, for CA1001: "Types that own disposable fields should be disposable".</param>
+        /// <param name="messageFormat">A localizable format message string, which can be passed as the first argument to <see cref="String.Format(string, object[])"/> when creating the diagnostic message with this descriptor.
+        /// For example, for CA1001: "Implement IDisposable on '{0}' because it creates members of the following IDisposable types: '{1}'."</param>
+        /// <param name="category">The category of the diagnostic (like Design, Naming etc.). For example, for CA1001: "Microsoft.Design".</param>
+        /// <param name="defaultSeverity">Default severity of the diagnostic.</param>
+        /// <param name="isEnabledByDefault">True if the diagnostic is enabled by default.</param>
+        /// <param name="description">An optional longer localizable description of the diagnostic.</param>
+        /// <param name="helpLinkUri">An optional hyperlink that provides a more detailed description regarding the diagnostic.</param>
+        /// <param name="customTags">Optional custom tags for the diagnostic. See <see cref="WellKnownDiagnosticTags"/> for some well known tags.</param>
+        /// <remarks>Example descriptor for rule CA1001:
+        ///     internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(RuleId,
+        ///         new LocalizableResourceString(nameof(FxCopRulesResources.TypesThatOwnDisposableFieldsShouldBeDisposable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources)),
+        ///         new LocalizableResourceString(nameof(FxCopRulesResources.TypeOwnsDisposableFieldButIsNotDisposable), FxCopRulesResources.ResourceManager, typeof(FxCopRulesResources)),
+        ///         FxCopDiagnosticCategory.Design,
+        ///         DiagnosticSeverity.Warning,
+        ///         isEnabledByDefault: true,
+        ///         helpLinkUri: "http://msdn.microsoft.com/library/ms182172.aspx",
+        ///         customTags: DiagnosticCustomTags.Microsoft);
+        /// </remarks>
+        public DiagnosticDescriptor(
+            string id,
+            LocalizableString title,
+            LocalizableString messageFormat,
+            string category,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            LocalizableString description = null,
+            string helpLinkUri = null,
+            params string[] customTags)
+            : this(id, title, messageFormat, category, defaultSeverity, isEnabledByDefault, description, helpLinkUri, customTags.AsImmutableOrEmpty())
+        {
+        }
+
+        internal DiagnosticDescriptor(
+            string id,
+            LocalizableString title,
+            LocalizableString messageFormat,
+            string category,
+            DiagnosticSeverity defaultSeverity,
+            bool isEnabledByDefault,
+            LocalizableString description,
+            string helpLinkUri,
+            ImmutableArray<string> customTags)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException(CodeAnalysisResources.DiagnosticIdCantBeNullOrWhitespace, nameof(id));
+            }
+
+            if (messageFormat == null)
+            {
+                throw new ArgumentNullException(nameof(messageFormat));
+            }
+
+            if (category == null)
+            {
+                throw new ArgumentNullException(nameof(category));
+            }
+
+            if (title == null)
+            {
+                throw new ArgumentNullException(nameof(title));
+            }
+
+            this.Id = id;
+            this.Title = title;
+            this.Category = category;
+            this.MessageFormat = messageFormat;
+            this.DefaultSeverity = defaultSeverity;
+            this.IsEnabledByDefault = isEnabledByDefault;
+            this.Description = description ?? string.Empty;
+            this.HelpLinkUri = helpLinkUri ?? string.Empty;
+            this.CustomTags = customTags;
+        }
+
+        public bool Equals(DiagnosticDescriptor other)
+        {
+            return
+                other != null &&
+                this.Category == other.Category &&
+                this.DefaultSeverity == other.DefaultSeverity &&
+                this.Description.Equals(other.Description) &&
+                this.HelpLinkUri == other.HelpLinkUri &&
+                this.Id == other.Id &&
+                this.IsEnabledByDefault == other.IsEnabledByDefault &&
+                this.MessageFormat.Equals(other.MessageFormat) &&
+                this.Title.Equals(other.Title);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as DiagnosticDescriptor);
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(this.Category.GetHashCode(),
+                Hash.Combine(this.DefaultSeverity.GetHashCode(),
+                Hash.Combine(this.Description.GetHashCode(),
+                Hash.Combine(this.HelpLinkUri.GetHashCode(),
+                Hash.Combine(this.Id.GetHashCode(),
+                Hash.Combine(this.IsEnabledByDefault.GetHashCode(),
+                Hash.Combine(this.MessageFormat.GetHashCode(),
+                    this.Title.GetHashCode())))))));
+        }
+
+        /// <summary>
+        /// Gets the effective severity of diagnostics created based on this descriptor and the given <see cref="CompilationOptions"/>.
+        /// </summary>
+        /// <param name="compilationOptions">Compilation options</param>
+        public ReportDiagnostic GetEffectiveSeverity(CompilationOptions compilationOptions)
+        {
+            if (compilationOptions == null)
+            {
+                throw new ArgumentNullException(nameof(compilationOptions));
+            }
+
+            // Create a dummy diagnostic to compute the effective diagnostic severity for given compilation options
+            // TODO: Once https://github.com/dotnet/roslyn/issues/3650 is fixed, we can avoid creating a no-location diagnostic here.
+            var effectiveDiagnostic = compilationOptions.FilterDiagnostic(Diagnostic.Create(this, Location.None));
+            return effectiveDiagnostic != null ? MapSeverityToReport(effectiveDiagnostic.Severity) : ReportDiagnostic.Suppress;
+        }
+
+        private static ReportDiagnostic MapSeverityToReport(DiagnosticSeverity severity)
+        {
+            switch (severity)
+            {
+                case DiagnosticSeverity.Hidden:
+                    return ReportDiagnostic.Hidden;
+                case DiagnosticSeverity.Info:
+                    return ReportDiagnostic.Info;
+                case DiagnosticSeverity.Warning:
+                    return ReportDiagnostic.Warn;
+                case DiagnosticSeverity.Error:
+                    return ReportDiagnostic.Error;
+                default:
+                    throw ExceptionUtilities.Unreachable;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if diagnostic descriptor is not configurable, i.e. cannot be suppressed or filtered or have its severity changed.
+        /// For example, compiler errors are always non-configurable.
+        /// </summary>
+        internal bool IsNotConfigurable()
+        {
+            return AnalyzerManager.HasNotConfigurableTag(this.CustomTags);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticFormatter.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticFormatter.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Formats <see cref="Diagnostic"/> messages.
+    /// </summary>
+    public class DiagnosticFormatter
+    {
+        /// <summary>
+        /// Formats the <see cref="Diagnostic"/> message using the optional <see cref="IFormatProvider"/>.
+        /// </summary>
+        /// <param name="diagnostic">The diagnostic.</param>
+        /// <param name="formatter">The formatter; or null to use the default formatter.</param>
+        /// <returns>The formatted message.</returns>
+        public virtual string Format(Diagnostic diagnostic, IFormatProvider formatter = null)
+        {
+            if (diagnostic == null)
+            {
+                throw new ArgumentNullException(nameof(diagnostic));
+            }
+
+            var culture = formatter as CultureInfo;
+
+            switch (diagnostic.Location.Kind)
+            {
+                case LocationKind.SourceFile:
+                case LocationKind.XmlFile:
+                case LocationKind.ExternalFile:
+                    var span = diagnostic.Location.GetLineSpan();
+                    var mappedSpan = diagnostic.Location.GetMappedLineSpan();
+                    if (!span.IsValid || !mappedSpan.IsValid)
+                    {
+                        goto default;
+                    }
+
+                    string path, basePath;
+                    if (mappedSpan.HasMappedPath)
+                    {
+                        path = mappedSpan.Path;
+                        basePath = span.Path;
+                    }
+                    else
+                    {
+                        path = span.Path;
+                        basePath = null;
+                    }
+
+                    return string.Format(formatter, "{0}{1}: {2}: {3}",
+                                         FormatSourcePath(path, basePath, formatter),
+                                         FormatSourceSpan(mappedSpan.Span, formatter),
+                                         GetMessagePrefix(diagnostic),
+                                         diagnostic.GetMessage(culture));
+
+                default:
+                    return string.Format(formatter, "{0}: {1}",
+                                         GetMessagePrefix(diagnostic),
+                                         diagnostic.GetMessage(culture));
+            }
+        }
+
+        internal virtual string FormatSourcePath(string path, string basePath, IFormatProvider formatter)
+        {
+            // ignore base path
+            return path;
+        }
+
+        internal virtual string FormatSourceSpan(LinePositionSpan span, IFormatProvider formatter)
+        {
+            return string.Format("({0},{1})", span.Start.Line + 1, span.Start.Character + 1);
+        }
+
+        internal string GetMessagePrefix(Diagnostic diagnostic)
+        {
+            string prefix;
+            switch (diagnostic.Severity)
+            {
+                case DiagnosticSeverity.Hidden:
+                    prefix = "hidden";
+                    break;
+                case DiagnosticSeverity.Info:
+                    prefix = "info";
+                    break;
+                case DiagnosticSeverity.Warning:
+                    prefix = "warning";
+                    break;
+                case DiagnosticSeverity.Error:
+                    prefix = "error";
+                    break;
+                default:
+                    throw ExceptionUtilities.UnexpectedValue(diagnostic.Severity);
+            }
+
+            return string.Format("{0} {1}", prefix, diagnostic.Id);
+        }
+
+        internal static readonly DiagnosticFormatter Instance = new DiagnosticFormatter();
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticInfo.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticInfo.cs
@@ -1,0 +1,479 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using Roslyn.Utilities;
+using System.Threading;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A DiagnosticInfo object has information about a diagnostic, but without any attached location information.
+    /// </summary>
+    /// <remarks>
+    /// More specialized diagnostics with additional information (e.g., ambiguity errors) can derive from this class to
+    /// provide access to additional information about the error, such as what symbols were involved in the ambiguity.
+    /// </remarks>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    internal class DiagnosticInfo : IFormattable, IObjectWritable, IObjectReadable, IMessageSerializable
+    {
+        private readonly CommonMessageProvider _messageProvider;
+        private readonly int _errorCode;
+        private readonly DiagnosticSeverity _defaultSeverity;
+        private readonly DiagnosticSeverity _effectiveSeverity;
+        private readonly object[] _arguments;
+
+        private static ImmutableDictionary<int, DiagnosticDescriptor> s_errorCodeToDescriptorMap = ImmutableDictionary<int, DiagnosticDescriptor>.Empty;
+
+        // Mark compiler errors as non-configurable to ensure they can never be suppressed or filtered.
+        private static readonly ImmutableArray<string> s_compilerErrorCustomTags = ImmutableArray.Create(WellKnownDiagnosticTags.Compiler, WellKnownDiagnosticTags.Telemetry, WellKnownDiagnosticTags.NotConfigurable);
+        private static readonly ImmutableArray<string> s_compilerNonErrorCustomTags = ImmutableArray.Create(WellKnownDiagnosticTags.Compiler, WellKnownDiagnosticTags.Telemetry);
+
+        // Only the compiler creates instances.
+        internal DiagnosticInfo(CommonMessageProvider messageProvider, int errorCode)
+        {
+            _messageProvider = messageProvider;
+            _errorCode = errorCode;
+            _defaultSeverity = messageProvider.GetSeverity(errorCode);
+            _effectiveSeverity = _defaultSeverity;
+        }
+
+        // Only the compiler creates instances.
+        internal DiagnosticInfo(CommonMessageProvider messageProvider, int errorCode, params object[] arguments)
+            : this(messageProvider, errorCode)
+        {
+            AssertMessageSerializable(arguments);
+
+            _arguments = arguments;
+        }
+
+        private DiagnosticInfo(DiagnosticInfo original, DiagnosticSeverity overriddenSeverity)
+        {
+            _messageProvider = original.MessageProvider;
+            _errorCode = original._errorCode;
+            _defaultSeverity = original.DefaultSeverity;
+            _arguments = original._arguments;
+
+            _effectiveSeverity = overriddenSeverity;
+        }
+
+        internal static DiagnosticDescriptor GetDescriptor(int errorCode, CommonMessageProvider messageProvider)
+        {
+            var defaultSeverity = messageProvider.GetSeverity(errorCode);
+            return GetOrCreateDescriptor(errorCode, defaultSeverity, messageProvider);
+        }
+
+        private static DiagnosticDescriptor GetOrCreateDescriptor(int errorCode, DiagnosticSeverity defaultSeverity, CommonMessageProvider messageProvider)
+        {
+            return ImmutableInterlocked.GetOrAdd(ref s_errorCodeToDescriptorMap, errorCode, code => CreateDescriptor(code, defaultSeverity, messageProvider));
+        }
+
+        private static DiagnosticDescriptor CreateDescriptor(int errorCode, DiagnosticSeverity defaultSeverity, CommonMessageProvider messageProvider)
+        {
+            var id = messageProvider.GetIdForErrorCode(errorCode);
+            var title = messageProvider.GetTitle(errorCode);
+            var description = messageProvider.GetDescription(errorCode);
+            var messageFormat = messageProvider.GetMessageFormat(errorCode);
+            var helpLink = messageProvider.GetHelpLink(errorCode);
+            var category = messageProvider.GetCategory(errorCode);
+            var customTags = GetCustomTags(defaultSeverity);
+            return new DiagnosticDescriptor(id, title, messageFormat, category, defaultSeverity,
+                isEnabledByDefault: true, description: description, helpLinkUri: helpLink, customTags: customTags);
+        }
+
+        [Conditional("DEBUG")]
+        internal static void AssertMessageSerializable(object[] args)
+        {
+            foreach (var arg in args)
+            {
+                Debug.Assert(arg != null);
+
+                if (arg is IMessageSerializable)
+                {
+                    continue;
+                }
+
+                var type = arg.GetType();
+                if (type == typeof(string) || type == typeof(AssemblyIdentity))
+                {
+                    continue;
+                }
+
+                var info = type.GetTypeInfo();
+                if (info.IsPrimitive)
+                {
+                    continue;
+                }
+
+                throw ExceptionUtilities.UnexpectedValue(type);
+            }
+        }
+
+        // Only the compiler creates instances.
+        internal DiagnosticInfo(CommonMessageProvider messageProvider, bool isWarningAsError, int errorCode, params object[] arguments)
+            : this(messageProvider, errorCode, arguments)
+        {
+            Debug.Assert(!isWarningAsError || _defaultSeverity == DiagnosticSeverity.Warning);
+
+            if (isWarningAsError)
+            {
+                _effectiveSeverity = DiagnosticSeverity.Error;
+            }
+        }
+
+        // Create a copy of this instance with a explicit overridden severity
+        internal DiagnosticInfo GetInstanceWithSeverity(DiagnosticSeverity severity)
+        {
+            return new DiagnosticInfo(this, severity);
+        }
+
+        #region Serialization
+
+        void IObjectWritable.WriteTo(ObjectWriter writer)
+        {
+            this.WriteTo(writer);
+        }
+
+        protected virtual void WriteTo(ObjectWriter writer)
+        {
+            writer.WriteValue(_messageProvider);
+            writer.WriteCompressedUInt((uint)_errorCode);
+            writer.WriteInt32((int)_effectiveSeverity);
+            writer.WriteInt32((int)_defaultSeverity);
+
+            int count = _arguments?.Length ?? 0;
+            writer.WriteCompressedUInt((uint)count);
+
+            if (count > 0)
+            {
+                foreach (var arg in _arguments)
+                {
+                    writer.WriteString(arg.ToString());
+                }
+            }
+        }
+
+        Func<ObjectReader, object> IObjectReadable.GetReader()
+        {
+            return this.GetReader();
+        }
+
+        protected virtual Func<ObjectReader, object> GetReader()
+        {
+            return (r) => new DiagnosticInfo(r);
+        }
+
+        protected DiagnosticInfo(ObjectReader reader)
+        {
+            _messageProvider = (CommonMessageProvider)reader.ReadValue();
+            _errorCode = (int)reader.ReadCompressedUInt();
+            _effectiveSeverity = (DiagnosticSeverity)reader.ReadInt32();
+            _defaultSeverity = (DiagnosticSeverity)reader.ReadInt32();
+
+            var count = (int)reader.ReadCompressedUInt();
+            if (count == 0)
+            {
+                _arguments = SpecializedCollections.EmptyObjects;
+            }
+            else if (count > 0)
+            {
+                _arguments = new string[count];
+                for (int i = 0; i < count; i++)
+                {
+                    _arguments[i] = reader.ReadString();
+                }
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// The error code, as an integer.
+        /// </summary>
+        public int Code { get { return _errorCode; } }
+
+        public DiagnosticDescriptor Descriptor
+        {
+            get
+            {
+                return GetOrCreateDescriptor(_errorCode, _defaultSeverity, _messageProvider);
+            }
+        }
+
+        /// <summary>
+        /// Returns the effective severity of the diagnostic: whether this diagnostic is informational, warning, or error.
+        /// If IsWarningsAsError is true, then this returns <see cref="DiagnosticSeverity.Error"/>, while <see cref="DefaultSeverity"/> returns <see cref="DiagnosticSeverity.Warning"/>.
+        /// </summary>
+        public DiagnosticSeverity Severity
+        {
+            get
+            {
+                return _effectiveSeverity;
+            }
+        }
+
+        /// <summary>
+        /// Returns whether this diagnostic is informational, warning, or error by default, based on the error code.
+        /// To get diagnostic's effective severity, use <see cref="Severity"/>.
+        /// </summary>
+        public DiagnosticSeverity DefaultSeverity
+        {
+            get
+            {
+                return _defaultSeverity;
+            }
+        }
+
+        /// <summary>
+        /// Gets the warning level. This is 0 for diagnostics with severity <see cref="DiagnosticSeverity.Error"/>,
+        /// otherwise an integer between 1 and 4.
+        /// </summary>
+        public int WarningLevel
+        {
+            get
+            {
+                if (_effectiveSeverity != _defaultSeverity)
+                {
+                    return Diagnostic.GetDefaultWarningLevel(_effectiveSeverity);
+                }
+
+                return _messageProvider.GetWarningLevel(_errorCode);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this is a warning treated as an error.
+        /// </summary>
+        /// <remarks>
+        /// True implies <see cref="Severity"/> = <see cref="DiagnosticSeverity.Error"/> and
+        /// <see cref="DefaultSeverity"/> = <see cref="DiagnosticSeverity.Warning"/>.
+        /// </remarks>
+        public bool IsWarningAsError
+        {
+            get
+            {
+                return this.DefaultSeverity == DiagnosticSeverity.Warning &&
+                    this.Severity == DiagnosticSeverity.Error;
+            }
+        }
+
+        /// <summary>
+        /// Get the diagnostic category for the given diagnostic code.
+        /// Default category is <see cref="Diagnostic.CompilerDiagnosticCategory"/>.
+        /// </summary>
+        public string Category
+        {
+            get
+            {
+                return _messageProvider.GetCategory(_errorCode);
+            }
+        }
+
+        internal ImmutableArray<string> CustomTags
+        {
+            get
+            {
+                return GetCustomTags(_defaultSeverity);
+            }
+        }
+
+        private static ImmutableArray<string> GetCustomTags(DiagnosticSeverity defaultSeverity)
+        {
+            return defaultSeverity == DiagnosticSeverity.Error ?
+                s_compilerErrorCustomTags :
+                s_compilerNonErrorCustomTags;
+        }
+
+        internal bool IsNotConfigurable()
+        {
+            // Only compiler errors are non-configurable.
+            return _defaultSeverity == DiagnosticSeverity.Error;
+        }
+
+        /// <summary>
+        /// If a derived class has additional information about other referenced symbols, it can
+        /// expose the locations of those symbols in a general way, so they can be reported along
+        /// with the error.
+        /// </summary>
+        public virtual IReadOnlyList<Location> AdditionalLocations
+        {
+            get
+            {
+                return SpecializedCollections.EmptyReadOnlyList<Location>();
+            }
+        }
+
+        /// <summary>
+        /// Get the message id (for example "CS1001") for the message. This includes both the error number
+        /// and a prefix identifying the source.
+        /// </summary>
+        public string MessageIdentifier
+        {
+            get
+            {
+                return _messageProvider.GetIdForErrorCode(_errorCode);
+            }
+        }
+
+        /// <summary>
+        /// Get the text of the message in the given language.
+        /// </summary>
+        public virtual string GetMessage(IFormatProvider formatProvider = null)
+        {
+            // Get the message and fill in arguments.
+            string message = _messageProvider.LoadMessage(_errorCode, formatProvider as CultureInfo);
+            if (string.IsNullOrEmpty(message))
+            {
+                return string.Empty;
+            }
+
+            if (_arguments == null || _arguments.Length == 0)
+            {
+                return message;
+            }
+
+            return String.Format(formatProvider, message, GetArgumentsToUse(formatProvider));
+        }
+
+        protected object[] GetArgumentsToUse(IFormatProvider formatProvider)
+        {
+            object[] argumentsToUse = null;
+            for (int i = 0; i < _arguments.Length; i++)
+            {
+                var embedded = _arguments[i] as DiagnosticInfo;
+                if (embedded != null)
+                {
+                    argumentsToUse = InitializeArgumentListIfNeeded(argumentsToUse);
+                    argumentsToUse[i] = embedded.GetMessage(formatProvider);
+                    continue;
+                }
+
+                var symbol = _arguments[i] as ISymbol;
+                if (symbol != null)
+                {
+                    argumentsToUse = InitializeArgumentListIfNeeded(argumentsToUse);
+                    argumentsToUse[i] = _messageProvider.GetErrorDisplayString(symbol);
+                }
+            }
+
+            return argumentsToUse ?? _arguments;
+        }
+
+        private object[] InitializeArgumentListIfNeeded(object[] argumentsToUse)
+        {
+            if (argumentsToUse != null)
+            {
+                return argumentsToUse;
+            }
+
+            var newArguments = new object[_arguments.Length];
+            Array.Copy(_arguments, newArguments, newArguments.Length);
+
+            return newArguments;
+        }
+
+        internal object[] Arguments
+        {
+            get { return _arguments; }
+        }
+
+        internal CommonMessageProvider MessageProvider
+        {
+            get { return _messageProvider; }
+        }
+
+        // TODO (tomat): remove
+        public override string ToString()
+        {
+            return ToString(null);
+        }
+
+        public string ToString(IFormatProvider formatProvider)
+        {
+            return ((IFormattable)this).ToString(null, formatProvider);
+        }
+
+        string IFormattable.ToString(string format, IFormatProvider formatProvider)
+        {
+            return String.Format(formatProvider, "{0}: {1}",
+                _messageProvider.GetMessagePrefix(this.MessageIdentifier, this.Severity, this.IsWarningAsError, formatProvider as CultureInfo),
+                this.GetMessage(formatProvider));
+        }
+
+        public sealed override int GetHashCode()
+        {
+            int hashCode = _errorCode;
+            if (_arguments != null)
+            {
+                for (int i = 0; i < _arguments.Length; i++)
+                {
+                    hashCode = Hash.Combine(_arguments[i], hashCode);
+                }
+            }
+
+            return hashCode;
+        }
+
+        public sealed override bool Equals(object obj)
+        {
+            DiagnosticInfo other = obj as DiagnosticInfo;
+
+            bool result = false;
+
+            if (other != null &&
+                other._errorCode == _errorCode &&
+                this.GetType() == obj.GetType())
+            {
+                if (_arguments == null && other._arguments == null)
+                {
+                    result = true;
+                }
+                else if (_arguments != null && other._arguments != null && _arguments.Length == other._arguments.Length)
+                {
+                    result = true;
+                    for (int i = 0; i < _arguments.Length; i++)
+                    {
+                        if (!object.Equals(_arguments[i], other._arguments[i]))
+                        {
+                            result = false;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            // There aren't message resources for our internal error codes, so make
+            // sure we don't call ToString for those.
+            switch (Code)
+            {
+                case InternalErrorCode.Unknown:
+                    return "Unresolved DiagnosticInfo";
+
+                case InternalErrorCode.Void:
+                    return "Void DiagnosticInfo";
+
+                default:
+                    return ToString();
+            }
+        }
+
+        /// <summary>
+        /// For a DiagnosticInfo that is lazily evaluated, this method evaluates it
+        /// and returns a non-lazy DiagnosticInfo.
+        /// </summary>
+        internal virtual DiagnosticInfo GetResolvedInfo()
+        {
+            // We should never call GetResolvedInfo on a non-lazy DiagnosticInfo
+            throw ExceptionUtilities.Unreachable;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticSeverity.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticSeverity.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Describes how severe a diagnostic is.
+    /// </summary>
+    public enum DiagnosticSeverity
+    {
+        /// <summary>
+        /// Something that is an issue, as determined by some authority,
+        /// but is not surfaced through normal means.
+        /// There may be different mechanisms that act on these issues.
+        /// </summary>
+        Hidden = 0,
+
+        /// <summary>
+        /// Information that does not indicate a problem (i.e. not prescriptive).
+        /// </summary>
+        Info = 1,
+
+        /// <summary>
+        /// Something suspicious but allowed.
+        /// </summary>
+        Warning = 2,
+
+        /// <summary>
+        /// Something not allowed by the rules of the language or other authority.
+        /// </summary>
+        Error = 3,
+    }
+
+    /// <summary>
+    /// Values for severity that are used internally by the compiler but are not exposed.
+    /// </summary>
+    internal static class InternalDiagnosticSeverity
+    {
+        /// <summary>
+        /// An unknown severity diagnostic is something whose severity has not yet been determined.
+        /// </summary>
+        public const DiagnosticSeverity Unknown = (DiagnosticSeverity)InternalErrorCode.Unknown;
+
+        /// <summary>
+        /// If an unknown diagnostic is resolved and found to be unnecessary then it is 
+        /// treated as a "Void" diagnostic
+        /// </summary>
+        public const DiagnosticSeverity Void = (DiagnosticSeverity)InternalErrorCode.Void;
+    }
+
+    /// <summary>
+    /// Values for ErrorCode/ERRID that are used internally by the compiler but are not exposed.
+    /// </summary>
+    internal static class InternalErrorCode
+    {
+        /// <summary>
+        /// The code has yet to be determined.
+        /// </summary>
+        public const int Unknown = -1;
+
+        /// <summary>
+        /// The code was lazily determined and does not need to be reported.
+        /// </summary>
+        public const int Void = -2;
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticWithInfo.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/DiagnosticWithInfo.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A diagnostic (such as a compiler error or a warning), along with the location where it occurred.
+    /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    internal class DiagnosticWithInfo : Diagnostic
+    {
+        private readonly DiagnosticInfo _info;
+        private readonly Location _location;
+        private readonly bool _isSuppressed;
+
+        internal DiagnosticWithInfo(DiagnosticInfo info, Location location, bool isSuppressed = false)
+        {
+            Debug.Assert(info != null);
+            Debug.Assert(location != null);
+            _info = info;
+            _location = location;
+            _isSuppressed = isSuppressed;
+        }
+
+        public override Location Location
+        {
+            get { return _location; }
+        }
+
+        public override IReadOnlyList<Location> AdditionalLocations
+        {
+            get { return this.Info.AdditionalLocations; }
+        }
+
+        internal override IReadOnlyList<string> CustomTags
+        {
+            get
+            {
+                return this.Info.CustomTags;
+            }
+        }
+
+        public override DiagnosticDescriptor Descriptor
+        {
+            get
+            {
+                return this.Info.Descriptor;
+            }
+        }
+
+        public override string Id
+        {
+            get { return this.Info.MessageIdentifier; }
+        }
+
+        internal override string Category
+        {
+            get { return this.Info.Category; }
+        }
+
+
+        internal sealed override int Code
+        {
+            get { return this.Info.Code; }
+        }
+
+        public sealed override DiagnosticSeverity Severity
+        {
+            get { return this.Info.Severity; }
+        }
+
+        public sealed override DiagnosticSeverity DefaultSeverity
+        {
+            get { return this.Info.DefaultSeverity; }
+        }
+
+        internal sealed override bool IsEnabledByDefault
+        {
+            // All compiler errors and warnings are enabled by default.
+            get { return true; }
+        }
+
+        public override bool IsSuppressed
+        {
+            get { return _isSuppressed; }
+        }
+
+        public sealed override int WarningLevel
+        {
+            get { return this.Info.WarningLevel; }
+        }
+
+        public override string GetMessage(IFormatProvider formatProvider = null)
+        {
+            return this.Info.GetMessage(formatProvider);
+        }
+
+        internal override IReadOnlyList<object> Arguments
+        {
+            get { return this.Info.Arguments; }
+        }
+
+        /// <summary>
+        /// Get the information about the diagnostic: the code, severity, message, etc.
+        /// </summary>
+        public DiagnosticInfo Info
+        {
+            get
+            {
+                if (_info.Severity == InternalDiagnosticSeverity.Unknown)
+                {
+                    return _info.GetResolvedInfo();
+                }
+
+                return _info;
+            }
+        }
+
+        /// <summary>
+        /// True if the DiagnosticInfo for this diagnostic requires (or required - this property
+        /// is immutable) resolution.
+        /// </summary>
+        internal bool HasLazyInfo
+        {
+            get
+            {
+                return _info.Severity == InternalDiagnosticSeverity.Unknown ||
+                    _info.Severity == InternalDiagnosticSeverity.Void;
+            }
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(this.Location.GetHashCode(), this.Info.GetHashCode());
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as Diagnostic);
+        }
+
+        public override bool Equals(Diagnostic obj)
+        {
+            if (this == obj)
+            {
+                return true;
+            }
+
+            var other = obj as DiagnosticWithInfo;
+
+            if (other == null || this.GetType() != other.GetType())
+            {
+                return false;
+            }
+
+            return
+                this.Location.Equals(other._location) &&
+                this.Info.Equals(other.Info) &&
+                this.AdditionalLocations.SequenceEqual(other.AdditionalLocations);
+        }
+
+        private string GetDebuggerDisplay()
+        {
+            switch (_info.Severity)
+            {
+                case InternalDiagnosticSeverity.Unknown:
+                    // If we called ToString before the diagnostic was resolved,
+                    // we would risk infinite recursion (e.g. if we were still computing
+                    // member lists).
+                    return "Unresolved diagnostic at " + this.Location;
+
+                case InternalDiagnosticSeverity.Void:
+                    // If we called ToString on a void diagnostic, the MessageProvider
+                    // would complain about the code.
+                    return "Void diagnostic at " + this.Location;
+
+                default:
+                    return ToString();
+            }
+        }
+
+        internal override Diagnostic WithLocation(Location location)
+        {
+            if (location == null)
+            {
+                throw new ArgumentNullException(nameof(location));
+            }
+
+            if (location != _location)
+            {
+                return new DiagnosticWithInfo(_info, location, _isSuppressed);
+            }
+
+            return this;
+        }
+
+        internal override Diagnostic WithSeverity(DiagnosticSeverity severity)
+        {
+            if (this.Severity != severity)
+            {
+                return new DiagnosticWithInfo(this.Info.GetInstanceWithSeverity(severity), _location, _isSuppressed);
+            }
+
+            return this;
+        }
+
+        internal override Diagnostic WithIsSuppressed(bool isSuppressed)
+        {
+            if (this.IsSuppressed != isSuppressed)
+            {
+                return new DiagnosticWithInfo(this.Info, _location, isSuppressed);
+            }
+
+            return this;
+        }
+
+        internal sealed override bool IsNotConfigurable()
+        {
+            return this.Info.IsNotConfigurable();
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/Diagnostic_SimpleDiagnostic.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/Diagnostic_SimpleDiagnostic.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A diagnostic (such as a compiler error or a warning), along with the location where it occurred.
+    /// </summary>
+    public abstract partial class Diagnostic
+    {
+        internal sealed class SimpleDiagnostic : Diagnostic
+        {
+            private readonly DiagnosticDescriptor _descriptor;
+            private readonly DiagnosticSeverity _severity;
+            private readonly int _warningLevel;
+            private readonly Location _location;
+            private readonly IReadOnlyList<Location> _additionalLocations;
+            private readonly object[] _messageArgs;
+            private readonly ImmutableDictionary<string, string> _properties;
+            private readonly bool _isSuppressed;
+
+            private SimpleDiagnostic(
+                DiagnosticDescriptor descriptor,
+                DiagnosticSeverity severity,
+                int warningLevel,
+                Location location,
+                IEnumerable<Location> additionalLocations,
+                object[] messageArgs,
+                ImmutableDictionary<string, string> properties,
+                bool isSuppressed)
+            {
+                if ((warningLevel == 0 && severity != DiagnosticSeverity.Error) ||
+                    (warningLevel != 0 && severity == DiagnosticSeverity.Error))
+                {
+                    throw new ArgumentException(nameof(warningLevel));
+                }
+
+                if (descriptor == null)
+                {
+                    throw new ArgumentNullException(nameof(descriptor));
+                }
+
+                _descriptor = descriptor;
+                _severity = severity;
+                _warningLevel = warningLevel;
+                _location = location ?? Location.None;
+                _additionalLocations = additionalLocations?.ToImmutableArray() ?? SpecializedCollections.EmptyReadOnlyList<Location>();
+                _messageArgs = messageArgs ?? SpecializedCollections.EmptyArray<object>();
+                _properties = properties ?? ImmutableDictionary<string, string>.Empty;
+                _isSuppressed = isSuppressed;
+            }
+
+            internal static SimpleDiagnostic Create(
+                DiagnosticDescriptor descriptor,
+                DiagnosticSeverity severity,
+                int warningLevel,
+                Location location,
+                IEnumerable<Location> additionalLocations,
+                object[] messageArgs,
+                ImmutableDictionary<string, string> properties,
+                bool isSuppressed = false)
+            {
+                return new SimpleDiagnostic(descriptor, severity, warningLevel, location, additionalLocations, messageArgs, properties, isSuppressed);
+            }
+
+            internal static SimpleDiagnostic Create(string id, LocalizableString title, string category, LocalizableString message, LocalizableString description, string helpLink,
+                                      DiagnosticSeverity severity, DiagnosticSeverity defaultSeverity,
+                                      bool isEnabledByDefault, int warningLevel, Location location,
+                                      IEnumerable<Location> additionalLocations, IEnumerable<string> customTags,
+                                      ImmutableDictionary<string, string> properties, bool isSuppressed = false)
+            {
+                var descriptor = new DiagnosticDescriptor(id, title, message,
+                     category, defaultSeverity, isEnabledByDefault, description, helpLink, customTags.ToImmutableArrayOrEmpty());
+                return new SimpleDiagnostic(descriptor, severity, warningLevel, location, additionalLocations, messageArgs: null, properties: properties, isSuppressed: isSuppressed);
+            }
+
+            public override DiagnosticDescriptor Descriptor
+            {
+                get { return _descriptor; }
+            }
+
+            public override string Id
+            {
+                get { return _descriptor.Id; }
+            }
+
+            public override string GetMessage(IFormatProvider formatProvider = null)
+            {
+                if (_messageArgs.Length == 0)
+                {
+                    return _descriptor.MessageFormat.ToString(formatProvider);
+                }
+
+                var localizedMessageFormat = _descriptor.MessageFormat.ToString(formatProvider);
+
+                try
+                {
+                    return string.Format(formatProvider, localizedMessageFormat, _messageArgs);
+                }
+                catch (Exception)
+                {
+                    // Analyzer reported diagnostic with invalid format arguments, so just return the unformatted message.
+                    return localizedMessageFormat;
+                }
+            }
+
+            internal override IReadOnlyList<object> Arguments
+            {
+                get { return _messageArgs; }
+            }
+
+            public override DiagnosticSeverity Severity
+            {
+                get { return _severity; }
+            }
+
+            public override bool IsSuppressed
+            {
+                get { return _isSuppressed; }
+            }
+
+            public override int WarningLevel
+            {
+                get { return _warningLevel; }
+            }
+
+            public override Location Location
+            {
+                get { return _location; }
+            }
+
+            public override IReadOnlyList<Location> AdditionalLocations
+            {
+                get { return _additionalLocations; }
+            }
+
+            public override ImmutableDictionary<string, string> Properties
+            {
+                get { return _properties; }
+            }
+
+            public override bool Equals(Diagnostic obj)
+            {
+                var other = obj as SimpleDiagnostic;
+                if (other == null)
+                {
+                    return false;
+                }
+
+                if (AnalyzerExecutor.IsAnalyzerExceptionDiagnostic(this))
+                {
+                    // We have custom Equals logic for diagnostics generated for analyzer exceptions.
+                    return AnalyzerExecutor.AreEquivalentAnalyzerExceptionDiagnostics(this, other);
+                }
+
+                return _descriptor.Equals(other._descriptor)
+                    && _messageArgs.SequenceEqual(other._messageArgs, (a, b) => a == b)
+                    && _location == other._location
+                    && _severity == other._severity
+                    && _warningLevel == other._warningLevel;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return this.Equals(obj as Diagnostic);
+            }
+
+            public override int GetHashCode()
+            {
+                return Hash.Combine(_descriptor,
+                    Hash.CombineValues(_messageArgs,
+                    Hash.Combine(_warningLevel,
+                    Hash.Combine(_location, (int)_severity))));
+            }
+
+            internal override Diagnostic WithLocation(Location location)
+            {
+                if (location == null)
+                {
+                    throw new ArgumentNullException(nameof(location));
+                }
+
+                if (location != _location)
+                {
+                    return new SimpleDiagnostic(_descriptor, _severity, _warningLevel, location, _additionalLocations, _messageArgs, _properties, _isSuppressed);
+                }
+
+                return this;
+            }
+
+            internal override Diagnostic WithSeverity(DiagnosticSeverity severity)
+            {
+                if (this.Severity != severity)
+                {
+                    var warningLevel = GetDefaultWarningLevel(severity);
+                    return new SimpleDiagnostic(_descriptor, severity, warningLevel, _location, _additionalLocations, _messageArgs, _properties, _isSuppressed);
+                }
+
+                return this;
+            }
+
+            internal override Diagnostic WithIsSuppressed(bool isSuppressed)
+            {
+                if (this.IsSuppressed != isSuppressed)
+                {
+                    return new SimpleDiagnostic(_descriptor, _severity, _warningLevel, _location, _additionalLocations, _messageArgs, _properties, isSuppressed);
+                }
+
+                return this;
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/ExternalFileLocation.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/ExternalFileLocation.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A program location in source code.
+    /// </summary>
+    internal sealed class ExternalFileLocation : Location, IEquatable<ExternalFileLocation>
+    {
+        private readonly TextSpan _sourceSpan;
+        private readonly FileLinePositionSpan _lineSpan;
+
+        internal ExternalFileLocation(string filePath, TextSpan sourceSpan, LinePositionSpan lineSpan)
+        {
+            _sourceSpan = sourceSpan;
+            _lineSpan = new FileLinePositionSpan(filePath, lineSpan);
+        }
+
+        public override TextSpan SourceSpan
+        {
+            get
+            {
+                return _sourceSpan;
+            }
+        }
+
+        public override FileLinePositionSpan GetLineSpan()
+        {
+            return _lineSpan;
+        }
+
+        public override FileLinePositionSpan GetMappedLineSpan()
+        {
+            return _lineSpan;
+        }
+
+        public override LocationKind Kind
+        {
+            get
+            {
+                return LocationKind.ExternalFile;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as ExternalFileLocation);
+        }
+
+        public bool Equals(ExternalFileLocation obj)
+        {
+            if (ReferenceEquals(obj, this))
+            {
+                return true;
+            }
+
+            return obj != null
+                && _sourceSpan == obj._sourceSpan
+                && _lineSpan.Equals(obj._lineSpan);
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(_lineSpan.GetHashCode(), _sourceSpan.GetHashCode());
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/FileLinePositionSpan.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/FileLinePositionSpan.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Represents a span of text in a source code file in terms of file name, line number, and offset within line.
+    /// However, the file is actually whatever was passed in when asked to parse; there may not really be a file.
+    /// </summary>
+    public struct FileLinePositionSpan : IEquatable<FileLinePositionSpan>
+    {
+        private readonly string _path;
+        private readonly LinePositionSpan _span;
+        private readonly bool _hasMappedPath;
+
+        /// <summary>
+        /// Path, or null if the span represents an invalid value.
+        /// </summary>
+        /// <remarks>
+        /// Path may be <see cref="string.Empty"/> if not available.
+        /// </remarks>
+        public string Path { get { return _path; } }
+
+        /// <summary>
+        /// True if the <see cref="Path"/> is a mapped path.
+        /// </summary>
+        /// <remarks>
+        /// A mapped path is a path specified in source via <code>#line</code> (C#) or <code>#ExternalSource</code> (VB) directives.
+        /// </remarks>
+        public bool HasMappedPath { get { return _hasMappedPath; } }
+
+        /// <summary>
+        /// Gets the <see cref="LinePosition"/> of the start of the span.
+        /// </summary>
+        /// <returns></returns>
+        public LinePosition StartLinePosition { get { return _span.Start; } }
+
+        /// <summary>
+        /// Gets the <see cref="LinePosition"/> of the end of the span.
+        /// </summary>
+        /// <returns></returns>
+        public LinePosition EndLinePosition { get { return _span.End; } }
+
+        /// <summary>
+        /// Gets the span.
+        /// </summary>
+        public LinePositionSpan Span
+        {
+            get
+            {
+                return _span;
+            }
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="FileLinePositionSpan"/> instance.
+        /// </summary>
+        /// <param name="path">The file identifier - typically a relative or absolute path.</param>
+        /// <param name="start">The start line position.</param>
+        /// <param name="end">The end line position.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+        public FileLinePositionSpan(string path, LinePosition start, LinePosition end)
+            : this(path, new LinePositionSpan(start, end))
+        {
+        }
+
+        /// <summary>
+        /// Initializes the <see cref="FileLinePositionSpan"/> instance.
+        /// </summary>
+        /// <param name="path">The file identifier - typically a relative or absolute path.</param>
+        /// <param name="span">The span.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="path"/> is null.</exception>
+        public FileLinePositionSpan(string path, LinePositionSpan span)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            _path = path;
+            _span = span;
+            _hasMappedPath = false;
+        }
+
+        internal FileLinePositionSpan(string path, LinePositionSpan span, bool hasMappedPath)
+        {
+            _path = path;
+            _span = span;
+            _hasMappedPath = hasMappedPath;
+        }
+
+        /// <summary>
+        /// Returns true if the span represents a valid location.
+        /// </summary>
+        public bool IsValid
+        {
+            get
+            {
+                // invalid span can be constructed by new FileLinePositionSpan()
+                return _path != null;
+            }
+        }
+
+        /// <summary>
+        /// Determines if two FileLinePositionSpan objects are equal.
+        /// </summary>
+        /// <remarks>
+        /// The path is treated as an opaque string, i.e. a case-sensitive comparison is used.
+        /// </remarks>
+        public bool Equals(FileLinePositionSpan other)
+        {
+            return _span.Equals(other._span)
+                && _hasMappedPath == other._hasMappedPath
+                && string.Equals(_path, other._path, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Determines if two FileLinePositionSpan objects are equal.
+        /// </summary>
+        public override bool Equals(object other)
+        {
+            return other is FileLinePositionSpan && Equals((FileLinePositionSpan)other);
+        }
+
+        /// <summary>
+        /// Serves as a hash function for FileLinePositionSpan.
+        /// </summary>
+        /// <returns>The hash code.</returns>
+        /// <remarks>
+        /// The path is treated as an opaque string, i.e. a case-sensitive hash is calculated.
+        /// </remarks>
+        public override int GetHashCode()
+        {
+            return Hash.Combine(_path, Hash.Combine(_hasMappedPath, _span.GetHashCode()));
+        }
+
+        /// <summary>
+        /// Returns a <see cref="System.String"/> that represents FileLinePositionSpan.
+        /// </summary>
+        /// <returns>The string representation of FileLinePositionSpan.</returns>
+        /// <example>Path: (0,0)-(5,6)</example>
+        public override string ToString()
+        {
+            return _path + ": " + _span;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/IMessageSerializable.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/IMessageSerializable.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Indicates that the implementing type can be serialized via <see cref="object.ToString"/> 
+    /// for diagnostic message purposes.
+    /// </summary>
+    /// <remarks>
+    /// Not appropriate on types that require localization, since localization should
+    /// happen after serialization.
+    /// </remarks>
+    internal interface IMessageSerializable
+    {
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableResourceString.FixedLocalizableString.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    public abstract partial class LocalizableString
+    {
+        private sealed class FixedLocalizableString : LocalizableString
+        {
+            /// <summary>
+            /// FixedLocalizableString representing an empty string.
+            /// </summary>
+            private static readonly FixedLocalizableString s_empty = new FixedLocalizableString(string.Empty);
+
+            private readonly string _fixedString;
+
+            public static FixedLocalizableString Create(string fixedResource)
+            {
+                if (string.IsNullOrEmpty(fixedResource))
+                {
+                    return s_empty;
+                }
+
+                return new FixedLocalizableString(fixedResource);
+            }
+
+            private FixedLocalizableString(string fixedResource)
+            {
+                _fixedString = fixedResource;
+            }
+
+            protected override string GetText(IFormatProvider formatProvider)
+            {
+                return _fixedString;
+            }
+
+            protected override bool AreEqual(object other)
+            {
+                var fixedStr = other as FixedLocalizableString;
+                return fixedStr != null && string.Equals(_fixedString, fixedStr._fixedString);
+            }
+
+            protected override int GetHash()
+            {
+                return _fixedString?.GetHashCode() ?? 0;
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableResourceString.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableResourceString.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Utilities;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Resources;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A localizable resource string that may possibly be formatted differently depending on culture.
+    /// </summary>
+    public sealed class LocalizableResourceString : LocalizableString, IObjectReadable, IObjectWritable
+    {
+        private readonly string _nameOfLocalizableResource;
+        private readonly ResourceManager _resourceManager;
+        private readonly Type _resourceSource;
+        private readonly string[] _formatArguments;
+
+        /// <summary>
+        /// Creates a localizable resource string with no formatting arguments.
+        /// </summary>
+        /// <param name="nameOfLocalizableResource">nameof the resource that needs to be localized.</param>
+        /// <param name="resourceManager"><see cref="ResourceManager"/> for the calling assembly.</param>
+        /// <param name="resourceSource">Type handling assembly's resource management. Typically, this is the static class generated for the resources file from which resources are accessed.</param>
+        public LocalizableResourceString(string nameOfLocalizableResource, ResourceManager resourceManager, Type resourceSource)
+            : this(nameOfLocalizableResource, resourceManager, resourceSource, SpecializedCollections.EmptyArray<string>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a localizable resource string that may possibly be formatted differently depending on culture.
+        /// </summary>
+        /// <param name="nameOfLocalizableResource">nameof the resource that needs to be localized.</param>
+        /// <param name="resourceManager"><see cref="ResourceManager"/> for the calling assembly.</param>
+        /// <param name="resourceSource">Type handling assembly's resource management. Typically, this is the static class generated for the resources file from which resources are accessed.</param>
+        /// <param name="formatArguments">Optional arguments for formatting the localizable resource string.</param>
+        public LocalizableResourceString(string nameOfLocalizableResource, ResourceManager resourceManager, Type resourceSource, params string[] formatArguments)
+        {
+            if (nameOfLocalizableResource == null)
+            {
+                throw new ArgumentNullException(nameof(nameOfLocalizableResource));
+            }
+
+            if (resourceManager == null)
+            {
+                throw new ArgumentNullException(nameof(resourceManager));
+            }
+
+            if (resourceSource == null)
+            {
+                throw new ArgumentNullException(nameof(resourceSource));
+            }
+
+            if (formatArguments == null)
+            {
+                throw new ArgumentNullException(nameof(formatArguments));
+            }
+
+            _resourceManager = resourceManager;
+            _nameOfLocalizableResource = nameOfLocalizableResource;
+            _resourceSource = resourceSource;
+            _formatArguments = formatArguments;
+        }
+
+        private LocalizableResourceString(ObjectReader reader)
+        {
+            _resourceSource = (Type)reader.ReadValue();
+            _nameOfLocalizableResource = reader.ReadString();
+            _resourceManager = new ResourceManager(_resourceSource);
+
+            var length = (int)reader.ReadCompressedUInt();
+            if (length == 0)
+            {
+                _formatArguments = SpecializedCollections.EmptyArray<string>();
+            }
+            else
+            {
+                var argumentsBuilder = ArrayBuilder<string>.GetInstance(length);
+                for (int i = 0; i < length; i++)
+                {
+                    argumentsBuilder.Add(reader.ReadString());
+                }
+
+                _formatArguments = argumentsBuilder.ToArrayAndFree();
+            }
+        }
+
+        Func<ObjectReader, object> IObjectReadable.GetReader()
+        {
+            return reader => new LocalizableResourceString(reader);
+        }
+
+        void IObjectWritable.WriteTo(ObjectWriter writer)
+        {
+            writer.WriteValue(_resourceSource);
+            writer.WriteString(_nameOfLocalizableResource);
+            var length = (uint)_formatArguments.Length;
+            writer.WriteCompressedUInt(length);
+            for (int i = 0; i < length; i++)
+            {
+                writer.WriteString(_formatArguments[i]);
+            }
+        }
+
+        protected override string GetText(IFormatProvider formatProvider)
+        {
+            var culture = formatProvider as CultureInfo ?? CultureInfo.CurrentUICulture;
+            var resourceString = _resourceManager.GetString(_nameOfLocalizableResource, culture);
+            return resourceString != null ?
+                (_formatArguments.Length > 0 ? string.Format(resourceString, _formatArguments) : resourceString) :
+                string.Empty;
+        }
+
+        protected override bool AreEqual(object other)
+        {
+            var otherResourceString = other as LocalizableResourceString;
+            return otherResourceString != null &&
+                _nameOfLocalizableResource == otherResourceString._nameOfLocalizableResource &&
+                _resourceManager == otherResourceString._resourceManager &&
+                _resourceSource == otherResourceString._resourceSource &&
+                _formatArguments.SequenceEqual(otherResourceString._formatArguments, (a, b) => a == b);
+        }
+
+        protected override int GetHash()
+        {
+            return Hash.Combine(_nameOfLocalizableResource.GetHashCode(),
+                Hash.Combine(_resourceManager.GetHashCode(),
+                Hash.Combine(_resourceSource.GetHashCode(),
+                Hash.CombineValues(_formatArguments))));
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableString.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocalizableString.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A string that may possibly be formatted differently depending on culture.
+    /// NOTE: Types implementing <see cref="LocalizableString"/> must be serializable.
+    /// </summary>
+    public abstract partial class LocalizableString : IFormattable, IEquatable<LocalizableString>
+    {
+        /// <summary>
+        /// Fired when an exception is raised by any of the public methods of <see cref="LocalizableString"/>.
+        /// If the exception handler itself throws an exception, that exception is ignored.
+        /// </summary>
+        public event EventHandler<Exception> OnException;
+
+        /// <summary>
+        /// Formats the value of the current instance using the optionally specified format. 
+        /// </summary>
+        public string ToString(IFormatProvider formatProvider)
+        {
+            try
+            {
+                return GetText(formatProvider);
+            }
+            catch (Exception ex)
+            {
+                RaiseOnException(ex);
+                return string.Empty;
+            }
+        }
+
+        public static explicit operator string (LocalizableString localizableResource)
+        {
+            return localizableResource.ToString(null);
+        }
+
+        public static implicit operator LocalizableString(string fixedResource)
+        {
+            return FixedLocalizableString.Create(fixedResource);
+        }
+
+        public sealed override string ToString()
+        {
+            return ToString(null);
+        }
+
+        string IFormattable.ToString(string ignored, IFormatProvider formatProvider)
+        {
+            return ToString(formatProvider);
+        }
+
+        public sealed override int GetHashCode()
+        {
+            try
+            {
+                return GetHash();
+            }
+            catch (Exception ex)
+            {
+                RaiseOnException(ex);
+                return 0;
+            }
+        }
+
+        public sealed override bool Equals(object other)
+        {
+            try
+            {
+                return AreEqual(other);
+            }
+            catch (Exception ex)
+            {
+                RaiseOnException(ex);
+                return false;
+            }
+        }
+
+        public bool Equals(LocalizableString other)
+        {
+            return Equals((object)other);
+        }
+
+        /// <summary>
+        /// Formats the value of the current instance using the optionally specified format.
+        /// Provides the implementation of ToString. ToString will provide a default value
+        /// if this method throws an exception.
+        /// </summary>
+        protected abstract string GetText(IFormatProvider formatProvider);
+
+        /// <summary>
+        /// Provides the implementation of GetHashCode. GetHashCode will provide a default value
+        /// if this method throws an exception.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract int GetHash();
+
+        /// <summary>
+        /// Provides the implementation of Equals. Equals will provide a default value
+        /// if this method throws an exception.
+        /// </summary>
+        /// <returns></returns>
+        protected abstract bool AreEqual(object other);
+
+        private void RaiseOnException(Exception ex)
+        {
+            if (ex is OperationCanceledException)
+            {
+                return;
+            }
+
+            try
+            {
+                OnException?.Invoke(this, ex);
+            }
+            catch
+            {
+                // Ignore exceptions from the exception handlers themselves.
+            }
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/Location.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/Location.cs
@@ -1,0 +1,174 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A program location in source code.
+    /// </summary>
+    [DebuggerDisplay("{GetDebuggerDisplay(), nq}")]
+    public abstract class Location
+    {
+        internal Location()
+        {
+        }
+
+        /// <summary>
+        /// Location kind (None/SourceFile/MetadataFile).
+        /// </summary>
+        public abstract LocationKind Kind { get; }
+
+        /// <summary>
+        /// Returns true if the location represents a specific location in a source code file.
+        /// </summary>
+        public bool IsInSource { get { return SourceTree != null; } }
+
+        /// <summary>
+        /// Returns true if the location is in metadata.
+        /// </summary>
+        public bool IsInMetadata { get { return MetadataModule != null; } }
+
+        /// <summary>
+        /// The syntax tree this location is located in or <c>null</c> if not in a syntax tree.
+        /// </summary>
+        public virtual SyntaxTree SourceTree { get { return null; } }
+
+        /// <summary>
+        /// Returns the metadata module the location is associated with or <c>null</c> if the module is not available.
+        /// </summary>
+        /// <remarks>
+        /// Might return null even if <see cref="IsInMetadata"/> returns true. The module symbol might not be available anymore, 
+        /// for example, if the location is serialized and deserialized.
+        /// </remarks>
+        public virtual IModuleSymbol MetadataModule { get { return null; } }
+
+        /// <summary>
+        /// The location within the syntax tree that this location is associated with.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="IsInSource"/> returns False this method returns an empty <see cref="TextSpan"/> which starts at position 0.
+        /// </remarks>
+        public virtual TextSpan SourceSpan { get { return default(TextSpan); } }
+
+        /// <summary>
+        /// Gets the location in terms of path, line and column.
+        /// </summary>
+        /// <returns>
+        /// <see cref="FileLinePositionSpan"/> that contains path, line and column information.
+        /// 
+        /// Returns an invalid span (see <see cref="FileLinePositionSpan.IsValid"/>) if the information is not available.
+        /// 
+        /// The values are not affected by line mapping directives (#line in C# or #ExternalSource in VB).
+        /// </returns>
+        public virtual FileLinePositionSpan GetLineSpan()
+        {
+            return default(FileLinePositionSpan);
+        }
+
+        /// <summary>
+        /// Gets the location in terms of path, line and column after applying source line mapping directives
+        /// (<code>#line</code> in C# or <code>#ExternalSource</code> in VB). 
+        /// </summary>
+        /// <returns>
+        /// <see cref="FileLinePositionSpan"/> that contains file, line and column information,
+        /// or an invalid span (see <see cref="FileLinePositionSpan.IsValid"/>) if not available.
+        /// </returns>
+        public virtual FileLinePositionSpan GetMappedLineSpan()
+        {
+            return default(FileLinePositionSpan);
+        }
+
+        // Derived classes should provide value equality semantics.
+        public abstract override bool Equals(object obj);
+        public abstract override int GetHashCode();
+
+        public override string ToString()
+        {
+            string result = Kind.ToString();
+            if (IsInSource)
+            {
+                result += "(" + this.SourceTree?.FilePath + this.SourceSpan + ")";
+            }
+            else if (IsInMetadata)
+            {
+                if (this.MetadataModule != null)
+                {
+                    result += "(" + this.MetadataModule.Name + ")";
+                }
+            }
+            else
+            {
+                var pos = GetLineSpan();
+                if (pos.Path != null)
+                {
+                    // user-visible line and column counts are 1-based, but internally are 0-based.
+                    result += "(" + pos.Path + "@" + (pos.StartLinePosition.Line + 1) + ":" + (pos.StartLinePosition.Character + 1) + ")";
+                }
+            }
+
+            return result;
+        }
+
+        public static bool operator ==(Location left, Location right)
+        {
+            if (object.ReferenceEquals(left, null))
+            {
+                return object.ReferenceEquals(right, null);
+            }
+
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Location left, Location right)
+        {
+            return !(left == right);
+        }
+
+        protected virtual string GetDebuggerDisplay()
+        {
+            string result = this.GetType().Name;
+            var pos = GetLineSpan();
+            if (pos.Path != null)
+            {
+                // user-visible line and column counts are 1-based, but internally are 0-based.
+                result += "(" + pos.Path + "@" + (pos.StartLinePosition.Line + 1) + ":" + (pos.StartLinePosition.Character + 1) + ")";
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// A location of kind LocationKind.None. 
+        /// </summary>
+        public static Location None { get { return NoLocation.Singleton; } }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="Location"/> for a span in a <see cref="SyntaxTree"/>.
+        /// </summary>
+        public static Location Create(SyntaxTree syntaxTree, TextSpan textSpan)
+        {
+            if (syntaxTree == null)
+            {
+                throw new ArgumentNullException(nameof(syntaxTree));
+            }
+
+            return new SourceLocation(syntaxTree, textSpan);
+        }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="Location"/> for a span in a file.
+        /// </summary>
+        public static Location Create(string filePath, TextSpan textSpan, LinePositionSpan lineSpan)
+        {
+            if (filePath == null)
+            {
+                throw new ArgumentNullException(nameof(filePath));
+            }
+
+            return new ExternalFileLocation(filePath, textSpan, lineSpan);
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocationKind.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/LocationKind.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Specifies the kind of location (source vs. metadata).
+    /// </summary>
+    public enum LocationKind : byte
+    {
+        /// <summary>
+        /// Unspecified location.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// The location represents a position in a source file.
+        /// </summary>
+        SourceFile = 1,
+
+        /// <summary>
+        /// The location represents a metadata file.
+        /// </summary>
+        MetadataFile = 2,
+
+        /// <summary>
+        /// The location represents a position in an XML file.
+        /// </summary>
+        XmlFile = 3,
+
+        /// <summary>
+        /// The location in some external file.
+        /// </summary>
+        ExternalFile = 4,
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/MetadataLocation.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/MetadataLocation.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A program location in metadata.
+    /// </summary>
+    internal sealed class MetadataLocation : Location, IEquatable<MetadataLocation>
+    {
+        private readonly IModuleSymbol _module;
+
+        internal MetadataLocation(IModuleSymbol module)
+        {
+            Debug.Assert(module != null);
+            _module = module;
+        }
+
+        public override LocationKind Kind
+        {
+            get { return LocationKind.MetadataFile; }
+        }
+
+        public override IModuleSymbol MetadataModule
+        {
+            get { return _module; }
+        }
+
+        public override int GetHashCode()
+        {
+            return _module.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            return Equals(obj as MetadataLocation);
+        }
+
+        public bool Equals(MetadataLocation other)
+        {
+            return other != null && other._module == _module;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/NoLocation.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/NoLocation.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A class that represents no location at all. Useful for errors in command line options, for example.
+    /// </summary>
+    /// <remarks></remarks>
+    internal sealed class NoLocation : Location
+    {
+        public static readonly Location Singleton = new NoLocation();
+
+        private NoLocation()
+        {
+        }
+
+        public override LocationKind Kind
+        {
+            get { return LocationKind.None; }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (object)this == obj;
+        }
+
+        public override int GetHashCode()
+        {
+            // arbitrary number, since all NoLocation's are equal
+            return 0x16487756;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/ReportDiagnostic.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/ReportDiagnostic.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// Describes how to report a warning diagnostic.
+    /// </summary>
+    public enum ReportDiagnostic
+    {
+        /// <summary>
+        /// Report a diagnostic by default.
+        /// </summary>
+        Default = 0,
+
+        /// <summary>
+        /// Report a diagnostic as an error.  
+        /// </summary>
+        Error = 1,
+
+        /// <summary>
+        /// Report a diagnostic as a warning even though /warnaserror is specified.
+        /// </summary>
+        Warn = 2,
+
+        /// <summary>
+        /// Report a diagnostic as an info.
+        /// </summary>
+        Info = 3,
+
+        /// <summary>
+        /// Report a diagnostic as hidden.
+        /// </summary>
+        Hidden = 4,
+
+        /// <summary>
+        /// Suppress a diagnostic.
+        /// </summary>
+        Suppress = 5,
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/SourceLocation.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/SourceLocation.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A program location in source code.
+    /// </summary>
+    internal sealed class SourceLocation : Location, IEquatable<SourceLocation>
+    {
+        private readonly SyntaxTree _syntaxTree;
+        private readonly TextSpan _span;
+
+        public SourceLocation(SyntaxTree syntaxTree, TextSpan span)
+        {
+            _syntaxTree = syntaxTree;
+            _span = span;
+        }
+
+        public SourceLocation(SyntaxNode node)
+            : this(node.SyntaxTree, node.Span)
+        {
+        }
+
+        public SourceLocation(SyntaxToken token)
+            : this(token.SyntaxTree, token.Span)
+        {
+        }
+
+        public SourceLocation(SyntaxNodeOrToken nodeOrToken)
+            : this(nodeOrToken.SyntaxTree, nodeOrToken.Span)
+        {
+        }
+
+        public SourceLocation(SyntaxTrivia trivia)
+            : this(trivia.SyntaxTree, trivia.Span)
+        {
+        }
+
+        public SourceLocation(SyntaxReference syntaxRef)
+            : this(syntaxRef.SyntaxTree, syntaxRef.Span)
+        {
+            // If we're using a syntaxref, we don't have a node in hand, so we couldn't get equality
+            // on syntax node, so associatedNodeOpt shouldn't be set. We never use this constructor
+            // when binding executable code anywhere, so it has no use.
+        }
+
+        public override LocationKind Kind
+        {
+            get
+            {
+                return LocationKind.SourceFile;
+            }
+        }
+
+        public override TextSpan SourceSpan
+        {
+            get
+            {
+                return _span;
+            }
+        }
+
+        public override SyntaxTree SourceTree
+        {
+            get
+            {
+                return _syntaxTree;
+            }
+        }
+
+        public override FileLinePositionSpan GetLineSpan()
+        {
+            // If there's no syntax tree (e.g. because we're binding speculatively),
+            // then just return an invalid span.
+            if (_syntaxTree == null)
+            {
+                FileLinePositionSpan result = default(FileLinePositionSpan);
+                Debug.Assert(!result.IsValid);
+                return result;
+            }
+
+            return _syntaxTree.GetLineSpan(_span);
+        }
+
+        public override FileLinePositionSpan GetMappedLineSpan()
+        {
+            // If there's no syntax tree (e.g. because we're binding speculatively),
+            // then just return an invalid span.
+            if (_syntaxTree == null)
+            {
+                FileLinePositionSpan result = default(FileLinePositionSpan);
+                Debug.Assert(!result.IsValid);
+                return result;
+            }
+
+            return _syntaxTree.GetMappedLineSpan(_span);
+        }
+
+        public bool Equals(SourceLocation other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other != null && other._syntaxTree == _syntaxTree && other._span == _span;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as SourceLocation);
+        }
+
+        public override int GetHashCode()
+        {
+            return Hash.Combine(_syntaxTree, _span.GetHashCode());
+        }
+
+        protected override string GetDebuggerDisplay()
+        {
+            return base.GetDebuggerDisplay() + "\"" + _syntaxTree.ToString().Substring(_span.Start, _span.Length) + "\"";
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/SuppressionInfo.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/SuppressionInfo.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.Diagnostics
+{
+    /// <summary>
+    /// Contains information about the source of diagnostic suppression.
+    /// </summary>
+    public sealed class SuppressionInfo
+    {
+        /// <summary>
+        /// <see cref="Diagnostic.Id"/> of the suppressed diagnostic.
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// If the diagnostic was suppressed by an attribute, then returns that attribute.
+        /// Otherwise, returns null.
+        /// </summary>
+        public AttributeData Attribute { get; }
+
+        internal SuppressionInfo(string id, AttributeData attribute)
+        {
+            Id = id;
+            Attribute = attribute;
+        }
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/WellKnownDiagnosticTags.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/WellKnownDiagnosticTags.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    public static class WellKnownDiagnosticTags
+    {
+        /// <summary>
+        /// Indicates that the diagnostic is related to some unnecessary source code.
+        /// </summary>
+        public const string Unnecessary = nameof(Unnecessary);
+
+        /// <summary>
+        /// Indicates that the diagnostic is related to edit and continue.
+        /// </summary>
+        public const string EditAndContinue = nameof(EditAndContinue);
+
+        /// <summary>
+        /// Indicates that the diagnostic is related to build.
+        /// </summary>
+        public const string Build = nameof(Build);
+
+        /// <summary>
+        /// Indicates that the diagnostic is reported by the compiler.
+        /// </summary>
+        public const string Compiler = nameof(Compiler);
+
+        /// <summary>
+        /// Indicates that the diagnostic can be used for telemetry
+        /// </summary>
+        public const string Telemetry = nameof(Telemetry);
+
+        /// <summary>
+        /// Indicates that the diagnostic is not configurable, i.e. it cannot be suppressed or filtered or have its severity changed.
+        /// </summary>
+        public const string NotConfigurable = nameof(NotConfigurable);
+
+        /// <summary>
+        /// Indicates that the diagnostic is related to an exception thrown by a <see cref="DiagnosticAnalyzer"/>.
+        /// </summary>
+        public const string AnalyzerException = nameof(AnalyzerException);
+    }
+}

--- a/src/Compilers/Core/Portable/FileSystem/Diagnostic/XmlLocation.cs
+++ b/src/Compilers/Core/Portable/FileSystem/Diagnostic/XmlLocation.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Xml.Linq;
+using System.Xml;
+using System.Diagnostics;
+
+namespace Microsoft.CodeAnalysis
+{
+    /// <summary>
+    /// A program location in an XML file.
+    /// </summary>
+    internal class XmlLocation : Location, IEquatable<XmlLocation>
+    {
+        private readonly FileLinePositionSpan _positionSpan;
+
+        private XmlLocation(string path, int lineNumber, int columnNumber)
+        {
+            LinePosition start = new LinePosition(lineNumber, columnNumber);
+            LinePosition end = new LinePosition(lineNumber, columnNumber + 1);
+            _positionSpan = new FileLinePositionSpan(path, start, end);
+        }
+
+        public static XmlLocation Create(XmlException exception, string path)
+        {
+            // Convert to 0-indexed (special case - sometimes 0,0).
+            int lineNumber = Math.Max(exception.LineNumber - 1, 0);
+            int columnNumber = Math.Max(exception.LinePosition - 1, 0);
+
+            return new XmlLocation(path, lineNumber, columnNumber);
+        }
+
+        public static XmlLocation Create(XObject obj, string path)
+        {
+            IXmlLineInfo xmlLineInfo = obj;
+            Debug.Assert(xmlLineInfo.LinePosition != 0);
+
+            // Convert to 0-indexed (special case - sometimes 0,0).
+            int lineNumber = Math.Max(xmlLineInfo.LineNumber - 1, 0);
+            int columnNumber = Math.Max(xmlLineInfo.LinePosition - 1, 0);
+
+            return new XmlLocation(path, lineNumber, columnNumber);
+        }
+
+        public override LocationKind Kind
+        {
+            get
+            {
+                return LocationKind.XmlFile;
+            }
+        }
+
+        public override FileLinePositionSpan GetLineSpan()
+        {
+            return _positionSpan;
+        }
+
+        public bool Equals(XmlLocation other)
+        {
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return other != null && other._positionSpan.Equals(_positionSpan);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as XmlLocation);
+        }
+
+        public override int GetHashCode()
+        {
+            return _positionSpan.GetHashCode();
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Shared/Utilities/CaretPreservingEditTransaction.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/CaretPreservingEditTransaction.cs
@@ -30,6 +30,20 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
+        public static CaretPreservingEditTransaction TryCreate(string description, 
+            ITextView textView,
+            ITextUndoHistoryRegistry undoHistoryRegistry,
+            IEditorOperationsFactoryService editorOperationsFactoryService)
+        {
+            ITextUndoHistory unused;
+            if (undoHistoryRegistry.TryGetHistory(textView.TextBuffer, out unused))
+            {
+                return new CaretPreservingEditTransaction(description, textView, undoHistoryRegistry, editorOperationsFactoryService);
+            }
+
+            return null;
+        }
+
         public void Complete()
         {
             if (!_active)


### PR DESCRIPTION
If we are unable to get an undo history for a textbuffer (because it was
part of a projection that has been unmapped), abort committing completion
(instead of crashing).