### PR TITLE
VB default type for tuple literals

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Statements.vb
@@ -1327,6 +1327,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             arrayLiteral = DirectCast(inferFrom, BoundArrayLiteral)
                             inferredType = arrayLiteral.InferredType
 
+                        Case BoundKind.TupleLiteral
+                            Dim tupleLiteral = DirectCast(inferFrom, BoundTupleLiteral)
+                            inferredType = tupleLiteral.InferredType
+
                         Case Else
                             inferredType = inferFrom.Type
                     End Select

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -722,6 +722,17 @@
      (a: 1, b: (c: 1, d: null))  does not have a natural type, because "null" does not have one
     -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>
+    <!-- 
+    InferredType is the type of the literal if there is no target type available.
+    Inferred type is a tuple type that combines default types of arguments.
+    
+    Important thing to note:
+    1) InferredType is generally available even if the literal otherwise has no type 
+       For example   (Nothing, Nothing)   has no type, but has InferredType (Object, Object)
+    2) Sometimes InferredType is not available.
+       For example   (AddressOf Main, AddressOf Main) has no InferredType because 
+       AddressOf Main has no default type
+    -->    
     <Field Name="InferredType" Type="TupleTypeSymbol" Null="allow"/>
     <Field Name="ArgumentNamesOpt" Type="ImmutableArray(Of String)" Null="allow"/>
   </Node>

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -722,6 +722,7 @@
      (a: 1, b: (c: 1, d: null))  does not have a natural type, because "null" does not have one
     -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>
+    <Field Name="InferredType" Type="TupleTypeSymbol" Null="disallow"/>
     <Field Name="ArgumentNamesOpt" Type="ImmutableArray(Of String)" Null="allow"/>
   </Node>
 

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -722,7 +722,7 @@
      (a: 1, b: (c: 1, d: null))  does not have a natural type, because "null" does not have one
     -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="allow"/>
-    <Field Name="InferredType" Type="TupleTypeSymbol" Null="disallow"/>
+    <Field Name="InferredType" Type="TupleTypeSymbol" Null="allow"/>
     <Field Name="ArgumentNamesOpt" Type="ImmutableArray(Of String)" Null="allow"/>
   </Node>
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -960,10 +960,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Nothing 'ConversionKind.NoConversion
             End If
 
-            Dim sourceType As TypeSymbol = source.Type
+            Dim sourceType As TypeSymbol = If(source.Kind = BoundKind.TupleLiteral,
+                                                DirectCast(source, BoundTupleLiteral).InferredType,
+                                                source.Type)
 
             If sourceType Is Nothing Then
-
                 userDefinedConversionsMightStillBeApplicable = source.GetMostEnclosedParenthesizedExpression().Kind = BoundKind.ArrayLiteral
 
                 ' The node doesn't have a type yet and reclassification failed.
@@ -1210,7 +1211,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Shared Function ClassifyTupleConversion(source As BoundTupleLiteral, destination As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind
+            If source.Type = destination Then
+                Return ConversionKind.Identity
+            End If
+
             Dim arguments = source.Arguments
+
+            Dim wideningConversion = ConversionKind.WideningTuple
+            Dim narrowingConversion = ConversionKind.NarrowingTuple
+
+            If destination.IsNullableType Then
+                destination = destination.GetNullableUnderlyingType()
+
+                wideningConversion = ConversionKind.WideningNullable
+                narrowingConversion = ConversionKind.NarrowingNullable
+            End If
+
+            ' tuple literal converts to its inferred type 
+            If source.InferredType.IsSameTypeIgnoringCustomModifiers(destination) Then
+                Return wideningConversion
+            End If
+
+            ' Now we can try element-wise conversion
 
             ' check if the type is actually compatible type for a tuple of given cardinality
             If Not destination.IsTupleOrCompatibleWithTupleOfCardinality(arguments.Length) Then
@@ -1221,7 +1243,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Debug.Assert(arguments.Count = targetElementTypes.Length)
 
             ' check arguments against flattened list of target element types 
-            Dim result As ConversionKind = ConversionKind.WideningTuple
+            Dim result As ConversionKind = wideningConversion
 
             For i As Integer = 0 To arguments.Length - 1
                 Dim argument = arguments(i)
@@ -1238,7 +1260,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 If IsNarrowingConversion(elementConversion) Then
-                    result = ConversionKind.NarrowingTuple
+                    result = narrowingConversion
                 End If
             Next
 
@@ -2053,7 +2075,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If sourceType Is Nothing Then
                 source = source.GetMostEnclosedParenthesizedExpression()
-                sourceType = If(source.Kind <> BoundKind.ArrayLiteral, source.Type, New ArrayLiteralTypeSymbol(DirectCast(source, BoundArrayLiteral)))
+                If source.Kind = BoundKind.ArrayLiteral Then
+                    sourceType = New ArrayLiteralTypeSymbol(DirectCast(source, BoundArrayLiteral))
+                ElseIf source.Kind = BoundKind.TupleLiteral Then
+                    sourceType = DirectCast(source, BoundTupleLiteral).InferredType
+                Else
+                    sourceType = source.Type
+                End If
             End If
 
             Debug.Assert(sourceType IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -965,7 +965,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                 source.Type)
 
             If sourceType Is Nothing Then
-                userDefinedConversionsMightStillBeApplicable = source.GetMostEnclosedParenthesizedExpression().Kind = BoundKind.ArrayLiteral
+                Dim mostEnclosing = source.GetMostEnclosedParenthesizedExpression().Kind
+                userDefinedConversionsMightStillBeApplicable = mostEnclosing = BoundKind.ArrayLiteral OrElse
+                                                               mostEnclosing = BoundKind.TupleLiteral
 
                 ' The node doesn't have a type yet and reclassification failed.
                 Return Nothing ' No conversion
@@ -1228,7 +1230,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' tuple literal converts to its inferred type 
-            If source.InferredType.IsSameTypeIgnoringCustomModifiers(destination) Then
+            If source.InferredType?.IsSameTypeIgnoringCustomModifiers(destination) Then
                 Return wideningConversion
             End If
 
@@ -2079,6 +2081,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     sourceType = New ArrayLiteralTypeSymbol(DirectCast(source, BoundArrayLiteral))
                 ElseIf source.Kind = BoundKind.TupleLiteral Then
                     sourceType = DirectCast(source, BoundTupleLiteral).InferredType
+                    If sourceType Is Nothing Then
+                        Return Nothing
+                    End If
                 Else
                     sourceType = source.Type
                 End If

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -563,16 +563,23 @@ HandleAsAGeneralExpression:
 
                         Dim arrayLiteral As BoundArrayLiteral = Nothing
                         Dim argumentTypeByAssumption As Boolean = False
+                        Dim expressionType As TypeSymbol
 
                         If Expression.Kind = BoundKind.ArrayLiteral Then
                             arrayLiteral = DirectCast(Expression, BoundArrayLiteral)
                             argumentTypeByAssumption = arrayLiteral.NumberOfCandidates <> 1
+                            expressionType = New ArrayLiteralTypeSymbol(arrayLiteral)
+
+                        ElseIf Expression.Kind = BoundKind.TupleLiteral Then
+                            expressionType = DirectCast(Expression, BoundTupleLiteral).InferredType
+                        Else
+                            expressionType = Expression.Type
                         End If
 
                         ' Need to create an ArrayLiteralTypeSymbol
                         inferenceOk = Graph.InferTypeArgumentsFromArgument(
                             Expression.Syntax,
-                            If(Expression.Kind <> BoundKind.ArrayLiteral, Expression.Type, New ArrayLiteralTypeSymbol(arrayLiteral)),
+                            expressionType,
                             argumentTypeByAssumption,
                             ParameterType,
                             Parameter,

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -319,7 +319,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Me._locations = locations
         End Sub
 
-        Friend Shared Function Create(locationOpt As Location, elementTypes As ImmutableArray(Of TypeSymbol), elementLocations As ImmutableArray(Of Location), elementNames As ImmutableArray(Of String), compilation As VisualBasicCompilation, Optional syntax As VisualBasicSyntaxNode = Nothing, Optional diagnostics As DiagnosticBag = Nothing) As TupleTypeSymbol
+        Friend Shared Function Create(
+                                     locationOpt As Location,
+                                     elementTypes As ImmutableArray(Of TypeSymbol),
+                                     elementLocations As ImmutableArray(Of Location),
+                                     elementNames As ImmutableArray(Of String),
+                                     compilation As VisualBasicCompilation,
+                                     Optional syntax As SyntaxNode = Nothing,
+                                     Optional diagnostics As DiagnosticBag = Nothing) As TupleTypeSymbol
+
             Debug.Assert(elementNames.IsDefault OrElse elementTypes.Length = elementNames.Length)
             Dim length As Integer = elementTypes.Length
 
@@ -477,7 +485,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return (numElements - 1) \ (RestPosition - 1) + 1
         End Function
 
-        Private Shared Function GetTupleUnderlyingType(elementTypes As ImmutableArray(Of TypeSymbol), syntax As VisualBasicSyntaxNode, compilation As VisualBasicCompilation, diagnostics As DiagnosticBag) As NamedTypeSymbol
+        Private Shared Function GetTupleUnderlyingType(elementTypes As ImmutableArray(Of TypeSymbol), syntax As SyntaxNode, compilation As VisualBasicCompilation, diagnostics As DiagnosticBag) As NamedTypeSymbol
             Dim numElements As Integer = elementTypes.Length
             Dim remainder As Integer
             Dim chainLength As Integer = TupleTypeSymbol.NumberOfValueTuples(numElements, remainder)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -3040,7 +3040,7 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Integer, Object, Integer)' cannot be converted to '(Integer, String)'.
         Dim x As (Integer, String) = (1, Nothing, 2)
                                      ~~~~~~~~~~~~~~~
 </errors>)
@@ -5500,7 +5500,7 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Object, Object, Object)' cannot be converted to '(Integer, Integer)'.
         x = (Nothing, Nothing, Nothing)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to '(Integer, Integer)'.
@@ -5518,6 +5518,9 @@ BC30201: Expression expected.
 BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
         x = (1, Function(t) t)
                 ~~~~~~~~~~~~~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = (1, Function(t) t)
+                         ~
 </errors>)
 
         End Sub
@@ -5549,7 +5552,7 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Object, Object, Object)' cannot be converted to '(Integer, Integer)'.
         x = DirectCast((Nothing, Nothing, Nothing), (Integer, Integer))
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to '(Integer, Integer)'.
@@ -5564,6 +5567,9 @@ BC30201: Expression expected.
 BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
         x = DirectCast((1, Function(t) t), (Integer, Integer))
                            ~~~~~~~~~~~~~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = DirectCast((1, Function(t) t), (Integer, Integer))
+                                    ~
 </errors>)
 
         End Sub
@@ -5595,7 +5601,7 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Object, Object, Object)' cannot be converted to '(Integer, Integer)'.
         x = (Nothing, Nothing, Nothing)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to '(Integer, Integer)'.
@@ -5613,6 +5619,9 @@ BC30201: Expression expected.
 BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
         x = (1, Function(t) t)
                 ~~~~~~~~~~~~~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = (1, Function(t) t)
+                         ~
 </errors>)
 
         End Sub
@@ -5644,7 +5653,7 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Object, Object, Object)' cannot be converted to '(String, String)'.
         x = (Nothing, Nothing, Nothing)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to '(String, String)'.
@@ -5668,6 +5677,9 @@ BC30512: Option Strict On disallows implicit conversions from 'Integer' to 'Stri
 BC36625: Lambda expression cannot be converted to 'String' because 'String' is not a delegate type.
         x = (1, Function(t) t)
                 ~~~~~~~~~~~~~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = (1, Function(t) t)
+                         ~
 </errors>)
 
         End Sub
@@ -5699,7 +5711,7 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(Object, Object, Object)' cannot be converted to '(Integer, Integer)'.
         x = ((Nothing, Nothing, Nothing), 1)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to '(Integer, Integer)'.
@@ -5717,6 +5729,12 @@ BC30201: Expression expected.
 BC36625: Lambda expression cannot be converted to 'Integer' because 'Integer' is not a delegate type.
         x = ((1, Function(t) t), 1)
                  ~~~~~~~~~~~~~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = ((1, Function(t) t), 1)
+                          ~
+BC36642: Option Strict On requires each lambda expression parameter to be declared with an 'As' clause if its type cannot be inferred.
+        x = ((1, Function(t) t), 1)
+                          ~
 </errors>)
 
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -150,6 +150,260 @@ BC30389: '(A As Integer, B As Integer).A' is not accessible in this context beca
         End Sub
 
         <Fact>
+        Public Sub TupleDefaultType001()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim t = (Nothing, Nothing)
+        console.writeline(t)            
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+(, )
+            ]]>)
+
+            verifier.VerifyIL("C.Main", <![CDATA[
+{
+  // Code size       18 (0x12)
+  .maxstack  2
+  IL_0000:  ldnull
+  IL_0001:  ldnull
+  IL_0002:  newobj     "Sub System.ValueTuple(Of Object, Object)..ctor(Object, Object)"
+  IL_0007:  box        "System.ValueTuple(Of Object, Object)"
+  IL_000c:  call       "Sub System.Console.WriteLine(Object)"
+  IL_0011:  ret
+}
+]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType001err()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="NoTuples">
+    <file name="a.vb"><![CDATA[
+
+Imports System
+Module C
+
+    Sub Main()
+        Dim t = (Nothing, Nothing)
+        console.writeline(t)            
+    End Sub
+End Module
+
+]]></file>
+</compilation>)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+        Dim t = (Nothing, Nothing)
+                ~~~~~~~~~~~~~~~~~~
+</errors>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType002()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim t1 = ({Nothing}, {Nothing})
+        console.writeline(t1.GetType())            
+
+        Dim t2 = {(Nothing, Nothing)}
+        console.writeline(t2.GetType())            
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+System.ValueTuple`2[System.Object[],System.Object[]]
+System.ValueTuple`2[System.Object,System.Object][]
+            ]]>)
+
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType003()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim t3 = Function(){(Nothing, Nothing)}
+        console.writeline(t3.GetType())            
+
+        Dim t4 = {Function()(Nothing, Nothing)}
+        console.writeline(t4.GetType())            
+
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+VB$AnonymousDelegate_0`1[System.ValueTuple`2[System.Object,System.Object][]]
+VB$AnonymousDelegate_0`1[System.ValueTuple`2[System.Object,System.Object]][]
+            ]]>)
+
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType004()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Test(({Nothing}, {{Nothing}}))
+        Test((Function(x as integer)x, Function(x as Long)x))
+    End Sub
+
+    function Test(of T, U)(x as (T, U)) as (U, T)
+        System.Console.WriteLine(GetType(T))
+        System.Console.WriteLine(GetType(U))
+        System.Console.WriteLine()
+
+        return (x.Item2, x.Item1)
+    End Function
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+System.Object[]
+System.Object[,]
+
+VB$AnonymousDelegate_0`2[System.Int32,System.Int32]
+VB$AnonymousDelegate_0`2[System.Int64,System.Int64]
+            ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType005()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Test((Function(x as integer)Function()x, Function(x as Long){({Nothing}, {Nothing})}))
+    End Sub
+
+    function Test(of T, U)(x as (T, U)) as (U, T)
+        System.Console.WriteLine(GetType(T))
+        System.Console.WriteLine(GetType(U))
+        System.Console.WriteLine()
+
+        return (x.Item2, x.Item1)
+    End Function
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+VB$AnonymousDelegate_0`2[System.Int32,VB$AnonymousDelegate_1`1[System.Int32]]
+VB$AnonymousDelegate_0`2[System.Int64,System.ValueTuple`2[System.Object[],System.Object[]][]]
+            ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType006()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Test((Nothing, Nothing), "q")
+        Test((Nothing, "q"), Nothing)
+
+        Test1("q", (Nothing, Nothing))
+        Test1(Nothing, ("q", Nothing))
+
+    End Sub
+
+    function Test(of T)(x as (T, T), y as T) as T
+        System.Console.WriteLine(GetType(T))
+
+        return y
+    End Function
+
+    function Test1(of T)(x as T, y as (T, T)) as T
+        System.Console.WriteLine(GetType(T))
+
+        return x
+    End Function
+
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:=<![CDATA[
+System.String
+System.String
+System.String
+System.String
+            ]]>)
+        End Sub
+
+        <Fact()>
+        Public Sub TupleDefaultType006err()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="NoTuples">
+    <file name="a.vb"><![CDATA[
+Imports System
+Module C
+
+    Sub Main()
+        Test1((Nothing, Nothing), Nothing)
+        Test2(Nothing, (Nothing, Nothing))
+    End Sub
+
+    function Test1(of T)(x as (T, T), y as T) as T
+        System.Console.WriteLine(GetType(T))
+        return y
+    End Function
+
+    function Test2(of T)(x as T, y as (T, T)) as T
+        System.Console.WriteLine(GetType(T))
+        return x
+    End Function
+End Module
+
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC36645: Data type(s) of the type parameter(s) in method 'Public Function Test1(Of T)(x As (T, T), y As T) As T' cannot be inferred from these arguments. Specifying the data type(s) explicitly might correct this error.
+        Test1((Nothing, Nothing), Nothing)
+        ~~~~~
+BC36645: Data type(s) of the type parameter(s) in method 'Public Function Test2(Of T)(x As T, y As (T, T)) As T' cannot be inferred from these arguments. Specifying the data type(s) explicitly might correct this error.
+        Test2(Nothing, (Nothing, Nothing))
+        ~~~~~
+</errors>)
+        End Sub
+
+        <Fact()>
         Public Sub DataFlow()
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
 <compilation>
@@ -754,12 +1008,10 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30491: Expression does not produce a value.
+BC30311: Value of type '(C As Object, D As Object, E As Object)' cannot be converted to '(A As String, B As String)'.
         Dim x as (A as String, B as String) = (C:=Nothing, D:=Nothing, E:=Nothing)
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)
-
-
         End Sub
 
         <Fact>
@@ -2063,11 +2315,21 @@ Imports System
 Module C
     Sub Main()
         System.Console.WriteLine(Test((Nothing,"q")))
+        System.Console.WriteLine(Test(("q", Nothing)))
+
+        System.Console.WriteLine(Test1((Nothing, Nothing), (Nothing,"q")))
+        System.Console.WriteLine(Test1(("q", Nothing), (Nothing, Nothing)))
     End Sub
 
     Function Test(of T)(x as (T, T)) as (T, T)
         Console.WriteLine(Gettype(T))
 
+        return x
+    End Function
+
+        Function Test1(of T)(x as (T, T), y as (T, T)) as (T, T)
+        Console.WriteLine(Gettype(T))
+        
         return x
     End Function
 End Module
@@ -2076,6 +2338,12 @@ End Module
 </compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
 System.String
 (, q)
+System.String
+(q, )
+System.String
+(, )
+System.String
+(q, )
             ]]>)
 
         End Sub


### PR DESCRIPTION
In a case if target type is missing, vb tuple will have its default type which is a tuple composed of default types of its arguments.

Example:
     Dim x = (Nothing, Nothing)   ' x has type  (Object, Object)

NOTE:  Method type inference has additional rule for not inferring directly form Nothing literal. That rule is recursively applied in cases where tuple  like (Nothing, Nothing)  is passed to a tuple parameter of the same cardinality like (T, U). - No inference is made in this scenario.
It is consistent with behavior of two separate Nothing arguments passed to two separate parameters. Any other solution would introduce changes in behavior when multiple arguments/parameters are grouped into a tuple or flattened back.

Fixes: https://github.com/dotnet/roslyn/issues/12961
