### PR TITLE
Abort completion commit when buffer is unmapped

### DIFF
--- a/src/EditorFeatures/Core/Shared/Utilities/CaretPreservingEditTransaction.cs
+++ b/src/EditorFeatures/Core/Shared/Utilities/CaretPreservingEditTransaction.cs
@@ -30,6 +30,20 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Utilities
             }
         }
 
+        public static CaretPreservingEditTransaction TryCreate(string description, 
+            ITextView textView,
+            ITextUndoHistoryRegistry undoHistoryRegistry,
+            IEditorOperationsFactoryService editorOperationsFactoryService)
+        {
+            ITextUndoHistory unused;
+            if (undoHistoryRegistry.TryGetHistory(textView.TextBuffer, out unused))
+            {
+                return new CaretPreservingEditTransaction(description, textView, undoHistoryRegistry, editorOperationsFactoryService);
+            }
+
+            return null;
+        }
+
         public void Complete()
         {
             if (!_active)


### PR DESCRIPTION
If we are unable to get an undo history for a textbuffer (because it was
part of a projection that has been unmapped), abort committing completion
(instead of crashing).