### PR TITLE
existing diagnostic tagger didn't check workspace diagnostics belong …

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -174,10 +174,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             private void OnDiagnosticsUpdated(DiagnosticsUpdatedArgs e)
             {
-                // First see if this is a document/project removal.  If so, clear out any state we
-                // have associated with any analyzers we have for that document/project.
-                ProcessRemovedDiagnostics(e);
-
                 // Do some quick checks to avoid doing any further work for diagnostics  we don't
                 // care about.
                 var ourDocument = _subjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
@@ -187,6 +183,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 {
                     return;
                 }
+
+                // First see if this is a document/project removal.  If so, clear out any state we
+                // have associated with any analyzers we have for that document/project.
+                ProcessRemovedDiagnostics(e);
 
                 // Make sure we can find an editor snapshot for these errors.  Otherwise we won't
                 // be able to make ITagSpans for them.  If we can't, just bail out.  This happens


### PR DESCRIPTION
…to before it removes them.

that caused host workspace's diagnostics to be removed when preview workspace's diagnostics are removed since two shared same documentId and projectId.

the code already had the logic to check what workspace the diagnostics belong to, it just happen to check that after removing diagnostics. fix is moving the checking before removing diagnostics.