### PR TITLE
Adding a secondary check to validate whether we are on Dev15 Preview 4 or Dev15 Preview 3 from within VS.

### DIFF
--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -135,6 +135,8 @@
   <PropertyGroup>
     <IsVSBeforeDev15Preview4 Condition="'$(OS)' == 'Windows_NT' AND '$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
     <IsVSBeforeDev15Preview4 Condition="'$(OS)' == 'Windows_NT' AND '$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
+    <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
+    <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
   </PropertyGroup>
 
   <Choose>


### PR DESCRIPTION
FYI. @dotnet/roslyn-infrastructure, @Pilchie 

I believe just the second check is enough for both command line and VS builds, but I have not confirmed.

Basically, VS Preview 4 loads a private registry hive so the first check doesn't work when building from within VS. So instead, we look for the `devenv.isolation.ini` file, which (AFAIK) is only available on Dev15 Preview 4 or later.