### PR TITLE
Update AnalyzerDependencyChecker to flag analyzers if an assembly wit…

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/IDEDiagnosticIds.cs
@@ -23,5 +23,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         public const string ErrorReadingRulesetId = "IDE1004";
         public const string InvokeDelegateWithConditionalAccessId = "IDE1005";
         public const string NamingRuleId = "IDE1006";
+        public const string LoadedAssemblyAnalyzerConflictId = "IDE1007";
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyResults.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/AnalyzerDependencyResults.cs
@@ -7,18 +7,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
 {
     internal sealed class AnalyzerDependencyResults
     {
-        public static readonly AnalyzerDependencyResults Empty = new AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict>.Empty, ImmutableArray<MissingAnalyzerDependency>.Empty);
+        public static readonly AnalyzerDependencyResults Empty = new AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict>.Empty, ImmutableArray<MissingAnalyzerDependency>.Empty, ImmutableArray<LoadedAssemblyAnalyzerConflict>.Empty);
 
-        public AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict> conflicts, ImmutableArray<MissingAnalyzerDependency> missingDependencies)
+        public AnalyzerDependencyResults(ImmutableArray<AnalyzerDependencyConflict> conflicts, ImmutableArray<MissingAnalyzerDependency> missingDependencies, ImmutableArray<LoadedAssemblyAnalyzerConflict> loadedAssemblyAnalyzerConflicts)
         {
             Debug.Assert(conflicts != default(ImmutableArray<AnalyzerDependencyConflict>));
             Debug.Assert(missingDependencies != default(ImmutableArray<MissingAnalyzerDependency>));
+            Debug.Assert(loadedAssemblyAnalyzerConflicts != default(ImmutableArray<LoadedAssemblyAnalyzerConflict>));
 
             Conflicts = conflicts;
             MissingDependencies = missingDependencies;
+            LoadedAssemblyAnalyzerConflicts = loadedAssemblyAnalyzerConflicts;
         }
 
         public ImmutableArray<AnalyzerDependencyConflict> Conflicts { get; }
         public ImmutableArray<MissingAnalyzerDependency> MissingDependencies { get; }
+        public ImmutableArray<LoadedAssemblyAnalyzerConflict> LoadedAssemblyAnalyzerConflicts { get; }
     }
 }

--- a/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/LoadedAssemblyAnalyzerConflict.cs
+++ b/src/VisualStudio/Core/Def/Implementation/AnalyzerDependency/LoadedAssemblyAnalyzerConflict.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis;
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.LanguageServices.Implementation
+{
+    internal sealed class LoadedAssemblyAnalyzerConflict
+    {
+        public LoadedAssemblyAnalyzerConflict(AssemblyIdentity loadedAssemblyIdentity, AssemblyIdentity conflictingAnalyzerIdentity, string conflictingAnalyzerFilePath)
+        {
+            Debug.Assert(loadedAssemblyIdentity != null);
+            Debug.Assert(conflictingAnalyzerIdentity != null);            
+            Debug.Assert(conflictingAnalyzerFilePath != null);
+
+            LoadedAssemblyIdentity = loadedAssemblyIdentity;
+            ConflictingAnalyzerIdentity = conflictingAnalyzerIdentity;
+            ConflictingAnalyzerFilePath = conflictingAnalyzerFilePath;
+        }
+
+        public AssemblyIdentity LoadedAssemblyIdentity { get; }
+        public AssemblyIdentity ConflictingAnalyzerIdentity { get; }
+        public string ConflictingAnalyzerFilePath { get; }        
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -181,6 +181,17 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Analyzer assembly &apos;{0}&apos; cannot be loaded as another assembly with same name but different version &apos;{1}&apos; has already been loaded in the process. You may need to restart the process for analyzers to work correctly..
+        /// </summary>
+        internal static string Analyzer_assembly_0_cannot_be_loaded_as_another_assembly_with_same_name_but_different_version_1_has_already_been_loaded_in_the_process_You_may_need_to_restart_the_process_for_analyzers_to_work_correctly {
+            get {
+                return ResourceManager.GetString("Analyzer_assembly_0_cannot_be_loaded_as_another_assembly_with_same_name_but_diffe" +
+                        "rent_version_1_has_already_been_loaded_in_the_process_You_may_need_to_restart_th" +
+                        "e_process_for_analyzers_to_work_correctly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Analyzer assembly &apos;{0}&apos; depends on &apos;{1}&apos; but it was not found. Analyzers may not run correctly unless the missing assembly is added as an analyzer reference as well..
         /// </summary>
         internal static string Analyzer_assembly_0_depends_on_1_but_it_was_not_found_Analyzers_may_not_run_correctly_unless_the_missing_assembly_is_added_as_an_analyzer_reference_as_well {
@@ -196,6 +207,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Analyzer_reference_to_0_in_project_1 {
             get {
                 return ResourceManager.GetString("Analyzer_reference_to_0_in_project_1", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to AnalyzerAndLoadedAssemblyConflict.
+        /// </summary>
+        internal static string AnalyzerAndLoadedAssemblyConflict {
+            get {
+                return ResourceManager.GetString("AnalyzerAndLoadedAssemblyConflict", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -429,6 +429,12 @@ Use the dropdown to view and switch to other projects this file may belong to.</
   <data name="Analyzer_assemblies_0_and_1_both_have_identity_2_but_different_contents_Only_one_will_be_loaded_and_analyzers_using_these_assemblies_may_not_run_correctly" xml:space="preserve">
     <value>Analyzer assemblies '{0}' and '{1}' both have identity '{2}' but different contents. Only one will be loaded and analyzers using these assemblies may not run correctly.</value>
   </data>
+  <data name="AnalyzerAndLoadedAssemblyConflict" xml:space="preserve">
+    <value>AnalyzerAndLoadedAssemblyConflict</value>
+  </data>
+  <data name="Analyzer_assembly_0_cannot_be_loaded_as_another_assembly_with_same_name_but_different_version_1_has_already_been_loaded_in_the_process_You_may_need_to_restart_the_process_for_analyzers_to_work_correctly" xml:space="preserve">
+    <value>Analyzer assembly '{0}' cannot be loaded as another assembly with same name but different version '{1}' has already been loaded in the process. You may need to restart the process for analyzers to work correctly.</value>
+  </data>
   <data name="_0_references" xml:space="preserve">
     <value>{0} references</value>
   </data>

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -47,6 +47,7 @@
     <Compile Include="..\..\..\Compilers\Shared\ShadowCopyAnalyzerAssemblyLoader.cs">
       <Link>InternalUtilities\ShadowCopyAnalyzerAssemblyLoader.cs</Link>
     </Compile>
+    <Compile Include="Implementation\AnalyzerDependency\LoadedAssemblyAnalyzerConflict.cs" />
     <Compile Include="Implementation\AnalyzerDependency\AnalyzerDependencyResults.cs" />
     <Compile Include="IAnalyzerNodeSetup.cs" />
     <Compile Include="Implementation\AnalyzerDependency\AnalyzerDependencyChecker.cs" />

--- a/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
+++ b/src/VisualStudio/Core/Test/ServicesVisualStudioTest.vbproj
@@ -14,6 +14,10 @@
     <ForceGenerationOfBindingRedirects>true</ForceGenerationOfBindingRedirects>
   </PropertyGroup>
   <ItemGroup Label="Project References">
+    <ProjectReference Include="..\..\..\Compilers\Core\CodeAnalysisTest\CodeAnalysisTest.csproj">
+      <Project>{A4C99B85-765C-4C65-9C2A-BB609AAB09E6}</Project>
+      <Name>CodeAnalysisTest</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\Compilers\Core\Portable\CodeAnalysis.csproj">
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -302,6 +302,7 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         SuggestedActions_GetSuggestedActions,
         AnalyzerDependencyCheckingService_LogConflict,
         AnalyzerDependencyCheckingService_LogMissingDependency,
+        AnalyzerDependencyCheckingService_LogLoadedAssemblyAnalyzerConflict,
         VirtualMemory_MemoryLow,
         Extension_Exception,
 


### PR DESCRIPTION
…h same name but different version has already been loaded.

This scenario is very likely when the user updates his analyzer nuget references, but we are unable to load the new analyzer as the previous one is already loaded. We will now show a diagnostic about this conflict and ask the user to restart the process.

Fixes #4381