### PR TITLE
Turn on /features:strict for all projects

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -212,6 +212,7 @@
     <DeployToSamplesSubfolder Condition="'$(DeployToSamplesSubfolder)' == ''">false</DeployToSamplesSubfolder>
     <FileAlignment>512</FileAlignment>
     <HighEntropyVA>true</HighEntropyVA>
+    <Features>strict</Features>
   </PropertyGroup>
 
   <!--

--- a/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/SyntaxAndDeclarationManager.cs
@@ -364,6 +364,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 Debug.Assert(!oldLoadDirectives.IsEmpty);
                 GetRemoveSetForLoadedTrees(oldLoadDirectives, loadDirectiveMap, loadedSyntaxTreeMap, removeSet);
             }
+            else
+            {
+                oldLoadDirectives = ImmutableArray<LoadDirective>.Empty;
+            }
 
             removeSet.Add(oldTree);
             totalReferencedTreeCount = removeSet.Count;

--- a/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LookupPosition.cs
@@ -405,7 +405,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                     LocalFunctionStatementSyntax localFunctionStmt = (LocalFunctionStatementSyntax)statement;
                     if (localFunctionStmt.Body != null)
                         return GetFirstExcludedToken(localFunctionStmt.Body);
-                    if (localFunctionStmt.SemicolonToken != null)
+                    if (localFunctionStmt.SemicolonToken != default(SyntaxToken))
                         return localFunctionStmt.SemicolonToken;
                     return localFunctionStmt.ParameterList.GetLastToken();
                 default:

--- a/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
+++ b/src/Compilers/Core/Portable/ReferenceManager/CommonReferenceManager.Resolution.cs
@@ -63,6 +63,8 @@ namespace Microsoft.CodeAnalysis
                 Debug.Assert(index >= 0);
                 _index = index + 1;
                 _kind = kind;
+                _aliasesOpt = default(ImmutableArray<string>);
+                _recursiveAliasesOpt = default(ImmutableArray<string>);
             }
 
             // initialized aliases

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -573,8 +573,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Class OverrideHidingHelper(Of TSymbol As Symbol)
         Inherits OverrideHidingHelper
 
-        ' Comparer for comparing signatures of TSymbols in a runtime-equivalent way
-        Private Shared ReadOnly s_runtimeSignatureComparer As IEqualityComparer(Of TSymbol)
+        ' Comparer for comparing signatures of TSymbols in a runtime-equivalent way.
+        ' It is not ReadOnly because it is initialized by a Shared Sub New of another instance of this class.
+        Private Shared s_runtimeSignatureComparer As IEqualityComparer(Of TSymbol)
 
         ' Initialize the various kinds of comparers.
         Shared Sub New()

--- a/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
+++ b/src/EditorFeatures/Core/Implementation/InlineRename/InlineRenameSession.OpenTextBufferManager.cs
@@ -587,7 +587,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.InlineRename
                         // GetSpanInView() can return an empty collection if the tracking span isn't mapped to anything
                         // in the current view, specifically a `@model SomeModelClass` directive in a Razor file.
                         var ss = textView.GetSpanInView(kvp.Value.TrackingSpan.GetSpan(snapshot)).FirstOrDefault();
-                        if (ss != null && (ss.IntersectsWith(selection.ActivePoint.Position) || ss.IntersectsWith(selection.AnchorPoint.Position)))
+                        if (ss != default(SnapshotSpan) && (ss.IntersectsWith(selection.ActivePoint.Position) || ss.IntersectsWith(selection.AnchorPoint.Position)))
                         {
                             return Tuple.Create(kvp.Key, ss);
                         }

--- a/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
+++ b/src/ExpressionEvaluator/Core/Source/ExpressionCompiler/EvaluationContextBase.cs
@@ -49,6 +49,7 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
         internal string GetErrorMessageAndMissingAssemblyIdentities(DiagnosticBag diagnostics, DiagnosticFormatter formatter, CultureInfo preferredUICulture, AssemblyIdentity linqLibrary, out bool useReferencedModulesOnly, out ImmutableArray<AssemblyIdentity> missingAssemblyIdentities)
         {
             var errors = diagnostics.AsEnumerable().Where(d => d.Severity == DiagnosticSeverity.Error);
+            missingAssemblyIdentities = default(ImmutableArray<AssemblyIdentity>);
             foreach (var error in errors)
             {
                 missingAssemblyIdentities = this.GetMissingAssemblyIdentities(error, linqLibrary);

--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.AnalysisData.cs
@@ -37,6 +37,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
             {
                 this.Version = version;
                 this.Items = items;
+                this.OldItems = default(ImmutableArray<DiagnosticData>);
             }
 
             public DocumentAnalysisData(VersionStamp version, ImmutableArray<DiagnosticData> oldItems, ImmutableArray<DiagnosticData> newItems) :


### PR DESCRIPTION
This enables us to get better definite assignment behavior for
struct types imported from metadata that have only private fields.
Closes #13203.

@AlekseyTs @dotnet/roslyn-interactive @dotnet/roslyn-compiler Please review
