### PR TITLE
Small change to DiagnosticFormatter

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Errors/DiagnosticFormatter.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/DiagnosticFormatter.vb
@@ -14,12 +14,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Friend Overrides Function FormatSourceSpan(span As LinePositionSpan, formatter As IFormatProvider) As String
-            Return String.Format("({0}) ", span.Start.Line + 1)
+            Return "(" & span.Start.Line + 1 &") "
         End Function
 
         ''' <summary>
         ''' Gets the current DiagnosticFormatter instance.
         ''' </summary>
-        Public Shared Shadows ReadOnly Property Instance As VisualBasicDiagnosticFormatter = New VisualBasicDiagnosticFormatter()
+        Public Shared Shadows ReadOnly Property Instance As New VisualBasicDiagnosticFormatter()
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Errors/DiagnosticFormatter.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/DiagnosticFormatter.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Friend Overrides Function FormatSourceSpan(span As LinePositionSpan, formatter As IFormatProvider) As String
-            Return "(" & span.Start.Line + 1 &") "
+            Return "(" & (span.Start.Line + 1).ToString() & ") "
         End Function
 
         ''' <summary>


### PR DESCRIPTION
Remove the String.Format, to use String Concatenation instead.
Simplify the Instance property,