### PR TITLE
remove vs.package.language=en-us

### DIFF
--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisExpressionEvaluator/Microsoft.CodeAnalysis.ExpressionEvaluator.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisExpressionEvaluator/Microsoft.CodeAnalysis.ExpressionEvaluator.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.ExpressionEvaluator
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=21BAC26D-2935-4D0D-A282-AD647E2592B5
 

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioInteractiveComponents/Microsoft.CodeAnalysis.VisualStudioInteractiveComponents.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.VisualStudio.InteractiveComponents
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=500fff63-afcf-4195-8db4-3fa8a5180e79
 

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetup/Microsoft.CodeAnalysis.VisualStudio.Setup.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetup/Microsoft.CodeAnalysis.VisualStudio.Setup.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.VisualStudio.Setup
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=0b5e8ddb-f12d-4131-a71d-77acc26a798f
 

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupInteractive/Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.VisualStudio.Setup.Interactive
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=A5E5EE8D-39AE-42FF-8BBF-53C5B09C07D7
 

--- a/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupNext/Microsoft.CodeAnalysis.VisualStudio.Setup.Next.swr
+++ b/src/Setup/DevDivVsix/MicrosoftCodeAnalysisLanguageServices/MicrosoftCodeAnalysisVisualStudioSetupNext/Microsoft.CodeAnalysis.VisualStudio.Setup.Next.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.CodeAnalysis.VisualStudio.Setup.Next
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=58293943-56F1-4734-82FC-0411DCF49DE1
 

--- a/src/Setup/DevDivVsix/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudio.InteractiveWindow.swr
+++ b/src/Setup/DevDivVsix/MicrosoftVisualStudioInteractiveWindow/Microsoft.VisualStudio.InteractiveWindow.swr
@@ -2,7 +2,6 @@ use vs
 
 package name=Microsoft.VisualStudio.InteractiveWindow
         version=$(Version)
-        vs.package.language=en-us
         vs.package.type=vsix
         vs.package.vsixId=1F42C6D0-F876-4AF0-8185-1BEB0A325BB2
 


### PR DESCRIPTION
this indicates to the installer that the package should **only** be installed on en-us machines, which is not what we want.

With this specifier removed the package can be installed for multiple languages.