### PR TITLE
Simplifying some code in framework type code style

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/PreferFrameworkType/PreferFrameworkTypeCodeFixProvider.cs
+++ b/src/Features/Core/Portable/CodeFixes/PreferFrameworkType/PreferFrameworkTypeCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.PreferFrameworkType
             var typeSymbol = (ITypeSymbol)semanticModel.GetSymbolInfo(node, cancellationToken).Symbol;
             var replacementNode = generator.TypeExpression(typeSymbol).WithTriviaFrom(node);
 
-            return await document.ReplaceNodeAsync(node, replacementNode, cancellationToken).ConfigureAwait(false);
+            return document.WithSyntaxRoot(root.ReplaceNode(node, replacementNode));
         }
 
         private class PreferFrameworkTypeCodeAction : CodeAction.DocumentChangeAction

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
@@ -38,6 +39,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
                 DiagnosticSeverity.Hidden,
                 isEnabledByDefault: true);
 
+        private PerLanguageOption<CodeStyleOption<bool>> GetOptionForDeclarationContext =>
+            CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration;
+
+        private PerLanguageOption<CodeStyleOption<bool>> GetOptionForMemberAccessContext =>
+            CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess;
+
         public bool RunInProcess => true;
 
         public DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
@@ -62,6 +69,17 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
                 return;
             }
 
+            var semanticModel = context.SemanticModel;
+            var cancellationToken = context.CancellationToken;
+            var language = semanticModel.Language;
+
+            // if the user never prefers this style, do not analyze at all.
+            // we don't know the context of the node yet, so check all predefined type option preferences and bail early.
+            if (!IsStylePreferred(optionSet, language))
+            {
+                return;
+            }
+
             var predefinedTypeNode = (TPredefinedTypeSyntax)context.Node;
 
             // check if the predefined type is replaceable with an equivalent framework type.
@@ -70,9 +88,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
                 return;
             }
 
-            var semanticModel = context.SemanticModel;
-            var cancellationToken = context.CancellationToken;
-
             // check we have a symbol so that the fixer can generate the right type syntax from it.
             var typeSymbol = semanticModel.GetSymbolInfo(predefinedTypeNode, cancellationToken).Symbol as ITypeSymbol;
             if (typeSymbol == null)
@@ -80,35 +95,63 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
                 return;
             }
 
-            string applicableDiagnosticId;
-            PerLanguageOption<CodeStyleOption<bool>> applicableOption;
-
-            // we have a predefined type syntax that is either in a member access context or a declaration context. 
-            if (IsInMemberAccessOrCrefReferenceContext(predefinedTypeNode))
+            // earlier we did a context insensitive check to see if this style was preferred in *any* context at all.
+            // now, we have to make a context sensitive check to see if options settings for our context requires us to report a diagnostic.
+            string diagnosticId;
+            DiagnosticSeverity diagnosticSeverity;
+            if (ShouldReportDiagnostic(predefinedTypeNode, optionSet, language, out diagnosticId, out diagnosticSeverity))
             {
-                applicableOption = CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess;
-                applicableDiagnosticId = IDEDiagnosticIds.PreferFrameworkTypeInMemberAccessDiagnosticId;
-            }
-            else
-            {
-                applicableOption = CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration;
-                applicableDiagnosticId = IDEDiagnosticIds.PreferFrameworkTypeInDeclarationsDiagnosticId;
-            }
-
-            var optionValue = optionSet.GetOption(applicableOption, semanticModel.Language);
-            var preferFrameworkType = !optionValue.Value;
-
-            if (preferFrameworkType && optionValue.Notification.Value != DiagnosticSeverity.Hidden)
-            {
-                var descriptor = new DiagnosticDescriptor(applicableDiagnosticId,
+                var descriptor = new DiagnosticDescriptor(diagnosticId,
                         s_preferFrameworkTypeTitle,
                         s_preferFrameworkTypeMessage,
                         DiagnosticCategory.Style,
-                        optionValue.Notification.Value,
+                        diagnosticSeverity,
                         isEnabledByDefault: true);
 
                 context.ReportDiagnostic(Diagnostic.Create(descriptor, predefinedTypeNode.GetLocation()));
             }
         }
+
+        /// <summary>
+        /// Detects the context of this occurrence of predefined type and determines if we should report it.
+        /// </summary>
+        private bool ShouldReportDiagnostic(TPredefinedTypeSyntax predefinedTypeNode, OptionSet optionSet, string language,
+            out string diagnosticId, out DiagnosticSeverity severity)
+        {
+            CodeStyleOption<bool> optionValue;
+
+            // we have a predefined type syntax that is either in a member access context or a declaration context. 
+            // check the appropriate option and determine if we should report a diagnostic.
+            if (IsInMemberAccessOrCrefReferenceContext(predefinedTypeNode))
+            {
+                diagnosticId = IDEDiagnosticIds.PreferFrameworkTypeInMemberAccessDiagnosticId;
+                optionValue = optionSet.GetOption(GetOptionForMemberAccessContext, language);
+            }
+            else
+            {
+                diagnosticId = IDEDiagnosticIds.PreferFrameworkTypeInDeclarationsDiagnosticId;
+                optionValue = optionSet.GetOption(GetOptionForDeclarationContext, language);
+            }
+
+            severity = optionValue.Notification.Value;
+            return OptionSettingPrefersFrameworkType(optionValue, severity);
+        }
+
+        private bool IsStylePreferred(OptionSet optionSet, string language) =>
+            IsFrameworkTypePreferred(optionSet, GetOptionForDeclarationContext, language) ||
+            IsFrameworkTypePreferred(optionSet, GetOptionForMemberAccessContext, language);
+
+        private bool IsFrameworkTypePreferred(OptionSet optionSet, PerLanguageOption<CodeStyleOption<bool>> option, string language)
+        {
+            var optionValue = optionSet.GetOption(option, language);
+            return OptionSettingPrefersFrameworkType(optionValue, optionValue.Notification.Value);
+        }
+
+        /// <summary>
+        /// checks if style is preferred and the enforcement is not None.
+        /// </summary>
+        /// <remarks>if predefined type is not preferred, it implies the preference is framework type.</remarks>
+        private static bool OptionSettingPrefersFrameworkType(CodeStyleOption<bool> optionValue, DiagnosticSeverity severity) =>
+            !optionValue.Value && severity != DiagnosticSeverity.Hidden;
     }
 }


### PR DESCRIPTION
Addressing some last pieces of feedback from https://github.com/dotnet/roslyn/pull/13132

1. Simplify some code, in general
2. Check options ahead of time before performing any analysis and bail early. 

No functional change, hence no new tests required.