### PR TITLE
Treat tuple type as a struct if underlying type is error type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -668,7 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _underlyingType.IsErrorType() ? true : _underlyingType.IsValueType;
+                return _underlyingType.IsErrorType() || _underlyingType.IsValueType;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -668,7 +668,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _underlyingType.IsValueType;
+                return _underlyingType.IsErrorType() ? true : _underlyingType.IsValueType;
             }
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2303,5 +2303,34 @@ class C
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(6, 42)
                 );
         }
+
+        [Fact, WorkItem(13081, "https://github.com/dotnet/roslyn/issues/13081")]
+        public void GettingDiagnosticsWhenValueTupleIsMissing()
+        {
+            var source = @"
+class C1
+{
+    static void Test(int arg1, (byte, byte) arg2)
+    {
+        foreach ((int, int) e in new (int, int)[10])
+        {
+        }
+    }
+}
+";
+            var comp = CreateCompilationWithMscorlib(source);
+            comp.VerifyDiagnostics(
+                // (4,32): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //     static void Test(int arg1, (byte, byte) arg2)
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(byte, byte)").WithArguments("System.ValueTuple`2").WithLocation(4, 32),
+                // (6,38): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         foreach ((int, int) e in new (int, int)[10])
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(int, int)").WithArguments("System.ValueTuple`2").WithLocation(6, 38),
+                // (6,18): error CS0518: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         foreach ((int, int) e in new (int, int)[10])
+                Diagnostic(ErrorCode.ERR_PredefinedTypeNotFound, "(int, int)").WithArguments("System.ValueTuple`2").WithLocation(6, 18)
+                );
+            // no crash
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1506,7 +1506,7 @@ public class C
 
             var expectedDiagnostics = new[]
             {
-                // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
+              // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public (int, int) TestTuple()
                 Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(8, 12),
                 // (4,19): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
@@ -1514,7 +1514,10 @@ public class C
                 Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "ValueTuple<string, string>").WithArguments("System.ValueTuple<T1, T2>").WithLocation(4, 19),
                 // (14,16): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //         return (1, 2);
-                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(14, 16)
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(14, 16),
+                // (19,9): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
+                //         (x, y) = new C();
+                Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(x, y) = new C()").WithArguments("System.ValueTuple<T1, T2>").WithLocation(19, 9)
             };
 
             var comp1 = CreateCompilationWithMscorlib(source, options: TestOptions.ReleaseDll,


### PR DESCRIPTION
This fixes assertion in `GenerateImplicitConversionError` (which was reaching the end of the method, rather than going into the path where `operand.IsLiteralNull()` and `targetType.IsValueType`.
Fixes https://github.com/dotnet/roslyn/issues/13088

Note that the change in `TupleTypeSymbol.IsValueType` is now consistent with `TupleTypeSymbol.IsReferenceType`. 
This makes me wonder why we have two methods (shouldn't one always be the opposite of the other?).

Also adds a test for issue https://github.com/dotnet/roslyn/issues/13081 which didn't repro.
Also adds a test for issue https://github.com/dotnet/roslyn/issues/11302 which didn't repro.

