### PR TITLE
Do not use snippets when finding spell-check suggestions.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -461,5 +461,49 @@ class C
 
             await TestAsync(text, expected, compareTokens: false);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
+        [WorkItem(13345, "https://github.com/dotnet/roslyn/issues/13345")]
+        public async Task TestMissingOnSnippet()
+        {
+            await TestAsync(
+@"
+class C
+{
+    void M()
+    {
+        // here 'for' is a snippet, and we should not offer it.
+        [|foo|];
+    }
+}
+",
+@"
+class C
+{
+    void M()
+    {
+        // here 'for' is a snippet, and we should not offer it.
+        for;
+    }
+}
+");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
+        [WorkItem(13345, "https://github.com/dotnet/roslyn/issues/13345")]
+        public async Task TestNotMissingOnKeyword()
+        {
+            await TestMissingAsync(
+@"
+class C
+{
+    void M()
+    {
+        // here 'for' is a keyword, and we should offer it.
+        var v = [|foo|];
+    }
+}
+");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -472,7 +472,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a snippet, and we should not offer it.
+        // here 'for' is a keyword, and we should offer to spell check to it.
         [|foo|];
     }
 }
@@ -482,7 +482,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a snippet, and we should not offer it.
+        // here 'for' is a keyword, and we should offer to spell check to it.
         for;
     }
 }
@@ -499,7 +499,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a keyword, and we should offer it.
+        // here 'for' is a snippet, and we should not offer to spell check to it.
         var v = [|foo|];
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -464,7 +464,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
         [WorkItem(13345, "https://github.com/dotnet/roslyn/issues/13345")]
-        public async Task TestMissingOnSnippet()
+        public async Task TestNotMissingOnKeywordWhichIsAlsoASnippet()
         {
             await TestAsync(
 @"
@@ -491,7 +491,7 @@ class C
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsSpellcheck)]
         [WorkItem(13345, "https://github.com/dotnet/roslyn/issues/13345")]
-        public async Task TestNotMissingOnKeyword()
+        public async Task TestMissingOnKeywordWhichIsOnlyASnippet()
         {
             await TestMissingAsync(
 @"

--- a/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/SpellCheck/SpellCheckTests.cs
@@ -472,7 +472,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a keyword, and we should offer to spell check to it.
+        // here 'for' is a keyword and snippet, so we should offer to spell check to it.
         [|foo|];
     }
 }
@@ -482,7 +482,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a keyword, and we should offer to spell check to it.
+        // here 'for' is a keyword and snippet, so we should offer to spell check to it.
         for;
     }
 }
@@ -499,7 +499,7 @@ class C
 {
     void M()
     {
-        // here 'for' is a snippet, and we should not offer to spell check to it.
+        // here 'for' is *only* a snippet, and we should not offer to spell check to it.
         var v = [|foo|];
     }
 }

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -136,33 +136,54 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
+        private ImmutableArray<CompletionProvider> GetProviders(
+            ImmutableHashSet<string> roles, CompletionTrigger trigger, OptionSet options)
+        {
+            return FilterProviders(GetProviders(roles, trigger), trigger, options);
+        }
+
         protected virtual ImmutableArray<CompletionProvider> GetProviders(
             ImmutableHashSet<string> roles, CompletionTrigger trigger)
         {
-            var snippetsRule = this.GetRules().SnippetsRule;
+            return GetProviders(roles);
+        }
+
+        private ImmutableArray<CompletionProvider> FilterProviders(
+            ImmutableArray<CompletionProvider> providers,
+            CompletionTrigger trigger,
+            OptionSet options)
+        {
+            // If the caller passed along specific options that affect snippets,
+            // then defer to those.  Otherwise if the caller just wants the default
+            // behavior, then get the snippets behavior from our own rules.
+            var optionsRule = options.GetOption(CompletionOptions.SnippetsBehavior, this.Language);
+            var snippetsRule = optionsRule != SnippetsRule.Default
+                ? optionsRule
+                : GetRules().SnippetsRule;
 
             if (snippetsRule == SnippetsRule.Default ||
                 snippetsRule == SnippetsRule.NeverInclude)
             {
-                return GetProviders(roles).Where(p => !p.IsSnippetProvider).ToImmutableArray();
+                return providers.Where(p => !p.IsSnippetProvider).ToImmutableArray();
             }
             else if (snippetsRule == SnippetsRule.AlwaysInclude)
             {
-                return GetProviders(roles);
+                return providers;
             }
             else if (snippetsRule == SnippetsRule.IncludeAfterTypingIdentifierQuestionTab)
             {
                 if (trigger.Kind == CompletionTriggerKind.Snippets)
                 {
-                    return GetProviders(roles).Where(p => p.IsSnippetProvider).ToImmutableArray();
+                    return providers.Where(p => p.IsSnippetProvider).ToImmutableArray();
                 }
                 else
                 {
-                    return GetProviders(roles).Where(p => !p.IsSnippetProvider).ToImmutableArray();
+                    return providers.Where(p => !p.IsSnippetProvider).ToImmutableArray();
                 }
             }
 
             return ImmutableArray<CompletionProvider>.Empty;
+
         }
 
         internal protected CompletionProvider GetProvider(CompletionItem item)
@@ -193,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var defaultItemSpan = this.GetDefaultCompletionListSpan(text, caretPosition);
 
             options = options ?? document.Options;
-            var providers = GetProviders(roles, trigger);
+            var providers = GetProviders(roles, trigger, options);
 
             var completionProviderToIndex = GetCompletionProviderToIndex(providers);
 
@@ -442,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return Char.IsLetterOrDigit(trigger.Character) || trigger.Character == '.';
             }
 
-            var providers = this.GetProviders(roles, CompletionTrigger.Default);
+            var providers = GetProviders(roles, trigger, options);
             return providers.Any(p => p.ShouldTriggerCompletion(text, caretPosition, trigger, options));
         }
 

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.Completion
             }
         }
 
-        private ImmutableArray<CompletionProvider> GetProviders(
+        private ImmutableArray<CompletionProvider> GetFilteredProviders(
             ImmutableHashSet<string> roles, CompletionTrigger trigger, OptionSet options)
         {
             return FilterProviders(GetProviders(roles, trigger), trigger, options);
@@ -214,7 +214,7 @@ namespace Microsoft.CodeAnalysis.Completion
             var defaultItemSpan = this.GetDefaultCompletionListSpan(text, caretPosition);
 
             options = options ?? document.Options;
-            var providers = GetProviders(roles, trigger, options);
+            var providers = GetFilteredProviders(roles, trigger, options);
 
             var completionProviderToIndex = GetCompletionProviderToIndex(providers);
 
@@ -463,7 +463,7 @@ namespace Microsoft.CodeAnalysis.Completion
                 return Char.IsLetterOrDigit(trigger.Character) || trigger.Character == '.';
             }
 
-            var providers = GetProviders(roles, trigger, options);
+            var providers = GetFilteredProviders(roles, trigger, options);
             return providers.Any(p => p.ShouldTriggerCompletion(text, caretPosition, trigger, options));
         }
 

--- a/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
+++ b/src/Features/Core/Portable/SpellCheck/AbstractSpellCheckCodeFixProvider.cs
@@ -53,8 +53,15 @@ namespace Microsoft.CodeAnalysis.SpellCheck
         {
             var document = context.Document;
             var service = CompletionService.GetService(document);
+
+            // Disable snippets from ever appearing in the completion items. It's
+            // very unlikely the user would ever mispell a snippet, then use spell-
+            // checking to fix it, then try to invoke the snippet.
+            var options = document.Options.WithChangedOption(
+                CompletionOptions.SnippetsBehavior, document.Project.Language, SnippetsRule.NeverInclude);
+
             var completionList = await service.GetCompletionsAsync(
-                document, nameNode.SpanStart, cancellationToken: cancellationToken).ConfigureAwait(false);
+                document, nameNode.SpanStart, options: options, cancellationToken: cancellationToken).ConfigureAwait(false);
             if (completionList == null)
             {
                 return;


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/13345