### PR TITLE
make VS to send over initial assets in batch mode

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -21,7 +21,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             private readonly object _gate;
 
-            private SolutionChecksumUpdator _checksumUpdator;
+            private SolutionChecksumUpdater _checksumUpdater;
             private CancellationTokenSource _shutdownCancellationTokenSource;
             private Task<RemoteHostClient> _instanceTask;
 
@@ -66,8 +66,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                     var token = _shutdownCancellationTokenSource.Token;
 
-                    // create solution checksum updator
-                    _checksumUpdator = new SolutionChecksumUpdator(this, token);
+                    // create solution checksum updater
+                    _checksumUpdater = new SolutionChecksumUpdater(this, token);
 
                     _instanceTask = Task.Run(() => EnableAsync(token), token);
                 }
@@ -90,8 +90,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
                     _shutdownCancellationTokenSource.Cancel();
 
-                    _checksumUpdator.Shutdown();
-                    _checksumUpdator = null;
+                    _checksumUpdater.Shutdown();
+                    _checksumUpdater = null;
 
                     try
                     {
@@ -122,7 +122,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 }
 
                 // ensure we have solution checksum
-                _checksumUpdator.EnsureSolutionChecksum(cancellationToken);
+                _checksumUpdater.EnsureSolutionChecksum(cancellationToken);
 
                 return instanceTask;
             }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -33,6 +33,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 _analyzerService = analyzerService;
             }
 
+            public Workspace Workspace => _workspace;
+
             public void Enable()
             {
                 lock (_gate)
@@ -65,7 +67,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     var token = _shutdownCancellationTokenSource.Token;
 
                     // create solution checksum updator
-                    _checksumUpdator = new SolutionChecksumUpdator(_workspace, token);
+                    _checksumUpdator = new SolutionChecksumUpdator(this, token);
 
                     _instanceTask = Task.Run(() => EnableAsync(token), token);
                 }

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs
@@ -14,7 +14,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
     internal partial class RemoteHostClientServiceFactory
     {
-        private class SolutionChecksumUpdator : GlobalOperationAwareIdleProcessor
+        private class SolutionChecksumUpdater : GlobalOperationAwareIdleProcessor
         {
             private readonly SemaphoreSlim _gate;
             private readonly RemoteHostClientService _service;
@@ -25,7 +25,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             private CancellationTokenSource _globalOperationCancellationSource;
             private ChecksumScope _lastSnapshot;
 
-            public SolutionChecksumUpdator(RemoteHostClientService service, CancellationToken shutdownToken) :
+            public SolutionChecksumUpdater(RemoteHostClientService service, CancellationToken shutdownToken) :
                 base(AggregateAsynchronousOperationListener.CreateEmptyListener(),
                      service.Workspace.Services.GetService<IGlobalOperationNotificationService>(),
                      service.Workspace.Options.GetOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS), shutdownToken)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdator.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.SolutionChecksumUpdator.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Execution;
 using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.SolutionCrawler;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
@@ -15,7 +16,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     {
         private class SolutionChecksumUpdator : GlobalOperationAwareIdleProcessor
         {
-            private readonly Workspace _workspace;
+            private readonly SemaphoreSlim _gate;
+            private readonly RemoteHostClientService _service;
             private readonly ISolutionChecksumService _checksumService;
             private readonly SemaphoreSlim _event;
 
@@ -23,19 +25,19 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             private CancellationTokenSource _globalOperationCancellationSource;
             private ChecksumScope _lastSnapshot;
 
-            public SolutionChecksumUpdator(
-                Workspace workspace,
-                CancellationToken shutdownToken) :
+            public SolutionChecksumUpdator(RemoteHostClientService service, CancellationToken shutdownToken) :
                 base(AggregateAsynchronousOperationListener.CreateEmptyListener(),
-                     workspace.Services.GetService<IGlobalOperationNotificationService>(),
-                     workspace.Options.GetOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS), shutdownToken)
+                     service.Workspace.Services.GetService<IGlobalOperationNotificationService>(),
+                     service.Workspace.Options.GetOption(RemoteHostOptions.SolutionChecksumMonitorBackOffTimeSpanInMS), shutdownToken)
             {
-                _workspace = workspace;
-                _checksumService = _workspace.Services.GetService<ISolutionChecksumService>();
+                _service = service;
+                _checksumService = service.Workspace.Services.GetService<ISolutionChecksumService>();
+
+                _gate = new SemaphoreSlim(initialCount: 1);
                 _event = new SemaphoreSlim(initialCount: 0);
 
                 // start listening workspace change event
-                _workspace.WorkspaceChanged += OnWorkspaceChanged;
+                _service.Workspace.WorkspaceChanged += OnWorkspaceChanged;
 
                 // create its own cancellation token source
                 _globalOperationCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(shutdownToken);
@@ -96,13 +98,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 base.Shutdown();
 
                 // stop listening workspace change event
-                _workspace.WorkspaceChanged -= OnWorkspaceChanged;
+                _service.Workspace.WorkspaceChanged -= OnWorkspaceChanged;
 
                 CancelAndDispose(_globalOperationCancellationSource);
 
-                // release last snapshot
-                _lastSnapshot?.Dispose();
-                _lastSnapshot = null;
+                using (_gate.DisposableWait(CancellationToken.None))
+                {
+                    // release last snapshot
+                    _lastSnapshot?.Dispose();
+                    _lastSnapshot = null;
+                }
             }
 
             private void OnWorkspaceChanged(object sender, WorkspaceChangeEventArgs e)
@@ -128,21 +133,40 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
 
             private async Task UpdateSolutionChecksumAsync(CancellationToken cancellationToken)
             {
-                // hold onto previous snapshot
-                var previousSnapshot = _lastSnapshot;
+                using (await _gate.DisposableWaitAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    // hold onto previous snapshot
+                    var previousSnapshot = _lastSnapshot;
 
-                // create a new one (incrementally update the snapshot)
-                _lastSnapshot = await _checksumService.CreateChecksumAsync(_workspace.CurrentSolution, cancellationToken).ConfigureAwait(false);
+                    // create a new one (incrementally update the snapshot)
+                    _lastSnapshot = await _checksumService.CreateChecksumAsync(_service.Workspace.CurrentSolution, cancellationToken).ConfigureAwait(false);
 
-                // let old one go.
-                previousSnapshot?.Dispose();
+                    // let old one go.
+                    previousSnapshot?.Dispose();
+                }
             }
 
             private void CreateInitialSolutionChecksum()
             {
                 // initial solution checksum creation won't be affected by global operation.
                 // cancellation can only happen if it is being shutdown.
-                Task.Run(() => UpdateSolutionChecksumAsync(ShutdownCancellationToken), ShutdownCancellationToken);
+                Task.Run(async () =>
+                {
+                    await UpdateSolutionChecksumAsync(ShutdownCancellationToken).ConfigureAwait(false);
+
+                    var remoteHostClient = await _service.GetRemoteHostClientAsync(ShutdownCancellationToken).ConfigureAwait(false);
+                    if (remoteHostClient == null)
+                    {
+                        return;
+                    }
+
+                    var solution = _service.Workspace.CurrentSolution;
+                    using (var session = await remoteHostClient.CreateServiceSessionAsync(WellKnownRemoteHostServices.RemoteHostService, solution, ShutdownCancellationToken).ConfigureAwait(false))
+                    {
+                        // ask remote host to sync initial asset
+                        await session.InvokeAsync(WellKnownRemoteHostServices.RemoteHostService_SynchronizeAsync).ConfigureAwait(false);
+                    }
+                }, ShutdownCancellationToken);
             }
 
             private static void CancelAndDispose(CancellationTokenSource cancellationSource)

--- a/src/VisualStudio/Core/Def/Implementation/Remote/WellKnownRemoteHostServices.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/WellKnownRemoteHostServices.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.VisualStudio.LanguageServices.Remote
+{
+    internal class WellKnownRemoteHostServices
+    {
+        public const string RemoteHostService = "remoteHostService";
+        public const string RemoteHostService_Connect = "Connect";
+        public const string RemoteHostService_SynchronizeAsync = "SynchronizeAsync";
+    }
+}

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.RemoteHostClientService.cs" />
     <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.SolutionChecksumUpdator.cs" />
     <Compile Include="Implementation\Remote\RemoteHostOptions.cs" />
+    <Compile Include="Implementation\Remote\WellKnownRemoteHostServices.cs" />
     <Compile Include="Implementation\Serialization\AssemblySerializationInfoService.cs" />
     <Compile Include="Implementation\SolutionSize\SolutionSizeTracker.cs" />
     <Compile Include="Implementation\TableDataSource\DiagnosticTableControlEventProcessorProvider.AggregateDiagnosticTableControlEventProcessor.cs" />

--- a/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
+++ b/src/VisualStudio/Core/Def/ServicesVisualStudio.csproj
@@ -114,7 +114,7 @@
     <Compile Include="Implementation\Remote\RemoteHostClient.cs" />
     <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.cs" />
     <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.RemoteHostClientService.cs" />
-    <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.SolutionChecksumUpdator.cs" />
+    <Compile Include="Implementation\Remote\RemoteHostClientServiceFactory.SolutionChecksumUpdater.cs" />
     <Compile Include="Implementation\Remote\RemoteHostOptions.cs" />
     <Compile Include="Implementation\Remote\WellKnownRemoteHostServices.cs" />
     <Compile Include="Implementation\Serialization\AssemblySerializationInfoService.cs" />

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSession.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.JsonRpcSession.cs
@@ -188,7 +188,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     writer.WriteValue(checksum);
                     writer.WriteString(checksumObject.Kind);
 
-                    await checksumObject.WriteToAsync(writer, _source.Token).ConfigureAwait(false);
+                    await checksumObject.WriteObjectToAsync(writer, _source.Token).ConfigureAwait(false);
                 }
 
                 private async Task WriteMultipleAssetsAsync(ObjectWriter writer, byte[][] checksums)
@@ -206,7 +206,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         writer.WriteValue(checksum.ToArray());
                         writer.WriteString(checksumObject.Kind);
 
-                        await checksumObject.WriteToAsync(writer, _source.Token).ConfigureAwait(false);
+                        await checksumObject.WriteObjectToAsync(writer, _source.Token).ConfigureAwait(false);
                     }
                 }
 

--- a/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
+++ b/src/VisualStudio/Next/Remote/ServiceHubRemoteHostClient.cs
@@ -25,13 +25,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
             using (Logger.LogBlock(FunctionId.ServiceHubRemoteHostClient_CreateAsync, cancellationToken))
             {
                 var primary = new HubClient("ManagedLanguage.IDE.RemoteHostClient");
-                var remoteHostStream = await primary.RequestServiceAsync(WellKnownServiceHubServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
+                var remoteHostStream = await primary.RequestServiceAsync(WellKnownRemoteHostServices.RemoteHostService, cancellationToken).ConfigureAwait(false);
 
                 var instance = new ServiceHubRemoteHostClient(workspace, primary, remoteHostStream);
 
                 // make sure connection is done right
                 var current = $"VS ({Process.GetCurrentProcess().Id})";
-                var host = await instance._rpc.InvokeAsync<string>(WellKnownServiceHubServices.RemoteHostService_Connect, current).ConfigureAwait(false);
+                var host = await instance._rpc.InvokeAsync<string>(WellKnownRemoteHostServices.RemoteHostService_Connect, current).ConfigureAwait(false);
 
                 // TODO: change this to non fatal watson and make VS to use inproc implementation
                 Contract.ThrowIfFalse(host == current.ToString());

--- a/src/VisualStudio/Next/ServicesVisualStudio.Next.csproj
+++ b/src/VisualStudio/Next/ServicesVisualStudio.Next.csproj
@@ -108,7 +108,7 @@
     <Compile Include="FindReferences\TaggedTextAndHighlightSpan.cs" />
     <Compile Include="Remote\JsonRpcClient.cs" />
     <Compile Include="Remote\RemoteHostClientFactory.cs" />
-    <Compile Include="Remote\ServiceHubRemoteHostClient.JsonRpcSnapshot.cs" />
+    <Compile Include="Remote\ServiceHubRemoteHostClient.JsonRpcSession.cs" />
     <Compile Include="Remote\ServiceHubRemoteHostClient.cs" />
     <Compile Include="ServicesVisualStudioNextResources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Workspaces/Core/Portable/Execution/Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/Asset.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Execution
             _writer = writer;
         }
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             _writer(_value, writer, cancellationToken);
             return SpecializedTasks.EmptyTask;
@@ -69,7 +69,7 @@ namespace Microsoft.CodeAnalysis.Execution
             _writer = writer;
         }
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             _writer(_language, _value, writer, cancellationToken);
             return SpecializedTasks.EmptyTask;
@@ -90,7 +90,7 @@ namespace Microsoft.CodeAnalysis.Execution
             _reference = reference;
         }
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             _serializer.SerializeMetadataReference(_reference, writer, cancellationToken);
             return SpecializedTasks.EmptyTask;
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.Execution
             _reference = reference;
         }
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             _serializer.SerializeAnalyzerReference(_reference, writer, cancellationToken);
             return SpecializedTasks.EmptyTask;
@@ -137,7 +137,7 @@ namespace Microsoft.CodeAnalysis.Execution
             _state = state;
         }
 
-        public override async Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override async Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             var text = await _state.GetTextAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Workspaces/Core/Portable/Execution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Execution/Checksum.cs
@@ -125,5 +125,15 @@ namespace Microsoft.CodeAnalysis.Execution
 
             return new Checksum(builder.MoveToImmutable());
         }
+
+        public static string GetChecksumLogInfo(Checksum checksum)
+        {
+            return checksum.ToString();
+        }
+
+        public static string GetChecksumsLogInfo(IEnumerable<Checksum> checksums)
+        {
+            return string.Join("|", checksums.Select(c => c.ToString()));
+        }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
@@ -32,11 +32,11 @@ namespace Microsoft.CodeAnalysis.Execution
         }
 
         /// <summary>
-        /// This will write out this object's data to bits
+        /// This will write out this object's data (the data the checksum is associated with) to bits
         /// 
         /// this hide how each data is serialized to bits
         /// </summary>
-        public abstract Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken);
+        public abstract Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -58,7 +58,7 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public object[] Children { get; }
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             return _serializer.SerializeChecksumObjectWithChildrenAsync(this, writer, cancellationToken);
         }

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.ChecksumObjectCache.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.ChecksumObjectCache.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using Roslyn.Utilities;
 
@@ -38,6 +39,45 @@ namespace Microsoft.CodeAnalysis.Execution
 
             private ConcurrentDictionary<string, ChecksumObject> LazyKindToChecksumObjectMap => Volatile.Read(ref _lazyKindToChecksumObjectMap);
             private ConcurrentDictionary<Checksum, ChecksumObject> LazyChecksumToChecksumObjectMap => Volatile.Read(ref _lazyChecksumToChecksumObjectMap);
+
+            public int Count
+            {
+                get
+                {
+                    var count = 0;
+                    var checksumObject = SingleElementChecksumObject;
+                    if (checksumObject != null)
+                    {
+                        count++;
+                    }
+
+                    var checksumMap = LazyChecksumToChecksumObjectMap;
+                    if (checksumMap != null)
+                    {
+                        count += checksumMap.Count;
+                    }
+
+                    return count;
+                }
+            }
+
+            public IEnumerable<Checksum> GetChecksums()
+            {
+                var checksumObject = SingleElementChecksumObject;
+                if (checksumObject != null)
+                {
+                    yield return checksumObject.Checksum;
+                }
+
+                var checksumMap = LazyChecksumToChecksumObjectMap;
+                if (checksumMap != null)
+                {
+                    foreach (var checksum in checksumMap.Keys)
+                    {
+                        yield return checksum;
+                    }
+                }
+            }
 
             public ChecksumObject Add(ChecksumObject checksumObject)
             {

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.TreeNodes.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.TreeNodes.cs
@@ -100,6 +100,8 @@ namespace Microsoft.CodeAnalysis.Execution
                     return asset;
                 }
 
+                // given checksum doesn't exist in this additional assets. but will exist
+                // in one of tree nodes/additional assets/global assets
                 return null;
             }
         }
@@ -318,6 +320,8 @@ namespace Microsoft.CodeAnalysis.Execution
                     return checksumObject;
                 }
 
+                // given checksum doesn't exist in this entry of tree node. but will exist
+                // in one of tree nodes/additional assets/global assets
                 return null;
             }
 

--- a/src/Workspaces/Core/Portable/Execution/ISolutionChecksumService.cs
+++ b/src/Workspaces/Core/Portable/Execution/ISolutionChecksumService.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -42,7 +44,9 @@ namespace Microsoft.CodeAnalysis.Execution
         /// </summary>
         ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken);
 
-        // TODO: provide a way to walk whole hierarchical checksum tree or return multiple ChecksumObject
-        //       based on given predicate
+        /// <summary>
+        /// Get <see cref="ChecksumObject"/> corresponding to given <see cref="Checksum"/>. 
+        /// </summary>
+        ImmutableDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/ISolutionChecksumService.cs
+++ b/src/Workspaces/Core/Portable/Execution/ISolutionChecksumService.cs
@@ -45,8 +45,8 @@ namespace Microsoft.CodeAnalysis.Execution
         ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken);
 
         /// <summary>
-        /// Get <see cref="ChecksumObject"/> corresponding to given <see cref="Checksum"/>. 
+        /// Get <see cref="ChecksumObject"/>s corresponding to given <see cref="Checksum"/>s. 
         /// </summary>
-        ImmutableDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken);
+        IReadOnlyDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken);
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/PooledList.cs
+++ b/src/Workspaces/Core/Portable/Execution/PooledList.cs
@@ -10,35 +10,18 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal static class Creator
     {
+        public static PooledObject<HashSet<Checksum>> CreateChecksumSet(IEnumerable<Checksum> checksums)
+        {
+            var items = SharedPools.Default<HashSet<Checksum>>().GetPooledObject();
+
+            items.Object.UnionWith(checksums);
+
+            return items;
+        }
+
         public static PooledObject<List<T>> CreateList<T>()
         {
             return SharedPools.Default<List<T>>().GetPooledObject();
-        }
-
-        public static PooledObject<List<T>> CreateList<T>(T item1, T item2)
-        {
-            var items = SharedPools.Default<List<T>>().GetPooledObject();
-
-            items.Object.Add(item1);
-            items.Object.Add(item2);
-
-            return items;
-        }
-
-        public static PooledObject<List<T>> CreateList<T>(T item1, T item2, T item3, T item4, T item5, T item6, T item7, T item8)
-        {
-            var items = SharedPools.Default<List<T>>().GetPooledObject();
-
-            items.Object.Add(item1);
-            items.Object.Add(item2);
-            items.Object.Add(item3);
-            items.Object.Add(item4);
-            items.Object.Add(item5);
-            items.Object.Add(item6);
-            items.Object.Add(item7);
-            items.Object.Add(item8);
-
-            return items;
         }
     }
 }

--- a/src/Workspaces/Core/Portable/Execution/SolutionChecksumService.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionChecksumService.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Composition;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -68,9 +72,22 @@ namespace Microsoft.CodeAnalysis.Execution
                 }
             }
 
+            public ImmutableDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken)
+            {
+                using (Logger.LogBlock(FunctionId.SolutionChecksumServiceFactory_GetChecksumObjects, GetChecksumsLogInfo, checksums, cancellationToken))
+                {
+                    return _treeCollection.GetChecksumObjects(checksums, cancellationToken);
+                }
+            }
+
             private static string GetChecksumLogInfo(Checksum checksum)
             {
                 return checksum.ToString();
+            }
+
+            private static string GetChecksumsLogInfo(IEnumerable<Checksum> checksums)
+            {
+                return string.Join("|", checksums.Select(c => c.ToString()));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Execution/SolutionChecksumService.cs
+++ b/src/Workspaces/Core/Portable/Execution/SolutionChecksumService.cs
@@ -1,10 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Host;
@@ -66,28 +63,18 @@ namespace Microsoft.CodeAnalysis.Execution
 
             public ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken)
             {
-                using (Logger.LogBlock(FunctionId.SolutionChecksumServiceFactory_GetChecksumObject, GetChecksumLogInfo, checksum, cancellationToken))
+                using (Logger.LogBlock(FunctionId.SolutionChecksumServiceFactory_GetChecksumObject, Checksum.GetChecksumLogInfo, checksum, cancellationToken))
                 {
                     return _treeCollection.GetChecksumObject(checksum, cancellationToken);
                 }
             }
 
-            public ImmutableDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken)
+            public IReadOnlyDictionary<Checksum, ChecksumObject> GetChecksumObjects(IEnumerable<Checksum> checksums, CancellationToken cancellationToken)
             {
-                using (Logger.LogBlock(FunctionId.SolutionChecksumServiceFactory_GetChecksumObjects, GetChecksumsLogInfo, checksums, cancellationToken))
+                using (Logger.LogBlock(FunctionId.SolutionChecksumServiceFactory_GetChecksumObjects, Checksum.GetChecksumsLogInfo, checksums, cancellationToken))
                 {
                     return _treeCollection.GetChecksumObjects(checksums, cancellationToken);
                 }
-            }
-
-            private static string GetChecksumLogInfo(Checksum checksum)
-            {
-                return checksum.ToString();
-            }
-
-            private static string GetChecksumsLogInfo(IEnumerable<Checksum> checksums)
-            {
-                return string.Join("|", checksums.Select(c => c.ToString()));
             }
         }
     }

--- a/src/Workspaces/Core/Portable/Log/FunctionId.cs
+++ b/src/Workspaces/Core/Portable/Log/FunctionId.cs
@@ -345,5 +345,10 @@ namespace Microsoft.CodeAnalysis.Internal.Log
         AssetService_GetAssetAsync,
         SnapshotService_RequestAssetAsync,
         CompilationService_GetCompilationAsync,
+        RemoteHostService_Synchronize,
+        AssetService_TryGetAsset,
+        AssetService_SynchronizeAssetsAsync,
+        AssetService_SynchronizeSolutionAssetsAsync,
+        SolutionChecksumServiceFactory_GetChecksumObjects,
     }
 }

--- a/src/Workspaces/CoreTest/Execution/Extensions.cs
+++ b/src/Workspaces/CoreTest/Execution/Extensions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.UnitTests.Execution
         // somehow, ImmutableArray<T>.Enumerator doesn't implement IEnumerator<T>
         public IEnumerator<T> GetEnumerator() => Children.Select(t => t).GetEnumerator();
 
-        public override Task WriteToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
         {
             throw new NotImplementedException("should not be called");
         }

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTestBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using (var writer = new ObjectWriter(stream))
             {
                 // serialize asset to bits
-                await checksumObject.WriteToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+                await checksumObject.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
 
                 stream.Position = 0;
                 using (var reader = new ObjectReader(stream))
@@ -160,7 +160,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using (var writer = new ObjectWriter(stream))
             {
                 // serialize asset to bits
-                await originalChecksumObject.WriteToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+                await originalChecksumObject.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
 
                 stream.Position = 0;
                 using (var reader = new ObjectReader(stream))
@@ -185,7 +185,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
             {
-                await solutionId.WriteToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+                await solutionId.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
 
                 stream.Position = 0;
                 using (var reader = new ObjectReader(stream))

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -476,7 +476,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream))
             {
-                await asset.WriteToAsync(writer, CancellationToken.None).ConfigureAwait(false);
+                await asset.WriteObjectToAsync(writer, CancellationToken.None).ConfigureAwait(false);
 
                 stream.Position = 0;
                 using (var reader = new ObjectReader(stream))

--- a/src/Workspaces/Remote/Core/Services/AssetSource.cs
+++ b/src/Workspaces/Remote/Core/Services/AssetSource.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Execution;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Remote
 {
@@ -12,6 +14,7 @@ namespace Microsoft.CodeAnalysis.Remote
     internal abstract class AssetSource
     {
         private static int s_serviceId = 0;
+
         private readonly int _currentId = 0;
 
         protected AssetSource()
@@ -21,7 +24,7 @@ namespace Microsoft.CodeAnalysis.Remote
             RoslynServices.AssetService.RegisterAssetSource(_currentId, this);
         }
 
-        public abstract Task<object> RequestAssetAsync(int serviceId, Checksum checksum, CancellationToken cancellationToken);
+        public abstract Task<IList<ValueTuple<Checksum, object>>> RequestAssetsAsync(int serviceId, ISet<Checksum> checksums, CancellationToken cancellationToken);
 
         public void Done()
         {

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Execution;
@@ -32,7 +34,7 @@ namespace Microsoft.CodeAnalysis.Remote
                 _assetChannelCancellationToken = assetChannelCancellationToken;
             }
 
-            public override async Task<object> RequestAssetAsync(int serviceId, Checksum checksum, CancellationToken callerCancellationToken)
+            public override async Task<IList<ValueTuple<Checksum, object>>> RequestAssetsAsync(int serviceId, ISet<Checksum> checksums, CancellationToken callerCancellationToken)
             {
                 // it should succeed as long as matching VS is alive
                 // TODO: add logging mechanism using Logger
@@ -44,37 +46,46 @@ namespace Microsoft.CodeAnalysis.Remote
                 //
                 // 2. Request to required this asset has cancelled. (callerCancellationToken)
                 using (var mergedCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(_assetChannelCancellationToken, callerCancellationToken))
-                using (RoslynLogger.LogBlock(FunctionId.SnapshotService_RequestAssetAsync, GetRequestLogInfo, serviceId, checksum, mergedCancellationToken.Token))
+                using (RoslynLogger.LogBlock(FunctionId.SnapshotService_RequestAssetAsync, GetRequestLogInfo, serviceId, checksums, mergedCancellationToken.Token))
                 {
                     return await _rpc.InvokeAsync(WellKnownServiceHubServices.AssetService_RequestAssetAsync,
-                        new object[] { serviceId, checksum.ToArray() },
-                        (s, c) => ReadAssetAsync(s, _logger, serviceId, checksum, c), mergedCancellationToken.Token).ConfigureAwait(false);
+                        new object[] { serviceId, checksums.Select(c => c.ToArray()).ToArray() },
+                        (s, c) => ReadAssetsAsync(s, _logger, serviceId, checksums, c), mergedCancellationToken.Token).ConfigureAwait(false);
                 }
             }
 
-            private static Task<object> ReadAssetAsync(
-                Stream stream, TraceSource logger, int serviceId, Checksum checksum, CancellationToken cancellationToken)
+            private static Task<IList<ValueTuple<Checksum, object>>> ReadAssetsAsync(
+                Stream stream, TraceSource logger, int serviceId, ISet<Checksum> checksums, CancellationToken cancellationToken)
             {
+                var results = new List<ValueTuple<Checksum, object>>();
                 using (var reader = new ObjectReader(stream))
                 {
                     var responseServiceId = reader.ReadInt32();
                     Contract.ThrowIfFalse(serviceId == responseServiceId);
 
-                    var responseChecksum = new Checksum(reader.ReadArray<byte>());
-                    Contract.ThrowIfFalse(checksum == responseChecksum);
+                    var count = reader.ReadInt32();
+                    Contract.ThrowIfFalse(count == checksums.Count);
 
-                    var kind = reader.ReadString();
+                    for (var i = 0; i < count; i++)
+                    {
+                        var responseChecksum = new Checksum(reader.ReadArray<byte>());
+                        Contract.ThrowIfFalse(checksums.Contains(responseChecksum));
 
-                    // in service hub, cancellation means simply closed stream
-                    var @object = RoslynServices.AssetService.Deserialize<object>(kind, reader, cancellationToken);
+                        var kind = reader.ReadString();
 
-                    return Task.FromResult(@object);
+                        // in service hub, cancellation means simply closed stream
+                        var @object = RoslynServices.AssetService.Deserialize<object>(kind, reader, cancellationToken);
+
+                        results.Add(ValueTuple.Create(responseChecksum, @object));
+                    }
+
+                    return Task.FromResult<IList<ValueTuple<Checksum, object>>>(results);
                 }
             }
 
-            private static string GetRequestLogInfo(int serviceId, Checksum checksum)
+            private static string GetRequestLogInfo(int serviceId, IEnumerable<Checksum> checksums)
             {
-                return $"{serviceId} - {checksum.ToString()}";
+                return $"{serviceId} - {string.Join("|", checksums.Select(c => c.ToString()))}";
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
+++ b/src/Workspaces/Remote/ServiceHub/Services/SnapshotService.JsonRpcAssetSource.cs
@@ -50,11 +50,11 @@ namespace Microsoft.CodeAnalysis.Remote
                 {
                     return await _rpc.InvokeAsync(WellKnownServiceHubServices.AssetService_RequestAssetAsync,
                         new object[] { serviceId, checksums.Select(c => c.ToArray()).ToArray() },
-                        (s, c) => ReadAssetsAsync(s, _logger, serviceId, checksums, c), mergedCancellationToken.Token).ConfigureAwait(false);
+                        (s, c) => ReadAssets(s, _logger, serviceId, checksums, c), mergedCancellationToken.Token).ConfigureAwait(false);
                 }
             }
 
-            private static Task<IList<ValueTuple<Checksum, object>>> ReadAssetsAsync(
+            private static IList<ValueTuple<Checksum, object>> ReadAssets(
                 Stream stream, TraceSource logger, int serviceId, ISet<Checksum> checksums, CancellationToken cancellationToken)
             {
                 var results = new List<ValueTuple<Checksum, object>>();
@@ -79,13 +79,13 @@ namespace Microsoft.CodeAnalysis.Remote
                         results.Add(ValueTuple.Create(responseChecksum, @object));
                     }
 
-                    return Task.FromResult<IList<ValueTuple<Checksum, object>>>(results);
+                    return results;
                 }
             }
 
             private static string GetRequestLogInfo(int serviceId, IEnumerable<Checksum> checksums)
             {
-                return $"{serviceId} - {string.Join("|", checksums.Select(c => c.ToString()))}";
+                return $"{serviceId} - {Checksum.GetChecksumsLogInfo(checksums)}";
             }
         }
     }

--- a/src/Workspaces/Remote/ServiceHub/Shared/WellKnownServiceHubServices.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/WellKnownServiceHubServices.cs
@@ -4,9 +4,6 @@ namespace Microsoft.CodeAnalysis.Remote
 {
     internal static class WellKnownServiceHubServices
     {
-        public const string RemoteHostService = "remoteHostService";
-        public const string RemoteHostService_Connect = "Connect";
-
         public const string SnapshotService = "snapshotService";
         public const string SnapshotService_Done = "Done";
 


### PR DESCRIPTION
this makes sending over roslyn-internal solution data to OOP from 3 minutes to 4 seconds.

after that, only changed assets are sent over which is usually less than 1-2ms.

this optimization is only for actually moving data between 2 processes. there are other things involved which need to be optimized as well to make whole system to be faster than right now (which takes about 1+ mins for initial solution load)