### PR TITLE
Prevent future backward compatibility issues around supporting deconstruction declaration as an out argument.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -7019,6 +7019,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Deconstruction is not supported for an &apos;out&apos; argument..
+        /// </summary>
+        internal static string ERR_OutVarDeconstructionIsNotSupported {
+            get {
+                return ResourceManager.GetString("ERR_OutVarDeconstructionIsNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{0}&apos; cannot define overloaded methods that differ only on ref and out.
         /// </summary>
         internal static string ERR_OverloadRefOut {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4944,4 +4944,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_InvalidInstrumentationKind" xml:space="preserve">
     <value>Invalid instrumentation kind: {0}</value>
   </data>
+  <data name="ERR_OutVarDeconstructionIsNotSupported" xml:space="preserve">
+    <value>Deconstruction is not supported for an 'out' argument.</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1431,6 +1431,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_ImplicitlyTypedOutVariableUsedInTheSameArgumentList = 8196,
         ERR_TypeInferenceFailedForImplicitlyTypedOutVariable = 8197,
         ERR_ExpressionTreeContainsOutVariable = 8198,
+        ERR_OutVarDeconstructionIsNotSupported = 8199,
         #endregion diagnostics for out var
     }
 }


### PR DESCRIPTION
Fixes #13148.

@dotnet/roslyn-compiler, @jcouv, @gafter Please review.  