### PR TITLE
Remove dependency on SemanticModel from FindRefs.

### DIFF
--- a/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
+++ b/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
@@ -470,7 +470,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
             private List<ValueTuple<SymbolDisplayPart, TextSpan>> AddSpans(
                 List<SymbolDisplayPart> parts)
             {
-                var result = new List<ValueTuple<SymbolDisplayPart, TextSpan>>();
+                var result = new List<ValueTuple<SymbolDisplayPart, TextSpan>>(parts.Count);
                 var position = 0;
 
                 foreach (var part in parts)

--- a/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
+++ b/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
@@ -400,8 +400,8 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
                 // (indeed, this happens with semantic classification as different
                 // providers produce different results in an arbitrary order).  Order
                 // them first before proceeding.
-                syntaxSpans = Order(syntaxSpans);
-                semanticSpans = Order(semanticSpans);
+                Order(syntaxSpans);
+                Order(semanticSpans);
 
                 // Produce SymbolDisplayParts for both sets of ClassifiedSpans.  This will
                 // also produce parts for the regions between the sections that the classifiers
@@ -416,9 +416,9 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
                 return CreateAllParts(syntaxParts, semanticParts);
             }
 
-            private List<ClassifiedSpan> Order(List<ClassifiedSpan> syntaxSpans)
+            private void Order(List<ClassifiedSpan> syntaxSpans)
             {
-                return syntaxSpans.OrderBy(s => s.TextSpan.Start).ToList();
+                syntaxSpans.Sort((s1, s2) => s1.TextSpan.Start - s2.TextSpan.Start);
             }
 
             private List<SymbolDisplayPart> CreateAllParts(

--- a/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
+++ b/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
@@ -396,16 +396,24 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
                 List<ClassifiedSpan> syntaxSpans, List<ClassifiedSpan> semanticSpans, 
                 TextSpan widenedSpan, SourceText sourceText)
             {
+                // The spans produced by the language services may not be ordered
+                // (indeed, this happens with semantic classification as different
+                // providers produce different results in an arbitrary order).  Order
+                // them first before proceeding.
                 syntaxSpans = Order(syntaxSpans);
                 semanticSpans = Order(semanticSpans);
 
+                // Produce SymbolDisplayParts for both sets of ClassifiedSpans.  This will
+                // also produce parts for the regions between the sections that the classifiers
+                // returned results for (i.e. for things like spaces and plain text).
                 var syntaxParts = Classifier.ConvertClassifications(
                     sourceText, widenedSpan.Start, syntaxSpans, insertSourceTextInGaps: true);
                 var semanticParts = Classifier.ConvertClassifications(
                     sourceText, widenedSpan.Start, semanticSpans, insertSourceTextInGaps: true);
 
-                var allParts = CreateAllParts(syntaxParts, semanticParts);
-                return allParts;
+                // Now merge the lists together, taking all the results from syntaxParts
+                // unless they were overridden by results in semanticParts.
+                return CreateAllParts(syntaxParts, semanticParts);
             }
 
             private List<ClassifiedSpan> Order(List<ClassifiedSpan> syntaxSpans)

--- a/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
+++ b/src/VisualStudio/Next/FindReferences/StreamingFindReferencesPresenter.TableDataSourceFindReferencesContext.cs
@@ -413,7 +413,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
 
                 // Now merge the lists together, taking all the results from syntaxParts
                 // unless they were overridden by results in semanticParts.
-                return CreateAllParts(syntaxParts, semanticParts);
+                return MergeParts(syntaxParts, semanticParts);
             }
 
             private void Order(List<ClassifiedSpan> syntaxSpans)
@@ -421,7 +421,7 @@ namespace Microsoft.VisualStudio.LanguageServices.FindReferences
                 syntaxSpans.Sort((s1, s2) => s1.TextSpan.Start - s2.TextSpan.Start);
             }
 
-            private List<SymbolDisplayPart> CreateAllParts(
+            private List<SymbolDisplayPart> MergeParts(
                 List<SymbolDisplayPart> syntaxParts,
                 List<SymbolDisplayPart> semanticParts)
             {

--- a/src/Workspaces/Core/Portable/Classification/Classifier.cs
+++ b/src/Workspaces/Core/Portable/Classification/Classifier.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.Classification
             return ConvertClassifications(sourceText, textSpan.Start, classifiedSpans, insertSourceTextInGaps);
         }
  
-        private static List<SymbolDisplayPart> ConvertClassifications(
+        internal static List<SymbolDisplayPart> ConvertClassifications(
             SourceText sourceText, int startPosition, IEnumerable<ClassifiedSpan> classifiedSpans, bool insertSourceTextInGaps = false)
         {
             var parts = new List<SymbolDisplayPart>();


### PR DESCRIPTION
I made a silly mistake and directly referenced SemanticModel from the new streaming find references code.  When TypeScript went to try to implement this, it blew up in their face :(

This change removes our dependency on SemanticModel and has us go through normal ILanguageServices to get the data we need.