### PR TITLE
Adjust scope of locals declared within a Yield Return and Local Declaration Statements according to the latest design.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // Check for variable declaration errors.
             // Use the binder that owns the scope for the local because this (the current) binder
             // might own nested scope.
-            bool hasErrors = localSymbol.Binder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
+            bool hasErrors = localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
             bool isVar;
             bool isConst = false;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2058,7 +2058,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                localSymbol.Binder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
+                localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
             }
 
             if (isVar)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Patterns.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // Check for variable declaration errors.
-            hasErrors |= localSymbol.Binder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
+            hasErrors |= localSymbol.ScopeBinder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
             if (this.ContainingMemberOrLambda.Kind == SymbolKind.Method
                 && ((MethodSymbol)this.ContainingMemberOrLambda).IsAsync

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     /// </summary>
     internal class SourceLocalSymbol : LocalSymbol
     {
-        protected readonly Binder binder;
+        private readonly Binder _scopeBinder;
 
         /// <summary>
         /// Might not be a method symbol.
@@ -47,7 +47,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private SourceLocalSymbol(
             Symbol containingSymbol,
-            Binder binder,
+            Binder scopeBinder,
             bool allowRefKind,
             TypeSyntax typeSyntax,
             SyntaxToken identifierToken,
@@ -55,9 +55,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             Debug.Assert(identifierToken.Kind() != SyntaxKind.None);
             Debug.Assert(declarationKind != LocalDeclarationKind.None);
-            Debug.Assert(binder != null);
+            Debug.Assert(scopeBinder != null);
 
-            this.binder = binder;
+            this._scopeBinder = scopeBinder;
             this._containingSymbol = containingSymbol;
             this._identifierToken = identifierToken;
             this._typeSyntax = allowRefKind ? typeSyntax.SkipRef(out this._refKind) : typeSyntax;
@@ -67,10 +67,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _locations = ImmutableArray.Create<Location>(identifierToken.GetLocation());
         }
 
-        internal Binder Binder
+        /// <summary>
+        /// Binder that owns the scope for the local, the one that returns it in its <see cref="Binder.Locals"/> array.
+        /// </summary>
+        internal Binder ScopeBinder
         {
-            get { return binder; }
+            get { return _scopeBinder; }
         }
+
+        /// <summary>
+        /// Binder that should be used to bind type syntax for the local.
+        /// </summary>
+        internal Binder TypeSyntaxBinder
+        {
+            get { return _scopeBinder; } // Scope binder should be good enough for this.
+        }
+
 
         public static SourceLocalSymbol MakeForeachLocal(
             MethodSymbol containingMethod,
@@ -103,22 +115,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /// <param name="containingSymbol"></param>
+        /// <param name="scopeBinder">
+        /// Binder that owns the scope for the local, the one that returns it in its <see cref="Binder.Locals"/> array.
+        /// </param>
+        /// <param name="allowRefKind"></param>
+        /// <param name="typeSyntax"></param>
+        /// <param name="identifierToken"></param>
+        /// <param name="declarationKind"></param>
+        /// <param name="initializer"></param>
+        /// <param name="initializerBinderOpt">
+        /// Binder that should be used to bind initializer, if different from the <paramref name="scopeBinder"/>.
+        /// </param>
+        /// <returns></returns>
         public static SourceLocalSymbol MakeLocal(
             Symbol containingSymbol,
-            Binder binder,
+            Binder scopeBinder,
             bool allowRefKind,
             TypeSyntax typeSyntax,
             SyntaxToken identifierToken,
             LocalDeclarationKind declarationKind,
-            EqualsValueClauseSyntax initializer = null)
+            EqualsValueClauseSyntax initializer = null,
+            Binder initializerBinderOpt = null)
         {
             Debug.Assert(declarationKind != LocalDeclarationKind.ForEachIterationVariable);
             if (initializer == null)
             {
-                return new SourceLocalSymbol(containingSymbol, binder, allowRefKind, typeSyntax, identifierToken, declarationKind);
+                return new SourceLocalSymbol(containingSymbol, scopeBinder, allowRefKind, typeSyntax, identifierToken, declarationKind);
             }
 
-            return new LocalWithInitializer(containingSymbol, binder, typeSyntax, identifierToken, initializer, declarationKind);
+            return new LocalWithInitializer(containingSymbol, scopeBinder, typeSyntax, identifierToken, initializer, initializerBinderOpt, declarationKind);
         }
 
         /// <param name="containingSymbol"></param>
@@ -249,7 +275,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_typeSyntax.IsVar)
                 {
                     bool isVar;
-                    TypeSymbol declType = this.binder.BindType(_typeSyntax, new DiagnosticBag(), out isVar);
+                    TypeSymbol declType = this.TypeSyntaxBinder.BindType(_typeSyntax, new DiagnosticBag(), out isVar);
                     return isVar;
                 }
 
@@ -261,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             var diagnostics = DiagnosticBag.GetInstance();
 
-            Binder typeBinder = this.binder;
+            Binder typeBinder = this.TypeSyntaxBinder;
 
             bool isVar;
             TypeSymbol declType;
@@ -427,6 +453,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private sealed class LocalWithInitializer : SourceLocalSymbol
         {
             private readonly EqualsValueClauseSyntax _initializer;
+            private readonly Binder _initializerBinderOpt;
 
             /// <summary>
             /// Store the constant value and the corresponding diagnostics together
@@ -446,6 +473,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 TypeSyntax typeSyntax,
                 SyntaxToken identifierToken,
                 EqualsValueClauseSyntax initializer,
+                Binder initializerBinderOpt,
                 LocalDeclarationKind declarationKind) :
                     base(containingSymbol, binder, true, typeSyntax, identifierToken, declarationKind)
             {
@@ -453,6 +481,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 Debug.Assert(initializer != null);
 
                 _initializer = initializer;
+                _initializerBinderOpt = initializerBinderOpt;
 
                 // byval locals are always returnable
                 // byref locals with initializers are assumed not returnable unless proven otherwise
@@ -463,43 +492,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             protected override TypeSymbol InferTypeOfVarVariable(DiagnosticBag diagnostics)
             {
-                // Since initializer might use Out Variable Declarations and Pattern Variable Declarations, we need to find 
-                // the right binder to use for the initializer.
-                // Climb up the syntax tree looking for a first binder that we can find, but stop at the first statement syntax.
-                CSharpSyntaxNode currentNode = _initializer;
-                Binder initializerBinder;
-
-                do
-                {
-                    initializerBinder = this.binder.GetBinder(currentNode);
-
-                    if (initializerBinder != null || currentNode is StatementSyntax)
-                    {
-                        break;
-                    }
-
-                    currentNode = currentNode.Parent;   
-                }
-                while (currentNode != null);
-
-#if DEBUG
-                Binder parentBinder = initializerBinder;
-
-                while (parentBinder != null)
-                {
-                    if (parentBinder == this.binder)
-                    {
-                        break;
-                    }
-
-                    parentBinder = parentBinder.Next;
-                }
-
-                Debug.Assert(parentBinder != null);
-#endif 
-
-                var newBinder = initializerBinder ?? this.binder;
-                var initializerOpt = newBinder.BindInferredVariableInitializer(diagnostics, RefKind, _initializer, _initializer);
+                var initializerOpt = (this._initializerBinderOpt ?? this.ScopeBinder).BindInferredVariableInitializer(diagnostics, RefKind, _initializer, _initializer);
                 return initializerOpt?.Type;
             }
 
@@ -522,7 +515,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var type = this.Type;
                     if (boundInitValue == null)
                     {
-                        var inProgressBinder = new LocalInProgressBinder(this, this.binder);
+                        var inProgressBinder = new LocalInProgressBinder(this, this._initializerBinderOpt ?? this.ScopeBinder);
                         boundInitValue = inProgressBinder.BindVariableOrAutoPropInitializer(_initializer, this.RefKind, type, diagnostics);
                     }
 
@@ -590,7 +583,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // Normally, it would not be safe to cast to a specific binder type.  However, we verified the type
                 // in the factory method call for this symbol.
-                return ((ForEachLoopBinder)this.binder).InferCollectionElementType(diagnostics, _collection);
+                return ((ForEachLoopBinder)this.ScopeBinder).InferCollectionElementType(diagnostics, _collection);
             }
 
             internal override SyntaxNode ForbiddenZone => _collection;
@@ -630,15 +623,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     case SyntaxKind.InvocationExpression:
                     case SyntaxKind.ObjectCreationExpression:
-                        (_enclosingBinderOpt ?? this.binder).BindExpression((ExpressionSyntax)_containingInvocation, diagnostics);
+                        (_enclosingBinderOpt ?? this.ScopeBinder).BindExpression((ExpressionSyntax)_containingInvocation, diagnostics);
                         result = this._type;
                         Debug.Assert((object)result != null);
                         return result;
 
                     case SyntaxKind.ThisConstructorInitializer:
                     case SyntaxKind.BaseConstructorInitializer:
-                        Debug.Assert(_enclosingBinderOpt == null || _enclosingBinderOpt == this.binder);
-                        (_enclosingBinderOpt ?? this.binder).BindConstructorInitializer(((ConstructorInitializerSyntax)_containingInvocation).ArgumentList, (MethodSymbol)this.binder.ContainingMember(), diagnostics);
+                        Debug.Assert(_enclosingBinderOpt == null || _enclosingBinderOpt == this.ScopeBinder);
+                        (_enclosingBinderOpt ?? this.ScopeBinder).BindConstructorInitializer(((ConstructorInitializerSyntax)_containingInvocation).ArgumentList, (MethodSymbol)this.ScopeBinder.ContainingMember(), diagnostics);
                         result = this._type;
                         Debug.Assert((object)result != null);
                         return result;
@@ -659,12 +652,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             public DeconstructionLocalSymbol(
                 Symbol containingSymbol,
-                Binder binder,
+                Binder scopeBinder,
                 TypeSyntax typeSyntax,
                 SyntaxToken identifierToken,
                 LocalDeclarationKind declarationKind,
                 SyntaxNode deconstruction)
-            : base(containingSymbol, binder, false, typeSyntax, identifierToken, declarationKind)
+            : base(containingSymbol, scopeBinder, false, typeSyntax, identifierToken, declarationKind)
             {
                 _deconstruction = deconstruction;
             }
@@ -676,18 +669,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 {
                     case SyntaxKind.DeconstructionDeclarationStatement:
                         var localDecl = (DeconstructionDeclarationStatementSyntax)_deconstruction;
-                        var localBinder = this.binder.GetBinder(localDecl);
+                        var localBinder = this.ScopeBinder.GetBinder(localDecl);
                         localBinder.BindDeconstructionDeclaration(localDecl, localDecl.Assignment.VariableComponent, localDecl.Assignment.Value, diagnostics);
                         break;
 
                     case SyntaxKind.ForStatement:
                         var forStatement = (ForStatementSyntax)_deconstruction;
-                        var forBinder = this.binder.GetBinder(forStatement);
+                        var forBinder = this.ScopeBinder.GetBinder(forStatement);
                         forBinder.BindDeconstructionDeclaration(forStatement, forStatement.Deconstruction.VariableComponent, forStatement.Deconstruction.Value, diagnostics);
                         break;
 
                     case SyntaxKind.ForEachComponentStatement:
-                        var foreachBinder = this.binder.GetBinder((ForEachComponentStatementSyntax)_deconstruction);
+                        var foreachBinder = this.ScopeBinder.GetBinder((ForEachComponentStatementSyntax)_deconstruction);
                         foreachBinder.BindForEachDeconstruction(diagnostics, foreachBinder);
                         break;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -1999,7 +1999,11 @@ partial class C
             CreateCompilationWithMscorlib(source, options: TestOptions.UnsafeReleaseDll).VerifyDiagnostics(
                 // (7,32): error CS1023: Embedded statement cannot be a declaration or labeled statement
                 //         fixed (int* ptr = arg) object o = null;
-                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "object o = null;"));
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "object o = null;").WithLocation(7, 32),
+                // (7,39): warning CS0219: The variable 'o' is assigned but its value is never used
+                //         fixed (int* ptr = arg) object o = null;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "o").WithArguments("o").WithLocation(7, 39)
+                );
         }
 
         [WorkItem(1040171, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/1040171")]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/ConstantTests.cs
@@ -2848,6 +2848,9 @@ class Program
                 // (6,26): error CS1023: Embedded statement cannot be a declaration or labeled statement
                 //         void f() { if () const int i = 0; }
                 Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(6, 26),
+                // (6,36): warning CS0219: The variable 'i' is assigned but its value is never used
+                //         void f() { if () const int i = 0; }
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(6, 36),
                 // (6,14): warning CS0168: The variable 'f' is declared but never used
                 //         void f() { if () const int i = 0; }
                 Diagnostic(ErrorCode.WRN_UnreferencedVar, "f").WithArguments("f").WithLocation(6, 14)
@@ -2904,7 +2907,10 @@ void f() { if () const int i = 0; }
     Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(2, 16),
     // (2,18): error CS1023: Embedded statement cannot be a declaration or labeled statement
     // void f() { if () const int i = 0; }
-    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(2, 18)
+    Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "const int i = 0;").WithLocation(2, 18),
+    // (2,28): warning CS0219: The variable 'i' is assigned but its value is never used
+    // void f() { if () const int i = 0; }
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "i").WithArguments("i").WithLocation(2, 28)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -2649,6 +2649,9 @@ public class X
                 // (98,29): error CS0103: The name 'y12' does not exist in the current context
                 //         while (TakeOutParam(y12, out var x12));
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(98, 29),
+                // (97,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(97, 17),
                 // (115,46): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                      TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(115, 46),
@@ -4307,6 +4310,9 @@ public unsafe class X
                 // (86,44): error CS0103: The name 'y12' does not exist in the current context
                 //         fixed (int* p = Dummy(TakeOutParam(y12, out var x12)))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 44),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,55): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                               TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 55)
@@ -4722,6 +4728,9 @@ public class X
                 // (107,33): error CS0103: The name 'y12' does not exist in the current context
                 //              Dummy(TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 33),
+                // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
                 // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44)
@@ -4954,6 +4963,9 @@ public class X
                 // (107,33): error CS0103: The name 'y12' does not exist in the current context
                 //              Dummy(TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 33),
+                // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
                 // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44)
@@ -5213,6 +5225,9 @@ public class X
                 // (107,33): error CS0103: The name 'y12' does not exist in the current context
                 //              Dummy(TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 33),
+                // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
                 // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44),
@@ -5451,6 +5466,9 @@ public class X
                 // (107,33): error CS0103: The name 'y12' does not exist in the current context
                 //              Dummy(TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 33),
+                // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
                 // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44)
@@ -5686,6 +5704,9 @@ public class X
                 // (107,33): error CS0103: The name 'y12' does not exist in the current context
                 //              Dummy(TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 33),
+                // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
                 // (124,44): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                    TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 44)
@@ -6303,6 +6324,9 @@ public class X
                 // (86,46): error CS0103: The name 'y12' does not exist in the current context
                 //         foreach (var i in Dummy(TakeOutParam(y12, out var x12)))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 46),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,57): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                                 TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 57),
@@ -6569,7 +6593,10 @@ public class X
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(91, 26),
                 // (100,26): error CS0103: The name 'y12' does not exist in the current context
                 //         if (TakeOutParam(y12, out var x12))
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(100, 26)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(100, 26),
+                // (101,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(101, 17)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -7171,15 +7198,12 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (19,50): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (19,50): error CS0128: A local variable named 'x4' is already defined in this scope
                 //         var d = Dummy(TakeOutParam(true, out var x4), x4);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(19, 50),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(19, 50),
                 // (24,23): error CS0841: Cannot use local variable 'x6' before it is declared
                 //         var d = Dummy(x6 && TakeOutParam(true, out var x6));
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(24, 23),
-                // (30,34): error CS0103: The name 'x8' does not exist in the current context
-                //         System.Console.WriteLine(x8);
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 34),
                 // (36,47): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                       TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(36, 47)
@@ -7196,7 +7220,8 @@ public class X
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAnOutLocal(model, x4Ref[0]);
-            VerifyModelForOutVar(model, x4Decl, x4Ref[1]);
+            VerifyNotAnOutLocal(model, x4Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x4Decl);
 
             var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").Single();
@@ -7205,8 +7230,7 @@ public class X
             var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(2, x8Ref.Length);
-            VerifyModelForOutVar(model, x8Decl, x8Ref[0]);
-            VerifyNotInScope(model, x8Ref[1]);
+            VerifyModelForOutVar(model, x8Decl, x8Ref);
 
             var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
             var x14Ref = GetReferences(tree, "x14").Single();
@@ -7267,15 +7291,12 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (19,53): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (19,53): error CS0128: A local variable named 'x4' is already defined in this scope
                 //         object d = Dummy(TakeOutParam(true, out var x4), x4);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(19, 53),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(19, 53),
                 // (24,26): error CS0841: Cannot use local variable 'x6' before it is declared
                 //         object d = Dummy(x6 && TakeOutParam(true, out var x6));
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(24, 26),
-                // (30,34): error CS0103: The name 'x8' does not exist in the current context
-                //         System.Console.WriteLine(x8);
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 34),
                 // (36,50): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                          TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(36, 50)
@@ -7292,7 +7313,8 @@ public class X
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAnOutLocal(model, x4Ref[0]);
-            VerifyModelForOutVar(model, x4Decl, x4Ref[1]);
+            VerifyNotAnOutLocal(model, x4Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x4Decl);
 
             var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
             var x6Ref = GetReferences(tree, "x6").Single();
@@ -7301,8 +7323,7 @@ public class X
             var x8Decl = GetOutVarDeclarations(tree, "x8").Single();
             var x8Ref = GetReferences(tree, "x8").ToArray();
             Assert.Equal(2, x8Ref.Length);
-            VerifyModelForOutVar(model, x8Decl, x8Ref[0]);
-            VerifyNotInScope(model, x8Ref[1]);
+            VerifyModelForOutVar(model, x8Decl, x8Ref);
 
             var x14Decl = GetOutVarDeclarations(tree, "x14").ToArray();
             var x14Ref = GetReferences(tree, "x14").Single();
@@ -7347,12 +7368,21 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (13,51): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (13,51): error CS0128: A local variable named 'x1' is already defined in this scope
                 //                  Dummy(TakeOutParam(true, out var x1), x1);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(13, 51),
-                // (20,54): error CS0136: A local or parameter named 'x2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 51),
+                // (13,56): error CS0841: Cannot use local variable 'x1' before it is declared
+                //                  Dummy(TakeOutParam(true, out var x1), x1);
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(13, 56),
+                // (13,56): error CS0165: Use of unassigned local variable 'x1'
+                //                  Dummy(TakeOutParam(true, out var x1), x1);
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(13, 56),
+                // (20,54): error CS0128: A local variable named 'x2' is already defined in this scope
                 //                     Dummy(TakeOutParam(true, out var x2), x2);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x2").WithArguments("x2").WithLocation(20, 54)
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(20, 54),
+                // (20,59): error CS0165: Use of unassigned local variable 'x2'
+                //                     Dummy(TakeOutParam(true, out var x2), x2);
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(20, 59)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -7361,14 +7391,16 @@ public class X
             var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(2, x1Ref.Length);
-            VerifyModelForOutVar(model, x1Decl, x1Ref[0]);
+            VerifyNotAnOutLocal(model, x1Ref[0]);
             VerifyNotAnOutLocal(model, x1Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x1Decl);
 
             var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").ToArray();
             Assert.Equal(2, x2Ref.Length);
-            VerifyModelForOutVar(model, x2Decl, x2Ref[0]);
+            VerifyNotAnOutLocal(model, x2Ref[0]);
             VerifyNotAnOutLocal(model, x2Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x2Decl);
         }
 
         [Fact]
@@ -7418,9 +7450,9 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (12,53): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //         object d = Dummy(TakeOutParam(true, out var x1), x1), 
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(12, 53),
+                // (13,16): error CS0128: A local variable named 'x1' is already defined in this scope
+                //                x1 = Dummy(x1);
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 16),
                 // (20,54): error CS0128: A local variable named 'x2' is already defined in this scope
                 //                d2 = Dummy(TakeOutParam(true, out var x2), x2);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(20, 54),
@@ -7435,8 +7467,7 @@ public class X
             var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(3, x1Ref.Length);
-            VerifyModelForOutVar(model, x1Decl, x1Ref[0], x1Ref[1]);
-            VerifyNotAnOutLocal(model, x1Ref[2]);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
 
             var x2Decl = GetOutVarDeclarations(tree, "x2").ToArray();
             var x2Ref = GetReferences(tree, "x2").ToArray();
@@ -7505,6 +7536,103 @@ var y1 = Dummy(TakeOutParam(true, out var x1), x1);
         }
 
         [Fact]
+        public void Scope_LocalDeclarationStmt_06()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    void Test1()
+    {
+        if (true)
+            var d =TakeOutParam(true, out var x1) && x1 != null;
+
+        x1++;
+    }
+
+    static bool TakeOutParam(object y, out object x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            compilation.VerifyDiagnostics(
+                // (11,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //             var d =TakeOutParam(true, out var x1) && x1 != null;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var d =TakeOutParam(true, out var x1) && x1 != null;").WithLocation(11, 13),
+                // (13,9): error CS0103: The name 'x1' does not exist in the current context
+                //         x1++;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(13, 9)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref[0]);
+            VerifyNotInScope(model, x1Ref[1]);
+
+            var d = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Where(id => id.Identifier.ValueText == "d").Single();
+            Assert.Equal("System.Boolean d", model.GetDeclaredSymbol(d).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void Scope_LocalDeclarationStmt_07()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    int Dummy(params object[] x) { return 0; }
+
+    void Test1()
+    {
+        SpeculateHere();
+    }
+
+    static bool TakeOutParam(object y, out int x) 
+    {
+        x = 123;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var statement = (LocalDeclarationStatementSyntax)SyntaxFactory.ParseStatement(@"
+var y1 = Dummy(TakeOutParam(true, out var x1), x1);
+");
+
+            bool success = model.TryGetSpeculativeSemanticModel(GetReferences(tree, "SpeculateHere").Single().SpanStart, statement, out model);
+            Assert.True(success);
+            Assert.NotNull(model);
+            tree = statement.SyntaxTree;
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+            Assert.Equal("System.Int32", model.GetTypeInfo(x1Ref[0]).Type.ToTestDisplayString());
+
+            Assert.Equal("System.Int32 y1", model.GetDeclaredSymbol(statement.Declaration.Variables.Single()).ToTestDisplayString());
+        }
+
+        [Fact]
         public void LocalDeclarationStmt_01()
         {
             var source =
@@ -7517,6 +7645,7 @@ public class X
                d2 = Dummy(new C(""c""), TakeOutParam(new C(""d""), out var x2), x2);
         System.Console.WriteLine(d1);
         System.Console.WriteLine(d2);
+        System.Console.WriteLine(x1);
     }
 
     static object Dummy(object x, object y, object z) 
@@ -7552,7 +7681,74 @@ class C
 @"b
 d
 a
-c");
+c
+b");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void LocalDeclarationStmt_02()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        if (true)
+        {
+            object d1 = Dummy(new C(""a""), TakeOutParam(new C(""b""), out var x1), x1);
+        }
+    }
+
+    static object Dummy(object x, object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return x;
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+
+class C
+{
+    private readonly string _val;
+
+    public C(string val)
+    {
+        _val = val;
+    }
+
+    public override string ToString()
+    {
+        return _val;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"b");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
         }
 
         [Fact]
@@ -7703,6 +7899,9 @@ public class X
                 // (86,34): error CS0103: The name 'y12' does not exist in the current context
                 //         lock (Dummy(TakeOutParam(y12, out var x12)))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 34),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,45): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                     TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 45)
@@ -8326,9 +8525,6 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (17,15): error CS0103: The name 'y1' does not exist in the current context
-                //         Dummy(y1); 
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "y1").WithArguments("y1").WithLocation(17, 15),
                 // (25,26): error CS0103: The name 'z2' does not exist in the current context
                 //                          z2;
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(25, 26),
@@ -8353,9 +8549,6 @@ public class X
                 // (49,36): error CS0103: The name 'v4' does not exist in the current context
                 //                                u4, v4 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(49, 36),
-                // (51,15): error CS0103: The name 'z4' does not exist in the current context
-                //         Dummy(z4); 
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z4").WithArguments("z4").WithLocation(51, 15),
                 // (52,15): error CS0103: The name 'u4' does not exist in the current context
                 //         Dummy(u4); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(52, 15),
@@ -8374,9 +8567,6 @@ public class X
                 // (66,36): error CS0103: The name 'v5' does not exist in the current context
                 //                                u5, v5 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(66, 36),
-                // (68,15): error CS0103: The name 'z5' does not exist in the current context
-                //         Dummy(z5); 
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z5").WithArguments("z5").WithLocation(68, 15),
                 // (69,15): error CS0103: The name 'u5' does not exist in the current context
                 //         Dummy(u5); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(69, 15),
@@ -8442,8 +8632,7 @@ public class X
             var y1Decl = GetOutVarDeclarations(tree, "y1").Single();
             var y1Ref = GetReferences(tree, "y1").ToArray();
             Assert.Equal(4, y1Ref.Length);
-            VerifyModelForOutVar(model, y1Decl, y1Ref[0], y1Ref[1], y1Ref[2]);
-            VerifyNotInScope(model, y1Ref[3]);
+            VerifyModelForOutVar(model, y1Decl, y1Ref);
 
             var y2Decl = GetOutVarDeclarations(tree, "y2").Single();
             var y2Ref = GetReferences(tree, "y2").ToArray();
@@ -8477,8 +8666,7 @@ public class X
             var z4Decl = GetOutVarDeclarations(tree, "z4").Single();
             var z4Ref = GetReferences(tree, "z4").ToArray();
             Assert.Equal(6, z4Ref.Length);
-            VerifyModelForOutVar(model, z4Decl, z4Ref[0], z4Ref[1], z4Ref[2], z4Ref[3], z4Ref[4]);
-            VerifyNotInScope(model, z4Ref[5]);
+            VerifyModelForOutVar(model, z4Decl, z4Ref);
 
             var u4Decl = GetOutVarDeclarations(tree, "u4").Single();
             var u4Ref = GetReferences(tree, "u4").ToArray();
@@ -8504,8 +8692,7 @@ public class X
             var z5Decl = GetOutVarDeclarations(tree, "z5").Single();
             var z5Ref = GetReferences(tree, "z5").ToArray();
             Assert.Equal(6, z5Ref.Length);
-            VerifyModelForOutVar(model, z5Decl, z5Ref[0], z5Ref[1], z5Ref[2], z5Ref[3], z5Ref[4]);
-            VerifyNotInScope(model, z5Ref[5]);
+            VerifyModelForOutVar(model, z5Decl, z5Ref);
 
             var u5Decl = GetOutVarDeclarations(tree, "u5").Single();
             var u5Ref = GetReferences(tree, "u5").ToArray();
@@ -8670,9 +8857,6 @@ public class X
                 // (22,36): error CS0103: The name 'v4' does not exist in the current context
                 //                                u4, v4 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(22, 36),
-                // (24,15): error CS0103: The name 'z4' does not exist in the current context
-                //         Dummy(z4); 
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z4").WithArguments("z4").WithLocation(24, 15),
                 // (25,15): error CS0103: The name 'u4' does not exist in the current context
                 //         Dummy(u4); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(25, 15),
@@ -8691,9 +8875,6 @@ public class X
                 // (40,36): error CS0103: The name 'v5' does not exist in the current context
                 //                                u5, v5 };
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(40, 36),
-                // (42,15): error CS0103: The name 'z5' does not exist in the current context
-                //         Dummy(z5); 
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "z5").WithArguments("z5").WithLocation(42, 15),
                 // (43,15): error CS0103: The name 'u5' does not exist in the current context
                 //         Dummy(u5); 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(43, 15),
@@ -8713,8 +8894,7 @@ public class X
             var z4Decl = GetOutVarDeclarations(tree, "z4").Single();
             var z4Ref = GetReferences(tree, "z4").ToArray();
             Assert.Equal(6, z4Ref.Length);
-            VerifyModelForOutVar(model, z4Decl, z4Ref[0], z4Ref[1], z4Ref[2], z4Ref[3], z4Ref[4]);
-            VerifyNotInScope(model, z4Ref[5]);
+            VerifyModelForOutVar(model, z4Decl, z4Ref);
 
             var u4Decl = GetOutVarDeclarations(tree, "u4").Single();
             var u4Ref = GetReferences(tree, "u4").ToArray();
@@ -8740,8 +8920,7 @@ public class X
             var z5Decl = GetOutVarDeclarations(tree, "z5").Single();
             var z5Ref = GetReferences(tree, "z5").ToArray();
             Assert.Equal(6, z5Ref.Length);
-            VerifyModelForOutVar(model, z5Decl, z5Ref[0], z5Ref[1], z5Ref[2], z5Ref[3], z5Ref[4]);
-            VerifyNotInScope(model, z5Ref[5]);
+            VerifyModelForOutVar(model, z5Decl, z5Ref);
 
             var u5Decl = GetOutVarDeclarations(tree, "u5").Single();
             var u5Ref = GetReferences(tree, "u5").ToArray();
@@ -8808,15 +8987,15 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (16,62): error CS0136: A local or parameter named 'y1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (16,62): error CS0128: A local variable named 'y1' is already defined in this scope
                 //         var res = from x1 in new[] { TakeOutParam(1, out var y1) ? y1 : 0}
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y1").WithArguments("y1").WithLocation(16, 62),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(16, 62),
                 // (17,62): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { TakeOutParam(2, out var y2) ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(17, 62),
-                // (18,62): error CS0136: A local or parameter named 'y3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (18,62): error CS0128: A local variable named 'y3' is already defined in this scope
                 //                   join x3 in new[] { TakeOutParam(3, out var y3) ? y3 : 0}
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y3").WithArguments("y3").WithLocation(18, 62),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(18, 62),
                 // (19,51): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on TakeOutParam(4, out var y4) ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(19, 51),
@@ -8855,7 +9034,19 @@ public class X
                 var yDecl = GetOutVarDeclarations(tree, id).Single();
                 var yRef = GetReferences(tree, id).ToArray();
                 Assert.Equal(3, yRef.Length);
-                VerifyModelForOutVar(model, yDecl, yRef[0]);
+
+                switch (i)
+                {
+                    case 1:
+                    case 3:
+                        VerifyModelForOutVarDuplicateInSameScope(model, yDecl);
+                        VerifyNotAnOutLocal(model, yRef[0]);
+                        break;
+                    default:
+                        VerifyModelForOutVar(model, yDecl, yRef[0]);
+                        break;
+                }
+
                 VerifyNotAnOutLocal(model, yRef[2]);
 
                 switch (i)
@@ -8870,7 +9061,6 @@ public class X
                         VerifyNotAnOutLocal(model, yRef[1]);
                         break;
                 }
-
             }
         }
 
@@ -10727,6 +10917,95 @@ public class X
         }
 
         [Fact]
+        public void Scope_SwitchLabelGuard_08()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        foreach (var x in Test(1)) {}
+    }
+
+    static System.Collections.IEnumerable Test(int val)
+    {
+        switch (val)
+        {
+            case 1 when TakeOutParam(123, out var x1):
+                yield return TakeOutParam(x1, out var y1);
+                System.Console.WriteLine(y1);
+                break;
+        }
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput: @"123").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y1").Single();
+
+            Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void Scope_SwitchLabelGuard_09()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        Test(1);
+    }
+
+    static void Test(int val)
+    {
+        switch (val)
+        {
+            case 1 when TakeOutParam(123, out var x1):
+                var z1 = x1 > 0 & TakeOutParam(x1, out var y1);
+                System.Console.WriteLine(y1);
+                System.Console.WriteLine(z1 ? 1 : 0);
+                break;
+        }
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            CompileAndVerify(compilation, expectedOutput: 
+@"123
+1").VerifyDiagnostics();
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y1").Single();
+            Assert.Equal("System.Int32", model.GetTypeInfo(yRef).Type.ToTestDisplayString());
+
+            var zRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z1").Single();
+            Assert.Equal("System.Boolean", model.GetTypeInfo(zRef).Type.ToTestDisplayString());
+        }
+
+        [Fact]
         public void Scope_SwitchLabelPattern_01()
         {
             var source =
@@ -11246,6 +11525,9 @@ public class X
                 // (86,35): error CS0103: The name 'y12' does not exist in the current context
                 //         using (Dummy(TakeOutParam(y12, out var x12), x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 35),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,46): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                      TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 46)
@@ -11456,6 +11738,9 @@ public class X
                 // (86,43): error CS0103: The name 'y12' does not exist in the current context
                 //         using (var d = Dummy(TakeOutParam(y12, out var x12), x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 43),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,54): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                              TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 54)
@@ -11666,6 +11951,9 @@ public class X
                 // (86,58): error CS0103: The name 'y12' does not exist in the current context
                 //         using (System.IDisposable d = Dummy(TakeOutParam(y12, out var x12), x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 58),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,69): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                                             TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 69)
@@ -12103,6 +12391,9 @@ public class X
                 // (86,29): error CS0103: The name 'y12' does not exist in the current context
                 //         while (TakeOutParam(y12, out var x12))
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 29),
+                // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+                //             var y12 = 12;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
                 // (99,46): error CS0128: A local variable named 'x14' is already defined in this scope
                 //                      TakeOutParam(2, out var x14), 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 46)
@@ -12460,27 +12751,33 @@ public class X
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
+                // (16,59): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //             yield return Dummy(TakeOutParam(true, out var x1), x1);
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(16, 59),
+                // (18,55): error CS0128: A local variable named 'x1' is already defined in this scope
+                //         yield return Dummy(TakeOutParam(true, out var x1), x1);
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(18, 55),
                 // (23,28): error CS0841: Cannot use local variable 'x2' before it is declared
                 //         yield return Dummy(x2, TakeOutParam(true, out var x2));
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x2").WithArguments("x2").WithLocation(23, 28),
                 // (28,55): error CS0136: A local or parameter named 'x3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //         yield return Dummy(TakeOutParam(true, out var x3), x3);
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x3").WithArguments("x3").WithLocation(28, 55),
-                // (35,55): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (35,55): error CS0128: A local variable named 'x4' is already defined in this scope
                 //         yield return Dummy(TakeOutParam(true, out var x4), x4);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(35, 55),
-                // (40,55): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //         yield return Dummy(TakeOutParam(true, out var x5), x5);
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(40, 55),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(35, 55),
+                // (41,13): error CS0128: A local variable named 'x5' is already defined in this scope
+                //         var x5 = 11;
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(41, 13),
+                // (41,13): warning CS0219: The variable 'x5' is assigned but its value is never used
+                //         var x5 = 11;
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x5").WithArguments("x5").WithLocation(41, 13),
                 // (61,92): error CS0128: A local variable named 'x8' is already defined in this scope
                 //         yield return Dummy(TakeOutParam(true, out var x8), x8, TakeOutParam(false, out var x8), x8);
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(61, 92),
-                // (72,15): error CS0103: The name 'x11' does not exist in the current context
+                // (72,15): error CS0841: Cannot use local variable 'x11' before it is declared
                 //         Dummy(x11);
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x11").WithArguments("x11").WithLocation(72, 15),
-                // (79,15): error CS0103: The name 'x12' does not exist in the current context
-                //         Dummy(x12);
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x12").WithArguments("x12").WithLocation(79, 15)
+                Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x11").WithArguments("x11").WithLocation(72, 15)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -12490,10 +12787,9 @@ public class X
             var x1Ref = GetReferences(tree, "x1").ToArray();
             Assert.Equal(3, x1Decl.Length);
             Assert.Equal(3, x1Ref.Length);
-            for (int i = 0; i < x1Decl.Length; i++)
-            {
-                VerifyModelForOutVar(model, x1Decl[i], x1Ref[i]);
-            }
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref[0], x1Ref[2]);
+            VerifyModelForOutVar(model, x1Decl[1], x1Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x1Decl[2]);
 
             var x2Decl = GetOutVarDeclarations(tree, "x2").Single();
             var x2Ref = GetReferences(tree, "x2").Single();
@@ -12507,13 +12803,13 @@ public class X
             var x4Ref = GetReferences(tree, "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAnOutLocal(model, x4Ref[0]);
-            VerifyModelForOutVar(model, x4Decl, x4Ref[1]);
+            VerifyNotAnOutLocal(model, x4Ref[1]);
+            VerifyModelForOutVarDuplicateInSameScope(model, x4Decl);
 
             var x5Decl = GetOutVarDeclarations(tree, "x5").Single();
             var x5Ref = GetReferences(tree, "x5").ToArray();
             Assert.Equal(2, x5Ref.Length);
-            VerifyModelForOutVar(model, x5Decl, x5Ref[0]);
-            VerifyNotAnOutLocal(model, x5Ref[1]);
+            VerifyModelForOutVar(model, x5Decl, x5Ref);
 
             var x8Decl = GetOutVarDeclarations(tree, "x8").ToArray();
             var x8Ref = GetReferences(tree, "x8").ToArray();
@@ -12532,14 +12828,107 @@ public class X
             var x11Decl = GetOutVarDeclarations(tree, "x11").Single();
             var x11Ref = GetReferences(tree, "x11").ToArray();
             Assert.Equal(2, x11Ref.Length);
-            VerifyNotInScope(model, x11Ref[0]);
-            VerifyModelForOutVar(model, x11Decl, x11Ref[1]);
+            VerifyModelForOutVar(model, x11Decl, x11Ref);
 
             var x12Decl = GetOutVarDeclarations(tree, "x12").Single();
             var x12Ref = GetReferences(tree, "x12").ToArray();
             Assert.Equal(2, x12Ref.Length);
-            VerifyModelForOutVar(model, x12Decl, x12Ref[0]);
-            VerifyNotInScope(model, x12Ref[1]);
+            VerifyModelForOutVar(model, x12Decl, x12Ref);
+        }
+
+        [Fact]
+        public void Scope_Yield_02()
+        {
+            var source =
+@"
+using System.Collections;
+
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    IEnumerable Test1()
+    {
+        if (true)
+            yield return TakeOutParam(true, out var x1);
+
+        x1++;
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            compilation.VerifyDiagnostics(
+                // (15,9): error CS0103: The name 'x1' does not exist in the current context
+                //         x1++;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(15, 9)
+                );
+
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").Single();
+            VerifyModelForOutVar(model, x1Decl);
+            VerifyNotInScope(model, x1Ref);
+        }
+
+        [Fact]
+        public void Scope_Yield_03()
+        {
+            var source =
+@"
+using System.Collections;
+
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    void Dummy(params object[] x) {}
+
+    IEnumerable Test1()
+    {
+        yield return 0;
+        SpeculateHere();
+    }
+
+    static bool TakeOutParam(object y, out int x) 
+    {
+        x = 123;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var statement = (YieldStatementSyntax)SyntaxFactory.ParseStatement(@"
+yield return Dummy(TakeOutParam(true, out var x1), x1);
+");
+
+            bool success = model.TryGetSpeculativeSemanticModel(GetReferences(tree, "SpeculateHere").Single().SpanStart, statement, out model);
+            Assert.True(success);
+            Assert.NotNull(model);
+            tree = statement.SyntaxTree;
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").Single();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl, x1Ref);
+            Assert.Equal("System.Int32", model.GetTypeInfo(x1Ref[0]).Type.ToTestDisplayString());
         }
 
         [Fact]
@@ -12558,7 +12947,63 @@ public class X
     static System.Collections.IEnumerable Test()
     {
         yield return Dummy(TakeOutParam(""yield1"", out var x1), x1);
-        yield return Dummy(TakeOutParam(""yield2"", out var x1), x1);
+        yield return Dummy(TakeOutParam(""yield2"", out var x2), x2);
+        System.Console.WriteLine(x1);
+    }
+
+    static object Dummy(object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return new object();
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+            CompileAndVerify(compilation, expectedOutput:
+@"yield1
+yield2
+yield1");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void Yield_02()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        foreach (var o in Test())
+        {}
+    }
+
+    static System.Collections.IEnumerable Test()
+    {
+        bool f = true;
+
+        if (f)        
+            yield return Dummy(TakeOutParam(""yield1"", out var x1), x1);
+
+        if (f)        
+        {
+            yield return Dummy(TakeOutParam(""yield2"", out var x1), x1);
+        }
     }
 
     static object Dummy(object y, object z) 
@@ -12578,6 +13023,16 @@ public class X
             CompileAndVerify(compilation, expectedOutput:
 @"yield1
 yield2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = GetOutVarDeclarations(tree, "x1").ToArray();
+            var x1Ref = GetReferences(tree, "x1").ToArray();
+            Assert.Equal(2, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForOutVar(model, x1Decl[0], x1Ref[0]);
+            VerifyModelForOutVar(model, x1Decl[1], x1Ref[1]);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -1617,7 +1617,10 @@ public class X
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y10").WithArguments("y10").WithLocation(91, 13),
     // (109,13): error CS0103: The name 'y12' does not exist in the current context
     //         if (y12 is var x12)
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(109, 13)
+    Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(109, 13),
+    // (110,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(110, 17)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -2265,9 +2268,6 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (17,15): error CS0103: The name 'y1' does not exist in the current context
-    //         Dummy(y1); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "y1").WithArguments("y1").WithLocation(17, 15),
     // (25,26): error CS0103: The name 'z2' does not exist in the current context
     //                          z2;
     Diagnostic(ErrorCode.ERR_NameNotInContext, "z2").WithArguments("z2").WithLocation(25, 26),
@@ -2292,9 +2292,6 @@ public class X
     // (49,36): error CS0103: The name 'v4' does not exist in the current context
     //                                u4, v4 };
     Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(49, 36),
-    // (51,15): error CS0103: The name 'z4' does not exist in the current context
-    //         Dummy(z4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z4").WithArguments("z4").WithLocation(51, 15),
     // (52,15): error CS0103: The name 'u4' does not exist in the current context
     //         Dummy(u4); 
     Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(52, 15),
@@ -2313,9 +2310,6 @@ public class X
     // (66,36): error CS0103: The name 'v5' does not exist in the current context
     //                                u5, v5 };
     Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(66, 36),
-    // (68,15): error CS0103: The name 'z5' does not exist in the current context
-    //         Dummy(z5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z5").WithArguments("z5").WithLocation(68, 15),
     // (69,15): error CS0103: The name 'u5' does not exist in the current context
     //         Dummy(u5); 
     Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(69, 15),
@@ -2381,8 +2375,7 @@ public class X
             var y1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "y1").Single();
             var y1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y1").ToArray();
             Assert.Equal(4, y1Ref.Length);
-            VerifyModelForDeclarationPattern(model, y1Decl, y1Ref[0], y1Ref[1], y1Ref[2]);
-            VerifyNotInScope(model, y1Ref[3]);
+            VerifyModelForDeclarationPattern(model, y1Decl, y1Ref);
 
             var y2Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "y2").Single();
             var y2Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "y2").ToArray();
@@ -2416,8 +2409,7 @@ public class X
             var z4Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "z4").Single();
             var z4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z4").ToArray();
             Assert.Equal(6, z4Ref.Length);
-            VerifyModelForDeclarationPattern(model, z4Decl, z4Ref[0], z4Ref[1], z4Ref[2], z4Ref[3], z4Ref[4]);
-            VerifyNotInScope(model, z4Ref[5]);
+            VerifyModelForDeclarationPattern(model, z4Decl, z4Ref);
 
             var u4Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "u4").Single();
             var u4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "u4").ToArray();
@@ -2443,8 +2435,7 @@ public class X
             var z5Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "z5").Single();
             var z5Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z5").ToArray();
             Assert.Equal(6, z5Ref.Length);
-            VerifyModelForDeclarationPattern(model, z5Decl, z5Ref[0], z5Ref[1], z5Ref[2], z5Ref[3], z5Ref[4]);
-            VerifyNotInScope(model, z5Ref[5]);
+            VerifyModelForDeclarationPattern(model, z5Decl, z5Ref);
 
             var u5Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "u5").Single();
             var u5Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "u5").ToArray();
@@ -2603,9 +2594,6 @@ public class X
     // (22,36): error CS0103: The name 'v4' does not exist in the current context
     //                                u4, v4 };
     Diagnostic(ErrorCode.ERR_NameNotInContext, "v4").WithArguments("v4").WithLocation(22, 36),
-    // (24,15): error CS0103: The name 'z4' does not exist in the current context
-    //         Dummy(z4); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z4").WithArguments("z4").WithLocation(24, 15),
     // (25,15): error CS0103: The name 'u4' does not exist in the current context
     //         Dummy(u4); 
     Diagnostic(ErrorCode.ERR_NameNotInContext, "u4").WithArguments("u4").WithLocation(25, 15),
@@ -2624,9 +2612,6 @@ public class X
     // (40,36): error CS0103: The name 'v5' does not exist in the current context
     //                                u5, v5 };
     Diagnostic(ErrorCode.ERR_NameNotInContext, "v5").WithArguments("v5").WithLocation(40, 36),
-    // (42,15): error CS0103: The name 'z5' does not exist in the current context
-    //         Dummy(z5); 
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "z5").WithArguments("z5").WithLocation(42, 15),
     // (43,15): error CS0103: The name 'u5' does not exist in the current context
     //         Dummy(u5); 
     Diagnostic(ErrorCode.ERR_NameNotInContext, "u5").WithArguments("u5").WithLocation(43, 15),
@@ -2646,8 +2631,7 @@ public class X
             var z4Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "z4").Single();
             var z4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z4").ToArray();
             Assert.Equal(6, z4Ref.Length);
-            VerifyModelForDeclarationPattern(model, z4Decl, z4Ref[0], z4Ref[1], z4Ref[2], z4Ref[3], z4Ref[4]);
-            VerifyNotInScope(model, z4Ref[5]);
+            VerifyModelForDeclarationPattern(model, z4Decl, z4Ref);
 
             var u4Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "u4").Single();
             var u4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "u4").ToArray();
@@ -2673,8 +2657,7 @@ public class X
             var z5Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "z5").Single();
             var z5Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "z5").ToArray();
             Assert.Equal(6, z5Ref.Length);
-            VerifyModelForDeclarationPattern(model, z5Decl, z5Ref[0], z5Ref[1], z5Ref[2], z5Ref[3], z5Ref[4]);
-            VerifyNotInScope(model, z5Ref[5]);
+            VerifyModelForDeclarationPattern(model, z5Decl, z5Ref);
 
             var u5Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "u5").Single();
             var u5Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "u5").ToArray();
@@ -2735,15 +2718,15 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, new[] { SystemCoreRef }, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-                // (16,47): error CS0136: A local or parameter named 'y1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (16,47): error CS0128: A local variable named 'y1' is already defined in this scope
                 //         var res = from x1 in new[] { 1 is var y1 ? y1 : 0}
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y1").WithArguments("y1").WithLocation(16, 47),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "y1").WithArguments("y1").WithLocation(16, 47),
                 // (17,47): error CS0136: A local or parameter named 'y2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                   from x2 in new[] { 2 is var y2 ? y2 : 0}
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y2").WithArguments("y2").WithLocation(17, 47),
-                // (18,47): error CS0136: A local or parameter named 'y3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                // (18,47): error CS0128: A local variable named 'y3' is already defined in this scope
                 //                   join x3 in new[] { 3 is var y3 ? y3 : 0}
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y3").WithArguments("y3").WithLocation(18, 47),
+                Diagnostic(ErrorCode.ERR_LocalDuplicate, "y3").WithArguments("y3").WithLocation(18, 47),
                 // (19,36): error CS0136: A local or parameter named 'y4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //                        on 4 is var y4 ? y4 : 0
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "y4").WithArguments("y4").WithLocation(19, 36),
@@ -2782,7 +2765,19 @@ public class X
                 var yDecl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == id).Single();
                 var yRef = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(name => name.Identifier.ValueText == id).ToArray();
                 Assert.Equal(3, yRef.Length);
-                VerifyModelForDeclarationPattern(model, yDecl, yRef[0]);
+
+                switch (i)
+                {
+                    case 1:
+                    case 3:
+                        VerifyModelForDeclarationPatternDuplicateInSameScope(model, yDecl);
+                        VerifyNotAPatternLocal(model, yRef[0]);
+                        break;
+                    default:
+                        VerifyModelForDeclarationPattern(model, yDecl, yRef[0]);
+                        break;
+                }
+
                 VerifyNotAPatternLocal(model, yRef[2]);
 
                 switch (i)
@@ -2797,7 +2792,6 @@ public class X
                         VerifyNotAPatternLocal(model, yRef[1]);
                         break;
                 }
-
             }
         }
 
@@ -6199,6 +6193,9 @@ public class X
     // (86,22): error CS0103: The name 'y12' does not exist in the current context
     //         using (Dummy(y12 is var x12, x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 22),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,31): error CS0128: A local variable named 'x14' is already defined in this scope
     //                      2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 31)
@@ -6403,6 +6400,9 @@ public class X
     // (86,30): error CS0103: The name 'y12' does not exist in the current context
     //         using (var d = Dummy(y12 is var x12, x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 30),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,39): error CS0128: A local variable named 'x14' is already defined in this scope
     //                              2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 39)
@@ -6607,6 +6607,9 @@ public class X
     // (86,45): error CS0103: The name 'y12' does not exist in the current context
     //         using (System.IDisposable d = Dummy(y12 is var x12, x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 45),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,54): error CS0128: A local variable named 'x14' is already defined in this scope
     //                                             2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 54)
@@ -6930,15 +6933,12 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (19,35): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    // (19,35): error CS0128: A local variable named 'x4' is already defined in this scope
     //         var d = Dummy(true is var x4, x4);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(19, 35),
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(19, 35),
     // (24,23): error CS0841: Cannot use local variable 'x6' before it is declared
     //         var d = Dummy(x6 && true is var x6);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(24, 23),
-    // (30,34): error CS0103: The name 'x8' does not exist in the current context
-    //         System.Console.WriteLine(x8);
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 34),
     // (36,32): error CS0128: A local variable named 'x14' is already defined in this scope
     //                       2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(36, 32)
@@ -6955,7 +6955,8 @@ public class X
             var x4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1]);
+            VerifyNotAPatternLocal(model, x4Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
 
             var x6Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x6").Single();
             var x6Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x6").Single();
@@ -6964,8 +6965,7 @@ public class X
             var x8Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x8").Single();
             var x8Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x8").ToArray();
             Assert.Equal(2, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0]);
-            VerifyNotInScope(model, x8Ref[1]);
+            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref);
 
             var x14Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x14").ToArray();
             var x14Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x14").Single();
@@ -7020,15 +7020,12 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (19,38): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    // (19,38): error CS0128: A local variable named 'x4' is already defined in this scope
     //         object d = Dummy(true is var x4, x4);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(19, 38),
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(19, 38),
     // (24,26): error CS0841: Cannot use local variable 'x6' before it is declared
     //         object d = Dummy(x6 && true is var x6);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x6").WithArguments("x6").WithLocation(24, 26),
-    // (30,34): error CS0103: The name 'x8' does not exist in the current context
-    //         System.Console.WriteLine(x8);
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "x8").WithArguments("x8").WithLocation(30, 34),
     // (36,35): error CS0128: A local variable named 'x14' is already defined in this scope
     //                          2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(36, 35)
@@ -7045,7 +7042,8 @@ public class X
             var x4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1]);
+            VerifyNotAPatternLocal(model, x4Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
 
             var x6Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x6").Single();
             var x6Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x6").Single();
@@ -7054,8 +7052,7 @@ public class X
             var x8Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x8").Single();
             var x8Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x8").ToArray();
             Assert.Equal(2, x8Ref.Length);
-            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref[0]);
-            VerifyNotInScope(model, x8Ref[1]);
+            VerifyModelForDeclarationPattern(model, x8Decl, x8Ref);
 
             var x14Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x14").ToArray();
             var x14Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x14").Single();
@@ -7094,12 +7091,21 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (13,36): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    // (13,36): error CS0128: A local variable named 'x1' is already defined in this scope
     //                  Dummy(true is var x1, x1);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(13, 36),
-    // (20,39): error CS0136: A local or parameter named 'x2' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 36),
+    // (13,40): error CS0841: Cannot use local variable 'x1' before it is declared
+    //                  Dummy(true is var x1, x1);
+    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x1").WithArguments("x1").WithLocation(13, 40),
+    // (13,40): error CS0165: Use of unassigned local variable 'x1'
+    //                  Dummy(true is var x1, x1);
+    Diagnostic(ErrorCode.ERR_UseDefViolation, "x1").WithArguments("x1").WithLocation(13, 40),
+    // (20,39): error CS0128: A local variable named 'x2' is already defined in this scope
     //                     Dummy(true is var x2, x2);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x2").WithArguments("x2").WithLocation(20, 39)
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(20, 39),
+    // (20,43): error CS0165: Use of unassigned local variable 'x2'
+    //                     Dummy(true is var x2, x2);
+    Diagnostic(ErrorCode.ERR_UseDefViolation, "x2").WithArguments("x2").WithLocation(20, 43)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -7108,14 +7114,16 @@ public class X
             var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
             var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
             Assert.Equal(2, x1Ref.Length);
-            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref[0]);
+            VerifyNotAPatternLocal(model, x1Ref[0]);
             VerifyNotAPatternLocal(model, x1Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x1Decl);
 
             var x2Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x2").Single();
             var x2Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x2").ToArray();
             Assert.Equal(2, x2Ref.Length);
-            VerifyModelForDeclarationPattern(model, x2Decl, x2Ref[0]);
+            VerifyNotAPatternLocal(model, x2Ref[0]);
             VerifyNotAPatternLocal(model, x2Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x2Decl);
         }
 
         [Fact]
@@ -7159,9 +7167,9 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (12,38): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-    //         object d = Dummy(true is var x1, x1), 
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(12, 38),
+    // (13,16): error CS0128: A local variable named 'x1' is already defined in this scope
+    //                x1 = Dummy(x1);
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(13, 16),
     // (20,39): error CS0128: A local variable named 'x2' is already defined in this scope
     //                d2 = Dummy(true is var x2, x2);
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x2").WithArguments("x2").WithLocation(20, 39),
@@ -7176,8 +7184,7 @@ public class X
             var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
             var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
             Assert.Equal(3, x1Ref.Length);
-            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref[0], x1Ref[1]);
-            VerifyNotAPatternLocal(model, x1Ref[2]);
+            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
 
             var x2Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x2").ToArray();
             var x2Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x2").ToArray();
@@ -7242,6 +7249,92 @@ var y1 = Dummy(11 is var x1, x1);
         }
 
         [Fact]
+        public void ScopeOfPatternVariables_LocalDeclarationStmt_06()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    void Test1()
+    {
+        if (true)
+            var d = true is var x1;
+
+        x1++;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics(
+                // (11,13): error CS1023: Embedded statement cannot be a declaration or labeled statement
+                //             var d = true is var x1;
+                Diagnostic(ErrorCode.ERR_BadEmbeddedStmt, "var d = true is var x1;").WithLocation(11, 13),
+                // (13,9): error CS0103: The name 'x1' does not exist in the current context
+                //         x1++;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(13, 9)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").Single();
+            VerifyModelForDeclarationPattern(model, x1Decl);
+            VerifyNotInScope(model, x1Ref);
+
+            var d = tree.GetRoot().DescendantNodes().OfType<VariableDeclaratorSyntax>().Where(id => id.Identifier.ValueText == "d").Single();
+            Assert.Equal("System.Boolean d", model.GetDeclaredSymbol(d).ToTestDisplayString());
+        }
+
+        [Fact]
+        public void ScopeOfPatternVariables_LocalDeclarationStmt_07()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    int Dummy(params object[] x) { return 0; }
+
+    void Test1()
+    {
+        SpeculateHere();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var statement = (LocalDeclarationStatementSyntax)SyntaxFactory.ParseStatement(@"
+var y1 = Dummy(11 is var x1, x1);
+");
+
+            bool success = model.TryGetSpeculativeSemanticModel(
+                tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "SpeculateHere").Single().SpanStart,
+                statement, out model);
+            Assert.True(success);
+            Assert.NotNull(model);
+            tree = statement.SyntaxTree;
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
+            Assert.Equal("System.Int32", model.GetTypeInfo(x1Ref[0]).Type.ToTestDisplayString());
+
+            Assert.Equal("System.Int32 y1", model.GetDeclaredSymbol(statement.Declaration.Variables.Single()).ToTestDisplayString());
+        }
+
+        [Fact]
         public void LocalDeclarationStmt_01()
         {
             var source =
@@ -7254,6 +7347,7 @@ public class X
                d2 = Dummy(new C(""c""), new C(""d"") is var x2, x2);
         System.Console.WriteLine(d1);
         System.Console.WriteLine(d2);
+        System.Console.WriteLine(x1);
     }
 
     static object Dummy(object x, object y, object z) 
@@ -7283,7 +7377,66 @@ class C
 @"b
 d
 a
-c");
+c
+b");
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").ToArray();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void LocalDeclarationStmt_02()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        if (true)
+        {
+            object d1 = Dummy(new C(""a""), new C(""b"") is var x1, x1);
+        }
+    }
+
+    static object Dummy(object x, object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return x;
+    }
+}
+
+class C
+{
+    private readonly string _val;
+
+    public C(string val)
+    {
+        _val = val;
+    }
+
+    public override string ToString()
+    {
+        return _val;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            CompileAndVerify(compilation, expectedOutput:
+@"b");
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").ToArray();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
         }
 
         [Fact]
@@ -7422,6 +7575,9 @@ public class X
     // (86,16): error CS0103: The name 'y12' does not exist in the current context
     //         while (y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 16),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,31): error CS0128: A local variable named 'x14' is already defined in this scope
     //                      2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 31)
@@ -7822,6 +7978,9 @@ public class X
     // (98,16): error CS0103: The name 'y12' does not exist in the current context
     //         while (y12 is var x12);
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(98, 16),
+    // (97,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(97, 17),
     // (115,31): error CS0128: A local variable named 'x14' is already defined in this scope
     //                      2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(115, 31),
@@ -8226,6 +8385,9 @@ public class X
     // (107,20): error CS0103: The name 'y12' does not exist in the current context
     //              Dummy(y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 20),
+    // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
     // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29)
@@ -8452,6 +8614,9 @@ public class X
     // (107,20): error CS0103: The name 'y12' does not exist in the current context
     //              Dummy(y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 20),
+    // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
     // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29)
@@ -8681,6 +8846,9 @@ public class X
     // (107,20): error CS0103: The name 'y12' does not exist in the current context
     //              Dummy(y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 20),
+    // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
     // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29),
@@ -8937,6 +9105,9 @@ public class X
     // (107,20): error CS0103: The name 'y12' does not exist in the current context
     //              Dummy(y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 20),
+    // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
     // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29)
@@ -9166,6 +9337,9 @@ public class X
     // (107,20): error CS0103: The name 'y12' does not exist in the current context
     //              Dummy(y12 is var x12)
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(107, 20),
+    // (109,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(109, 17),
     // (124,29): error CS0128: A local variable named 'x14' is already defined in this scope
     //                    2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(124, 29)
@@ -9759,6 +9933,9 @@ public class X
     // (86,33): error CS0103: The name 'y12' does not exist in the current context
     //         foreach (var i in Dummy(y12 is var x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 33),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,42): error CS0128: A local variable named 'x14' is already defined in this scope
     //                                 2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 42),
@@ -9998,6 +10175,9 @@ public class X
     // (86,21): error CS0103: The name 'y12' does not exist in the current context
     //         lock (Dummy(y12 is var x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 21),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,30): error CS0128: A local variable named 'x14' is already defined in this scope
     //                     2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 30)
@@ -10366,6 +10546,9 @@ public unsafe class X
     // (86,31): error CS0103: The name 'y12' does not exist in the current context
     //         fixed (int* p = Dummy(y12 is var x12))
     Diagnostic(ErrorCode.ERR_NameNotInContext, "y12").WithArguments("y12").WithLocation(86, 31),
+    // (87,17): warning CS0219: The variable 'y12' is assigned but its value is never used
+    //             var y12 = 12;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "y12").WithArguments("y12").WithLocation(87, 17),
     // (99,40): error CS0128: A local variable named 'x14' is already defined in this scope
     //                               2 is var x14, 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x14").WithArguments("x14").WithLocation(99, 40)
@@ -10647,27 +10830,33 @@ public class X
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
 
             compilation.VerifyDiagnostics(
+    // (16,44): error CS0136: A local or parameter named 'x1' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    //             yield return Dummy(true is var x1, x1);
+    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x1").WithArguments("x1").WithLocation(16, 44),
+    // (18,40): error CS0128: A local variable named 'x1' is already defined in this scope
+    //         yield return Dummy(true is var x1, x1);
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x1").WithArguments("x1").WithLocation(18, 40),
     // (23,28): error CS0841: Cannot use local variable 'x2' before it is declared
     //         yield return Dummy(x2, true is var x2);
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x2").WithArguments("x2").WithLocation(23, 28),
     // (28,40): error CS0136: A local or parameter named 'x3' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
     //         yield return Dummy(true is var x3, x3);
     Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x3").WithArguments("x3").WithLocation(28, 40),
-    // (35,40): error CS0136: A local or parameter named 'x4' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+    // (35,40): error CS0128: A local variable named 'x4' is already defined in this scope
     //         yield return Dummy(true is var x4, x4);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x4").WithArguments("x4").WithLocation(35, 40),
-    // (40,40): error CS0136: A local or parameter named 'x5' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-    //         yield return Dummy(true is var x5, x5);
-    Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x5").WithArguments("x5").WithLocation(40, 40),
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x4").WithArguments("x4").WithLocation(35, 40),
+    // (41,13): error CS0128: A local variable named 'x5' is already defined in this scope
+    //         var x5 = 11;
+    Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(41, 13),
+    // (41,13): warning CS0219: The variable 'x5' is assigned but its value is never used
+    //         var x5 = 11;
+    Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x5").WithArguments("x5").WithLocation(41, 13),
     // (61,61): error CS0128: A local variable named 'x8' is already defined in this scope
     //         yield return Dummy(true is var x8, x8, false is var x8, x8);
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x8").WithArguments("x8").WithLocation(61, 61),
-    // (72,15): error CS0103: The name 'x11' does not exist in the current context
+    // (72,15): error CS0841: Cannot use local variable 'x11' before it is declared
     //         Dummy(x11);
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "x11").WithArguments("x11").WithLocation(72, 15),
-    // (79,15): error CS0103: The name 'x12' does not exist in the current context
-    //         Dummy(x12);
-    Diagnostic(ErrorCode.ERR_NameNotInContext, "x12").WithArguments("x12").WithLocation(79, 15)
+    Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x11").WithArguments("x11").WithLocation(72, 15)
                 );
 
             var tree = compilation.SyntaxTrees.Single();
@@ -10677,10 +10866,9 @@ public class X
             var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
             Assert.Equal(3, x1Decl.Length);
             Assert.Equal(3, x1Ref.Length);
-            for (int i = 0; i < x1Decl.Length; i++)
-            {
-                VerifyModelForDeclarationPattern(model, x1Decl[i], x1Ref[i]);
-            }
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref[0], x1Ref[2]);
+            VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x1Decl[2]);
 
             var x2Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x2").Single();
             var x2Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x2").Single();
@@ -10694,13 +10882,13 @@ public class X
             var x4Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x4").ToArray();
             Assert.Equal(2, x4Ref.Length);
             VerifyNotAPatternLocal(model, x4Ref[0]);
-            VerifyModelForDeclarationPattern(model, x4Decl, x4Ref[1]);
+            VerifyNotAPatternLocal(model, x4Ref[1]);
+            VerifyModelForDeclarationPatternDuplicateInSameScope(model, x4Decl);
 
             var x5Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x5").Single();
             var x5Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x5").ToArray();
             Assert.Equal(2, x5Ref.Length);
-            VerifyModelForDeclarationPattern(model, x5Decl, x5Ref[0]);
-            VerifyNotAPatternLocal(model, x5Ref[1]);
+            VerifyModelForDeclarationPattern(model, x5Decl, x5Ref);
 
             var x8Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x8").ToArray();
             var x8Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x8").ToArray();
@@ -10719,14 +10907,98 @@ public class X
             var x11Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x11").Single();
             var x11Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x11").ToArray();
             Assert.Equal(2, x11Ref.Length);
-            VerifyNotInScope(model, x11Ref[0]);
-            VerifyModelForDeclarationPattern(model, x11Decl, x11Ref[1]);
+            VerifyModelForDeclarationPattern(model, x11Decl, x11Ref);
 
             var x12Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x12").Single();
             var x12Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x12").ToArray();
             Assert.Equal(2, x12Ref.Length);
-            VerifyModelForDeclarationPattern(model, x12Decl, x12Ref[0]);
-            VerifyNotInScope(model, x12Ref[1]);
+            VerifyModelForDeclarationPattern(model, x12Decl, x12Ref);
+        }
+
+        [Fact]
+        public void ScopeOfPatternVariables_Yield_02()
+        {
+            var source =
+@"
+using System.Collections;
+
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    object Dummy(params object[] x) { return null;}
+
+    IEnumerable Test1()
+    {
+        if (true)
+            yield return Dummy(true is var x1);
+
+        x1++;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+
+            compilation.VerifyDiagnostics(
+                // (17,9): error CS0103: The name 'x1' does not exist in the current context
+                //         x1++;
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(17, 9)
+                );
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").Single();
+            VerifyModelForDeclarationPattern(model, x1Decl);
+            VerifyNotInScope(model, x1Ref);
+        }
+
+        [Fact]
+        public void ScopeOfPatternVariables_Yield_03()
+        {
+            var source =
+@"
+using System.Collections;
+
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    object Dummy(params object[] x) { return null;}
+
+    IEnumerable Test1()
+    {
+        SpeculateHere();
+        yield 0;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var statement = (YieldStatementSyntax)SyntaxFactory.ParseStatement(@"
+yield return (Dummy(11 is var x1, x1));
+");
+
+            bool success = model.TryGetSpeculativeSemanticModel(
+                tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "SpeculateHere").Single().SpanStart,
+                statement, out model);
+            Assert.True(success);
+            Assert.NotNull(model);
+            tree = statement.SyntaxTree;
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").Single();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(1, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl, x1Ref);
+            Assert.Equal("System.Int32", model.GetTypeInfo(x1Ref[0]).Type.ToTestDisplayString());
         }
 
         [Fact]
@@ -10745,7 +11017,57 @@ public class X
     static System.Collections.IEnumerable Test()
     {
         yield return Dummy(""yield1"" is var x1, x1);
-        yield return Dummy(""yield2"" is var x1, x1);
+        yield return Dummy(""yield2"" is var x2, x2);
+        System.Console.WriteLine(x1);
+    }
+
+    static object Dummy(object y, object z) 
+    {
+        System.Console.WriteLine(z);
+        return new object();
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            CompileAndVerify(compilation, expectedOutput:
+@"yield1
+yield2
+yield1");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").ToArray();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(1, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref);
+        }
+
+        [Fact]
+        public void Yield_02()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+        foreach (var o in Test())
+        {}
+    }
+
+    static System.Collections.IEnumerable Test()
+    {
+        bool f = true;
+
+        if (f)
+            yield return Dummy(""yield1"" is var x1, x1);
+
+        if (f)
+        {
+            yield return Dummy(""yield2"" is var x1, x1);
+        }
     }
 
     static object Dummy(object y, object z) 
@@ -10759,6 +11081,16 @@ public class X
             CompileAndVerify(compilation, expectedOutput:
 @"yield1
 yield2");
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var x1Decl = tree.GetRoot().DescendantNodes().OfType<DeclarationPatternSyntax>().Where(p => p.Identifier.ValueText == "x1").ToArray();
+            var x1Ref = tree.GetRoot().DescendantNodes().OfType<IdentifierNameSyntax>().Where(id => id.Identifier.ValueText == "x1").ToArray();
+            Assert.Equal(2, x1Decl.Length);
+            Assert.Equal(2, x1Ref.Length);
+            VerifyModelForDeclarationPattern(model, x1Decl[0], x1Ref[0]);
+            VerifyModelForDeclarationPattern(model, x1Decl[1], x1Ref[1]);
         }
 
         [Fact]


### PR DESCRIPTION
Related to #12597.

@dotnet/roslyn-compiler, @gafter Please review. 