### PR TITLE
add more cancellation checking in LB code path.

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer_GetDiagnosticsForSpan.cs
@@ -99,6 +99,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     var containsFullResult = true;
                     foreach (var stateSet in _stateSets)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
+
                         containsFullResult &= await TryGetSyntaxAndSemanticDiagnosticsAsync(stateSet, list, cancellationToken).ConfigureAwait(false);
 
                         // check whether compilation end code fix is enabled
@@ -314,6 +316,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     return true;
                 }
 
+                cancellationToken.ThrowIfCancellationRequested();
+
                 // check whether we want up-to-date document wide diagnostics
                 var supportsSemanticInSpan = stateSet.Analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis();
                 if (!BlockForData(kind, supportsSemanticInSpan))
@@ -360,6 +364,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
                     list.AddRange(existingData.Where(ShouldInclude));
                     return true;
                 }
+
+                cancellationToken.ThrowIfCancellationRequested();
 
                 // check whether we want up-to-date document wide diagnostics
                 var supportsSemanticInSpan = stateSet.Analyzer.SupportsSpanBasedSemanticDiagnosticAnalysis();


### PR DESCRIPTION
code path where code fix uses didn't check cancellation itself but just pass it down to workspace/compiler. but that will make it to not cancel if all diagnostics are already calculated and cached. so it will always run to end and then right after that, code fix service will throw cancellation exception.

by adding some cancellation here, we can prevent us from doing unnecessary work.