### PR TITLE
Fix parsing of local functions with line breaks

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4771,7 +4771,7 @@ tryAgain:
                                 isNonEqualsBinaryToken)
                             {
                                 var isPossibleLocalFunctionToken =
-                                    currentTokenKind == SyntaxKind.OpenParenToken |
+                                    currentTokenKind == SyntaxKind.OpenParenToken ||
                                     currentTokenKind == SyntaxKind.LessThanToken;
 
                                 // Make sure this isn't a local function

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -4770,11 +4770,19 @@ tryAgain:
                                 currentTokenKind == SyntaxKind.MinusGreaterThanToken ||
                                 isNonEqualsBinaryToken)
                             {
-                                var missingIdentifier = CreateMissingIdentifierToken();
-                                missingIdentifier = this.AddError(missingIdentifier, offset, width, ErrorCode.ERR_IdentifierExpected);
+                                var isPossibleLocalFunctionToken =
+                                    currentTokenKind == SyntaxKind.OpenParenToken |
+                                    currentTokenKind == SyntaxKind.LessThanToken;
 
-                                localFunction = null;
-                                return _syntaxFactory.VariableDeclarator(missingIdentifier, null, null);
+                                // Make sure this isn't a local function
+                                if (!isPossibleLocalFunctionToken || !IsLocalFunctionAfterIdentifier())
+                                {
+                                    var missingIdentifier = CreateMissingIdentifierToken();
+                                    missingIdentifier = this.AddError(missingIdentifier, offset, width, ErrorCode.ERR_IdentifierExpected);
+
+                                    localFunction = null;
+                                    return _syntaxFactory.VariableDeclarator(missingIdentifier, null, null);
+                                }
                             }
                         }
                     }
@@ -4939,6 +4947,36 @@ tryAgain:
 
             localFunction = null;
             return _syntaxFactory.VariableDeclarator(name, argumentList, initializer);
+        }
+
+        // Is there a local function after an eaten identifier?
+        private bool IsLocalFunctionAfterIdentifier()
+        {
+            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.OpenParenToken ||
+                         this.CurrentToken.Kind == SyntaxKind.LessThanToken);
+            var resetPoint = this.GetResetPoint();
+
+            try
+            {
+                var typeParameterListOpt = this.ParseTypeParameterList(allowVariance: false);
+                var paramList = ParseParenthesizedParameterList(
+                    allowThisKeyword: true, allowDefaults: true, allowAttributes: true);
+
+                if (!paramList.IsMissing &&
+                     (this.CurrentToken.Kind == SyntaxKind.OpenBraceToken ||
+                      this.CurrentToken.Kind == SyntaxKind.EqualsGreaterThanToken ||
+                      this.CurrentToken.ContextualKind == SyntaxKind.WhereKeyword))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                Reset(ref resetPoint);
+                Release(ref resetPoint);
+            }
         }
 
         private bool IsPossibleEndOfVariableDeclaration()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -12,7 +12,67 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public class LocalFunctionParsingTests : ParsingTests
     {
-        internal static readonly CSharpParseOptions LocalFuncOptions = TestOptions.Regular.WithLocalFunctionsFeature();
+        [Fact]
+        [WorkItem(12280, "https://github.com/dotnet/roslyn/issues/12280")]
+        public void LocalFuncWithWhitespace()
+        {
+            var file = ParseFile(@"
+class C
+{
+    void Main()
+    {
+        int
+            foo() => 5;
+
+        int
+            foo() { return 5; }
+
+        int
+            foo<T>() => 5;
+
+        int
+            foo<T>() { return 5; }
+
+        int
+            foo<T>() where T : IFace => 5;
+
+        int
+            foo<T>() where T : IFace { return 5; }
+    }
+}");
+            Assert.NotNull(file);
+            file.SyntaxTree.GetDiagnostics().Verify();
+
+            file = ParseFile(@"
+class C
+{
+    void M()
+    {
+        int
+            foo() where T : IFace => 5;
+        int
+            foo() where T : IFace { return 5; }
+        int
+            foo<T>) { }
+    }
+}");
+            file.SyntaxTree.GetDiagnostics().Verify(
+                // (7,19): error CS0080: Constraints are not allowed on non-generic declarations
+                //             foo() where T : IFace => 5;
+                Diagnostic(ErrorCode.ERR_ConstraintOnlyAllowedOnGenericDecl, "where").WithLocation(7, 19),
+                // (9,19): error CS0080: Constraints are not allowed on non-generic declarations
+                //             foo() where T : IFace { return 5; }
+                Diagnostic(ErrorCode.ERR_ConstraintOnlyAllowedOnGenericDecl, "where").WithLocation(9, 19),
+                // (11,19): error CS1003: Syntax error, '(' expected
+                //             foo<T>) { }
+                Diagnostic(ErrorCode.ERR_SyntaxError, ")").WithArguments("(", ")").WithLocation(11, 19));
+
+            var m = Assert.IsType<MethodDeclarationSyntax>(file.DescendantNodes()
+                .Where(n => n.Kind() == SyntaxKind.MethodDeclaration)
+                .Single());
+            Assert.All(m.Body.Statements,
+                s => Assert.Equal(SyntaxKind.LocalFunctionStatement, s.Kind()));
+        }
 
         [Fact]
         public void NeverEndingTest()

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParsingErrorRecoveryTests.cs
@@ -43,7 +43,7 @@ class C
     // brace on previous method. Parsing currently assumes the former,
     // assuming the tokens are parseable as a local func.
     {accessibility} void M4() {{}}
-}}", LocalFunctionParsingTests.LocalFuncOptions);
+}}");
 
             Assert.NotNull(file);
             file.GetDiagnostics().Verify(


### PR DESCRIPTION
The compiler has various heuristics around line breaks, specifically to
handle the case where someone is typeing above an existing statement.
Preserving these heuristics is important for the IDE, so we'll lookahead
to verify the presence of a local function and, if one is not present,
we'll fallback to the existing heuristics.

Fixes #12280.