### PR TITLE
Extract method refactoring should handle tuples in VB

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5146,6 +5146,17 @@ class C
             Assert.Equal(SymbolKind.ErrorType, types[1].Kind);
         }
 
+        [Fact, WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")]
+        public void CreateTupleTypeSymbol_UnderlyingTypeIsError()
+        {
+            var comp = CSharpCompilation.Create("test", references: new[] { MscorlibRef });
+
+            TypeSymbol intType = comp.GetSpecialType(SpecialType.System_Int32);
+            var vt2 = comp.CreateErrorTypeSymbol(null, "ValueTuple", 2).Construct(intType, intType);
+
+            Assert.Throws<ArgumentException>(() => comp.CreateTupleTypeSymbol(vt2, default(ImmutableArray<string>)));
+        }
+
         [Fact]
         public void CreateTupleTypeSymbol_BadNames()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5154,7 +5154,7 @@ class C
             TypeSymbol intType = comp.GetSpecialType(SpecialType.System_Int32);
             var vt2 = comp.CreateErrorTypeSymbol(null, "ValueTuple", 2).Construct(intType, intType);
 
-            Assert.Throws<ArgumentException>(() => comp.CreateTupleTypeSymbol(vt2, default(ImmutableArray<string>)));
+            Assert.Throws<ArgumentException>(() => comp.CreateTupleTypeSymbol(underlyingType: vt2));
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
+++ b/src/Compilers/VisualBasic/Portable/Syntax/SyntaxFacts.vb
@@ -107,6 +107,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         Else
                             Return parentQualName.Right Is node
                         End If
+                    Case SyntaxKind.TupleElement
+                        Return DirectCast(parent, TupleElementSyntax).Type Is node
                 End Select
             End If
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -5896,7 +5896,8 @@ fourth]]>)
 
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/13277"), WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")>
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/13277")>
+        <WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")>
         Public Sub CreateTupleTypeSymbol_UnderlyingTypeIsError()
 
             Dim comp = VisualBasicCompilation.Create("test", references:={MscorlibRef})
@@ -5906,6 +5907,32 @@ fourth]]>)
 
             Dim tuple = comp.CreateTupleTypeSymbol(vt2, Nothing)
             ' Crashes in IsTupleCompatible
+
+        End Sub
+
+        <Fact>
+        Public Sub GetSymbolInfoOnTupleType()
+            Dim verifier = CompileAndVerify(
+ <compilation>
+     <file name="a.vb">
+Module C
+     Function M() As (System.Int32, String)
+        throw new System.Exception()
+     End Function
+End Module
+
+    </file>
+ </compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            Dim comp = verifier.Compilation
+            Dim tree = comp.SyntaxTrees(0)
+            Dim model = comp.GetSemanticModel(tree, ignoreAccessibility:=False)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+            Dim type = nodes.OfType(Of QualifiedNameSyntax)().First()
+            Assert.Equal("System.Int32", type.ToString())
+            Assert.NotNull(model.GetSymbolInfo(type))
+            Assert.NotNull(model.GetSymbolInfo(type).Symbol)
 
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -5911,6 +5911,7 @@ fourth]]>)
         End Sub
 
         <Fact>
+        <WorkItem(13042, "https://github.com/dotnet/roslyn/issues/13042")>
         Public Sub GetSymbolInfoOnTupleType()
             Dim verifier = CompileAndVerify(
  <compilation>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -5896,6 +5896,19 @@ fourth]]>)
 
         End Sub
 
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/13277"), WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")>
+        Public Sub CreateTupleTypeSymbol_UnderlyingTypeIsError()
+
+            Dim comp = VisualBasicCompilation.Create("test", references:={MscorlibRef})
+
+            Dim intType As TypeSymbol = comp.GetSpecialType(SpecialType.System_Int32)
+            Dim vt2 = comp.CreateErrorTypeSymbol(Nothing, "ValueTuple", 2).Construct(intType, intType)
+
+            Dim tuple = comp.CreateTupleTypeSymbol(vt2, Nothing)
+            ' Crashes in IsTupleCompatible
+
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -5932,8 +5932,8 @@ End Module
 
             Dim type = nodes.OfType(Of QualifiedNameSyntax)().First()
             Assert.Equal("System.Int32", type.ToString())
-            Assert.NotNull(model.GetSymbolInfo(type))
             Assert.NotNull(model.GetSymbolInfo(type).Symbol)
+            Assert.Equal("System.Int32", model.GetSymbolInfo(type).Symbol.ToTestDisplayString())
 
         End Sub
 

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -295,44 +295,19 @@ compareTokens:=False)
         End Function
 
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)>
+        <WorkItem(13042, "https://github.com/dotnet/roslyn/issues/13042")>
         Public Async Function TestTuples() As Task
 
             Await TestAsync(
-<Text>Class Program
-    Sub Main(args As String())
-        [|Dim x = (1, 2)|]
-        M(x)
-    End Sub
+NewLines("Class Program \n Sub Main(args As String()) \n [|Dim x = (1, 2)|] \n M(x) \n End Sub
+Private Sub M(x As (Integer, Integer)) \n End Sub \n End Class
+Namespace System \n Structure ValueTuple(Of T1, T2) \n End Structure \n End Namespace"),
+NewLines("Class Program \n Sub Main(args As String()) \n Dim x As (Integer, Integer) = {|Rename:NewMethod|}() \n M(x) \n End Sub
+Private Shared Function NewMethod() As (Integer, Integer) \n Return (1, 2) \n End Function
+Private Sub M(x As (Integer, Integer)) \n End Sub \n End Class
+Namespace System \n Structure ValueTuple(Of T1, T2) \n End Structure \n End Namespace"))
 
-    Private Sub M(x As (Integer, Integer))
-    End Sub
-End Class
-
-Namespace System
-    Structure ValueTuple(Of T1, T2)
-    End Structure
-End Namespace
-</Text>.Value.Replace(vbLf, vbCrLf),
-<Text>Class Program
-    Sub Main(args As String())
-        Dim x As (Integer, Integer) = {|Rename:NewMethod|}()
-        M(x)
-    End Sub
-
-    Private Shared Function NewMethod() As (Integer, Integer)
-        Return (1, 2)
-    End Function
-
-    Private Sub M(x As (Integer, Integer))
-    End Sub
-End Class
-
-Namespace System
-    Structure ValueTuple(Of T1, T2)
-    End Structure
-End Namespace
-</Text>.Value.Replace(vbLf, vbCrLf),
-compareTokens:=False)
         End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -293,5 +293,46 @@ End Class
 </Text>.Value.Replace(vbLf, vbCrLf),
 compareTokens:=False)
         End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)>
+        Public Async Function TestTuples() As Task
+
+            Await TestAsync(
+<Text>Class Program
+    Sub Main(args As String())
+        [|Dim x = (1, 2)|]
+        M(x)
+    End Sub
+
+    Private Sub M(x As (Integer, Integer))
+    End Sub
+End Class
+
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace
+</Text>.Value.Replace(vbLf, vbCrLf),
+<Text>Class Program
+    Sub Main(args As String())
+        Dim x As (Integer, Integer) = {|Rename:NewMethod|}()
+        M(x)
+    End Sub
+
+    Private Shared Function NewMethod() As (Integer, Integer)
+        Return (1, 2)
+    End Function
+
+    Private Sub M(x As (Integer, Integer))
+    End Sub
+End Class
+
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace
+</Text>.Value.Replace(vbLf, vbCrLf),
+compareTokens:=False)
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -299,13 +299,33 @@ compareTokens:=False)
         Public Async Function TestTuples() As Task
 
             Await TestAsync(
-NewLines("Class Program \n Sub Main(args As String()) \n [|Dim x = (1, 2)|] \n M(x) \n End Sub
-Private Sub M(x As (Integer, Integer)) \n End Sub \n End Class
-Namespace System \n Structure ValueTuple(Of T1, T2) \n End Structure \n End Namespace"),
-NewLines("Class Program \n Sub Main(args As String()) \n Dim x As (Integer, Integer) = {|Rename:NewMethod|}() \n M(x) \n End Sub
-Private Shared Function NewMethod() As (Integer, Integer) \n Return (1, 2) \n End Function
-Private Sub M(x As (Integer, Integer)) \n End Sub \n End Class
-Namespace System \n Structure ValueTuple(Of T1, T2) \n End Structure \n End Namespace"))
+"Class Program
+    Sub Main(args As String())
+        [|Dim x = (1, 2)|]
+        M(x)
+    End Sub
+    Private Sub M(x As (Integer, Integer))
+    End Sub
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace",
+"Class Program
+    Sub Main(args As String())
+        Dim x As (Integer, Integer) = {|Rename:NewMethod|}()
+        M(x)
+    End Sub
+    Private Shared Function NewMethod() As (Integer, Integer)
+        Return (1, 2)
+    End Function
+    Private Sub M(x As (Integer, Integer))
+    End Sub
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace")
 
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -132,7 +132,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(
                 types.Select(Function(t, i) SyntaxFactory.TupleElement(
                     If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), GenerateTypeSyntax(t)))))
-
         End Function
 
         Public Overrides Function VisitNamedType(symbol As INamedTypeSymbol) As TypeSyntax

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -127,14 +127,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Dim list = New SeparatedSyntaxList(Of TupleElementSyntax)()
             Dim types = symbol.TupleElementTypes
             Dim names = symbol.TupleElementNames
-            Dim hasNames = Not (names.IsDefault)
+            Dim hasNames = Not names.IsDefault
 
-            For pos As Integer = 1 To types.Length
-                Dim name = If(hasNames, SyntaxFactory.IdentifierName(names(pos - 1)), Nothing)
-                list = list.Add(SyntaxFactory.TupleElement(name, GenerateTypeSyntax(types(pos - 1))))
-            Next
+            Return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(
+               types.Select(Function(t, i) SyntaxFactory.TupleElement(If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), GenerateTypeSyntax(t)))))
 
-            Return SyntaxFactory.TupleType(list)
         End Function
 
         Public Overrides Function VisitNamedType(symbol As INamedTypeSymbol) As TypeSyntax

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -130,7 +130,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Dim hasNames = Not names.IsDefault
 
             Return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(
-               types.Select(Function(t, i) SyntaxFactory.TupleElement(If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), GenerateTypeSyntax(t)))))
+                types.Select(Function(t, i) SyntaxFactory.TupleElement(
+                    If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), GenerateTypeSyntax(t)))))
 
         End Function
 

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -123,15 +123,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
                 SyntaxFactory.TypeArgumentList(SyntaxFactory.SeparatedList(symbol.TypeArguments.[Select](Function(t) t.Accept(Me)))))
         End Function
 
-        Private Function CreateTupleTypeSyntax(symbol As INamedTypeSymbol) As TypeSyntax
-            Dim list = New SeparatedSyntaxList(Of TupleElementSyntax)()
+        Private Shared Function CreateTupleTypeSyntax(symbol As INamedTypeSymbol) As TypeSyntax
             Dim types = symbol.TupleElementTypes
             Dim names = symbol.TupleElementNames
             Dim hasNames = Not names.IsDefault
 
             Return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(
                 types.Select(Function(t, i) SyntaxFactory.TupleElement(
-                    If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), GenerateTypeSyntax(t)))))
+                    If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), t.GenerateTypeSyntax()))))
         End Function
 
         Public Overrides Function VisitNamedType(symbol As INamedTypeSymbol) As TypeSyntax


### PR DESCRIPTION
Refactorings involving a VB tuple type would result in `Object` instead of the proper tuple type.
That is fixed by the change in `CreateSimpleTypeSyntax` (matching the corresponding C# code).

Beyond that, there was also a (sneaky) issue with the simplification code. It would leave `(System.Int32, System.Int32)`, instead of simplifying to `(Integer, Integer)`. 
This was caused by `ExpressionSyntaxExpressions.TryReduce` looking up the type for `System.Int32` (see call to `SimplificationHelpers.GetOriginalSymbolInfo`) but finding no symbol. The fix is in `SyntaxFacts.IsInTypeOnlyContext`. It turns out the same fix was already introduced in C# for some other scenario...

@CyrusNajmabadi @VSadov @dotnet/roslyn-compiler for review.

Fixes https://github.com/dotnet/roslyn/issues/13042