### PR TITLE
Fix build to pick up VS.Tools.Roslyn nupkg

### DIFF
--- a/src/Tools/MicroBuild/publish-assets.ps1
+++ b/src/Tools/MicroBuild/publish-assets.ps1
@@ -51,7 +51,7 @@ try
         if (-not $test) 
         {
             <# Do not overwrite existing packages. #>
-            robocopy /xo /xn /xc (Join-Path $packagesDropDir "Roslyn") $coreXTRoot "VS.ExternalAPIs.Roslyn.*.nupkg"
+            robocopy /xo /xn /xc (Join-Path $packagesDropDir "Roslyn") $coreXTRoot "*.nupkg"
 
             <# TODO: Once all dependencies are available on NuGet we can merge the following two commands. #>
             robocopy /xo /xn /xc (Join-Path $packagesDropDir "ManagedDependencies") $coreXTRoot "VS.ExternalAPIs.*.nupkg"


### PR DESCRIPTION
To fix microbuild error: 
```
** Error ** Unable to find version '2.0.0-beta5-60830-06' of package 'VS.Tools.Roslyn'.
```

/cc @tmat @dotnet/roslyn-infrastructure 