### PR TITLE
Explicitly state that suppression state column in error list is only …

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/SuppressionStateColumnDefinition.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/Suppression/SuppressionStateColumnDefinition.cs
@@ -18,8 +18,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
     internal class SuppressionStateColumnDefinition : TableColumnDefinitionBase
     {
         public const string ColumnName = "suppressionstate";
-        private static readonly string[] s_defaultFilters = new[] { ServicesVSResources.Active, ServicesVSResources.Suppressed };
-        private static readonly string[] s_defaultCheckedFilters = new[] { ServicesVSResources.Active };
+        private static readonly string[] s_defaultFilters = new[] { ServicesVSResources.Active, ServicesVSResources.NotApplicable, ServicesVSResources.Suppressed };
+        private static readonly string[] s_defaultCheckedFilters = new[] { ServicesVSResources.Active, ServicesVSResources.NotApplicable };
 
         public override string Name => ColumnName;
         public override string DisplayName => ServicesVSResources.Suppression_State;
@@ -37,6 +37,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
             {
                 tableControl.SetFilter(ColumnName, new ColumnHashSetFilter(suppressionStateColumn, excluded: ServicesVSResources.Suppressed));
             }
+        }
+
+        public override bool TryCreateToolTip(ITableEntryHandle entry, out object toolTip)
+        {
+            object content;
+            if (entry.TryGetValue(ColumnName, out content) &&
+                content as string == ServicesVSResources.NotApplicable)
+            {
+                toolTip = ServicesVSResources.SuppressionNotSupportedToolTip;
+                return true;
+            }
+
+            toolTip = null;
+            return false;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TableDataSource/VisualStudioDiagnosticListTable.BuildTableDataSource.cs
@@ -233,9 +233,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TableDataSource
                             content = item.ProjectGuids;
                             return ((Guid[])content).Length > 0;
                         case SuppressionStateColumnDefinition.ColumnName:
-                            // Build doesn't report suppressed diagnostics.
+                            // Build doesn't support suppression.
                             Contract.ThrowIfTrue(data.IsSuppressed);
-                            content = ServicesVSResources.Active;
+                            content = ServicesVSResources.NotApplicable;
                             return true;
                         default:
                             content = null;

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -1141,6 +1141,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to N/A.
+        /// </summary>
+        internal static string NotApplicable {
+            get {
+                return ResourceManager.GetString("NotApplicable", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to OK.
         /// </summary>
         internal static string OK {
@@ -1539,6 +1548,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Suppression_State {
             get {
                 return ResourceManager.GetString("Suppression_State", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Suppression state is supported only for intellisense diagnostics, which are for the current solution snapshot. Switch to &apos;Intellisense&apos; diagnostics for suppression..
+        /// </summary>
+        internal static string SuppressionNotSupportedToolTip {
+            get {
+                return ResourceManager.GetString("SuppressionNotSupportedToolTip", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -480,6 +480,12 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="Suppressed" xml:space="preserve">
     <value>Suppressed</value>
   </data>
+  <data name="NotApplicable" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="SuppressionNotSupportedToolTip" xml:space="preserve">
+    <value>Suppression state is supported only for intellisense diagnostics, which are for the current solution snapshot. Switch to 'Intellisense' diagnostics for suppression.</value>
+  </data>
   <data name="Suppress_diagnostics" xml:space="preserve">
     <value>Suppress diagnostics</value>
   </data>


### PR DESCRIPTION
…supported for intellisense diagnostics

1. Suppression state column shows N/A for build diagnostics.
2. A descriptive tooltip is now shown on error list entries with unsupported suppression state, guiding users to switch to intellisense diagnostics for suppression.

Fixes #11371