### PR TITLE
Code Model: Implement CodeNamespace.Comment and CodeNamespace.DocComment properties

### DIFF
--- a/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeNamespace.cs
+++ b/src/VisualStudio/Core/Impl/CodeModel/InternalElements/CodeNamespace.cs
@@ -86,14 +86,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                // Namespaces don't support comments
-                throw Exceptions.ThrowENotImpl();
+                return CodeModelService.GetComment(LookupNode());
             }
 
             set
             {
-                // Namespaces don't support comments
-                throw Exceptions.ThrowENotImpl();
+                UpdateNode(FileCodeModel.UpdateComment, value);
             }
         }
 
@@ -101,14 +99,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.CodeModel.Inter
         {
             get
             {
-                // Namespaces can't have doc comments
-                return string.Empty;
+                return CodeModelService.GetDocComment(LookupNode());
             }
 
             set
             {
-                // We don't allow you to set, since you can't set things that don't exist.
-                throw Exceptions.ThrowENotImpl();
+                UpdateNode(FileCodeModel.UpdateDocComment, value);
             }
         }
 

--- a/src/VisualStudio/Core/Test/CodeModel/AbstractCodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/AbstractCodeNamespaceTests.vb
@@ -13,11 +13,19 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel
         End Function
 
         Protected Overrides Function GetComment(codeElement As EnvDTE.CodeNamespace) As String
-            Throw New NotImplementedException()
+            Return codeElement.Comment
+        End Function
+
+        Protected Overrides Function GetCommentSetter(codeElement As EnvDTE.CodeNamespace) As Action(Of String)
+            Return Sub(value) codeElement.Comment = value
         End Function
 
         Protected Overrides Function GetDocComment(codeElement As EnvDTE.CodeNamespace) As String
-            Throw New NotImplementedException()
+            Return codeElement.DocComment
+        End Function
+
+        Protected Overrides Function GetDocCommentSetter(codeElement As EnvDTE.CodeNamespace) As Action(Of String)
+            Return Sub(value) codeElement.DocComment = value
         End Function
 
         Protected Overrides Function GetFullName(codeElement As EnvDTE.CodeNamespace) As String

--- a/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/CSharp/CodeNamespaceTests.vb
@@ -9,6 +9,386 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.CodeModel.CSharp
     Public Class CodeNamespaceTests
         Inherits AbstractCodeNamespaceTests
 
+#Region "Comment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment1() As Task
+            Dim code =
+<Code>
+namespace $$N { }
+</Code>
+
+            Await TestComment(code, String.Empty)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment2() As Task
+            Dim code =
+<Code>
+// Foo
+// Bar
+namespace $$N { }
+</Code>
+
+            Await TestComment(code, "Foo" & vbCrLf & "Bar" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment3() As Task
+            Dim code =
+<Code>
+namespace N1 { } // Foo
+// Bar
+namespace $$N2 { }
+</Code>
+
+            Await TestComment(code, "Bar" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment4() As Task
+            Dim code =
+<Code>
+namespace N1 { } // Foo
+/* Bar */
+namespace $$N2 { }
+</Code>
+
+            Await TestComment(code, "Bar" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment5() As Task
+            Dim code =
+<Code>
+namespace N1 { } // Foo
+/*
+    Bar
+*/
+namespace $$N2 { }
+</Code>
+
+            Await TestComment(code, "Bar" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment6() As Task
+            Dim code =
+<Code>
+namespace N1 { } // Foo
+/*
+    Hello
+    World!
+*/
+namespace $$N2 { }
+</Code>
+
+            Await TestComment(code, "Hello" & vbCrLf & "World!" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment7() As Task
+            Dim code =
+<Code>
+namespace N1 { } // Foo
+/*
+    Hello
+    
+    World!
+*/
+namespace $$N2 { }
+</Code>
+
+            Await TestComment(code, "Hello" & vbCrLf & vbCrLf & "World!" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment8() As Task
+            Dim code =
+<Code>
+/* This
+ * is
+ * a
+ * multi-line
+ * comment!
+ */
+namespace $$N { }
+</Code>
+
+            Await TestComment(code, "This" & vbCrLf & "is" & vbCrLf & "a" & vbCrLf & "multi-line" & vbCrLf & "comment!" & vbCrLf)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment9() As Task
+            Dim code =
+<Code>
+// Foo
+/// &lt;summary&gt;Bar&lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Await TestComment(code, String.Empty)
+        End Function
+
+#End Region
+
+#Region "DocComment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment1() As Task
+            Dim code =
+<Code>
+/// &lt;summary&gt;Hello World&lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Await TestDocComment(code, "<doc>" & vbCrLf & "<summary>Hello World</summary>" & vbCrLf & "</doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment2() As Task
+            Dim code =
+<Code>
+/// &lt;summary&gt;
+/// Hello World
+/// &lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Await TestDocComment(code, "<doc>" & vbCrLf & "<summary>" & vbCrLf & "Hello World" & vbCrLf & "</summary>" & vbCrLf & "</doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment3() As Task
+            Dim code =
+<Code>
+///    &lt;summary&gt;
+/// Hello World
+///&lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Await TestDocComment(code, "<doc>" & vbCrLf & "    <summary>" & vbCrLf & " Hello World" & vbCrLf & "</summary>" & vbCrLf & "</doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment4() As Task
+            Dim code =
+<Code>
+/// &lt;summary&gt;
+/// Summary
+/// &lt;/summary&gt;
+/// &lt;remarks&gt;Remarks&lt;/remarks&gt;
+namespace $$N { }
+</Code>
+
+            Await TestDocComment(code, "<doc>" & vbCrLf & "<summary>" & vbCrLf & "Summary" & vbCrLf & "</summary>" & vbCrLf & "<remarks>Remarks</remarks>" & vbCrLf & "</doc>")
+        End Function
+
+#End Region
+
+#Region "Set Comment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment1() As Task
+            Dim code =
+<Code>
+// Foo
+
+// Bar
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+namespace N { }
+</Code>
+
+            Await TestSetComment(code, expected, Nothing)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment2() As Task
+            Dim code =
+<Code>
+// Foo
+/// &lt;summary&gt;Bar&lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+// Foo
+/// &lt;summary&gt;Bar&lt;/summary&gt;
+// Bar
+namespace N { }
+</Code>
+
+            Await TestSetComment(code, expected, "Bar")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment3() As Task
+            Dim code =
+<Code>
+// Foo
+
+// Bar
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+// Blah
+namespace N { }
+</Code>
+
+            Await TestSetComment(code, expected, "Blah")
+        End Function
+
+#End Region
+
+#Region "Set DocComment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_Nothing() As Task
+            Dim code =
+<Code>
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, Nothing, ThrowsArgumentException(Of String))
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_InvalidXml1() As Task
+            Dim code =
+<Code>
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Blah</doc>", ThrowsArgumentException(Of String))
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_InvalidXml2() As Task
+            Dim code =
+<Code>
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc___><summary>Blah</summary></doc___>", ThrowsArgumentException(Of String))
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment1() As Task
+            Dim code =
+<Code>
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+/// &lt;summary&gt;Hello World&lt;/summary&gt;
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Hello World</summary></doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment2() As Task
+            Dim code =
+<Code>
+/// &lt;summary&gt;Hello World&lt;/summary&gt;
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+/// &lt;summary&gt;Blah&lt;/summary&gt;
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Blah</summary></doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment3() As Task
+            Dim code =
+<Code>
+// Foo
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+// Foo
+/// &lt;summary&gt;Blah&lt;/summary&gt;
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Blah</summary></doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment4() As Task
+            Dim code =
+<Code>
+/// &lt;summary&gt;FogBar&lt;/summary&gt;
+// Foo
+namespace $$N { }
+</Code>
+
+            Dim expected =
+<Code>
+/// &lt;summary&gt;Blah&lt;/summary&gt;
+// Foo
+namespace N { }
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Blah</summary></doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment5() As Task
+            Dim code =
+<Code>
+namespace N1
+{
+    namespace $$N2 { }
+}
+</Code>
+
+            Dim expected =
+<Code>
+namespace N1
+{
+    /// &lt;summary&gt;Hello World&lt;/summary&gt;
+    namespace N2 { }
+}
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Hello World</summary></doc>")
+        End Function
+
+#End Region
+
 #Region "Remove tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>

--- a/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeNamespaceTests.vb
+++ b/src/VisualStudio/Core/Test/CodeModel/VisualBasic/CodeNamespaceTests.vb
@@ -405,6 +405,422 @@ End Namespace
 
 #End Region
 
+#Region "Comment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment1() As Task
+            Dim code =
+<Code>
+' Foo
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result = " Foo"
+
+            Await TestComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment2() As Task
+            Dim code =
+<Code>
+' Foo
+' Bar
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result = " Foo" & vbCrLf &
+                         " Bar"
+
+            Await TestComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment3() As Task
+            Dim code =
+<Code>
+' Foo
+
+' Bar
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result = " Bar"
+
+            Await TestComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment4() As Task
+            Dim code =
+<Code>
+Namespace N1
+End Namespace ' Foo
+
+' Bar
+Namespace $$N2
+End Namespace
+</Code>
+
+            Dim result = " Bar"
+
+            Await TestComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestComment5() As Task
+            Dim code =
+<Code>
+' Foo
+''' &lt;summary&gt;Bar&lt;/summary&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result = ""
+
+            Await TestComment(code, result)
+        End Function
+
+#End Region
+
+#Region "DocComment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment1() As Task
+            Dim code =
+<Code>
+''' &lt;summary&gt;
+''' Foo
+''' &lt;/summary&gt;
+''' &lt;remarks&gt;&lt;/remarks&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result =
+" <summary>" & vbCrLf &
+" Foo" & vbCrLf &
+" </summary>" & vbCrLf &
+" <remarks></remarks>"
+
+            Await TestDocComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment2() As Task
+            Dim code =
+<Code>
+'''     &lt;summary&gt;
+''' Hello World
+''' &lt;/summary&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result =
+"     <summary>" & vbCrLf &
+" Hello World" & vbCrLf &
+" </summary>"
+
+            Await TestDocComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment3() As Task
+            Dim code =
+<Code>
+''' &lt;summary&gt;
+''' Foo
+''' &lt;/summary&gt;
+' Bar
+''' &lt;remarks&gt;&lt;/remarks&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim result =
+" <remarks></remarks>"
+
+            Await TestDocComment(code, result)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestDocComment4() As Task
+            Dim code =
+<Code>
+Namespace N1
+    ''' &lt;summary&gt;
+    ''' Foo
+    ''' &lt;/summary&gt;
+    ''' &lt;remarks&gt;&lt;/remarks&gt;
+    Namespace $$N2
+    End Namespace
+End Namespace
+</Code>
+
+            Dim result =
+" <summary>" & vbCrLf &
+" Foo" & vbCrLf &
+" </summary>" & vbCrLf &
+" <remarks></remarks>"
+
+            Await TestDocComment(code, result)
+        End Function
+
+#End Region
+
+#Region "Set Comment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment1() As Task
+            Dim code =
+<Code>
+' Foo
+
+' Bar
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+' Foo
+
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetComment(code, expected, Nothing)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment2() As Task
+            Dim code =
+<Code>
+' Foo
+''' &lt;summary&gt;Bar&lt;/summary&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+' Foo
+''' &lt;summary&gt;Bar&lt;/summary&gt;
+' Bar
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetComment(code, expected, "Bar")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetComment3() As Task
+            Dim code =
+<Code>
+' Foo
+
+' Bar
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+' Foo
+
+' Blah
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetComment(code, expected, "Blah")
+        End Function
+
+#End Region
+
+#Region "Set DocComment tests"
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_Nothing1() As Task
+            Dim code =
+<Code>
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, Nothing)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_Nothing2() As Task
+            Dim code =
+<Code>
+''' &lt;summary&gt;
+''' Foo
+''' &lt;/summary&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, Nothing)
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_InvalidXml1() As Task
+            Dim code =
+<Code>
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+''' &lt;doc&gt;&lt;summary&gt;Blah&lt;/doc&gt;
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc><summary>Blah</doc>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment_InvalidXml2() As Task
+            Dim code =
+<Code>
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+''' &lt;doc___&gt;&lt;summary&gt;Blah&lt;/summary&gt;&lt;/doc___&gt;
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<doc___><summary>Blah</summary></doc___>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment1() As Task
+            Dim code =
+<Code>
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+''' &lt;summary&gt;Hello World&lt;/summary&gt;
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<summary>Hello World</summary>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment2() As Task
+            Dim code =
+<Code>
+''' &lt;summary&gt;Hello World&lt;/summary&gt;
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+''' &lt;summary&gt;Blah&lt;/summary&gt;
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<summary>Blah</summary>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment3() As Task
+            Dim code =
+<Code>
+' Foo
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+' Foo
+''' &lt;summary&gt;Blah&lt;/summary&gt;
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<summary>Blah</summary>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment4() As Task
+            Dim code =
+<Code>
+''' &lt;summary&gt;FogBar&lt;/summary&gt;
+' Foo
+Namespace $$N
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+''' &lt;summary&gt;Blah&lt;/summary&gt;
+' Foo
+Namespace N
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<summary>Blah</summary>")
+        End Function
+
+        <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>
+        Public Async Function TestSetDocComment5() As Task
+            Dim code =
+<Code>
+Namespace N1
+    Namespace $$N2
+    End Namespace
+End Namespace
+</Code>
+
+            Dim expected =
+<Code>
+Namespace N1
+    ''' &lt;summary&gt;Hello World&lt;/summary&gt;
+    Namespace N2
+    End Namespace
+End Namespace
+</Code>
+
+            Await TestSetDocComment(code, expected, "<summary>Hello World</summary>")
+        End Function
+
+#End Region
+
 #Region "Remove tests"
 
         <ConditionalWpfFact(GetType(x86)), Trait(Traits.Feature, Traits.Features.CodeModel)>


### PR DESCRIPTION
This change properly implements the CodeNamespace.Comment and CodeNamespace.DocComment properties. Historically, C# would throw an exception if either of these properties were accessed on a CodeNamespace, but VB allowed them to work. With this change, the properties will work for *both* C# and VB (even though DocComment doesn't make much sense). Technically, this is a breaking change for C# in the sense that an exception will no longer be thrown. However, I expect that it will generally make life a bit easier for Code Model consumers by keeping the implementations consistent between C# and VB.

cc @dotnet/roslyn-ide 