### PR TITLE
Adding an IVT for 'Microsoft.VisualStudio.TestImpact.Visualizer' to 'Workspaces.csproj'

### DIFF
--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -267,6 +267,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.SolutionExplorer" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.VisualBasic" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.Xaml" />
+    <InternalsVisibleTo Include="Microsoft.VisualStudio.TestImpact.Visualizer" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.VisualBasic.Repl" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.Setup" />
     <InternalsVisibleTo Include="Roslyn.VisualStudio.DiagnosticsWindow" />


### PR DESCRIPTION
FYI. @jasonmalinowski, @dpoeschl, @mattwar, @Pilchie
Also FYI. @dotnet/roslyn-ide, @dotnet/testimpact 

The IVT is removed in the PR that makes the API public: https://github.com/dotnet/roslyn/pull/13407

If the API shape needs to be changed, the removal of the IVT should be included in that PR as well.