### PR TITLE
Long changes

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/Text/TextChangeTests.cs
@@ -622,7 +622,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [Fact]
-        public void TestMergeChanges_Overlapping()
+        public void TestMergeChanges_Overlapping_NewInsideOld()
         {
             var original = SourceText.From("Hello World");
             var change1 = original.WithChanges(new TextChange(new TextSpan(6, 0), "Cruel "));
@@ -633,6 +633,48 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(1, changes.Count);
             Assert.Equal(new TextSpan(6, 0), changes[0].Span);
             Assert.Equal("Cool ", changes[0].NewText);
+        }
+
+        [Fact]
+        public void TestMergeChanges_Overlapping_OldInsideNew()
+        {
+            var original = SourceText.From("Hello World");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(6, 0), "Cruel "));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(2, 14), "ar"));
+            Assert.Equal("Heard", change2.ToString());
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal(1, changes.Count);
+            Assert.Equal(new TextSpan(2, 8), changes[0].Span);
+            Assert.Equal("ar", changes[0].NewText);
+        }
+
+        [Fact]
+        public void TestMergeChanges_Overlapping_NewBeforeOld()
+        {
+            var original = SourceText.From("Hello World");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(6, 0), "Cruel "));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(4, 6), " Bel"));
+            Assert.Equal("Hell Bell World", change2.ToString());
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal(1, changes.Count);
+            Assert.Equal(new TextSpan(4, 2), changes[0].Span);
+            Assert.Equal(" Bell ", changes[0].NewText);
+        }
+
+        [Fact]
+        public void TestMergeChanges_Overlapping_OldBeforeNew()
+        {
+            var original = SourceText.From("Hello World");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(6, 0), "Cruel "));
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(7, 6), "wazy V"));
+            Assert.Equal("Hello Cwazy Vorld", change2.ToString());
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal(1, changes.Count);
+            Assert.Equal(new TextSpan(6, 1), changes[0].Span);
+            Assert.Equal("Cwazy V", changes[0].NewText);
         }
 
         [Fact]
@@ -679,6 +721,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal("o", changes[0].NewText);
             Assert.Equal(new TextSpan(8, 0), changes[1].Span);
             Assert.Equal("l", changes[1].NewText);
+        }
+
+        [Fact]
+        public void TestMergeChanges_BeforeAdjacent()
+        {
+            var original = SourceText.From("Hell");
+            var change1 = original.WithChanges(new TextChange(new TextSpan(4, 0), " World"));
+            Assert.Equal("Hell World", change1.ToString());
+            var change2 = change1.WithChanges(new TextChange(new TextSpan(4, 0), "o"));
+            Assert.Equal("Hello World", change2.ToString());
+
+            var changes = change2.GetTextChanges(original);
+            Assert.Equal(1, changes.Count);
+            Assert.Equal(new TextSpan(4, 0), changes[0].Span);
+            Assert.Equal("o World", changes[0].NewText);
         }
     }
 }

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Microsoft.CodeAnalysis.Text
@@ -15,7 +16,7 @@ namespace Microsoft.CodeAnalysis.Text
         // store old text weakly so we don't form unwanted chains of old texts (especially chains of ChangedTexts)
         // It is only used to identify the old text in GetChangeRanges which only returns the changes if old text matches identity.
         private readonly WeakReference<SourceText> _weakOldText;
-        private readonly ImmutableArray<TextChangeRange> _changes;
+        private readonly ChangeInfo _changes;
 
         public ChangedText(SourceText oldText, SourceText newText, ImmutableArray<TextChangeRange> changeRanges)
             : base(checksumAlgorithm: oldText.ChecksumAlgorithm)
@@ -28,7 +29,197 @@ namespace Microsoft.CodeAnalysis.Text
 
             _newText = newText;
             _weakOldText = new WeakReference<SourceText>(oldText);
-            _changes = changeRanges;
+            _changes = new ChangeInfo(changeRanges);
+
+            Map(oldText, _changes);
+        }
+
+        private class ChangeInfo
+        {
+            public ImmutableArray<TextChangeRange> ChangeRanges { get; }
+
+            public ChangeInfo(ImmutableArray<TextChangeRange> changeRanges)
+            {
+                this.ChangeRanges = changeRanges;
+            }
+        }
+
+        private static ConditionalWeakTable<object, ChangeInfo> s_nextChangeMap 
+            = new ConditionalWeakTable<object, ChangeInfo>();
+
+        private static void Map(SourceText originalText, ChangeInfo changes)
+        {
+            var originalChange = originalText as ChangedText;
+            if (originalChange != null)
+            {
+                s_nextChangeMap.Add(originalChange._changes, changes);
+            }
+            else 
+            {
+                s_nextChangeMap.Add(originalText, changes);
+            }
+        }
+
+        private ChangeInfo GetNextChanges(object sourceTextOrChangeInfo)
+        {
+            ChangeInfo info;
+            s_nextChangeMap.TryGetValue(sourceTextOrChangeInfo, out info);
+            return info;
+        }
+
+        private bool IsChangedFrom(SourceText oldText)
+        {
+            for (var info = GetNextChanges(oldText); info != null; info = GetNextChanges(info))
+            {
+                if (info == _changes)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static ImmutableArray<TextChangeRange> Merge(ImmutableArray<TextChangeRange> oldChanges, ImmutableArray<TextChangeRange> newChanges)
+        {
+            var list = new List<TextChangeRange>(oldChanges.Length + newChanges.Length);
+
+            int oldIndex = 0;
+            int newIndex = 0;
+            int oldDelta = 0;
+
+nextNewChange:
+            if (newIndex < newChanges.Length)
+            {
+                var newChange = newChanges[newIndex];
+
+nextOldChange:
+                if (oldIndex < oldChanges.Length)
+                {
+                    var oldChange = oldChanges[oldIndex];
+
+tryAgain:
+                    if (oldChange.Span.Length == 0 && oldChange.NewLength == 0)
+                    {
+                        // old change is a non-change, just ignore it and move on
+                        oldIndex++;
+                        goto nextOldChange;
+                    }
+                    else if (newChange.Span.Length == 0 && newChange.NewLength == 0)
+                    {
+                        // new change is a non-change, just ignore it and move on
+                        newIndex++;
+                        goto nextNewChange;
+                    }
+                    else if (newChange.Span.End < (oldChange.Span.Start + oldDelta))
+                    {
+                        // new change occurs entirely before old change
+                        var adjustedNewChange = new TextChangeRange(new TextSpan(newChange.Span.Start - oldDelta, newChange.Span.Length), newChange.NewLength);
+                        AddRange(list, adjustedNewChange);
+                        newIndex++;
+                        goto nextNewChange;
+                    }
+                    else if (newChange.Span.Start > oldChange.Span.Start + oldDelta + oldChange.NewLength)
+                    {
+                        // new change occurs entirely after old change
+                        AddRange(list, oldChange);
+                        oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength;
+                        oldIndex++;
+                        goto nextOldChange;
+                    }
+                    else if (newChange.Span.Start < oldChange.Span.Start + oldDelta)
+                    {
+                        // new change starts before old change, but overlaps
+                        // add as much of new change deletion as possible and try again
+                        var newChangeLeadingDeletion = (oldChange.Span.Start + oldDelta) - newChange.Span.Start;
+                        AddRange(list, new TextChangeRange(new TextSpan(newChange.Span.Start, newChangeLeadingDeletion), newChange.NewLength));
+                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, oldChange.Span.Length - newChangeLeadingDeletion), 0);
+                        goto tryAgain;
+                    }
+                    else if (newChange.Span.Start > oldChange.Span.Start + oldDelta)
+                    {
+                        // new change starts after old change, but overlaps
+                        // add as much of the old change as possible and try again
+                        var oldChangeLeadingInsertion = newChange.Span.Start - (oldChange.Span.Start + oldDelta);
+                        AddRange(list, new TextChangeRange(oldChange.Span, oldChangeLeadingInsertion));
+                        oldDelta = oldDelta - oldChange.Span.Length + oldChangeLeadingInsertion;
+                        oldChange = new TextChangeRange(new TextSpan(oldChange.Span.Start, 0), oldChange.NewLength - oldChangeLeadingInsertion);
+                        goto tryAgain;
+                    }
+                    else if (newChange.Span.Start == oldChange.Span.Start + oldDelta)
+                    {
+                        // new change and old change start at same position
+                        if (oldChange.NewLength == 0)
+                        {
+                            // old change is just a deletion, go ahead and old change now and deal with new change separately
+                            AddRange(list, oldChange);
+                            oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength;
+                            oldIndex++;
+                            goto nextOldChange;
+                        }
+                        else if (newChange.Span.Length == 0)
+                        {
+                            // new change is just an insertion, go ahead and tack it on with old change
+                            AddRange(list, new TextChangeRange(oldChange.Span, oldChange.NewLength + newChange.NewLength));
+                            oldDelta = oldDelta - oldChange.Span.Length + oldChange.NewLength;
+                            oldIndex++;
+                            newIndex++;
+                            goto nextNewChange;
+                        }
+                        else 
+                        {
+                            // delete as much from old change as new change can
+                            // a new change deletion is a reduction in the old change insertion
+                            var oldChangeReduction = Math.Min(oldChange.NewLength, newChange.Span.Length);
+                            AddRange(list, new TextChangeRange(oldChange.Span, oldChange.NewLength - oldChangeReduction));
+                            oldDelta = oldDelta - oldChange.Span.Length + (oldChange.NewLength - oldChangeReduction);
+                            oldIndex++;
+
+                            // deduct the amount removed from oldChange from newChange's deletion span (since its already been applied)
+                            newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length - oldChangeReduction), newChange.NewLength);
+                            goto nextOldChange;
+                        }
+                    }
+                }
+                else 
+                {
+                    // no more old changes, just add adjusted new change
+                    var adjustedNewChange = new TextChangeRange(new TextSpan(newChange.Span.Start - oldDelta, newChange.Span.Length), newChange.NewLength);
+                    AddRange(list, adjustedNewChange);
+                    newIndex++;
+                    goto nextNewChange;
+                }
+            }
+            else 
+            {
+                // no more new changes, just add remaining old changes
+                while (oldIndex < oldChanges.Length)
+                {
+                    AddRange(list, oldChanges[oldIndex]);
+                    oldIndex++;
+                }
+            }
+
+            return list.ToImmutableArray();
+        }
+
+        private static void AddRange(List<TextChangeRange> list, TextChangeRange range)
+        {
+            if (list.Count > 0)
+            {
+                var last = list[list.Count - 1];
+                if (last.Span.End == range.Span.Start)
+                {
+                    list[list.Count - 1] = new TextChangeRange(new TextSpan(last.Span.Start, last.Span.Length + range.Span.Length), last.NewLength + range.NewLength);
+                    return;
+                }
+                else 
+                {
+                    Debug.Assert(range.Span.Start > last.Span.End);
+                }
+            }
+
+            list.Add(range);
         }
 
         public override Encoding Encoding
@@ -38,7 +229,7 @@ namespace Microsoft.CodeAnalysis.Text
 
         public IEnumerable<TextChangeRange> Changes
         {
-            get { return _changes; }
+            get { return _changes.ChangeRanges; }
         }
 
         public override int Length
@@ -89,7 +280,7 @@ namespace Microsoft.CodeAnalysis.Text
             var changed = _newText.WithChanges(changes) as ChangedText;  
             if (changed != null)
             {
-                return new ChangedText(this, changed._newText, changed._changes);
+                return new ChangedText(this, changed._newText, changed._changes.ChangeRanges);
             }
             else 
             {
@@ -116,17 +307,57 @@ namespace Microsoft.CodeAnalysis.Text
                 if (actualOldText == oldText)
                 {
                     // same identity, so the changes must be the ones we have.
-                    return _changes;
+                    return _changes.ChangeRanges;
+                }
+
+                // if we've got a solid path to old text, merge all the change ranges
+                var path = GetPath(oldText);
+                if (path.Count > 1)
+                {
+                    var ranges = path[0]._changes.ChangeRanges;
+                    for (int i = 1; i < path.Count; i++)
+                    {
+                        ranges = Merge(ranges, path[i]._changes.ChangeRanges);
+                    }
+
+                    return ranges;                   
                 }
 
                 if (actualOldText.GetChangeRanges(oldText).Count == 0)
                 {
                     // the bases are different instances, but the contents are considered to be the same.
-                    return _changes;
+                    return _changes.ChangeRanges;
                 }
             }
 
             return ImmutableArray.Create(new TextChangeRange(new TextSpan(0, oldText.Length), _newText.Length));
+        }
+
+        private List<ChangedText> GetPath(SourceText oldText)
+        {
+            var list = new List<ChangedText>();
+            list.Add(this);
+
+            var text = this;
+            while (text != null)
+            {
+                SourceText actualOldText;
+                text._weakOldText.TryGetTarget(out actualOldText);
+
+                if (actualOldText == oldText)
+                {
+                    return list;
+                }
+
+                text = actualOldText as ChangedText;
+                if (text != null)
+                {
+                    list.Insert(0, text);
+                }
+            }
+
+            list.Clear();
+            return list;
         }
 
         /// <summary>
@@ -156,7 +387,7 @@ namespace Microsoft.CodeAnalysis.Text
             // true if last segment ends with CR and we need to check for CR+LF code below assumes that both CR and LF are also line breaks alone
             var endsWithCR = false;
 
-            foreach (var change in _changes)
+            foreach (var change in _changes.ChangeRanges)
             {
                 // include existing line starts that occur before this change
                 if (change.Span.Start > position)

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -6,17 +6,14 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 
 namespace Microsoft.CodeAnalysis.Text
 {
     internal sealed class ChangedText : SourceText
     {
         private readonly SourceText _newText;
-
-        // store old text weakly so we don't form unwanted chains of old texts (especially chains of ChangedTexts)
-        // It is only used to identify the old text in GetChangeRanges which only returns the changes if old text matches identity.
-        private readonly WeakReference<SourceText> _weakOldText;
-        private readonly ChangeInfo _changes;
+        private readonly ChangeInfo _info;
 
         public ChangedText(SourceText oldText, SourceText newText, ImmutableArray<TextChangeRange> changeRanges)
             : base(checksumAlgorithm: oldText.ChecksumAlgorithm)
@@ -28,56 +25,213 @@ namespace Microsoft.CodeAnalysis.Text
             Debug.Assert(!changeRanges.IsDefault);
 
             _newText = newText;
-            _weakOldText = new WeakReference<SourceText>(oldText);
-            _changes = new ChangeInfo(changeRanges);
-
-            Map(oldText, _changes);
+            _info = new ChangeInfo(changeRanges, new WeakReference<SourceText>(oldText), (oldText as ChangedText)?._info);
         }
 
         private class ChangeInfo
         {
             public ImmutableArray<TextChangeRange> ChangeRanges { get; }
 
-            public ChangeInfo(ImmutableArray<TextChangeRange> changeRanges)
+            // store old text weakly so we don't form unwanted chains of old texts (especially chains of ChangedTexts)
+            // used to identify the changes in GetChangeRanges.
+            public WeakReference<SourceText> WeakOldText { get; }
+
+            public ChangeInfo Previous { get; private set; }
+
+            public ChangeInfo(ImmutableArray<TextChangeRange> changeRanges, WeakReference<SourceText> weakOldText, ChangeInfo previous)
             {
                 this.ChangeRanges = changeRanges;
+                this.WeakOldText = weakOldText;
+                this.Previous = previous;
+                Clean();
+            }
+
+            // clean up 
+            private void Clean()
+            {
+                // look for last info in the chain that still has reference to old text
+                ChangeInfo lastInfo = this;
+                for (var info = this; info != null; info = info.Previous)
+                {
+                    SourceText tmp;
+                    if (info.WeakOldText.TryGetTarget(out tmp))
+                    {
+                        lastInfo = info;
+                    }
+                }
+
+                // break chain for any info's beyond that so they get GC'd
+                ChangeInfo prev;
+                while (lastInfo != null)
+                {
+                    prev = lastInfo.Previous;
+                    lastInfo.Previous = null;
+                    lastInfo = prev;
+                }
             }
         }
 
-        private static ConditionalWeakTable<object, ChangeInfo> s_nextChangeMap 
-            = new ConditionalWeakTable<object, ChangeInfo>();
-
-        private static void Map(SourceText originalText, ChangeInfo changes)
+        public override Encoding Encoding
         {
-            var originalChange = originalText as ChangedText;
-            if (originalChange != null)
+            get { return _newText.Encoding; }
+        }
+
+        public IEnumerable<TextChangeRange> Changes
+        {
+            get { return _info.ChangeRanges; }
+        }
+
+        public override int Length
+        {
+            get { return _newText.Length; }
+        }
+
+        internal override int StorageSize
+        {
+            get { return _newText.StorageSize; }
+        }
+
+        internal override ImmutableArray<SourceText> Segments
+        {
+            get { return _newText.Segments; }
+        }
+
+        internal override SourceText StorageKey
+        {
+            get { return _newText.StorageKey; }
+        }
+
+        public override char this[int position]
+        {
+            get { return _newText[position]; }
+        }
+
+        public override string ToString(TextSpan span)
+        {
+            return _newText.ToString(span);
+        }
+
+        public override SourceText GetSubText(TextSpan span)
+        {
+            return _newText.GetSubText(span);
+        }
+
+        public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
+        {
+            _newText.CopyTo(sourceIndex, destination, destinationIndex, count);
+        }
+
+        public override SourceText WithChanges(IEnumerable<TextChange> changes)
+        {
+            // compute changes against newText to avoid capturing strong references to this ChangedText instance.
+            // _newText will only ever be one of CompositeText, SubText, StringText or LargeText, so calling WithChanges on it 
+            // will either produce a ChangeText instance or the original instance in case of a empty change.
+            var changed = _newText.WithChanges(changes) as ChangedText;  
+            if (changed != null)
             {
-                s_nextChangeMap.Add(originalChange._changes, changes);
+                return new ChangedText(this, changed._newText, changed._info.ChangeRanges);
             }
             else 
             {
-                s_nextChangeMap.Add(originalText, changes);
+                // change was empty, so just return this same instance
+                return this;
             }
         }
 
-        private ChangeInfo GetNextChanges(object sourceTextOrChangeInfo)
+        public override IReadOnlyList<TextChangeRange> GetChangeRanges(SourceText oldText)
         {
-            ChangeInfo info;
-            s_nextChangeMap.TryGetValue(sourceTextOrChangeInfo, out info);
-            return info;
+            if (oldText == null)
+            {
+                throw new ArgumentNullException(nameof(oldText));
+            }
+
+            if (this == oldText)
+            {
+                return TextChangeRange.NoChanges;
+            }
+
+            // try this quick check first
+            SourceText actualOldText;
+            if (_info.WeakOldText.TryGetTarget(out actualOldText) && actualOldText == oldText)
+            {
+                // the supplied old text is the one we directly reference, so the changes must be the ones we have.
+                return _info.ChangeRanges;
+            }
+
+            // otherwise look to see if there are a series of changes from the old text to this text and merge them.
+            if (IsChangedFrom(oldText))
+            {
+                var changes = GetChangesBetween(oldText, this);
+                if (changes.Count > 1)
+                {
+                    return Merge(changes);
+                }
+            }
+
+            // the SourceText subtype for editor snapshots knows when two snapshots from the same buffer have the same contents
+            if (actualOldText != null && actualOldText.GetChangeRanges(oldText).Count == 0)
+            {
+                // the texts are different instances, but the contents are considered to be the same.
+                return _info.ChangeRanges;
+            }
+
+            return ImmutableArray.Create(new TextChangeRange(new TextSpan(0, oldText.Length), _newText.Length));
         }
 
         private bool IsChangedFrom(SourceText oldText)
         {
-            for (var info = GetNextChanges(oldText); info != null; info = GetNextChanges(info))
+            for (var info = _info; info != null; info = info.Previous)
             {
-                if (info == _changes)
+                SourceText text;
+                if (info.WeakOldText.TryGetTarget(out text) && text == oldText)
                 {
                     return true;
                 }
             }
 
             return false;
+        }
+
+        private static IReadOnlyList<ImmutableArray<TextChangeRange>> GetChangesBetween(SourceText oldText, ChangedText newText)
+        {
+            var list = new List<ImmutableArray<TextChangeRange>>();
+
+            var change = newText._info;
+            list.Add(change.ChangeRanges);
+
+            while (change != null)
+            {
+                SourceText actualOldText;
+                change.WeakOldText.TryGetTarget(out actualOldText);
+
+                if (actualOldText == oldText)
+                {
+                    return list;
+                }
+
+                change = change.Previous;
+                if (change != null)
+                {
+                    list.Insert(0, change.ChangeRanges);
+                }
+            }
+
+            // did not find old text, so not connected?
+            list.Clear();
+            return list;
+        }
+
+        private static ImmutableArray<TextChangeRange> Merge(IReadOnlyList<ImmutableArray<TextChangeRange>> changeSets)
+        {
+            Debug.Assert(changeSets.Count > 1);
+
+            var merged = changeSets[0];
+            for (int i = 1; i < changeSets.Count; i++)
+            {
+                merged = Merge(merged, changeSets[i]);
+            }
+
+            return merged;
         }
 
         private static ImmutableArray<TextChangeRange> Merge(ImmutableArray<TextChangeRange> oldChanges, ImmutableArray<TextChangeRange> newChanges)
@@ -88,17 +242,17 @@ namespace Microsoft.CodeAnalysis.Text
             int newIndex = 0;
             int oldDelta = 0;
 
-nextNewChange:
+        nextNewChange:
             if (newIndex < newChanges.Length)
             {
                 var newChange = newChanges[newIndex];
 
-nextOldChange:
+            nextOldChange:
                 if (oldIndex < oldChanges.Length)
                 {
                     var oldChange = oldChanges[oldIndex];
 
-tryAgain:
+                tryAgain:
                     if (oldChange.Span.Length == 0 && oldChange.NewLength == 0)
                     {
                         // old change is a non-change, just ignore it and move on
@@ -167,7 +321,7 @@ tryAgain:
                             newIndex++;
                             goto nextNewChange;
                         }
-                        else 
+                        else
                         {
                             // delete as much from old change as new change can
                             // a new change deletion is a reduction in the old change insertion
@@ -182,7 +336,7 @@ tryAgain:
                         }
                     }
                 }
-                else 
+                else
                 {
                     // no more old changes, just add adjusted new change
                     var adjustedNewChange = new TextChangeRange(new TextSpan(newChange.Span.Start - oldDelta, newChange.Span.Length), newChange.NewLength);
@@ -191,7 +345,7 @@ tryAgain:
                     goto nextNewChange;
                 }
             }
-            else 
+            else
             {
                 // no more new changes, just add remaining old changes
                 while (oldIndex < oldChanges.Length)
@@ -211,154 +365,17 @@ tryAgain:
                 var last = list[list.Count - 1];
                 if (last.Span.End == range.Span.Start)
                 {
+                    // merge changes together if they are adjacent
                     list[list.Count - 1] = new TextChangeRange(new TextSpan(last.Span.Start, last.Span.Length + range.Span.Length), last.NewLength + range.NewLength);
                     return;
                 }
-                else 
+                else
                 {
                     Debug.Assert(range.Span.Start > last.Span.End);
                 }
             }
 
             list.Add(range);
-        }
-
-        public override Encoding Encoding
-        {
-            get { return _newText.Encoding; }
-        }
-
-        public IEnumerable<TextChangeRange> Changes
-        {
-            get { return _changes.ChangeRanges; }
-        }
-
-        public override int Length
-        {
-            get { return _newText.Length; }
-        }
-
-        internal override int StorageSize
-        {
-            get { return _newText.StorageSize; }
-        }
-
-        internal override ImmutableArray<SourceText> Segments
-        {
-            get { return _newText.Segments; }
-        }
-
-        internal override SourceText StorageKey
-        {
-            get { return _newText.StorageKey; }
-        }
-
-        public override char this[int position]
-        {
-            get { return _newText[position]; }
-        }
-
-        public override string ToString(TextSpan span)
-        {
-            return _newText.ToString(span);
-        }
-
-        public override SourceText GetSubText(TextSpan span)
-        {
-            return _newText.GetSubText(span);
-        }
-
-        public override void CopyTo(int sourceIndex, char[] destination, int destinationIndex, int count)
-        {
-            _newText.CopyTo(sourceIndex, destination, destinationIndex, count);
-        }
-
-        public override SourceText WithChanges(IEnumerable<TextChange> changes)
-        {
-            // compute changes against newText to avoid capturing strong references to this ChangedText instance.
-            // _newText will only ever be one of CompositeText, SubText, StringText or LargeText, so calling WithChanges on it 
-            // will either produce a ChangeText instance or the original instance in case of a empty change.
-            var changed = _newText.WithChanges(changes) as ChangedText;  
-            if (changed != null)
-            {
-                return new ChangedText(this, changed._newText, changed._changes.ChangeRanges);
-            }
-            else 
-            {
-                // change was empty, so just return this same instance
-                return this;
-            }
-        }
-
-        public override IReadOnlyList<TextChangeRange> GetChangeRanges(SourceText oldText)
-        {
-            if (oldText == null)
-            {
-                throw new ArgumentNullException(nameof(oldText));
-            }
-
-            if (this == oldText)
-            {
-                return TextChangeRange.NoChanges;
-            }
-
-            SourceText actualOldText;
-            if (_weakOldText.TryGetTarget(out actualOldText))
-            {
-                if (actualOldText == oldText)
-                {
-                    // same identity, so the changes must be the ones we have.
-                    return _changes.ChangeRanges;
-                }
-
-                // if we've got a solid path to old text, merge all the change ranges
-                var path = GetPath(oldText);
-                if (path.Count > 1)
-                {
-                    var ranges = path[0]._changes.ChangeRanges;
-                    for (int i = 1; i < path.Count; i++)
-                    {
-                        ranges = Merge(ranges, path[i]._changes.ChangeRanges);
-                    }
-
-                    return ranges;                   
-                }
-
-                if (actualOldText.GetChangeRanges(oldText).Count == 0)
-                {
-                    // the bases are different instances, but the contents are considered to be the same.
-                    return _changes.ChangeRanges;
-                }
-            }
-
-            return ImmutableArray.Create(new TextChangeRange(new TextSpan(0, oldText.Length), _newText.Length));
-        }
-
-        private List<ChangedText> GetPath(SourceText oldText)
-        {
-            var list = new List<ChangedText>();
-            list.Add(this);
-
-            var text = this;
-            while (text != null)
-            {
-                SourceText actualOldText;
-                text._weakOldText.TryGetTarget(out actualOldText);
-
-                if (actualOldText == oldText)
-                {
-                    return list;
-                }
-
-                text = actualOldText as ChangedText;
-                if (text != null)
-                {
-                    list.Insert(0, text);
-                }
-            }
-
-            list.Clear();
-            return list;
         }
 
         /// <summary>
@@ -369,7 +386,7 @@ tryAgain:
             SourceText oldText;
             TextLineCollection oldLineInfo;
 
-            if (!_weakOldText.TryGetTarget(out oldText) || !oldText.TryGetLines(out oldLineInfo))
+            if (!_info.WeakOldText.TryGetTarget(out oldText) || !oldText.TryGetLines(out oldLineInfo))
             {
                 // no old line starts? do it the hard way.
                 return base.GetLinesCore();
@@ -388,7 +405,7 @@ tryAgain:
             // true if last segment ends with CR and we need to check for CR+LF code below assumes that both CR and LF are also line breaks alone
             var endsWithCR = false;
 
-            foreach (var change in _changes.ChangeRanges)
+            foreach (var change in _info.ChangeRanges)
             {
                 // include existing line starts that occur before this change
                 if (change.Span.Start > position)

--- a/src/Compilers/Core/Portable/Text/ChangedText.cs
+++ b/src/Compilers/Core/Portable/Text/ChangedText.cs
@@ -132,8 +132,8 @@ tryAgain:
                         // new change starts before old change, but overlaps
                         // add as much of new change deletion as possible and try again
                         var newChangeLeadingDeletion = (oldChange.Span.Start + oldDelta) - newChange.Span.Start;
-                        AddRange(list, new TextChangeRange(new TextSpan(newChange.Span.Start, newChangeLeadingDeletion), newChange.NewLength));
-                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, oldChange.Span.Length - newChangeLeadingDeletion), 0);
+                        AddRange(list, new TextChangeRange(new TextSpan(newChange.Span.Start - oldDelta, newChangeLeadingDeletion), 0));
+                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length - newChangeLeadingDeletion), newChange.NewLength);
                         goto tryAgain;
                     }
                     else if (newChange.Span.Start > oldChange.Span.Start + oldDelta)
@@ -144,6 +144,7 @@ tryAgain:
                         AddRange(list, new TextChangeRange(oldChange.Span, oldChangeLeadingInsertion));
                         oldDelta = oldDelta - oldChange.Span.Length + oldChangeLeadingInsertion;
                         oldChange = new TextChangeRange(new TextSpan(oldChange.Span.Start, 0), oldChange.NewLength - oldChangeLeadingInsertion);
+                        newChange = new TextChangeRange(new TextSpan(oldChange.Span.Start + oldDelta, newChange.Span.Length), newChange.NewLength);
                         goto tryAgain;
                     }
                     else if (newChange.Span.Start == oldChange.Span.Start + oldDelta)


### PR DESCRIPTION
@VSadov @jaredpar @Pilchie @DustinCampbell 

I'm looking for feedback on this potential change to the internal ChangedText implementation.

The purpose of this is to improve the the GetTextChanges API so that it can work against source texts separated by more than one explicit change, without keeping all old texts alive.  

Currently, if old text parameter is not the exact text that the current source text was created from (via a WithChanges call), it will report that the entire source text is a change from the old text.

The solution implements an algorithm that merges the change deltas across all the changes to compute the correct single set of deltas between the old and current source texts, given that there are a series of ChangedText instances between them.

It avoids holding onto old texts by instead holding onto a chain of ChangeInfo's instances, that in turn hold onto the old texts weakly.  The chain of ChangeInfo's gets broken opportunistically to keep these nominal allocations from accruing.

Note: this is not an existing scenario that I'm trying to fix.  However, we've already had to make many other changes to SourceText for scenarios we did not plan for but customers have come to rely on.  This is one of the remaining holes in the implementation.
