### PR TITLE
Implemented case insensitivity for VB tuples.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8801,7 +8801,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tuple membername &apos;{0}&apos; is disallowed at any position..
+        ///   Looks up a localized string similar to Tuple member name &apos;{0}&apos; is disallowed at any position..
         /// </summary>
         internal static string ERR_TupleReservedMemberNameAnyPosition {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4849,7 +4849,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>
   <data name="ERR_TupleReservedMemberNameAnyPosition" xml:space="preserve">
-    <value>Tuple membername '{0}' is disallowed at any position.</value>
+    <value>Tuple member name '{0}' is disallowed at any position.</value>
   </data>
   <data name="ERR_PredefinedTypeMemberNotFoundInAssembly" xml:space="preserve">
     <value>Member '{0}' was not found on type '{1}' from assembly '{2}'.</value>

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3033,7 +3033,7 @@ class C
                 // (6,42): error CS8125: Tuple member name 'Item2' is only allowed at position 2.
                 //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item2").WithArguments("Item2", "2").WithLocation(6, 42),
-                // (6,100): error CS8126: Tuple membername 'Rest' is disallowed at any position.
+                // (6,100): error CS8126: Tuple member name 'Rest' is disallowed at any position.
                 //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 100),
                 // (6,111): error CS8125: Tuple member name 'Item2' is only allowed at position 2.
@@ -3042,7 +3042,7 @@ class C
                 // (6,125): error CS8125: Tuple member name 'Item4' is only allowed at position 4.
                 //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberName, "Item4").WithArguments("Item4", "4").WithLocation(6, 125),
-                // (6,189): error CS8126: Tuple membername 'Rest' is disallowed at any position.
+                // (6,189): error CS8126: Tuple member name 'Rest' is disallowed at any position.
                 //         (int Item1, string Item3, string Item2, int Item4, int Item5, int Item6, int Item7, string Rest) x = (Item2: "bad", Item4: "bad", Item3: 3, Item4: 4, Item5: 5, Item6: 6, Item7: 7, Rest: "bad");
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 189)
                );
@@ -3063,22 +3063,22 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef });
             comp.VerifyDiagnostics(
-                // (6,18): error CS8126: Tuple membername 'CompareTo' is disallowed at any position.
+                // (6,18): error CS8126: Tuple member name 'CompareTo' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "CompareTo").WithArguments("CompareTo").WithLocation(6, 18),
-                // (6,43): error CS8126: Tuple membername 'Deconstruct' is disallowed at any position.
+                // (6,43): error CS8126: Tuple member name 'Deconstruct' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Deconstruct").WithArguments("Deconstruct").WithLocation(6, 43),
-                // (6,59): error CS8126: Tuple membername 'Equals' is disallowed at any position.
+                // (6,59): error CS8126: Tuple member name 'Equals' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Equals").WithArguments("Equals").WithLocation(6, 59),
-                // (6,70): error CS8126: Tuple membername 'GetHashCode' is disallowed at any position.
+                // (6,70): error CS8126: Tuple member name 'GetHashCode' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "GetHashCode").WithArguments("GetHashCode").WithLocation(6, 70),
-                // (6,86): error CS8126: Tuple membername 'Rest' is disallowed at any position.
+                // (6,86): error CS8126: Tuple member name 'Rest' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "Rest").WithArguments("Rest").WithLocation(6, 86),
-                // (6,95): error CS8126: Tuple membername 'ToString' is disallowed at any position.
+                // (6,95): error CS8126: Tuple member name 'ToString' is disallowed at any position.
                 //         var x = (CompareTo: 2, Create: 3, Deconstruct: 4, Equals: 5, GetHashCode: 6, Rest: 8, ToString: 10);
                 Diagnostic(ErrorCode.ERR_TupleReservedMemberNameAnyPosition, "ToString").WithArguments("ToString").WithLocation(6, 95)
                 );

--- a/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
+++ b/src/Compilers/Core/Portable/CaseInsensitiveComparison.cs
@@ -181,6 +181,34 @@ namespace Microsoft.CodeAnalysis
                 return true;
             }
 
+            public static bool StartsWith(string value, string possibleStart)
+            {
+                if ((object)value == possibleStart)
+                {
+                    return true;
+                }
+
+                if ((object)value == null || (object)possibleStart == null)
+                {
+                    return false;
+                }
+
+                if (value.Length < possibleStart.Length)
+                {
+                    return false;
+                }
+
+                for(int i = 0; i < possibleStart.Length; i++)
+                {
+                    if (!AreEqualLowerUnicode(value[i], possibleStart[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
             public override int GetHashCode(string str)
             {
                 int hashCode = Hash.FnvOffsetBias;
@@ -219,6 +247,14 @@ namespace Microsoft.CodeAnalysis
         /// <param name="possibleEnd"></param>
         /// <returns></returns>
         public static bool EndsWith(string value, string possibleEnd) => OneToOneUnicodeComparer.EndsWith(value, possibleEnd);
+
+        /// <summary>
+        /// Determines if the string 'value' starts with string 'possibleStart'.
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="possibleStart"></param>
+        /// <returns></returns>
+        public static bool StartsWith(string value, string possibleStart) => OneToOneUnicodeComparer.StartsWith(value, possibleStart);
 
         /// <summary>
         /// Compares two VB identifiers according to the VB identifier comparison rules.

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,11 +1,11 @@
 *REMOVED*Microsoft.CodeAnalysis.Compilation.Emit(System.IO.Stream peStream, System.IO.Stream pdbStream = null, System.IO.Stream xmlDocumentationStream = null, System.IO.Stream win32Resources = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ResourceDescription> manifestResources = null, Microsoft.CodeAnalysis.Emit.EmitOptions options = null, Microsoft.CodeAnalysis.IMethodSymbol debugEntryPoint = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Emit.EmitResult
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.ChildThatContainsPosition(int position) -> Microsoft.CodeAnalysis.SyntaxNodeOrToken
+*REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.SerializeTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.ToFullString() -> string
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.WriteTo(System.IO.TextWriter writer) -> void
 *REMOVED*override abstract Microsoft.CodeAnalysis.SyntaxNode.ToString() -> string
 *REMOVED*static Microsoft.CodeAnalysis.Text.SourceText.From(System.IO.Stream stream, System.Text.Encoding encoding = null, Microsoft.CodeAnalysis.Text.SourceHashAlgorithm checksumAlgorithm = Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha1, bool throwIfBinaryDetected = false) -> Microsoft.CodeAnalysis.Text.SourceText
 *REMOVED*static Microsoft.CodeAnalysis.Text.SourceText.From(byte[] buffer, int length, System.Text.Encoding encoding = null, Microsoft.CodeAnalysis.Text.SourceHashAlgorithm checksumAlgorithm = Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha1, bool throwIfBinaryDetected = false) -> Microsoft.CodeAnalysis.Text.SourceText
-*REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.SerializeTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 Microsoft.CodeAnalysis.CommandLineArguments.EmbeddedFiles.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.CommandLineSourceFile>
 Microsoft.CodeAnalysis.CommandLineArguments.SourceLink.get -> string
 Microsoft.CodeAnalysis.Compilation.CreateAnonymousTypeSymbol(System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol> memberTypes, System.Collections.Immutable.ImmutableArray<string> memberNames) -> Microsoft.CodeAnalysis.INamedTypeSymbol
@@ -779,6 +779,7 @@ override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWhileUntilLoopSta
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitWithStatement(Microsoft.CodeAnalysis.Semantics.IWithStatement operation) -> void
 override Microsoft.CodeAnalysis.Semantics.OperationWalker.VisitYieldBreakStatement(Microsoft.CodeAnalysis.Semantics.IReturnStatement operation) -> void
 override Microsoft.CodeAnalysis.SyntaxNode.ToString() -> string
+static Microsoft.CodeAnalysis.CaseInsensitiveComparison.StartsWith(string value, string possibleStart) -> bool
 static Microsoft.CodeAnalysis.EmbeddedText.FromBytes(string filePath, System.ArraySegment<byte> bytes, Microsoft.CodeAnalysis.Text.SourceHashAlgorithm checksumAlgorithm = Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha1) -> Microsoft.CodeAnalysis.EmbeddedText
 static Microsoft.CodeAnalysis.EmbeddedText.FromSource(string filePath, Microsoft.CodeAnalysis.Text.SourceText text) -> Microsoft.CodeAnalysis.EmbeddedText
 static Microsoft.CodeAnalysis.EmbeddedText.FromStream(string filePath, System.IO.Stream stream, Microsoft.CodeAnalysis.Text.SourceHashAlgorithm checksumAlgorithm = Microsoft.CodeAnalysis.Text.SourceHashAlgorithm.Sha1) -> Microsoft.CodeAnalysis.EmbeddedText

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -318,7 +318,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim hasNaturalType = True
 
             ' set of names already used
-            Dim uniqueFieldNames = PooledHashSet(Of String).GetInstance()
+            Dim uniqueFieldNames = New HashSet(Of String)(IdentifierComparison.Comparer)
 
             Dim boundArguments = ArrayBuilder(Of BoundExpression).GetInstance(arguments.Count)
             Dim elementTypes = ArrayBuilder(Of TypeSymbol).GetInstance(arguments.Count)
@@ -358,8 +358,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     hasNaturalType = False
                 End If
             Next
-
-            uniqueFieldNames.Free()
 
             If countOfExplicitNames <> 0 AndAlso countOfExplicitNames <> elementTypes.Count Then
                 hasErrors = True
@@ -423,7 +421,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Shared Function CheckTupleMemberName(name As String, index As Integer, syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag, uniqueFieldNames As PooledHashSet(Of String)) As Boolean
+        Private Shared Function CheckTupleMemberName(name As String, index As Integer, syntax As VisualBasicSyntaxNode, diagnostics As DiagnosticBag, uniqueFieldNames As HashSet(Of String)) As Boolean
             Dim reserved As Integer = TupleTypeSymbol.IsElementNameReserved(name)
             If reserved = 0 Then
                 Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_TupleReservedMemberNameAnyPosition, name)

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -694,7 +694,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim elementNames As ArrayBuilder(Of String) = Nothing
 
                 ' set of names already used
-                Dim uniqueFieldNames = PooledHashSet(Of String).GetInstance()
+                Dim uniqueFieldNames = New HashSet(Of String)(IdentifierComparison.Comparer)
                 Dim countOfExplicitNames As Integer = 0
 
                 For i As Integer = 0 To numElements - 1
@@ -723,8 +723,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Binder.CollectTupleFieldMemberNames(name, i + 1, numElements, elementNames)
                 Next
-
-                uniqueFieldNames.Free()
 
                 If countOfExplicitNames <> 0 AndAlso countOfExplicitNames <> numElements Then
                     Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_TupleExplicitNamesOnAllMembersOrNone)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -542,8 +542,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return "Item" & position
         End Function
 
+        Private Shared ForbiddenNames As HashSet(Of String) = New HashSet(Of String)(
+            {"CompareTo", "Deconstruct", "Equals", "GetHashCode", "Rest", "ToString"},
+            IdentifierComparison.Comparer)
+
         Private Shared Function IsElementNameForbidden(name As String) As Boolean
-            Return name = "CompareTo" OrElse name = "Deconstruct" OrElse name = "Equals" OrElse name = "GetHashCode" OrElse name = "Rest" OrElse name = "ToString"
+            Return ForbiddenNames.Contains(name)
         End Function
 
         Friend Shared Function IsElementNameReserved(name As String) As Integer
@@ -551,12 +555,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             If TupleTypeSymbol.IsElementNameForbidden(name) Then
                 result = 0
             Else
-                If name.StartsWith("Item", StringComparison.Ordinal) Then
+                If IdentifierComparison.StartsWith(name, "Item") Then
                     Dim s As String = name.Substring(4)
                     Dim num As Integer
 
                     If Integer.TryParse(s, num) Then
-                        If num > 0 AndAlso String.Equals(name, TupleTypeSymbol.TupleMemberName(num), StringComparison.Ordinal) Then
+                        If num > 0 AndAlso IdentifierComparison.Equals(name, TupleTypeSymbol.TupleMemberName(num)) Then
                             result = num
                             Return result
                         End If
@@ -664,21 +668,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 
                                     Dim defaultName As String = TupleMemberName(tupleFieldIndex + 1)
-                                    ' Add a field with default name if the given name Is different
-                                    If namesOfVirtualFields(tupleFieldIndex) <> defaultName Then
+
+                                    ' Add a field with default name regardless
+                                    members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, defaultName, -members.Count - 1, Nothing))
+
+                                    If Not IdentifierComparison.Equals(namesOfVirtualFields(tupleFieldIndex), defaultName) Then
                                         ' The name given doesn't match default name ItemTupleTypeSymbol.RestPosition, etc.
-                                        members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, defaultName, -members.Count - 1, Nothing))
-                                    End If
+                                        ' Add a field with the given name
+                                        Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))
 
-                                    ' Add a field with the given name
-                                    Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))
-
-                                    If field.Name = namesOfVirtualFields(tupleFieldIndex) Then
-                                        members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex, location))
-                                    Else
-                                        members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex, location))
+                                        If IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
+                                            members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex, location))
+                                        Else
+                                            members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex, location))
+                                        End If
                                     End If
-                                ElseIf field.Name = namesOfVirtualFields(tupleFieldIndex) Then
+                                ElseIf IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
                                     members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex,
                                                                                     If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))))
                                 Else
@@ -839,7 +844,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Overrides Function GetMembers(name As String) As ImmutableArray(Of Symbol)
-            Return Me.GetMembers().WhereAsArray(Function(m As Symbol) m.Name = name)
+            Return Me.GetMembers().WhereAsArray(Function(m As Symbol) IdentifierComparison.Equals(m.Name, name))
         End Function
 
         Public Overrides Function GetTypeMembers() As ImmutableArray(Of NamedTypeSymbol)

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -10389,7 +10389,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Tuple membername &apos;{0}&apos; is disallowed at any position..
+        '''  Looks up a localized string similar to Tuple member name &apos;{0}&apos; is disallowed at any position..
         '''</summary>
         Friend ReadOnly Property ERR_TupleReservedMemberNameAnyPosition() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5386,7 +5386,7 @@
     <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>
   <data name="ERR_TupleReservedMemberNameAnyPosition" xml:space="preserve">
-    <value>Tuple membername '{0}' is disallowed at any position.</value>
+    <value>Tuple member name '{0}' is disallowed at any position.</value>
   </data>
   <data name="ERR_TupleTooFewElements" xml:space="preserve">
     <value>Tuple must contain at least two elements.</value>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -3701,7 +3701,7 @@ BC37261: Tuple member name 'Item3' is only allowed at position 3.
 BC37261: Tuple member name 'Item2' is only allowed at position 2.
         Dim x As (Item1 As Integer, Item3 As String, Item2 As Integer, Item4 As Integer, Item5 As Integer, Item6 As Integer, Item7 As Integer, Rest As Integer) =
                                                      ~~~~~
-BC37260: Tuple membername 'Rest' is disallowed at any position.
+BC37260: Tuple member name 'Rest' is disallowed at any position.
         Dim x As (Item1 As Integer, Item3 As String, Item2 As Integer, Item4 As Integer, Item5 As Integer, Item6 As Integer, Item7 As Integer, Rest As Integer) =
                                                                                                                                                ~~~~
 BC37261: Tuple member name 'Item2' is only allowed at position 2.
@@ -3710,7 +3710,7 @@ BC37261: Tuple member name 'Item2' is only allowed at position 2.
 BC37261: Tuple member name 'Item4' is only allowed at position 4.
             (Item2:="bad", Item4:="bad", Item3:=3, Item4:=4, Item5:=5, Item6:=6, Item7:=7, Rest:="bad")
                            ~~~~~
-BC37260: Tuple membername 'Rest' is disallowed at any position.
+BC37260: Tuple member name 'Rest' is disallowed at any position.
             (Item2:="bad", Item4:="bad", Item3:=3, Item4:=4, Item5:=5, Item6:=6, Item7:=7, Rest:="bad")
                                                                                            ~~~~
 </errors>)
@@ -3735,22 +3735,22 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC37260: Tuple membername 'CompareTo' is disallowed at any position.
+BC37260: Tuple member name 'CompareTo' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                  ~~~~~~~~~
-BC37260: Tuple membername 'Deconstruct' is disallowed at any position.
+BC37260: Tuple member name 'Deconstruct' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                                           ~~~~~~~~~~~
-BC37260: Tuple membername 'Equals' is disallowed at any position.
+BC37260: Tuple member name 'Equals' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                                                           ~~~~~~
-BC37260: Tuple membername 'GetHashCode' is disallowed at any position.
+BC37260: Tuple member name 'GetHashCode' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                                                                      ~~~~~~~~~~~
-BC37260: Tuple membername 'Rest' is disallowed at any position.
+BC37260: Tuple member name 'Rest' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                                                                                      ~~~~
-BC37260: Tuple membername 'ToString' is disallowed at any position.
+BC37260: Tuple member name 'ToString' is disallowed at any position.
         Dim x = (CompareTo:=2, Create:=3, Deconstruct:=4, Equals:=5, GetHashCode:=6, Rest:=8, ToString:=10)
                                                                                               ~~~~~~~~
 </errors>)
@@ -5935,6 +5935,176 @@ End Module
             Assert.NotNull(model.GetSymbolInfo(type).Symbol)
             Assert.Equal("System.Int32", model.GetSymbolInfo(type).Symbol.ToTestDisplayString())
 
+        End Sub
+
+        <Fact>
+        Public Sub CaseSensitivity001()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Module Module1
+    Sub Main()
+        Dim x2 = (A:=10, B:=20)
+        System.Console.Write(x2.a)
+        System.Console.Write(x2.item2)
+        
+        Dim x3 = (item1 := 1, item2 := 2)
+        System.Console.Write(x3.Item1)
+        System.Console.WriteLine(x3.Item2)
+
+    End Sub
+End Module
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[102012]]>)
+
+        End Sub
+
+        <Fact>
+        Public Sub CaseSensitivity002()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+        <![CDATA[
+
+Module Module1
+    Sub Main()
+        Dim x1 = (A:=10, a:=20)
+        System.Console.Write(x1.a)
+        System.Console.Write(x1.A)
+
+        Dim x2 as (A as Integer, a As Integer) = (10, 20)
+        System.Console.Write(x1.a)
+        System.Console.Write(x1.A)
+
+        Dim x3 = (I1:=10, item1:=20)
+        Dim x4 = (Item1:=10, item1:=20)
+        Dim x5 = (item1:=10, item1:=20)
+        Dim x6 = (tostring:=10, item1:=20)
+    End Sub
+End Module
+        ]]>
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
+        System.Console.Write(x1.a)
+                             ~~~~
+BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
+        System.Console.Write(x1.A)
+                             ~~~~
+BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
+        System.Console.Write(x1.a)
+                             ~~~~
+BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
+        System.Console.Write(x1.A)
+                             ~~~~
+BC37261: Tuple member name 'item1' is only allowed at position 1.
+        Dim x3 = (I1:=10, item1:=20)
+                          ~~~~~
+BC37261: Tuple member name 'item1' is only allowed at position 1.
+        Dim x4 = (Item1:=10, item1:=20)
+                             ~~~~~
+BC37261: Tuple member name 'item1' is only allowed at position 1.
+        Dim x5 = (item1:=10, item1:=20)
+                             ~~~~~
+BC37260: Tuple member name 'tostring' is disallowed at any position.
+        Dim x6 = (tostring:=10, item1:=20)
+                  ~~~~~~~~
+BC37261: Tuple member name 'item1' is only allowed at position 1.
+        Dim x6 = (tostring:=10, item1:=20)
+                                ~~~~~
+</errors>)
+
+        End Sub
+
+        Public Sub CaseSensitivity003()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x as (Item1 as String, itEm2 as String, Bob as string) = (Nothing, Nothing, Nothing)
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+(, , )
+            ]]>)
+
+
+            Dim comp = verifier.Compilation
+            Dim tree = comp.SyntaxTrees(0)
+
+            Dim model = comp.GetSemanticModel(tree, ignoreAccessibility:=False)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(Nothing, Nothing, Nothing)", node.ToString())
+            Assert.Null(model.GetTypeInfo(node).Type)
+
+            Dim fields = From m In model.GetTypeInfo(node).ConvertedType.GetMembers()
+                         Where m.Kind = SymbolKind.Field
+                         Order By m.Name
+                         Select m.Name
+
+            ' check no duplication of original/default ItemX fields
+            Assert.Equal("Bob#Item1#Item2#Item3", fields.Join("#"))
+        End Sub
+
+        Public Sub CaseSensitivity004()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+
+    Sub Main()
+        Dim x = (
+                    I1 := 1,
+                    I2 := 2,
+                    I3 := 3,
+                    ITeM4 := 4,
+                    I5 := 5,
+                    I6 := 6,
+                    I7 := 7,
+                    ITeM8 := 8,
+                    ItEM9 := 9
+                )
+
+        System.Console.WriteLine(x.ToString())
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[
+(1, 2, 3, 4, 5, 6, 7, 8, 9)
+            ]]>)
+
+
+            Dim comp = verifier.Compilation
+            Dim tree = comp.SyntaxTrees(0)
+
+            Dim model = comp.GetSemanticModel(tree, ignoreAccessibility:=False)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Dim fields = From m In model.GetTypeInfo(node).Type.GetMembers()
+                         Where m.Kind = SymbolKind.Field
+                         Order By m.Name
+                         Select m.Name
+
+            ' check no duplication of original/default ItemX fields
+            Assert.Equal("I1#I2#I3#I5#I6#I7#Item1#Item2#Item3#Item4#Item5#Item6#Item7#Item8#Item9#Rest", fields.Join("#"))
         End Sub
 
     End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -6021,6 +6021,7 @@ BC37261: Tuple member name 'item1' is only allowed at position 1.
 
         End Sub
 
+        <Fact>
         Public Sub CaseSensitivity003()
 
             Dim verifier = CompileAndVerify(
@@ -6060,6 +6061,7 @@ End Module
             Assert.Equal("Bob#Item1#Item2#Item3", fields.Join("#"))
         End Sub
 
+        <Fact>
         Public Sub CaseSensitivity004()
 
             Dim verifier = CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -5990,12 +5990,18 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
+BC37262: Tuple member names must be unique.
+        Dim x1 = (A:=10, a:=20)
+                         ~
 BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
         System.Console.Write(x1.a)
                              ~~~~
 BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
         System.Console.Write(x1.A)
                              ~~~~
+BC37262: Tuple member names must be unique.
+        Dim x2 as (A as Integer, a As Integer) = (10, 20)
+                                 ~
 BC31429: 'A' is ambiguous because multiple kinds of members with this name exist in structure '(A As Integer, a As Integer)'.
         System.Console.Write(x1.a)
                              ~~~~


### PR DESCRIPTION
* tuples with names differing only by case are not allowed
* names that match predefined element names except for case do not result in additional names
* name-related errors are checked in case-insensitive fasion