### PR TITLE
Decouple SyntaxList from SyntaxListBuilder.

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -303,22 +303,24 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             _leadingTriviaCache.Clear();
             this.LexSyntaxTrivia(afterFirstToken: TextWindow.Position > 0, isTrailing: false, triviaList: ref _leadingTriviaCache);
-            return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken), SyntaxList.List(_leadingTriviaCache), 0, 0);
+            return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken),
+                _leadingTriviaCache?.ToListNode(), position: 0, index: 0);
         }
 
         internal SyntaxTriviaList LexSyntaxTrailingTrivia()
         {
             _trailingTriviaCache.Clear();
             this.LexSyntaxTrivia(afterFirstToken: true, isTrailing: true, triviaList: ref _trailingTriviaCache);
-            return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken), SyntaxList.List(_trailingTriviaCache), 0, 0);
+            return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken), 
+                _trailingTriviaCache?.ToListNode(), position: 0, index: 0);
         }
 
         private SyntaxToken Create(ref TokenInfo info, SyntaxListBuilder leading, SyntaxListBuilder trailing, SyntaxDiagnosticInfo[] errors)
         {
             Debug.Assert(info.Kind != SyntaxKind.IdentifierToken || info.StringValue != null);
 
-            var leadingNode = SyntaxList.List(leading);
-            var trailingNode = SyntaxList.List(trailing);
+            var leadingNode = leading?.ToListNode();
+            var trailingNode = trailing?.ToListNode();
 
             SyntaxToken token;
             if (info.RequiresTextForXmlEntity)

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -304,7 +304,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _leadingTriviaCache.Clear();
             this.LexSyntaxTrivia(afterFirstToken: TextWindow.Position > 0, isTrailing: false, triviaList: ref _leadingTriviaCache);
             return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken),
-                _leadingTriviaCache?.ToListNode(), position: 0, index: 0);
+                _leadingTriviaCache.ToListNode(), position: 0, index: 0);
         }
 
         internal SyntaxTriviaList LexSyntaxTrailingTrivia()
@@ -312,7 +312,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             _trailingTriviaCache.Clear();
             this.LexSyntaxTrivia(afterFirstToken: true, isTrailing: true, triviaList: ref _trailingTriviaCache);
             return new SyntaxTriviaList(default(Microsoft.CodeAnalysis.SyntaxToken), 
-                _trailingTriviaCache?.ToListNode(), position: 0, index: 0);
+                _trailingTriviaCache.ToListNode(), position: 0, index: 0);
         }
 
         private SyntaxToken Create(ref TokenInfo info, SyntaxListBuilder leading, SyntaxListBuilder trailing, SyntaxDiagnosticInfo[] errors)

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxList.cs
@@ -96,16 +96,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal static CSharpSyntaxNode List(SyntaxListBuilder builder)
-        {
-            if (builder != null)
-            {
-                return builder.ToListNode();
-            }
-
-            return null;
-        }
-
         internal abstract void CopyTo(ArrayElement<CSharpSyntaxNode>[] array, int offset);
 
         internal static CSharpSyntaxNode Concat(CSharpSyntaxNode left, CSharpSyntaxNode right)

--- a/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.shproj
+++ b/src/Dependencies/PooledObjects/Microsoft.CodeAnalysis.PooledObjects.shproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
-    <ProjectGuid>cd77a8cc-2885-47a7-b99c-fbf13353400b</ProjectGuid>
+    <ProjectGuid>c1930979-c824-496b-a630-70f5369a636f</ProjectGuid>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />


### PR DESCRIPTION
This will make it easier to move SyntaxList to the core layer.