### PR TITLE
push file read to Background thread.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             this.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
         }
 
-        private async void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+        private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
         {
             switch (e.Kind)
             {
@@ -76,7 +76,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                     var oldDocument = e.OldSolution.GetDocument(e.DocumentId);
                     var newDocument = e.NewSolution.GetDocument(e.DocumentId);
 
-                    await DocumentChangedAsync(oldDocument, newDocument).ConfigureAwait(false);
+                    // make sure we do this in background thread. we don't care about ordering of events
+                    // we just need to refresh OB at some point if it ever needs to be updated
+                    Task.Run(() => DocumentChangedAsync(oldDocument, newDocument));
                     break;
 
                 case WorkspaceChangeKind.ProjectAdded:


### PR DESCRIPTION
this should fix /workaround one particular case of dead lock but it won't fix the root cause of this where DispatcherSynchronizationContext Wait allowing re-enterance of COM call which, if re-entered code ever use Wait/Result, causes VS to dead lock.

alternative to this fix is using Dispatcher.CurrentDispatcer.DisableProcessing(), but since workspace event is so busy code path, didn't want to play with global state (resource) all other people are using.