### PR TITLE
Run data flow analysis over field initializers when instrumenting for dynamic analysis

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -888,6 +888,14 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                         if (body != null && ((methodSymbol.ContainingType.IsStructType() && !methodSymbol.IsImplicitConstructor) || instrumentForDynamicAnalysis))
                         {
+                            if (instrumentForDynamicAnalysis && methodSymbol.IsImplicitConstructor)
+                            {
+                                // Flow analysis over the initializers is necessary in order to find assignments to fields.
+                                // Bodies of implicit constructors do not get flow analysis later, so the initializers
+                                // are analyzed here.
+                                DataFlowPass.Analyze(_compilation, methodSymbol, analyzedInitializers, diagsForCurrentMethod, requireOutParamsAssigned: false);
+                            }
+
                             // In order to get correct diagnostics, we need to analyze initializers and the body together.
                             body = body.Update(body.Locals, body.LocalFunctions, body.Statements.Insert(0, analyzedInitializers));
                             includeInitializersInBody = false;

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -276,6 +276,7 @@ True
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
             verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.CreatePayload", expectedCreatePayloadIL);
             verifier.VerifyIL("Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload", expectedFlushPayloadIL);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -468,6 +469,7 @@ True
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
             verifier.VerifyIL("Program.Barney", expectedBarneyIL);
             verifier.VerifyIL(".cctor", expectedPIDStaticConstructorIL);
+            verifier.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_UnreachableCode, "Console").WithLocation(16, 9));
         }
 
         [Fact]
@@ -671,9 +673,11 @@ True
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
             verifier.VerifyIL("MyBox<T>.GetValue", expectedReleaseGetValueIL);
-            
+            verifier.VerifyDiagnostics();
+
             verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
             verifier.VerifyIL("MyBox<T>.GetValue", expectedDebugGetValueIL);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -743,8 +747,10 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
+            verifier.VerifyDiagnostics();
+            verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -846,8 +852,10 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
+            verifier.VerifyDiagnostics();
+            verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -922,8 +930,10 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.ReleaseExe);
+            verifier.VerifyDiagnostics();
+            verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput, options: TestOptions.DebugExe);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1018,6 +1028,10 @@ True
 ";
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics(
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "x").WithArguments("x").WithLocation(14, 13),
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "a").WithArguments("a").WithLocation(15, 13),
+                Diagnostic(ErrorCode.WRN_UnreferencedVar, "b").WithArguments("b").WithLocation(15, 16));
         }
 
         [Fact]
@@ -1110,6 +1124,7 @@ True
 ";
            
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, options: TestOptions.UnsafeDebugExe, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1187,7 +1202,7 @@ public class Program
             }
             x++;
         }
-        catch (System.Exception e)
+        catch (System.Exception)
         {
             x++;
         }
@@ -1210,7 +1225,7 @@ public class Program
                 ;
             }
         }
-        catch (System.Exception e)
+        catch (System.Exception)
         {
         }
 
@@ -1295,7 +1310,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1385,7 +1401,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_UnassignedInternalField, "Subject").WithArguments("Teacher.Subject", "null").WithLocation(37, 40));
         }
 
         [Fact]
@@ -1460,7 +1477,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1561,7 +1579,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1580,7 +1599,7 @@ public class C
 
     static void TestMain()                                      // Method 2
     {
-        C local = new C(); local = new C(1, 2);
+        C local = new C(); local = new C(1, s_z);
     }
 
     static int Init() => 33;                                    // Method 3
@@ -1671,7 +1690,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1691,7 +1711,7 @@ public class C
     static void TestMain()                                      // Method 2
     {
         C local = new C();
-        int x = local._x + C.s_x;
+        int x = local._x + local._y + C.s_x + C.s_y + C.s_z;
     }
 
     static int Init() => 33;                                    // Method 3
@@ -1754,7 +1774,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]
@@ -1876,7 +1897,8 @@ True
 True
 ";
 
-            CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+            verifier.VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -142,7 +142,7 @@ True
   IL_0038:  ret
 }
                 ]]>.Value)
-
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -197,7 +197,8 @@ True
             Dim preprocessorSymbols = ImmutableArray.Create(New KeyValuePair(Of String, Object)("_MyType", "Console"))
             Dim parseOptions = VisualBasicParseOptions.Default.WithPreprocessorSymbols(preprocessorSymbols)
 
-            CompileAndVerify(source, expectedOutput, TestOptions.ReleaseExe.WithParseOptions(parseOptions))
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput, TestOptions.ReleaseExe.WithParseOptions(parseOptions))
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -278,7 +279,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -417,6 +419,7 @@ True
   IL_0063:  ret
 }
                 ]]>.Value)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -491,7 +494,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -593,7 +597,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -747,7 +752,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -825,7 +831,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -911,7 +918,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -975,7 +983,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -1070,7 +1079,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -1140,7 +1150,15 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics(
+                Diagnostic(ERRID.WRN_UnusedLocal, "y").WithArguments("y").WithLocation(3, 16),
+                Diagnostic(ERRID.WRN_UnusedLocal, "o1").WithArguments("o1").WithLocation(14, 13),
+                Diagnostic(ERRID.WRN_UnusedLocal, "aa").WithArguments("aa").WithLocation(6, 17),
+                Diagnostic(ERRID.WRN_UnusedLocal, "o4").WithArguments("o4").WithLocation(14, 67),
+                Diagnostic(ERRID.WRN_UnusedLocal, "bb").WithArguments("bb").WithLocation(6, 21),
+                Diagnostic(ERRID.WRN_UnusedLocal, "cc").WithArguments("cc").WithLocation(7, 17),
+                Diagnostic(ERRID.WRN_UnusedLocal, "dd").WithArguments("dd").WithLocation(7, 32))
         End Sub
 
         <Fact>
@@ -1224,7 +1242,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -1334,7 +1353,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -1422,7 +1442,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>
@@ -1553,7 +1574,8 @@ True
 True
 ]]>
 
-            CompileAndVerify(source, expectedOutput)
+            Dim verifier As CompilationVerifier = CompileAndVerify(source, expectedOutput)
+            verifier.VerifyDiagnostics()
         End Sub
 
         <Fact>


### PR DESCRIPTION
When compiling with instrumentation for dynamic analysis, data flow analysis was not being run over initializers incorporated into synthesized constructors. This led to spurious diagnostics claiming that fields with initializers were not being initialized, because the initializations were never seen by flow analysis. This change set corrects that, and adds verification of diagnostics to all instrumentation tests.

@dotnet/roslyn-compiler @jcouv @cston @AlekseyTs @dotnet/testimpact @tannergooding @shyamnamboodiripad @ManishJayaswal 