### PR TITLE
Add new options for switch case statement blocks

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.Designer.cs
@@ -79,6 +79,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Always indent switch case sections.
+        /// </summary>
+        internal static string Always_indent_switch_case {
+            get {
+                return ResourceManager.GetString("Always_indent_switch_case", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Automatically format _block on }.
         /// </summary>
         internal static string Automatically_format_block_on {
@@ -300,15 +309,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         internal static string Indent_block_contents {
             get {
                 return ResourceManager.GetString("Indent_block_contents", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Indent case contents.
-        /// </summary>
-        internal static string Indent_case_contents {
-            get {
-                return ResourceManager.GetString("Indent_case_contents", resourceCulture);
             }
         }
         
@@ -628,6 +628,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Never indent switch case sections.
+        /// </summary>
+        internal static string Never_indent_switch_case {
+            get {
+                return ResourceManager.GetString("Never_indent_switch_case", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to New line options for braces.
         /// </summary>
         internal static string New_line_options_for_braces {
@@ -660,6 +669,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         internal static string Only_add_new_line_on_enter_after_end_of_fully_typed_word {
             get {
                 return ResourceManager.GetString("Only_add_new_line_on_enter_after_end_of_fully_typed_word", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Only indent statements inside switch case sections.
+        /// </summary>
+        internal static string Only_indent_statement_switch_case {
+            get {
+                return ResourceManager.GetString("Only_indent_statement_switch_case", resourceCulture);
             }
         }
         
@@ -1119,6 +1137,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp {
         internal static string Surround_With {
             get {
                 return ResourceManager.GetString("Surround_With", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Switch Case Statement Indentation.
+        /// </summary>
+        internal static string Switch_Case_Indentation {
+            get {
+                return ResourceManager.GetString("Switch_Case_Indentation", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
+++ b/src/VisualStudio/CSharp/Impl/CSharpVSResources.resx
@@ -153,9 +153,6 @@
   <data name="Indent_open_and_close_braces" xml:space="preserve">
     <value>Indent open and close braces</value>
   </data>
-  <data name="Indent_case_contents" xml:space="preserve">
-    <value>Indent case contents</value>
-  </data>
   <data name="Indent_case_labels" xml:space="preserve">
     <value>Indent case labels</value>
   </data>
@@ -488,5 +485,17 @@
   </data>
   <data name="Show_completion_list_after_a_character_is_deleted" xml:space="preserve">
     <value>Show completion list after a character is _deleted</value>
+  </data>
+  <data name="Always_indent_switch_case" xml:space="preserve">
+    <value>Always indent switch case sections</value>
+  </data>
+  <data name="Never_indent_switch_case" xml:space="preserve">
+    <value>Never indent switch case sections</value>
+  </data>
+  <data name="Only_indent_statement_switch_case" xml:space="preserve">
+    <value>Only indent statements inside switch case sections</value>
+  </data>
+  <data name="Switch_Case_Indentation" xml:space="preserve">
+    <value>Switch Case Statement Indentation</value>
   </data>
 </root>

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -157,7 +157,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set { SetBooleanOption(CSharpFormattingOptions.IndentBraces, value); }
         }
 
-        public int Indent_CaseContents
+        public int Indent_CaseContents_New
         {
             get
             {
@@ -167,6 +167,20 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
             set
             {
                 _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.IndentSwitchCaseSection, value);
+            }
+        }
+
+        public int Indent_CaseContents
+        {
+            get
+            {
+                var option = _workspace.Options.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection);
+                return option == SwitchCaseIndentOptions.NeverIndent ? 0 : 1;
+            }
+
+            set
+            {
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.IndentSwitchCaseSection, value == 0 ? SwitchCaseIndentOptions.NeverIndent : SwitchCaseIndentOptions.AlwaysIndent);
             }
         }
 

--- a/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/AutomationObject.cs
@@ -159,8 +159,15 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Options
 
         public int Indent_CaseContents
         {
-            get { return GetBooleanOption(CSharpFormattingOptions.IndentSwitchCaseSection); }
-            set { SetBooleanOption(CSharpFormattingOptions.IndentSwitchCaseSection, value); }
+            get
+            {
+                return (int)_workspace.Options.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection);
+            }
+
+            set
+            {
+                _workspace.Options = _workspace.Options.WithChangedOption(CSharpFormattingOptions.IndentSwitchCaseSection, value);
+            }
         }
 
         public int Indent_CaseLabels

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/IndentationViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/IndentationViewModel.cs
@@ -41,6 +41,10 @@ class MyClass
         switch (foo){
         case 2:
             break;
+        case 3:
+        {
+            break;
+        }
         }
 //]
     }
@@ -62,8 +66,13 @@ class MyClass
         {
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentBlock, CSharpVSResources.Indent_block_contents, BlockContentPreview, this, options));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentBraces, CSharpVSResources.Indent_open_and_close_braces, IndentBracePreview, this, options));
-            Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentSwitchCaseSection, CSharpVSResources.Indent_case_contents, SwitchCasePreview, this, options));
             Items.Add(new CheckBoxOptionViewModel(CSharpFormattingOptions.IndentSwitchSection, CSharpVSResources.Indent_case_labels, SwitchCasePreview, this, options));
+
+            Items.Add(new TextBlock() { Text = CSharpVSResources.Switch_Case_Indentation });
+
+            Items.Add(new RadioButtonViewModel<SwitchCaseIndentOptions>(CSharpVSResources.Never_indent_switch_case, SwitchCasePreview, "switch", SwitchCaseIndentOptions.NeverIndent, CSharpFormattingOptions.IndentSwitchCaseSection, this, options));
+            Items.Add(new RadioButtonViewModel<SwitchCaseIndentOptions>(CSharpVSResources.Only_indent_statement_switch_case, SwitchCasePreview, "switch", SwitchCaseIndentOptions.OnlyIndentStatements, CSharpFormattingOptions.IndentSwitchCaseSection, this, options));
+            Items.Add(new RadioButtonViewModel<SwitchCaseIndentOptions>(CSharpVSResources.Always_indent_switch_case, SwitchCasePreview, "switch", SwitchCaseIndentOptions.AlwaysIndent, CSharpFormattingOptions.IndentSwitchCaseSection, this, options));
 
             Items.Add(new TextBlock() { Text = CSharpVSResources.Label_Indentation });
 

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -130,13 +130,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
     public enum SwitchCaseIndentOptions
     {
-        /// Never Indent
-        NeverIndent = 1,
-
         /// Always Indent
-        AlwaysIndent = 2,
+        AlwaysIndent = 1,
+
+        /// Never Indent
+        NeverIndent = 0,
 
         /// Only Indent Statements
-        OnlyIndentStatements = 3,
+        OnlyIndentStatements = 2,
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -65,7 +65,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
         public static Option<bool> IndentSwitchSection { get; } = new Option<bool>(IndentFeatureName, "IndentSwitchSection", defaultValue: true);
 
-        public static Option<bool> IndentSwitchCaseSection { get; } = new Option<bool>(IndentFeatureName, "IndentSwitchCaseSection", defaultValue: true);
+        public static Option<SwitchCaseIndentOptions> IndentSwitchCaseSection { get; } = new Option<SwitchCaseIndentOptions>(IndentFeatureName, "IndentSwitchCaseSection", defaultValue: SwitchCaseIndentOptions.AlwaysIndent);
 
         public static Option<LabelPositionOptions> LabelPositioning { get; } = new Option<LabelPositionOptions>(IndentFeatureName, "LabelPositioning", defaultValue: LabelPositionOptions.OneLess);
 
@@ -126,5 +126,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
 
         /// Remove Spacing
         Remove = 2
+    }
+
+    public enum SwitchCaseIndentOptions
+    {
+        /// Never Indent
+        NeverIndent = 1,
+
+        /// Always Indent
+        AlwaysIndent = 2,
+
+        /// Only Indent Statements
+        OnlyIndentStatements = 3,
     }
 }

--- a/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/Rules/IndentBlockFormattingRule.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         private void AddSwitchIndentationOperation(List<IndentBlockOperation> list, SyntaxNode node, OptionSet optionSet)
         {
             var section = node as SwitchSectionSyntax;
-            if (section == null || !optionSet.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection))
+            if (section == null || optionSet.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection) == SwitchCaseIndentOptions.NeverIndent)
             {
                 return;
             }
@@ -55,6 +55,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             // can this ever happen?
             if (section.Labels.Count == 0 &&
                 section.Statements.Count == 0)
+            {
+                return;
+            }
+
+            if (section.Statements.Count == 1 &&
+                section.Statements[0] is BlockSyntax &&
+                optionSet.GetOption(CSharpFormattingOptions.IndentSwitchCaseSection) == SwitchCaseIndentOptions.OnlyIndentStatements)
             {
                 return;
             }

--- a/src/Workspaces/CSharp/Portable/PublicAPI.Shipped.txt
+++ b/src/Workspaces/CSharp/Portable/PublicAPI.Shipped.txt
@@ -9,7 +9,6 @@ Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions.NoIndent = 2 -> Mi
 Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions.OneLess = 1 -> Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBlock.get -> Microsoft.CodeAnalysis.Options.Option<bool>
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentBraces.get -> Microsoft.CodeAnalysis.Options.Option<bool>
-static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchCaseSection.get -> Microsoft.CodeAnalysis.Options.Option<bool>
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchSection.get -> Microsoft.CodeAnalysis.Options.Option<bool>
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.LabelPositioning.get -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.LabelPositionOptions>
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.NewLineForCatch.get -> Microsoft.CodeAnalysis.Options.Option<bool>

--- a/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.AlwaysIndent = 2 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.NeverIndent = 1 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.OnlyIndentStatements = 3 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchCaseSection.get -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions>

--- a/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,5 +1,5 @@
 Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
-Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.AlwaysIndent = 2 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
-Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.NeverIndent = 1 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
-Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.OnlyIndentStatements = 3 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.AlwaysIndent = 1 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.NeverIndent = 0 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
+Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions.OnlyIndentStatements = 2 -> Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions
 static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions.IndentSwitchCaseSection.get -> Microsoft.CodeAnalysis.Options.Option<Microsoft.CodeAnalysis.CSharp.Formatting.SwitchCaseIndentOptions>

--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -1027,7 +1027,7 @@ class D
             changingOptions.Add(CSharpFormattingOptions.IndentBraces, true);
             changingOptions.Add(CSharpFormattingOptions.IndentBlock, false);
             changingOptions.Add(CSharpFormattingOptions.IndentSwitchSection, false);
-            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, false);
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, SwitchCaseIndentOptions.NeverIndent);
             changingOptions.Add(CSharpFormattingOptions.NewLinesForBracesInLambdaExpressionBody, false);
             changingOptions.Add(CSharpFormattingOptions.LabelPositioning, LabelPositionOptions.LeftMost);
             await AssertFormatAsync(@"class Class2
@@ -1057,7 +1057,7 @@ class D
             changingOptions.Add(CSharpFormattingOptions.IndentBraces, true);
             changingOptions.Add(CSharpFormattingOptions.IndentBlock, false);
             changingOptions.Add(CSharpFormattingOptions.IndentSwitchSection, false);
-            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, false);
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, SwitchCaseIndentOptions.NeverIndent);
             changingOptions.Add(CSharpFormattingOptions.LabelPositioning, LabelPositionOptions.LeftMost);
             await AssertFormatAsync(@"class Class2
     {
@@ -1134,6 +1134,132 @@ l:
         goto l;
     }
 }", false, changingOptions);
+        }
+
+        [WorkItem(12304, "https://github.com/dotnet/roslyn/issues/12304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task TestSwitchDefaultBehavior()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchSection, true);
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, SwitchCaseIndentOptions.AlwaysIndent);
+
+            var code = @"class C
+{
+void M()
+{
+switch (1)
+{
+case 1:
+{
+break;
+}
+case 2:
+break;
+}
+}
+}";
+            var expected = @"class C
+{
+    void M()
+    {
+        switch (1)
+        {
+            case 1:
+                {
+                    break;
+                }
+            case 2:
+                break;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expected, code, false, changingOptions);
+        }
+
+        [WorkItem(12304, "https://github.com/dotnet/roslyn/issues/12304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task TestSwitchNeverIndentBehavior()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchSection, true);
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, SwitchCaseIndentOptions.NeverIndent);
+
+            var code = @"class C
+{
+void M()
+{
+switch (1)
+{
+case 1:
+{
+break;
+}
+case 2:
+break;
+}
+}
+}";
+            var expected = @"class C
+{
+    void M()
+    {
+        switch (1)
+        {
+            case 1:
+            {
+                break;
+            }
+            case 2:
+            break;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expected, code, false, changingOptions);
+        }
+
+        [WorkItem(12304, "https://github.com/dotnet/roslyn/issues/12304")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task TestSwitchOnlyIndentStatementsBehavior()
+        {
+            var changingOptions = new Dictionary<OptionKey, object>();
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchSection, true);
+            changingOptions.Add(CSharpFormattingOptions.IndentSwitchCaseSection, SwitchCaseIndentOptions.OnlyIndentStatements);
+
+            var code = @"class C
+{
+void M()
+{
+switch (1)
+{
+case 1:
+{
+break;
+}
+case 2:
+break;
+}
+}
+}";
+            var expected = @"class C
+{
+    void M()
+    {
+        switch (1)
+        {
+            case 1:
+            {
+                break;
+            }
+            case 2:
+                break;
+        }
+    }
+}";
+
+            await AssertFormatAsync(expected, code, false, changingOptions);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]


### PR DESCRIPTION
Change "Indent case contents" to be a radio button for three options:
1. Always indent case block
2. Never indent case block
3. Only indent if case block is statements and not if case block is a block statement.

Fixes #12304. 
