### PR TITLE
Remove unneeded roslyn-build-tools

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -26,7 +26,6 @@
     <add key="myget.org symreader-portable" value="https://dotnet.myget.org/F/symreader-portable/api/v3/index.json" />
     <add key="myget.org roslyn-master-nightly" value="https://dotnet.myget.org/F/roslyn-master-nightly/api/v3/index.json" />
     <add key="myget.org devcore" value="https://www.myget.org/F/vs-devcore/api/v3/index.json" />
-    <add key="myget.org roslyn-build-tools" value = "https://dotnet.myget.org/F/roslyn-build-tools/api/v3/index.json" />
     <add key="myget.org roslyn-tools" value = "https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>


### PR DESCRIPTION
Moved the packages on that feed to roslyn-tools.  Deleting the feed entry as we no longer need it now.