### PR TITLE
push file read to Background thread.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Library/ObjectBrowser/AbstractObjectBrowserLibraryManager.cs
@@ -66,7 +66,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
             this.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
         }
 
-        private async void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
+        private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
         {
             switch (e.Kind)
             {
@@ -76,7 +76,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Library.ObjectB
                     var oldDocument = e.OldSolution.GetDocument(e.DocumentId);
                     var newDocument = e.NewSolution.GetDocument(e.DocumentId);
 
-                    await DocumentChangedAsync(oldDocument, newDocument).ConfigureAwait(false);
+                    // make sure we do this in background thread. we don't care about ordering of events
+                    // we just need to refresh OB at some point if it ever needs to be updated
+                    Task.Run(() => DocumentChangedAsync(oldDocument, newDocument));
                     break;
 
                 case WorkspaceChangeKind.ProjectAdded:


### PR DESCRIPTION
this is port of https://github.com/dotnet/roslyn/pull/13246 for microupdate

this should push reading file to happen in background thread. this should reduce chance where VS deadlock due to this issue - https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems?id=169649&_a=edit

this will not fix the root cause of it, but will remove this specific case from happening.

risk should be low and end user experience will be no deadlock on this code path.

for this particular dead lock, user doesn't require to do any explicit behavior. just using VS normally can lead to this dead lock, but it requires very specific condition to meet to happen so it is not like it happens every time. (the condition is DispatcherSynchronizationContext.Wait is called and Wait pick up pending COM call to UI thread which internally calls DispatcherSynchronizationContext.Wait again which waiting for the first task to come back)
