### PR TITLE
[Public API] Make 'Workspace.DocumentActiveContextChanged' public

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SyntacticClassificationTaggerProvider.TagComputer.cs
@@ -389,11 +389,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
                     span.Snapshot.AsText(), span.Span.ToTextSpan(), classifiedSpans, CancellationToken.None);
             }
 
-            private void OnDocumentActiveContextChanged(object sender, DocumentEventArgs args)
+            private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs args)
             {
-                if (_workspace != null)
+                if (_workspace != null && _workspace == args.Solution.Workspace)
                 {
-                    ParseIfThisDocument(null, args.Document.Project.Solution, args.Document.Id);
+                    ParseIfThisDocument(null, args.Solution, args.NewActiveContextDocumentId);
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Suggestions/SuggestedActionsSourceProvider.cs
@@ -746,10 +746,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Suggestions
                 }
             }
 
-            private void OnActiveContextChanged(object sender, DocumentEventArgs e)
+            private void OnActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
             {
                 // REVIEW: it would be nice for changed event to pass in both old and new document.
-                OnSuggestedActionsChanged(e.Document.Project.Solution.Workspace, e.Document.Id, e.Document.Project.Solution.WorkspaceVersion);
+                OnSuggestedActionsChanged(e.Solution.Workspace, e.NewActiveContextDocumentId, e.Solution.WorkspaceVersion);
             }
 
             private void OnDiagnosticsUpdated(object sender, DiagnosticsUpdatedArgs e)

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.DocumentActiveContextChangedEventSource.cs
@@ -25,11 +25,11 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
                 workspace.DocumentActiveContextChanged -= OnDocumentActiveContextChanged;
             }
 
-            private void OnDocumentActiveContextChanged(object sender, DocumentEventArgs e)
+            private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
             {
                 var document = SubjectBuffer.AsTextContainer().GetOpenDocumentInCurrentContext();
 
-                if (document != null && document.Id == e.Document.Id)
+                if (document != null && document.Id == e.NewActiveContextDocumentId)
                 {
                     this.RaiseChanged();
                 }

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticAnalyzerService_IncrementalAnalyzer.cs
@@ -61,9 +61,9 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             return new IncrementalAnalyzerDelegatee(this, workspace, _hostAnalyzerManager, _hostDiagnosticUpdateSource);
         }
 
-        private void OnDocumentActiveContextChanged(object sender, DocumentEventArgs e)
+        private void OnDocumentActiveContextChanged(object sender, DocumentActiveContextChangedEventArgs e)
         {
-            Reanalyze(e.Document.Project.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.Document.Id), highPriority: true);
+            Reanalyze(e.Solution.Workspace, documentIds: SpecializedCollections.SingletonEnumerable(e.NewActiveContextDocumentId), highPriority: true);
         }
 
         // internal for testing

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -14,11 +14,19 @@ Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Name.set -> void
 Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Value.get -> Microsoft.CodeAnalysis.DiagnosticSeverity
 Microsoft.CodeAnalysis.CodeStyle.NotificationOption.Value.set -> void
 Microsoft.CodeAnalysis.Document.GetOptionsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Options.DocumentOptionSet>
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.DocumentActiveContextChangedEventArgs(Microsoft.CodeAnalysis.Solution solution, Microsoft.CodeAnalysis.Text.SourceTextContainer sourceTextContainer, Microsoft.CodeAnalysis.DocumentId oldActiveContextDocumentId, Microsoft.CodeAnalysis.DocumentId newActiveContextDocumentId) -> void
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.NewActiveContextDocumentId.get -> Microsoft.CodeAnalysis.DocumentId
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.OldActiveContextDocumentId.get -> Microsoft.CodeAnalysis.DocumentId
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.Solution.get -> Microsoft.CodeAnalysis.Solution
+Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs.SourceTextContainer.get -> Microsoft.CodeAnalysis.Text.SourceTextContainer
 Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
 Microsoft.CodeAnalysis.Options.DocumentOptionSet
 Microsoft.CodeAnalysis.Options.DocumentOptionSet.GetOption<T>(Microsoft.CodeAnalysis.Options.PerLanguageOption<T> option) -> T
 Microsoft.CodeAnalysis.Options.OptionSet.OptionSet() -> void
 Microsoft.CodeAnalysis.Solution.Options.get -> Microsoft.CodeAnalysis.Options.OptionSet
+Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged -> System.EventHandler<Microsoft.CodeAnalysis.DocumentActiveContextChangedEventArgs>
+Microsoft.CodeAnalysis.Workspace.RaiseDocumentActiveContextChangedEventAsync(Microsoft.CodeAnalysis.Text.SourceTextContainer sourceTextContainer, Microsoft.CodeAnalysis.DocumentId oldActiveContextDocumentId, Microsoft.CodeAnalysis.DocumentId newActiveContextDocumentId) -> System.Threading.Tasks.Task
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement) -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.SyntaxNode>
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.InsertSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, int index, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CodeStyle.NotificationOption.ToString() -> string

--- a/src/Workspaces/Core/Portable/Workspace/DocumentActiveContextChangedEventArgs.cs
+++ b/src/Workspaces/Core/Portable/Workspace/DocumentActiveContextChangedEventArgs.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis
+{
+    public sealed class DocumentActiveContextChangedEventArgs : EventArgs
+    {
+        public Solution Solution { get; }
+        public SourceTextContainer SourceTextContainer { get; }
+        public DocumentId OldActiveContextDocumentId { get; }
+        public DocumentId NewActiveContextDocumentId { get; }
+
+        public DocumentActiveContextChangedEventArgs(Solution solution, SourceTextContainer sourceTextContainer, DocumentId oldActiveContextDocumentId, DocumentId newActiveContextDocumentId)
+        {
+            Contract.ThrowIfNull(solution);
+            Contract.ThrowIfNull(sourceTextContainer);
+            Contract.ThrowIfNull(oldActiveContextDocumentId);
+            Contract.ThrowIfNull(newActiveContextDocumentId);
+
+            this.Solution = solution;
+            this.SourceTextContainer = sourceTextContainer;
+            this.OldActiveContextDocumentId = oldActiveContextDocumentId;
+            this.NewActiveContextDocumentId = newActiveContextDocumentId;
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
+++ b/src/Workspaces/Core/Portable/Workspace/Workspace_Editor.cs
@@ -355,13 +355,16 @@ namespace Microsoft.CodeAnalysis
         {
             using (_serializationLock.DisposableWait())
             {
+                DocumentId oldActiveContextDocumentId;
+
                 using (_stateLock.DisposableWait())
                 {
+                    oldActiveContextDocumentId = _bufferToDocumentInCurrentContextMap[container];
                     _bufferToDocumentInCurrentContextMap[container] = documentId;
                 }
 
                 // fire and forget
-                this.RaiseDocumentActiveContextChangedEventAsync(this.CurrentSolution.GetDocument(documentId));
+                this.RaiseDocumentActiveContextChangedEventAsync(container, oldActiveContextDocumentId: oldActiveContextDocumentId, newActiveContextDocumentId: documentId);
             }
         }
 

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -548,6 +548,7 @@
     <Compile Include="Versions\ISemanticVersionTrackingService.cs" />
     <Compile Include="Versions\PersistedVersionStampLogger.cs" />
     <Compile Include="Workspace\AdhocWorkspace.cs" />
+    <Compile Include="Workspace\DocumentActiveContextChangedEventArgs.cs" />
     <Compile Include="Workspace\Host\Caching\ICachedObjectOwner.cs" />
     <Compile Include="Workspace\Host\Caching\CacheOptions.cs" />
     <Compile Include="Workspace\Host\Caching\ProjectCacheServiceFactory.cs" />


### PR DESCRIPTION
This change makes 'Workspace.DocumentActiveContextChanged' public and
introduces DocumentActiveContextChangedEventArgs to hold the relevant
set of arguments. All of its usages have also been updated.

This also introduces a change to make an old version of
RaiseDocumentActiveContextChangedEventAsync (a protected method of
Workspace) [Obsolete] and throw.