### PR TITLE
Small clean up: remove unnecessary #ifs, usings, whitespace

### DIFF
--- a/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
+++ b/src/Compilers/Core/Portable/Emit/DebugDocumentsBuilder.cs
@@ -3,10 +3,8 @@
 using Roslyn.Utilities;
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Microsoft.CodeAnalysis.Emit
 {
@@ -83,7 +81,5 @@ namespace Microsoft.CodeAnalysis.Emit
 
             return normalizedPath;
         }
-
-
     }
 }

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.Empty.Set.cs
@@ -9,10 +9,7 @@ namespace Roslyn.Utilities
     {
         private partial class Empty
         {
-            internal class Set<T> : Collection<T>, ISet<T>
-#if COMPILERCORE
-                , IReadOnlySet<T>
-#endif
+            internal class Set<T> : Collection<T>, ISet<T>, IReadOnlySet<T>
             {
                 public static readonly new Set<T> Instance = new Set<T>();
 

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Set.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.ReadOnly.Set.cs
@@ -9,10 +9,7 @@ namespace Roslyn.Utilities
     {
         private partial class ReadOnly
         {
-            internal class Set<TUnderlying, T> : Collection<TUnderlying, T>, ISet<T>
-#if COMPILERCORE
-                , IReadOnlySet<T>
-#endif
+            internal class Set<TUnderlying, T> : Collection<TUnderlying, T>, ISet<T>, IReadOnlySet<T>
                 where TUnderlying : ISet<T>
             {
                 public Set(TUnderlying underlying)

--- a/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/SpecializedCollections.cs
@@ -44,12 +44,10 @@ namespace Roslyn.Utilities
             return Empty.Set<T>.Instance;
         }
 
-#if COMPILERCORE
         public static IReadOnlySet<T> EmptyReadOnlySet<T>()
         {
             return Empty.Set<T>.Instance;
         }
-#endif
 
         public static IDictionary<TKey, TValue> EmptyDictionary<TKey, TValue>()
         {
@@ -100,13 +98,11 @@ namespace Roslyn.Utilities
                 : new ReadOnly.Set<ISet<T>, T>(set);
         }
 
-#if COMPILERCORE
         public static IReadOnlySet<T> StronglyTypedReadOnlySet<T>(ISet<T> set)
         {
             return set == null || set.Count == 0
                 ? EmptyReadOnlySet<T>()
                 : new ReadOnly.Set<ISet<T>, T>(set);
         }
-#endif
     }
 }


### PR DESCRIPTION
`#if`s were needed temporarily pending an internal change that is now in.

Also removing unnecessary usings and whitespace that slipped in with my last change.

@tmat @agocke @jaredpar @gafter