### PR TITLE
Fix truncation of display parts for tuple property

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                           elementNames);
         }
 
-        public static TupleTypeSymbol Create(ImmutableArray<Location> locations, NamedTypeSymbol tupleCompatibleType, ImmutableArray<Location> elementLocations, ImmutableArray<string> elementNames)
+        private static TupleTypeSymbol Create(ImmutableArray<Location> locations, NamedTypeSymbol tupleCompatibleType, ImmutableArray<Location> elementLocations, ImmutableArray<string> elementNames)
         {
             Debug.Assert(tupleCompatibleType.IsTupleCompatible());
 

--- a/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
+++ b/src/EditorFeatures/CSharpTest/QuickInfo/SemanticQuickInfoSourceTests.cs
@@ -1774,6 +1774,26 @@ class C : I
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
+        public async Task TupleProperty()
+        {
+            await TestInMethodAsync(@"
+interface I
+{
+    (int, int) Name { get; set; }
+}
+
+class C : I
+{
+    (int, int) I.Name$$
+    {
+       get { throw new System.Exception(); }
+       set { }
+    }
+}",
+                MainDescription("(int, int) C.Name { get; set; }"));
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.QuickInfo)]
         public async Task Operator()
         {
             await TestInClassAsync(@"

--- a/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
+++ b/src/Features/CSharp/Portable/LanguageServices/CSharpSymbolDisplayService.SymbolDescriptionBuilder.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.LanguageServices
                 else
                 {
                     var fullParts = ToMinimalDisplayParts(symbol, s_propertySignatureDisplayFormat);
-                    var neededParts = fullParts.SkipWhile(p => p.Symbol == null);
+                    var neededParts = fullParts.SkipWhile(p => p.Symbol == null && string.CompareOrdinal(p.ToString(), "(") != 0);
                     AddToGroup(SymbolDescriptionGroups.MainDescription, neededParts);
                 }
             }


### PR DESCRIPTION
Adjust the truncation logic for displaying parts for a property with tuple type.
Previously, it would skip until the first part with a non-null symbol, which would be "int". The proposed truncation logic considers an open-paren.

The picture shows the bug (there is a missing paren):
![image](https://cloud.githubusercontent.com/assets/12466233/14964085/9b47c7c0-105b-11e6-9156-8d31225fb286.png)

I looked in the code for other instanced of display parts being truncated, but didn't find any so far.

Fixes https://github.com/dotnet/roslyn/issues/11016

@CyrusNajmabadi for review.