### PR TITLE
Bugfix: possible NRE in SymbolsAreCompatibleCore

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AbstractSpeculationAnalyzer.cs
@@ -381,14 +381,14 @@ namespace Microsoft.CodeAnalysis.Shared.Utilities
                     var type = methodSymbol.ContainingType;
                     var newType = newMethodSymbol.ContainingType;
                     if ((type != null && newType != null) &&
-                        (
+                        ((
                             type.IsEnumType() &&
                             type.EnumUnderlyingType != null &&
                             type.EnumUnderlyingType.SpecialType == newType.SpecialType) ||
                         (
                             newType.IsEnumType() &&
                             newType.EnumUnderlyingType != null &&
-                            newType.EnumUnderlyingType.SpecialType == type.SpecialType))
+                            newType.EnumUnderlyingType.SpecialType == type.SpecialType)))
                     {
                         return true;
                     }


### PR DESCRIPTION
Changing `a && b || c` to `a && (b || c)`