### PR TITLE
Add some omitted "this." prefixes.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -909,7 +909,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return syntaxOffset;
             }
 
-            if (declaration.Declarations.Length >= 1 && position == declaration.Declarations[0].Location.SourceSpan.Start)
+            if (this.declaration.Declarations.Length >= 1 && position == this.declaration.Declarations[0].Location.SourceSpan.Start)
             {
                 // With dynamic analysis instrumentation, the introducing declaration of a type can provide
                 // the syntax associated with both the analysis payload local of a synthesized constructor


### PR DESCRIPTION
I just merged a PR that accidently omitted "this." from a couple of member references.

@jcouv @dotnet/roslyn-compiler 