### PR TITLE
Closure struct should not be abstract

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -14,16 +14,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal abstract class SynthesizedContainer : NamedTypeSymbol
     {
-        private readonly string _name;
-        private readonly TypeMap _typeMap;
         private readonly ImmutableArray<TypeParameterSymbol> _typeParameters;
         private readonly ImmutableArray<TypeParameterSymbol> _constructedFromTypeParameters;
 
         protected SynthesizedContainer(string name, int parameterCount, bool returnsVoid)
         {
             Debug.Assert(name != null);
-            _name = name;
-            _typeMap = TypeMap.Empty;
+            Name = name;
+            TypeMap = TypeMap.Empty;
             _typeParameters = CreateTypeParameters(parameterCount, returnsVoid);
             _constructedFromTypeParameters = default(ImmutableArray<TypeParameterSymbol>);
         }
@@ -31,15 +29,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected SynthesizedContainer(string name, MethodSymbol containingMethod)
         {
             Debug.Assert(name != null);
-            _name = name;
+            Name = name;
             if (containingMethod == null)
             {
-                _typeMap = TypeMap.Empty;
+                TypeMap = TypeMap.Empty;
                 _typeParameters = ImmutableArray<TypeParameterSymbol>.Empty;
             }
             else
             {
-                _typeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, out _typeParameters, out _constructedFromTypeParameters);
+                TypeMap = TypeMap.Empty.WithConcatAlphaRename(containingMethod, this, out _typeParameters, out _constructedFromTypeParameters);
             }
         }
 
@@ -49,9 +47,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(!typeParameters.IsDefault);
             Debug.Assert(typeMap != null);
 
-            _name = name;
+            Name = name;
             _typeParameters = typeParameters;
-            _typeMap = typeMap;
+            TypeMap = typeMap;
         }
 
         private ImmutableArray<TypeParameterSymbol> CreateTypeParameters(int parameterCount, bool returnsVoid)
@@ -70,20 +68,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             return typeParameters.ToImmutableAndFree();
         }
 
-        internal TypeMap TypeMap
-        {
-            get { return _typeMap; }
-        }
+        internal TypeMap TypeMap { get; }
 
-        internal virtual MethodSymbol Constructor
-        {
-            get { return null; }
-        }
+        internal virtual MethodSymbol Constructor => null;
 
-        internal sealed override bool IsInterface
-        {
-            get { return this.TypeKind == TypeKind.Interface; }
-        }
+        internal sealed override bool IsInterface => this.TypeKind == TypeKind.Interface;
 
         internal override void AddSynthesizedAttributes(ModuleCompilationState compilationState, ref ArrayBuilder<SynthesizedAttributeData> attributes)
         {
@@ -107,71 +96,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Note: Can be default if this SynthesizedContainer was constructed with <see cref="SynthesizedContainer(string, int, bool)"/>
         /// </summary>
-        internal ImmutableArray<TypeParameterSymbol> ConstructedFromTypeParameters
-        {
-            get { return _constructedFromTypeParameters; }
-        }
+        internal ImmutableArray<TypeParameterSymbol> ConstructedFromTypeParameters => _constructedFromTypeParameters;
 
-        public sealed override ImmutableArray<TypeParameterSymbol> TypeParameters
-        {
-            get { return _typeParameters; }
-        }
+        public sealed override ImmutableArray<TypeParameterSymbol> TypeParameters => _typeParameters;
 
-        public sealed override string Name
-        {
-            get { return _name; }
-        }
+        public sealed override string Name { get; }
 
-        public override ImmutableArray<Location> Locations
-        {
-            get { return ImmutableArray<Location>.Empty; }
-        }
+        public override ImmutableArray<Location> Locations => ImmutableArray<Location>.Empty;
 
-        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences
-        {
-            get { return ImmutableArray<SyntaxReference>.Empty; }
-        }
+        public override ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => ImmutableArray<SyntaxReference>.Empty;
 
-        public override IEnumerable<string> MemberNames
-        {
-            get { return SpecializedCollections.EmptyEnumerable<string>(); }
-        }
+        public override IEnumerable<string> MemberNames => SpecializedCollections.EmptyEnumerable<string>();
 
-        public override NamedTypeSymbol ConstructedFrom
-        {
-            get { return this; }
-        }
+        public override NamedTypeSymbol ConstructedFrom => this;
 
-        public override bool IsSealed
-        {
-            get { return true; }
-        }
+        public override bool IsSealed => true;
 
-        public override bool IsAbstract
-        {
-            get { return (object)Constructor == null && this.TypeKind != TypeKind.Struct; }
-        }
+        public override bool IsAbstract => (object)Constructor == null && this.TypeKind != TypeKind.Struct;
 
-        internal override ImmutableArray<TypeSymbol> TypeArgumentsNoUseSiteDiagnostics
-        {
-            get { return StaticCast<TypeSymbol>.From(TypeParameters); }
-        }
+        internal override ImmutableArray<TypeSymbol> TypeArgumentsNoUseSiteDiagnostics => StaticCast<TypeSymbol>.From(TypeParameters);
 
-        internal override bool HasTypeArgumentsCustomModifiers
-        {
-            get
-            {
-                return false;
-            }
-        }
+        internal override bool HasTypeArgumentsCustomModifiers => false;
 
-        internal override ImmutableArray<ImmutableArray<CustomModifier>> TypeArgumentsCustomModifiers
-        {
-            get
-            {
-                return CreateEmptyTypeArgumentsCustomModifiers();
-            }
-        }
+        internal override ImmutableArray<ImmutableArray<CustomModifier>> TypeArgumentsCustomModifiers => CreateEmptyTypeArgumentsCustomModifiers();
 
         public override ImmutableArray<Symbol> GetMembers()
         {
@@ -198,144 +145,64 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers()
-        {
-            return this.GetMembersUnordered();
-        }
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers() => this.GetMembersUnordered();
 
-        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name)
-        {
-            return this.GetMembers(name);
-        }
+        internal override ImmutableArray<Symbol> GetEarlyAttributeDecodingMembers(string name) => this.GetMembers(name);
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers()
-        {
-            return ImmutableArray<NamedTypeSymbol>.Empty;
-        }
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers() => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name)
-        {
-            return ImmutableArray<NamedTypeSymbol>.Empty;
-        }
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name) => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity)
-        {
-            return ImmutableArray<NamedTypeSymbol>.Empty;
-        }
+        public override ImmutableArray<NamedTypeSymbol> GetTypeMembers(string name, int arity) => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        public override Accessibility DeclaredAccessibility
-        {
-            get { return Accessibility.Private; }
-        }
+        public override Accessibility DeclaredAccessibility => Accessibility.Private;
 
-        public override bool IsStatic
-        {
-            get { return false; }
-        }
+        public override bool IsStatic => false;
 
-        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved)
-        {
-            return ImmutableArray<NamedTypeSymbol>.Empty;
-        }
+        internal override ImmutableArray<NamedTypeSymbol> InterfacesNoUseSiteDiagnostics(ConsList<Symbol> basesBeingResolved) => ImmutableArray<NamedTypeSymbol>.Empty;
 
-        internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit()
-        {
-            return CalculateInterfacesToEmit();
-        }
+        internal override ImmutableArray<NamedTypeSymbol> GetInterfacesToEmit() => CalculateInterfacesToEmit();
 
         internal override NamedTypeSymbol BaseTypeNoUseSiteDiagnostics
-        {
-            get { return ContainingAssembly.GetSpecialType(this.TypeKind == TypeKind.Struct ? SpecialType.System_ValueType : SpecialType.System_Object); }
-        }
+            => ContainingAssembly.GetSpecialType(this.TypeKind == TypeKind.Struct ? SpecialType.System_ValueType : SpecialType.System_Object);
 
-        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved)
-        {
-            return BaseTypeNoUseSiteDiagnostics;
-        }
+        internal override NamedTypeSymbol GetDeclaredBaseType(ConsList<Symbol> basesBeingResolved) => BaseTypeNoUseSiteDiagnostics;
 
-        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved)
-        {
-            return InterfacesNoUseSiteDiagnostics(basesBeingResolved);
-        }
+        internal override ImmutableArray<NamedTypeSymbol> GetDeclaredInterfaces(ConsList<Symbol> basesBeingResolved) => InterfacesNoUseSiteDiagnostics(basesBeingResolved);
 
-        public override bool MightContainExtensionMethods
-        {
-            get { return false; }
-        }
+        public override bool MightContainExtensionMethods => false;
 
-        public override int Arity
-        {
-            get { return TypeParameters.Length; }
-        }
+        public override int Arity => TypeParameters.Length;
 
-        internal override bool MangleName
-        {
-            get { return Arity > 0; }
-        }
+        internal override bool MangleName => Arity > 0;
 
-        public override bool IsImplicitlyDeclared
-        {
-            get { return true; }
-        }
+        public override bool IsImplicitlyDeclared => true;
 
-        internal override bool ShouldAddWinRTMembers
-        {
-            get { return false; }
-        }
+        internal override bool ShouldAddWinRTMembers => false;
 
-        internal override bool IsWindowsRuntimeImport
-        {
-            get { return false; }
-        }
+        internal override bool IsWindowsRuntimeImport => false;
 
-        internal override bool IsComImport
-        {
-            get { return false; }
-        }
+        internal override bool IsComImport => false;
 
-        internal sealed override ObsoleteAttributeData ObsoleteAttributeData
-        {
-            get { return null; }
-        }
+        internal sealed override ObsoleteAttributeData ObsoleteAttributeData => null;
 
-        internal sealed override ImmutableArray<string> GetAppliedConditionalSymbols()
-        {
-            return ImmutableArray<string>.Empty;
-        }
+        internal sealed override ImmutableArray<string> GetAppliedConditionalSymbols() => ImmutableArray<string>.Empty;
 
-        internal override bool HasDeclarativeSecurity
-        {
-            get { return false; }
-        }
+        internal override bool HasDeclarativeSecurity => false;
 
-        internal override CharSet MarshallingCharSet
-        {
-            get { return DefaultMarshallingCharSet; }
-        }
+        internal override CharSet MarshallingCharSet => DefaultMarshallingCharSet;
 
-        internal override bool IsSerializable
-        {
-            get { return false; }
-        }
+        internal override bool IsSerializable => false;
 
         internal override IEnumerable<Cci.SecurityAttribute> GetSecurityInformation()
         {
             throw ExceptionUtilities.Unreachable;
         }
 
-        internal override AttributeUsageInfo GetAttributeUsageInfo()
-        {
-            return default(AttributeUsageInfo);
-        }
+        internal override AttributeUsageInfo GetAttributeUsageInfo() => default(AttributeUsageInfo);
 
-        internal override TypeLayout Layout
-        {
-            get { return default(TypeLayout); }
-        }
+        internal override TypeLayout Layout => default(TypeLayout);
 
-        internal override bool HasSpecialName
-        {
-            get { return false; }
-        }
+        internal override bool HasSpecialName => false;
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Synthesized/SynthesizedContainer.cs
@@ -149,7 +149,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override bool IsAbstract
         {
-            get { return (object)Constructor == null; }
+            get { return (object)Constructor == null && this.TypeKind != TypeKind.Struct; }
         }
 
         internal override ImmutableArray<TypeSymbol> TypeArgumentsNoUseSiteDiagnostics

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -1083,6 +1083,7 @@ Foo();
             Assert.True(foo.IsStatic);
             Assert.Equal(RefKind.Ref, foo.Parameters[0].RefKind);
             Assert.True(foo.Parameters[0].Type.IsValueType);
+            Assert.False(foo.Parameters[0].Type.IsAbstract);
         }
 
         [Fact]


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/13191.

This confuses tools like Reflector and custom tools that don't expect `struct`s to be marked `abstract`.

It does not seem to be an issue for CLR or peverify (maybe it should?).