### PR TITLE
Adjust scope of locals declared within a Switch Statement according to the latest design.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -279,10 +279,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.DoStatement:
                 case SyntaxKind.LockStatement:
-                case SyntaxKind.IfStatement: 
+                case SyntaxKind.IfStatement:
                     Binder binder = this.GetBinder(node);
                     Debug.Assert(binder != null);
-                    return binder.WrapWithVariablesIfAny(node, binder.BindStatement(node, diagnostics)); 
+                    return binder.WrapWithVariablesIfAny(node, binder.BindStatement(node, diagnostics));
+
+                case SyntaxKind.SwitchStatement:
+                    var switchStatement = (SwitchStatementSyntax)node;
+                    binder = this.GetBinder(switchStatement.Expression);
+                    Debug.Assert(binder != null);
+                    return binder.WrapWithVariablesIfAny(switchStatement.Expression, binder.BindStatement(node, diagnostics));
 
                 default:
                     return BindStatement(node, diagnostics);
@@ -2974,7 +2980,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(node != null);
             Binder switchBinder = this.GetBinder(node);
-            return switchBinder.GetBinder(node.Expression).WrapWithVariablesIfAny(node.Expression, switchBinder.BindSwitchExpressionAndSections(node, switchBinder, diagnostics));
+            return switchBinder.BindSwitchExpressionAndSections(node, switchBinder, diagnostics);
         }
 
         internal virtual BoundStatement BindSwitchExpressionAndSections(SwitchStatementSyntax node, Binder originalBinder, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/BlockBinder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
@@ -20,6 +21,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public BlockBinder(Binder enclosing, BlockSyntax block, BinderFlags additionalFlags)
             : base(enclosing, enclosing.Flags | additionalFlags)
         {
+            Debug.Assert(block != null);
             _block = block;
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
@@ -18,6 +19,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public EmbeddedStatementBinder(Binder enclosing, StatementSyntax statement)
             : base(enclosing, enclosing.Flags)
         {
+            Debug.Assert(statement != null);
             _statements = new SyntaxList<StatementSyntax>(statement);
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/EmbeddedStatementBinder.cs
@@ -8,29 +8,27 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal sealed class BlockBinder : LocalScopeBinder
+    /// <summary>
+    /// This binder owns the scope for an embedded statement.
+    /// </summary>
+    internal sealed class EmbeddedStatementBinder : LocalScopeBinder
     {
-        private readonly BlockSyntax _block;
+        private readonly SyntaxList<StatementSyntax> _statements;
 
-        public BlockBinder(Binder enclosing, BlockSyntax block)
-            : this(enclosing, block, enclosing.Flags)
+        public EmbeddedStatementBinder(Binder enclosing, StatementSyntax statement)
+            : base(enclosing, enclosing.Flags)
         {
-        }
-
-        public BlockBinder(Binder enclosing, BlockSyntax block, BinderFlags additionalFlags)
-            : base(enclosing, enclosing.Flags | additionalFlags)
-        {
-            _block = block;
+            _statements = new SyntaxList<StatementSyntax>(statement);
         }
 
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
-            return BuildLocals(_block.Statements, this);
+            return BuildLocals(_statements, this);
         }
 
         protected override ImmutableArray<LocalFunctionSymbol> BuildLocalFunctions()
         {
-            return BuildLocalFunctions(_block.Statements);
+            return BuildLocalFunctions(_statements);
         }
 
         internal override bool IsLocalFunctionsScopeBinder
@@ -44,7 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LabelSymbol> BuildLabels()
         {
             ArrayBuilder<LabelSymbol> labels = null;
-            base.BuildLabels(_block.Statements, ref labels);
+            base.BuildLabels(_statements, ref labels);
             return (labels != null) ? labels.ToImmutableAndFree() : ImmutableArray<LabelSymbol>.Empty;
         }
 
@@ -70,7 +68,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             get
             {
-                return _block;
+                return _statements.First();
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableBinder.cs
@@ -21,7 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            ExpressionVariableFinder.FindExpressionVariables(this, builder, (CSharpSyntaxNode)ScopeDesignator);
+            ExpressionVariableFinder.FindExpressionVariables(this, builder, (CSharpSyntaxNode)ScopeDesignator, 
+                                                             GetBinder((CSharpSyntaxNode)ScopeDesignator));
             return builder.ToImmutableAndFree();
         }
 

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -108,6 +108,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             Visit(node.Condition);
         }
 
+        public override void VisitSwitchStatement(SwitchStatementSyntax node)
+        {
+            Visit(node.Expression);
+        }
+
         public override void VisitDeclarationPattern(DeclarationPatternSyntax node)
         {
             _localsBuilder.Add(SourceLocalSymbol.MakeLocal(_scopeBinder.ContainingMemberOrLambda, _scopeBinder, false, node.Type, node.Identifier, LocalDeclarationKind.PatternVariable));

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -16,9 +16,9 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// </summary>
     internal sealed class InMethodBinder : LocalScopeBinder
     {
-        private readonly MultiDictionary<string, ParameterSymbol> _parameterMap;
+        private MultiDictionary<string, ParameterSymbol> _lazyParameterMap;
         private readonly MethodSymbol _methodSymbol;
-        private SmallDictionary<string, Symbol> _definitionMap;
+        private SmallDictionary<string, Symbol> _lazyDefinitionMap;
         private IteratorInfo _iteratorInfo;
 
         private class IteratorInfo
@@ -54,31 +54,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             : base(enclosing, GetFlags(owner, enclosing))
         {
             Debug.Assert((object)owner != null);
-
             _methodSymbol = owner;
-
-            var parameters = owner.Parameters;
-            if (!parameters.IsEmpty)
-            {
-                RecordDefinition(parameters);
-                _parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length, EqualityComparer<string>.Default);
-                foreach (var parameter in parameters)
-                {
-                    _parameterMap.Add(parameter.Name, parameter);
-                }
-            }
-
-            var typeParameters = owner.TypeParameters;
-
-            if (!typeParameters.IsDefaultOrEmpty)
-            {
-                RecordDefinition(typeParameters);
-            }
         }
 
-        private void RecordDefinition<T>(ImmutableArray<T> definitions) where T : Symbol
+        private void RecordDefinition<T>(SmallDictionary<string, Symbol> declarationMap, ImmutableArray<T> definitions) where T : Symbol
         {
-            var declarationMap = _definitionMap ?? (_definitionMap = new SmallDictionary<string, Symbol>());
             foreach (Symbol s in definitions)
             {
                 if (!declarationMap.ContainsKey(s.Name))
@@ -229,12 +209,25 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             Debug.Assert(result.IsClear);
 
-            if (_parameterMap == null || (options & LookupOptions.NamespaceAliasesOnly) != 0)
+            if (_methodSymbol.ParameterCount == 0 || (options & LookupOptions.NamespaceAliasesOnly) != 0)
             {
                 return;
             }
 
-            foreach (var parameterSymbol in _parameterMap[name])
+            var parameterMap = _lazyParameterMap;
+            if (parameterMap == null)
+            {
+                var parameters = _methodSymbol.Parameters;
+                parameterMap = new MultiDictionary<string, ParameterSymbol>(parameters.Length, EqualityComparer<string>.Default);
+                foreach (var parameter in parameters)
+                {
+                    parameterMap.Add(parameter.Name, parameter);
+                }
+
+                _lazyParameterMap = parameterMap;
+            }
+
+            foreach (var parameterSymbol in parameterMap[name])
             {
                 result.MergeEqual(originalBinder.CheckViability(parameterSymbol, arity, options, null, diagnose, ref useSiteDiagnostics));
             }
@@ -321,8 +314,28 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal override bool EnsureSingleDefinition(Symbol symbol, string name, Location location, DiagnosticBag diagnostics)
         {
             Symbol existingDeclaration;
-            var map = _definitionMap;
-            if (map != null && map.TryGetValue(name, out existingDeclaration))
+
+
+            var parameters = _methodSymbol.Parameters;
+            var typeParameters = _methodSymbol.TypeParameters;
+
+            if (parameters.IsEmpty && typeParameters.IsEmpty)
+            {
+                return false;
+            }
+
+            var map = _lazyDefinitionMap;
+
+            if (map == null)
+            {
+                map = new SmallDictionary<string, Symbol>();
+                RecordDefinition(map, parameters);
+                RecordDefinition(map, typeParameters);
+
+                _lazyDefinitionMap = map;
+            }
+
+            if (map.TryGetValue(name, out existingDeclaration))
             {
                 return ReportConflictWithParameter(existingDeclaration, symbol, name, location, diagnostics);
             }

--- a/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/InMethodBinder.cs
@@ -57,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _methodSymbol = owner;
         }
 
-        private void RecordDefinition<T>(SmallDictionary<string, Symbol> declarationMap, ImmutableArray<T> definitions) where T : Symbol
+        private static void RecordDefinition<T>(SmallDictionary<string, Symbol> declarationMap, ImmutableArray<T> definitions) where T : Symbol
         {
             foreach (Symbol s in definitions)
             {

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -74,17 +74,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else if (syntax.Kind() != SyntaxKind.Block && (statement = syntax as StatementSyntax) != null)
             {
-                CSharpSyntaxNode embeddedScopeDisagnator;
-                enclosing = builder.GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDisagnator);
+                CSharpSyntaxNode embeddedScopeDesignator;
+                enclosing = builder.GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDesignator);
 
                 if ((object)rootBinderAdjusterOpt != null)
                 {
-                    enclosing = rootBinderAdjusterOpt(enclosing, embeddedScopeDisagnator);
+                    enclosing = rootBinderAdjusterOpt(enclosing, embeddedScopeDesignator);
                 }
 
-                if (embeddedScopeDisagnator != null)
+                if (embeddedScopeDesignator != null)
                 {
-                    builder.AddToMap(embeddedScopeDisagnator, enclosing);
+                    builder.AddToMap(embeddedScopeDesignator, enclosing);
                 }
 
                 builder.Visit(statement, enclosing);
@@ -740,7 +740,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             _map[node] = binder;
         }
 
-        private Binder GetBinderForPossibleEmbeddedStatement(StatementSyntax statement, Binder enclosing, out CSharpSyntaxNode embeddedScopeDisagnator)
+        private Binder GetBinderForPossibleEmbeddedStatement(StatementSyntax statement, Binder enclosing, out CSharpSyntaxNode embeddedScopeDesignator)
         {
             switch (statement.Kind())
             {
@@ -756,17 +756,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.LockStatement:
                 case SyntaxKind.IfStatement:
                     Debug.Assert((object)_containingMemberOrLambda == enclosing.ContainingMemberOrLambda);
-                    embeddedScopeDisagnator = statement;
+                    embeddedScopeDesignator = statement;
                     return new EmbeddedStatementBinder(enclosing, statement);
 
                 case SyntaxKind.SwitchStatement:
                     Debug.Assert((object)_containingMemberOrLambda == enclosing.ContainingMemberOrLambda);
                     var switchStatement = (SwitchStatementSyntax)statement;
-                    embeddedScopeDisagnator = switchStatement.Expression;
+                    embeddedScopeDesignator = switchStatement.Expression;
                     return new ExpressionVariableBinder(switchStatement.Expression, enclosing);
 
                 default:
-                    embeddedScopeDisagnator = null;
+                    embeddedScopeDesignator = null;
                     return enclosing;
             }
         }
@@ -775,12 +775,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (statement != null)
             {
-                CSharpSyntaxNode embeddedScopeDisagnator;
-                enclosing = GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDisagnator);
+                CSharpSyntaxNode embeddedScopeDesignator;
+                enclosing = GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDesignator);
 
-                if (embeddedScopeDisagnator != null)
+                if (embeddedScopeDesignator != null)
                 {
-                    AddToMap(embeddedScopeDisagnator, enclosing);
+                    AddToMap(embeddedScopeDesignator, enclosing);
                 }
 
                 Visit(statement, enclosing);

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
+using System;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -49,19 +50,53 @@ namespace Microsoft.CodeAnalysis.CSharp
         // Currently the types of these are restricted to only be whatever the syntax parameter is, plus any LocalFunctionStatementSyntax contained within it.
         // This may change if the language is extended to allow iterator lambdas, in which case the lambda would also be returned.
         // (lambdas currently throw a diagnostic in WithLambdaParametersBinder.GetIteratorElementType when a yield is used within them)
-        public static SmallDictionary<CSharpSyntaxNode, Binder> BuildMap(Symbol containingMemberOrLambda, CSharpSyntaxNode syntax, Binder enclosing, ArrayBuilder<CSharpSyntaxNode> methodsWithYields)
+        public static SmallDictionary<CSharpSyntaxNode, Binder> BuildMap(
+            Symbol containingMemberOrLambda, 
+            CSharpSyntaxNode syntax, 
+            Binder enclosing, 
+            ArrayBuilder<CSharpSyntaxNode> methodsWithYields,
+            Func<Binder, CSharpSyntaxNode, Binder> rootBinderAdjusterOpt = null)
         {
             var builder = new LocalBinderFactory(containingMemberOrLambda, syntax, enclosing, methodsWithYields);
 
+            StatementSyntax statement;
             if (syntax is ExpressionSyntax)
             {
-                var binder = new ExpressionVariableBinder(syntax, enclosing);
-                builder.AddToMap(syntax, binder);
-                builder.Visit(syntax, binder);
+                enclosing = new ExpressionVariableBinder(syntax, enclosing);
+
+                if ((object)rootBinderAdjusterOpt != null)
+                {
+                    enclosing = rootBinderAdjusterOpt(enclosing, syntax);
+                }
+
+                builder.AddToMap(syntax, enclosing);
+                builder.Visit(syntax, enclosing);
+            }
+            else if (syntax.Kind() != SyntaxKind.Block && (statement = syntax as StatementSyntax) != null)
+            {
+                CSharpSyntaxNode embeddedScopeDisagnator;
+                enclosing = builder.GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDisagnator);
+
+                if ((object)rootBinderAdjusterOpt != null)
+                {
+                    enclosing = rootBinderAdjusterOpt(enclosing, embeddedScopeDisagnator);
+                }
+
+                if (embeddedScopeDisagnator != null)
+                {
+                    builder.AddToMap(embeddedScopeDisagnator, enclosing);
+                }
+
+                builder.Visit(statement, enclosing);
             }
             else
             {
-                builder.Visit(syntax);
+                if ((object)rootBinderAdjusterOpt != null)
+                {
+                    enclosing = rootBinderAdjusterOpt(enclosing, null);
+                }
+
+                builder.Visit(syntax, enclosing);
             }
 
             // the other place this is possible is in a local function
@@ -295,7 +330,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitBlock(BlockSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var blockBinder = new BlockBinder(_enclosing, node.Statements);
+            var blockBinder = new BlockBinder(_enclosing, node);
             AddToMap(node, blockBinder);
 
             // Visit all the statements inside this block
@@ -472,12 +507,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override void VisitSwitchStatement(SwitchStatementSyntax node)
         {
             Debug.Assert((object)_containingMemberOrLambda == _enclosing.ContainingMemberOrLambda);
-            var patternBinder = new ExpressionVariableBinder(node.Expression, _enclosing);
-            AddToMap(node.Expression, patternBinder);
+            AddToMap(node.Expression, _enclosing);
+            Visit(node.Expression, _enclosing);
 
-            Visit(node.Expression, patternBinder);
-
-            var switchBinder = SwitchBinder.Create(patternBinder, node);
+            var switchBinder = SwitchBinder.Create(_enclosing, node);
             AddToMap(node, switchBinder);
 
             foreach (SwitchSectionSyntax section in node.Sections)
@@ -707,32 +740,47 @@ namespace Microsoft.CodeAnalysis.CSharp
             _map[node] = binder;
         }
 
+        private Binder GetBinderForPossibleEmbeddedStatement(StatementSyntax statement, Binder enclosing, out CSharpSyntaxNode embeddedScopeDisagnator)
+        {
+            switch (statement.Kind())
+            {
+                case SyntaxKind.LocalDeclarationStatement:
+                case SyntaxKind.LabeledStatement:
+                case SyntaxKind.LocalFunctionStatement:
+                // It is an error to have a declaration or a label in an embedded statement,
+                // but we still want to bind it.  
+
+                case SyntaxKind.ExpressionStatement:
+                case SyntaxKind.WhileStatement:
+                case SyntaxKind.DoStatement:
+                case SyntaxKind.LockStatement:
+                case SyntaxKind.IfStatement:
+                    Debug.Assert((object)_containingMemberOrLambda == enclosing.ContainingMemberOrLambda);
+                    embeddedScopeDisagnator = statement;
+                    return new EmbeddedStatementBinder(enclosing, statement);
+
+                case SyntaxKind.SwitchStatement:
+                    Debug.Assert((object)_containingMemberOrLambda == enclosing.ContainingMemberOrLambda);
+                    var switchStatement = (SwitchStatementSyntax)statement;
+                    embeddedScopeDisagnator = switchStatement.Expression;
+                    return new ExpressionVariableBinder(switchStatement.Expression, enclosing);
+
+                default:
+                    embeddedScopeDisagnator = null;
+                    return enclosing;
+            }
+        }
+
         private void VisitPossibleEmbeddedStatement(StatementSyntax statement, Binder enclosing)
         {
             if (statement != null)
             {
-                switch (statement.Kind())
+                CSharpSyntaxNode embeddedScopeDisagnator;
+                enclosing = GetBinderForPossibleEmbeddedStatement(statement, enclosing, out embeddedScopeDisagnator);
+
+                if (embeddedScopeDisagnator != null)
                 {
-                    case SyntaxKind.LocalDeclarationStatement:
-                    case SyntaxKind.LabeledStatement:
-                    case SyntaxKind.LocalFunctionStatement:
-                        // It is an error to have a declaration or a label in an embedded statement,
-                        // but we still want to bind it.  We'll pretend that the statement was
-                        // inside a block.
-
-                    case SyntaxKind.ExpressionStatement:
-                    case SyntaxKind.WhileStatement:
-                    case SyntaxKind.DoStatement:
-                    case SyntaxKind.LockStatement:
-                    case SyntaxKind.IfStatement:
-                        Debug.Assert((object)_containingMemberOrLambda == enclosing.ContainingMemberOrLambda);
-                        var blockBinder = new BlockBinder(enclosing, new SyntaxList<StatementSyntax>(statement));
-                        AddToMap(statement, blockBinder);
-                        Visit(statement, blockBinder);
-                        return;
-
-                    default:
-                        break;
+                    AddToMap(embeddedScopeDisagnator, enclosing);
                 }
 
                 Visit(statement, enclosing);

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -193,7 +193,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     case SyntaxKind.ExpressionStatement:
                     case SyntaxKind.IfStatement:
-                        ExpressionVariableFinder.FindExpressionVariables(this, locals, innerStatement, enclosingBinder);
+                        ExpressionVariableFinder.FindExpressionVariables(this, locals, innerStatement, enclosingBinder.GetBinder(innerStatement) ?? enclosingBinder);
+                        break;
+
+                    case SyntaxKind.SwitchStatement:
+                        var switchStatement = (SwitchStatementSyntax)innerStatement;
+                        ExpressionVariableFinder.FindExpressionVariables(this, locals, innerStatement, enclosingBinder.GetBinder(switchStatement.Expression) ?? enclosingBinder);
                         break;
 
                     case SyntaxKind.WhileStatement:

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private void EnsureSwitchGoverningExpressionAndDiagnosticsBound()
         {
             var switchGoverningDiagnostics = new DiagnosticBag();
-            var boundSwitchExpression = BindSwitchExpression(SwitchSyntax.Expression, switchGoverningDiagnostics);
+            var boundSwitchExpression = BindSwitchExpression(switchGoverningDiagnostics);
             _switchGoverningDiagnostics = switchGoverningDiagnostics;
             Interlocked.CompareExchange(ref _switchGoverningExpression, boundSwitchExpression, null);
         }
@@ -380,7 +380,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         // Bind the switch expression
-        private BoundExpression BindSwitchExpression(ExpressionSyntax node, DiagnosticBag diagnostics)
+        private BoundExpression BindSwitchExpression(DiagnosticBag diagnostics)
         {
             // We are at present inside the switch binder, but the switch expression is not
             // bound in the context of the switch binder; it's bound in the context of the
@@ -395,7 +395,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             //
             // The "x" in "switch(x)" refers to this.x, not the local x that is in scope inside the switch block.
 
-            Debug.Assert(node == SwitchSyntax.Expression);
+            Debug.Assert(ScopeDesignator == SwitchSyntax);
+            ExpressionSyntax node = SwitchSyntax.Expression;
             var binder = this.GetBinder(node);
             Debug.Assert(binder != null);
 

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Binder\ConstantFieldsInProgressBinder.cs" />
     <Compile Include="Binder\ContextualAttributeBinder.cs" />
     <Compile Include="Binder\EarlyWellKnownAttributeBinder.cs" />
+    <Compile Include="Binder\EmbeddedStatementBinder.cs" />
     <Compile Include="Binder\ExecutableCodeBinder.cs" />
     <Compile Include="Binder\ExtensionMethodScope.cs" />
     <Compile Include="Binder\FixedStatementBinder.cs" />

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -246,8 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 else if (current is ExpressionSyntax && 
                             ((current.Parent as LambdaExpressionSyntax)?.Body == current ||
                              (current.Parent as SwitchStatementSyntax)?.Expression == current ||
-                             (current.Parent as CommonForEachStatementSyntax)?.Expression == current ||
-                             (current.Parent as IfStatementSyntax)?.Condition == current))
+                             (current.Parent as CommonForEachStatementSyntax)?.Expression == current))
                 {
                     binder = rootBinder.GetBinder(current);
                 }

--- a/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MethodBodySemanticModel.cs
@@ -126,13 +126,6 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var methodSymbol = (MethodSymbol)this.MemberSymbol;
             binder = new ExecutableCodeBinder(statement, methodSymbol, binder);
-
-            // local declaration statements need to be wrapped in a block so the local gets seen 
-            if (!statement.IsKind(SyntaxKind.Block))
-            {
-                binder = new BlockBinder(binder, new SyntaxList<StatementSyntax>(statement));
-            }
-
             speculativeModel = CreateSpeculative(parentModel, methodSymbol, statement, binder, position);
             return true;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -637,8 +637,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     case SyntaxKind.ThisConstructorInitializer:
                     case SyntaxKind.BaseConstructorInitializer:
-                        Debug.Assert(_enclosingBinderOpt == null);
-                        this.binder.BindConstructorInitializer(((ConstructorInitializerSyntax)_containingInvocation).ArgumentList, (MethodSymbol)this.binder.ContainingMember(), diagnostics);
+                        Debug.Assert(_enclosingBinderOpt == null || _enclosingBinderOpt == this.binder);
+                        (_enclosingBinderOpt ?? this.binder).BindConstructorInitializer(((ConstructorInitializerSyntax)_containingInvocation).ArgumentList, (MethodSymbol)this.binder.ContainingMember(), diagnostics);
                         result = this._type;
                         Debug.Assert((object)result != null);
                         return result;

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxNodeExtensions.cs
@@ -74,8 +74,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // All these nodes are valid scope designators due to the pattern matching feature.
                     ((syntax.Parent as LambdaExpressionSyntax)?.Body == syntax ||
                      (syntax.Parent as SwitchStatementSyntax)?.Expression == syntax ||
-                     (syntax.Parent as CommonForEachStatementSyntax)?.Expression == syntax ||
-                     (syntax.Parent as IfStatementSyntax)?.Condition == syntax));
+                     (syntax.Parent as CommonForEachStatementSyntax)?.Expression == syntax));
         }
 
         /// <summary>

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
@@ -102,9 +102,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         protected override ImmutableArray<LocalSymbol> BuildLocals()
         {
-            var builder = ArrayBuilder<LocalSymbol>.GetInstance();
-            builder.AddRange(_aliases);
-            return builder.ToImmutableAndFree();
+            return _aliases;
         }
 
         internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(CSharpSyntaxNode scopeDesignator)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.cs
@@ -104,23 +104,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         {
             var builder = ArrayBuilder<LocalSymbol>.GetInstance();
             builder.AddRange(_aliases);
-            var declaration = _syntax as LocalDeclarationStatementSyntax;
-            if (declaration != null)
-            {
-                var kind = declaration.IsConst ? LocalDeclarationKind.Constant : LocalDeclarationKind.RegularVariable;
-                foreach (var variable in declaration.Declaration.Variables)
-                {
-                    var local = SourceLocalSymbol.MakeLocal(
-                        _containingMethod, 
-                        this, 
-                        true,
-                        declaration.Declaration.Type, 
-                        variable.Identifier, 
-                        kind, 
-                        variable.Initializer);
-                    builder.Add(local);
-                }
-            }
             return builder.ToImmutableAndFree();
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -831,12 +831,12 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
 
             Binder originalRootBinder = null;
-            CSharpSyntaxNode declaredLocalsScopeDisagnator = null;
+            CSharpSyntaxNode declaredLocalsScopeDesignator = null;
             var executableBinder = new ExecutableCodeBinder(syntax, substitutedSourceMethod, binder,
-                                              (rootBinder, declaredLocalsScopeDisagnatorOpt) =>
+                                              (rootBinder, declaredLocalsScopeDesignatorOpt) =>
                                               {
                                                   originalRootBinder = rootBinder;
-                                                  declaredLocalsScopeDisagnator = declaredLocalsScopeDisagnatorOpt;
+                                                  declaredLocalsScopeDesignator = declaredLocalsScopeDesignatorOpt;
                                                   binder = new EEMethodBinder(method, substitutedSourceMethod, rootBinder);
 
                                                   if (methodNotType)
@@ -854,9 +854,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             Debug.Assert(originalRootBinder != null);
             Debug.Assert(executableBinder.Next != binder);
 
-            if (declaredLocalsScopeDisagnator != null)
+            if (declaredLocalsScopeDesignator != null)
             {
-                declaredLocals = originalRootBinder.GetDeclaredLocalsForScope(declaredLocalsScopeDisagnator);
+                declaredLocals = originalRootBinder.GetDeclaredLocalsForScope(declaredLocalsScopeDesignator);
+            }
+            else
+            {
+                declaredLocals = ImmutableArray<LocalSymbol>.Empty;
             }
 
             return binder;

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CompilationContext.cs
@@ -123,7 +123,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 typeName,
                 methodName,
                 this,
-                (method, diags) =>
+                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals) =>
                 {
                     var hasDisplayClassThis = _displayClassVariables.ContainsKey(GeneratedNames.ThisProxyFieldName());
                     var binder = ExtendBinderChain(
@@ -132,8 +132,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         method,
                         this.NamespaceBinder,
                         hasDisplayClassThis,
-                        _methodNotType);
+                        _methodNotType,
+                        out declaredLocals);
                     var statementSyntax = _syntax as StatementSyntax;
+
                     return (statementSyntax == null) ?
                         BindExpression(binder, (ExpressionSyntax)_syntax, diags, out properties) :
                         BindStatement(binder, statementSyntax, diags, out properties);
@@ -187,7 +189,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 typeName,
                 methodName,
                 this,
-                (method, diags) =>
+                (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals) =>
                 {
                     var hasDisplayClassThis = _displayClassVariables.ContainsKey(GeneratedNames.ThisProxyFieldName());
                     var binder = ExtendBinderChain(
@@ -196,7 +198,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                         method,
                         this.NamespaceBinder,
                         hasDisplayClassThis,
-                        methodNotType: true);
+                        methodNotType: true,
+                        declaredLocals: out declaredLocals);
                     return BindAssignment(binder, (ExpressionSyntax)_syntax, diags);
                 });
 
@@ -302,8 +305,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                                     alias);
                                 var methodName = GetNextMethodName(methodBuilder);
                                 var syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken));
-                                var aliasMethod = this.CreateMethod(container, methodName, syntax, (method, diags) =>
+                                var aliasMethod = this.CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diags, out ImmutableArray<LocalSymbol> declaredLocals) =>
                                 {
+                                    declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                                     var expression = new BoundLocal(syntax, local, constantValueOpt: null, type: local.Type);
                                     return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
                                 });
@@ -488,8 +492,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetLocalMethod(EENamedTypeSymbol container, string methodName, string localName, int localIndex)
         {
             var syntax = SyntaxFactory.IdentifierName(localName);
-            return this.CreateMethod(container, methodName, syntax, (method, diagnostics) =>
+            return this.CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals) =>
             {
+                declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var local = method.LocalsForBinding[localIndex];
                 var expression = new BoundLocal(syntax, local, constantValueOpt: local.GetConstantValue(null, null, diagnostics), type: local.Type);
                 return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
@@ -499,8 +504,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetParameterMethod(EENamedTypeSymbol container, string methodName, string parameterName, int parameterIndex)
         {
             var syntax = SyntaxFactory.IdentifierName(parameterName);
-            return this.CreateMethod(container, methodName, syntax, (method, diagnostics) =>
+            return this.CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals) =>
             {
+                declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var parameter = method.Parameters[parameterIndex];
                 var expression = new BoundParameter(syntax, parameter);
                 return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
@@ -510,8 +516,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetThisMethod(EENamedTypeSymbol container, string methodName)
         {
             var syntax = SyntaxFactory.ThisExpression();
-            return this.CreateMethod(container, methodName, syntax, (method, diagnostics) =>
+            return this.CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals) =>
             {
+                declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var expression = new BoundThisReference(syntax, GetNonDisplayClassContainer(container.SubstitutedSourceType));
                 return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
             });
@@ -520,8 +527,9 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private EEMethodSymbol GetTypeVariablesMethod(EENamedTypeSymbol container, string methodName, NamedTypeSymbol typeVariablesType)
         {
             var syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken));
-            return this.CreateMethod(container, methodName, syntax, (method, diagnostics) =>
+            return this.CreateMethod(container, methodName, syntax, (EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals) =>
             {
+                declaredLocals = ImmutableArray<LocalSymbol>.Empty;
                 var type = method.TypeMap.SubstituteNamedType(typeVariablesType);
                 var expression = new BoundObjectCreationExpression(syntax, type.InstanceConstructors[0]);
                 var statement = new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
@@ -532,9 +540,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
         private static BoundStatement BindExpression(Binder binder, ExpressionSyntax syntax, DiagnosticBag diagnostics, out ResultProperties resultProperties)
         {
             var flags = DkmClrCompilationResultFlags.None;
-
-            binder = binder.GetBinder(syntax);
-            Debug.Assert(binder != null);
 
             // In addition to C# expressions, the native EE also supports
             // type names which are bound to a representation of the type
@@ -594,8 +599,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
 
             resultProperties = expression.ExpressionSymbol.GetResultProperties(flags, expression.ConstantValue != null);
-            return binder.WrapWithVariablesIfAny(syntax,
-                                                 new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true });
+            return new BoundReturnStatement(syntax, RefKind.None, expression) { WasCompilerGenerated = true };
         }
 
         private static BoundStatement BindStatement(Binder binder, StatementSyntax syntax, DiagnosticBag diagnostics, out ResultProperties properties)
@@ -619,17 +623,13 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         private static BoundStatement BindAssignment(Binder binder, ExpressionSyntax syntax, DiagnosticBag diagnostics)
         {
-            binder = binder.GetBinder(syntax);
-            Debug.Assert(binder != null);
-
             var expression = binder.BindValue(syntax, diagnostics, Binder.BindValueKind.RValue);
             if (diagnostics.HasAnyErrors())
             {
                 return null;
             }
 
-            return binder.WrapWithVariablesIfAny(syntax,
-                                                 new BoundExpressionStatement(expression.Syntax, expression) { WasCompilerGenerated = true });
+            return new BoundExpressionStatement(expression.Syntax, expression) { WasCompilerGenerated = true };
         }
 
         private static Binder CreateBinderChain(
@@ -787,7 +787,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             EEMethodSymbol method,
             Binder binder,
             bool hasDisplayClassThis,
-            bool methodNotType)
+            bool methodNotType,
+            out ImmutableArray<LocalSymbol> declaredLocals)
         {
             var substitutedSourceMethod = GetSubstitutedSourceMethod(method.SubstitutedSourceMethod, hasDisplayClassThis);
             var substitutedSourceType = substitutedSourceMethod.ContainingType;
@@ -816,9 +817,10 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 binder = new WithTypeArgumentsBinder(substitutedSourceMethod.TypeArguments, binder);
             }
 
+            // Method locals and parameters shadow pseudo-variables.
+            // That is why we place PlaceholderLocalBinder and ExecutableCodeBinder before EEMethodBinder.
             if (methodNotType)
             {
-                // Method locals and parameters shadow pseudo-variables.
                 var typeNameDecoder = new EETypeNameDecoder(binder.Compilation, (PEModuleSymbol)substitutedSourceMethod.ContainingModule);
                 binder = new PlaceholderLocalBinder(
                     syntax,
@@ -828,14 +830,35 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                     binder);
             }
 
-            binder = new EEMethodBinder(method, substitutedSourceMethod, binder);
+            Binder originalRootBinder = null;
+            CSharpSyntaxNode declaredLocalsScopeDisagnator = null;
+            var executableBinder = new ExecutableCodeBinder(syntax, substitutedSourceMethod, binder,
+                                              (rootBinder, declaredLocalsScopeDisagnatorOpt) =>
+                                              {
+                                                  originalRootBinder = rootBinder;
+                                                  declaredLocalsScopeDisagnator = declaredLocalsScopeDisagnatorOpt;
+                                                  binder = new EEMethodBinder(method, substitutedSourceMethod, rootBinder);
 
-            if (methodNotType)
+                                                  if (methodNotType)
+                                                  {
+                                                      binder = new SimpleLocalScopeBinder(method.LocalsForBinding, binder);
+                                                  }
+
+                                                  return binder;
+                                              });
+
+            // We just need to trigger the process of building the binder map
+            // so that the lambda above was executed.
+            executableBinder.GetBinder(syntax);
+
+            Debug.Assert(originalRootBinder != null);
+            Debug.Assert(executableBinder.Next != binder);
+
+            if (declaredLocalsScopeDisagnator != null)
             {
-                binder = new SimpleLocalScopeBinder(method.LocalsForBinding, binder);
+                declaredLocals = originalRootBinder.GetDeclaredLocalsForScope(declaredLocalsScopeDisagnator);
             }
 
-            binder = new ExecutableCodeBinder(syntax, binder.ContainingMemberOrLambda, binder);
             return binder;
         }
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Rewriters/LocalDeclarationRewriter.cs
@@ -12,51 +12,72 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
     internal sealed class LocalDeclarationRewriter
     {
-        internal static BoundNode Rewrite(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, BoundNode node)
+        internal static BoundStatement Rewrite(CSharpCompilation compilation, EENamedTypeSymbol container, HashSet<LocalSymbol> declaredLocals, BoundStatement node, ImmutableArray<LocalSymbol> declaredLocalsArray)
         {
             var builder = ArrayBuilder<BoundStatement>.GetInstance();
-            bool hasChanged;
+
+            foreach (var local in declaredLocalsArray)
+            {
+                CreateLocal(compilation, declaredLocals, builder, local, node.Syntax);
+            }
 
             // Rewrite top-level declarations only.
             switch (node.Kind)
             {
                 case BoundKind.LocalDeclaration:
-                    RewriteLocalDeclaration(compilation, container, declaredLocals, builder, (BoundLocalDeclaration)node);
-                    hasChanged = true;
+                    Debug.Assert(declaredLocals.Contains(((BoundLocalDeclaration)node).LocalSymbol));
+                    RewriteLocalDeclaration(builder, (BoundLocalDeclaration)node);
                     break;
+
                 case BoundKind.MultipleLocalDeclarations:
                     foreach (var declaration in ((BoundMultipleLocalDeclarations)node).LocalDeclarations)
                     {
-                        RewriteLocalDeclaration(compilation, container, declaredLocals, builder, declaration);
+                        Debug.Assert(declaredLocals.Contains(declaration.LocalSymbol));
+                        RewriteLocalDeclaration(builder, declaration);
                     }
-                    hasChanged = true;
+
                     break;
+
                 default:
-                    hasChanged = false;
-                    break;
+                    if (builder.Count == 0)
+                    {
+                        builder.Free();
+                        return node;
+                    }
+
+                    builder.Add(node);
+                    break; 
             }
 
-            if (hasChanged)
-            {
-                node = BoundBlock.SynthesizedNoLocals(node.Syntax, builder.ToImmutable());
-            }
-
-            builder.Free();
-            return node;
+            return BoundBlock.SynthesizedNoLocals(node.Syntax, builder.ToImmutableAndFree());
         }
 
         private static void RewriteLocalDeclaration(
-            CSharpCompilation compilation,
-            EENamedTypeSymbol container,
-            HashSet<LocalSymbol> declaredLocals,
             ArrayBuilder<BoundStatement> statements,
             BoundLocalDeclaration node)
         {
             Debug.Assert(node.ArgumentsOpt.IsDefault);
 
-            var local = node.LocalSymbol;
-            var syntax = node.Syntax;
+            var initializer = node.InitializerOpt;
+            if (initializer != null)
+            {
+                var local = node.LocalSymbol;
+                var syntax = node.Syntax;
 
+                // Generate assignment to local. The assignment will
+                // be rewritten in PlaceholderLocalRewriter.
+                var assignment = new BoundAssignmentOperator(
+                    syntax,
+                    new BoundLocal(syntax, local, constantValueOpt: null, type: local.Type),
+                    initializer,
+                    RefKind.None,
+                    local.Type);
+                statements.Add(new BoundExpressionStatement(syntax, assignment));
+            }
+        }
+
+        private static void CreateLocal(CSharpCompilation compilation, HashSet<LocalSymbol> declaredLocals, ArrayBuilder<BoundStatement> statements, LocalSymbol local, CSharpSyntaxNode syntax)
+        {
             declaredLocals.Add(local);
 
             var typeType = compilation.GetWellKnownType(WellKnownType.System_Type);
@@ -77,20 +98,6 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 method: method,
                 arguments: ImmutableArray.Create(type, name, customTypeInfoPayloadId, customTypeInfoPayload));
             statements.Add(new BoundExpressionStatement(syntax, call));
-
-            var initializer = node.InitializerOpt;
-            if (initializer != null)
-            {
-                // Generate assignment to local. The assignment will
-                // be rewritten in PlaceholderLocalRewriter.
-                var assignment = new BoundAssignmentOperator(
-                    syntax,
-                    new BoundLocal(syntax, local, constantValueOpt: null, type: local.Type),
-                    initializer,
-                    RefKind.None,
-                    local.Type);
-                statements.Add(new BoundExpressionStatement(syntax, assignment));
-            }
         }
 
         private static BoundExpression GetCustomTypeInfoPayloadId(CSharpSyntaxNode syntax, MethodSymbol guidConstructor, bool hasCustomTypeInfoPayload)

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/EEMethodSymbol.cs
@@ -12,7 +12,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 {
-    internal delegate BoundStatement GenerateMethodBody(EEMethodSymbol method, DiagnosticBag diagnostics);
+    internal delegate BoundStatement GenerateMethodBody(EEMethodSymbol method, DiagnosticBag diagnostics, out ImmutableArray<LocalSymbol> declaredLocals);
 
     /// <summary>
     /// Synthesized expression evaluation method.
@@ -402,7 +402,8 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
         internal override void GenerateMethodBody(TypeCompilationState compilationState, DiagnosticBag diagnostics)
         {
-            var body = _generateMethodBody(this, diagnostics);
+            ImmutableArray<LocalSymbol> declaredLocalsArray;
+            var body = _generateMethodBody(this, diagnostics, out declaredLocalsArray);
             var compilation = compilationState.Compilation;
 
             _lazyReturnType = CalculateReturnType(compilation, body);
@@ -436,7 +437,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
                 try
                 {
                     // Rewrite local declaration statement.
-                    body = (BoundStatement)LocalDeclarationRewriter.Rewrite(compilation, _container, declaredLocals, body);
+                    body = (BoundStatement)LocalDeclarationRewriter.Rewrite(compilation, _container, declaredLocals, body, declaredLocalsArray);
 
                     // Verify local declaration names.
                     foreach (var local in declaredLocals)


### PR DESCRIPTION
Related to #12597.
Adjusted implementation of ExpressionEvaluator to handle new scoping rules. Some out and pattern variables become new EE variables.
Added unit-test for #13159.

@dotnet/roslyn-compiler Please review.
CC @dotnet/roslyn-interactive, @cston for EE changes.  