### PR TITLE
Add new packages to RedistPackageNames list...

### DIFF
--- a/src/NuGet/BuildNuGets.csx
+++ b/src/NuGet/BuildNuGets.csx
@@ -76,6 +76,7 @@ var ThirdPartyNoticesPath = Path.Combine(NuGetAdditionalFilesPath, "ThirdPartyNo
 var NetCompilersPropsPath = Path.Combine(NuGetAdditionalFilesPath, "Microsoft.Net.Compilers.props");
 
 string[] RedistPackageNames = {
+    "Microsoft.CodeAnalysis",
     "Microsoft.CodeAnalysis.Common",
     "Microsoft.CodeAnalysis.Compilers",
     "Microsoft.CodeAnalysis.CSharp.Features",
@@ -85,7 +86,7 @@ string[] RedistPackageNames = {
     "Microsoft.CodeAnalysis.EditorFeatures",
     "Microsoft.CodeAnalysis.EditorFeatures.Text",
     "Microsoft.CodeAnalysis.Features",
-    "Microsoft.CodeAnalysis",
+    "Microsoft.CodeAnalysis.Remote.Workspaces",
     "Microsoft.CodeAnalysis.Scripting.Common",
     "Microsoft.CodeAnalysis.Scripting",
     "Microsoft.CodeAnalysis.VisualBasic.Features",
@@ -94,6 +95,7 @@ string[] RedistPackageNames = {
     "Microsoft.CodeAnalysis.VisualBasic.Workspaces",
     "Microsoft.CodeAnalysis.Workspaces.Common",
     "Microsoft.VisualStudio.LanguageServices",
+    "Microsoft.VisualStudio.LanguageServices.Next",
 };
 
 string[] NonRedistPackageNames = {
@@ -107,7 +109,9 @@ string[] TestPackageNames = {
 
 };
 
-// the following packages will only be publised on myget not on nuget:
+// The following packages will only be published on myget not on nuget
+// Packages listed here must also appear in RedistPackageNames (above)
+// or they will not be published anywhere at all
 var PreReleaseOnlyPackages = new HashSet<string>
 {
     "Microsoft.CodeAnalysis.VisualBasic.Scripting",


### PR DESCRIPTION
It is not sufficient to list a package in PreReleaseOnlyPackages.  It must
also be listed in the "master" list.  I've updated the comment to reflect
that fact.