### PR TITLE
set references to some assemblies to `<Private>false</Private>`

### DIFF
--- a/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
+++ b/src/ExpressionEvaluator/Package/ExpressionEvaluatorPackage.csproj
@@ -38,6 +38,7 @@
     <ProjectReference Include="..\..\VisualStudio\Core\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\VisualStudio\Setup\VisualStudioSetup.csproj">
       <Project>{201EC5B7-F91E-45E5-B9F2-67A266CCE6FC}</Project>

--- a/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
+++ b/src/InteractiveWindow/VisualStudio/VisualStudioInteractiveWindow.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\VisualStudio\Core\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
+++ b/src/VisualStudio/CSharp/Repl/CSharpVisualStudioRepl.csproj
@@ -56,6 +56,7 @@
     <ProjectReference Include="..\..\Core\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\InteractiveServices\VisualStudioInteractiveServices.csproj">
       <Project>{a31228bb-f05c-4d4a-b98a-0e681d876b7c}</Project>

--- a/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
+++ b/src/VisualStudio/Core/SolutionExplorerShim/SolutionExplorerShim.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
+++ b/src/VisualStudio/TestSetup/VisualStudioTestSetup.csproj
@@ -57,6 +57,7 @@
     <ProjectReference Include="..\Core\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\Setup\VisualStudioSetup.csproj">
       <Project>{201ec5b7-f91e-45e5-b9f2-67a266cce6fc}</Project>

--- a/src/VisualStudio/VisualBasic/Repl/BasicVisualStudioRepl.vbproj
+++ b/src/VisualStudio/VisualBasic/Repl/BasicVisualStudioRepl.vbproj
@@ -60,6 +60,7 @@
     <ProjectReference Include="..\..\Core\Impl\ServicesVisualStudioImpl.csproj">
       <Project>{c0e80510-4fbe-4b0c-af2c-4f473787722c}</Project>
       <Name>ServicesVisualStudioImpl</Name>
+      <Private>false</Private>
     </ProjectReference>
     <ProjectReference Include="..\..\InteractiveServices\VisualStudioInteractiveServices.csproj">
       <Project>{a31228bb-f05c-4d4a-b98a-0e681d876b7c}</Project>


### PR DESCRIPTION
This prevents the VSIX packages from getting bloated with extra binaries.  The runtime dependency is still present, but they'll get picked up from the NGENed images.

Fixes #13207.