### PR TITLE
Expose CodeLens API to CodeLens, cleanup API

### DIFF
--- a/src/EditorFeatures/Test/CodeLens/AbstractCodeLensTest.cs
+++ b/src/EditorFeatures/Test/CodeLens/AbstractCodeLensTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeLens
                         foreach (var span in annotatedSpan.Value)
                         {
                             var declarationSyntaxNode = syntaxNode.FindNode(span);
-                            var result = await new CodeLensReferenceService().FindMethodReferenceLocationsAsync(workspace.CurrentSolution,
+                            var result = await new CodeLensReferenceService().FindReferenceMethodsAsync(workspace.CurrentSolution,
                                 annotatedDocument.Id, declarationSyntaxNode, CancellationToken.None);
                             var count = result.Count();
                             Assert.Equal(expected, count);

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -84,7 +84,9 @@ namespace Microsoft.CodeAnalysis.CodeLens
             // Returns nodes from source not equal to actual location
             return from syntaxReference in symbol.DeclaringSyntaxReferences
                    let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
-                   where _queriedNode != candidateSyntaxNode
+                   where !(_queriedNode.Span == candidateSyntaxNode.Span &&
+                           _queriedNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath,
+                               StringComparison.OrdinalIgnoreCase))
                    select candidateSyntaxNode.GetLocation();
         }
 

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -78,21 +78,14 @@ namespace Microsoft.CodeAnalysis.CodeLens
                    (definition as IMethodSymbol)?.AssociatedSymbol != null;
         }
 
-        /// <summary>
-        /// Returns partial symbol locations whose node does not match the queried syntaxNode
-        /// </summary>
-        /// <param name="symbol">Symbol whose locations are queried</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Partial locations</returns>
+        // Returns partial symbol locations whose node does not match the queried syntaxNode
         private IEnumerable<Location> GetPartialLocations(ISymbol symbol, CancellationToken cancellationToken)
         {
             // Returns nodes from source not equal to actual location
             return from syntaxReference in symbol.DeclaringSyntaxReferences
-                let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
-                where !(_queriedNode.Span == candidateSyntaxNode.Span &&
-                        _queriedNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath,
-                            StringComparison.OrdinalIgnoreCase))
-                select syntaxReference.SyntaxTree.GetLocation(syntaxReference.Span);
+                   let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
+                   where _queriedNode != candidateSyntaxNode
+                   select candidateSyntaxNode.GetLocation();
         }
 
         public void OnDefinitionFound(ISymbol symbol)

--- a/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensFindReferenceProgress.cs
@@ -51,60 +51,48 @@ namespace Microsoft.CodeAnalysis.CodeLens
             _queriedSymbol = queriedDefinition;
             _queriedNode = queriedNode;
             _aggregateCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _locations = new ConcurrentSet<Location>();
+            _locations = new ConcurrentSet<Location>(LocationComparer.Instance);
 
             SearchCap = searchCap;
+        }
+
+        public void OnStarted()
+        {
         }
 
         public void OnCompleted()
         {
         }
 
-        /// <summary>
-        /// Returns partial symbol locations whose node does not match the given syntaxNode
-        /// </summary>
-        /// <param name="symbol">Symbol whose locations are queried</param>
-        /// <param name="syntaxNode">Syntax node to compare against to exclude location - actual location being queried</param>
-        /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Partial locations</returns>
-        private static IEnumerable<Location> GetPartialLocations(ISymbol symbol, SyntaxNode syntaxNode, CancellationToken cancellationToken)
+        public void OnFindInDocumentStarted(Document document)
         {
-            // Returns nodes from source not equal to actual location and matches the definition locations to syntax references, ignores metadata locations
-            return from syntaxReference in symbol.DeclaringSyntaxReferences
-                   let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
-                   where !(syntaxNode.Span == candidateSyntaxNode.Span &&
-                           syntaxNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath, StringComparison.OrdinalIgnoreCase))
-                   from sourceLocation in symbol.Locations
-                   where !sourceLocation.IsInMetadata
-                         && candidateSyntaxNode.SyntaxTree.Equals(sourceLocation.SourceTree)
-                         && candidateSyntaxNode.Span.Contains(sourceLocation.SourceSpan)
-                   select sourceLocation;
         }
 
-        /// <summary>
-        /// Exclude the following kind of symbols:
-        ///  1. Implicitly declared symbols (such as implicit fields backing properties)
-        ///  2. Symbols that can't be referenced by name (such as property getters and setters).
-        ///  3. Metadata only symbols, i.e. symbols with no location in source.
-        /// </summary>
-        private static bool FilterReference(ISymbol queriedSymbol, ISymbol definition, ReferenceLocation reference)
+        public void OnFindInDocumentCompleted(Document document)
         {
-            var isImplicitlyDeclared = definition.IsImplicitlyDeclared || definition.IsAccessor();
-            // FindRefs treats a constructor invocation as a reference to the constructor symbol and to the named type symbol that defines it.
-            // While we need to count the cascaded symbol definition from the named type to its constructor, we should not double count the
-            // reference location for the invocation while computing references count for the named type symbol. 
-            var isImplicitReference = queriedSymbol.Kind == SymbolKind.NamedType &&
-                                      (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
-            return isImplicitlyDeclared ||
-                   isImplicitReference ||
-                   (!definition.Locations.Any(loc => loc.IsInSource) && !reference.Location.IsInSource);
         }
 
         private static bool FilterDefinition(ISymbol definition)
         {
             return definition.IsImplicitlyDeclared ||
-                   (definition as IMethodSymbol)?.AssociatedSymbol != null ||
-                   !definition.Locations.Any(loc => loc.IsInSource);
+                   (definition as IMethodSymbol)?.AssociatedSymbol != null;
+        }
+
+        /// <summary>
+        /// Returns partial symbol locations whose node does not match the queried syntaxNode
+        /// </summary>
+        /// <param name="symbol">Symbol whose locations are queried</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Partial locations</returns>
+        private IEnumerable<Location> GetPartialLocations(ISymbol symbol, CancellationToken cancellationToken)
+        {
+            // Returns nodes from source not equal to actual location
+            return from syntaxReference in symbol.DeclaringSyntaxReferences
+                let candidateSyntaxNode = syntaxReference.GetSyntax(cancellationToken)
+                where !(_queriedNode.Span == candidateSyntaxNode.Span &&
+                        _queriedNode.SyntaxTree.FilePath.Equals(candidateSyntaxNode.SyntaxTree.FilePath,
+                            StringComparison.OrdinalIgnoreCase))
+                select syntaxReference.SyntaxTree.GetLocation(syntaxReference.Span);
         }
 
         public void OnDefinitionFound(ISymbol symbol)
@@ -118,9 +106,11 @@ namespace Microsoft.CodeAnalysis.CodeLens
             // Add remote locations for all the syntax references except the queried syntax node.
             // To query for the partial locations, filter definition locations that occur in source whose span is part of
             // span of any syntax node from Definition.DeclaringSyntaxReferences except for the queried syntax node.
-            _locations.AddRange(symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any()
-                ? GetPartialLocations(symbol, _queriedNode, _aggregateCancellationTokenSource.Token)
-                : symbol.Locations);
+            var locations = symbol.Locations.Intersect(_queriedSymbol.Locations, LocationComparer.Instance).Any()
+                ? GetPartialLocations(symbol, _aggregateCancellationTokenSource.Token)
+                : symbol.Locations;
+
+            _locations.AddRange(locations.Where(location => location.IsInSource));
 
             if (SearchCapReached)
             {
@@ -128,17 +118,29 @@ namespace Microsoft.CodeAnalysis.CodeLens
             }
         }
 
-        public void OnFindInDocumentCompleted(Document document)
+        /// <summary>
+        /// Exclude the following kind of symbols:
+        ///  1. Implicitly declared symbols (such as implicit fields backing properties)
+        ///  2. Symbols that can't be referenced by name (such as property getters and setters).
+        ///  3. Metadata only symbols, i.e. symbols with no location in source.
+        /// </summary>
+        private bool FilterReference(ISymbol definition, ReferenceLocation reference)
         {
-        }
-
-        public void OnFindInDocumentStarted(Document document)
-        {
+            var isImplicitlyDeclared = definition.IsImplicitlyDeclared || definition.IsAccessor();
+            // FindRefs treats a constructor invocation as a reference to the constructor symbol and to the named type symbol that defines it.
+            // While we need to count the cascaded symbol definition from the named type to its constructor, we should not double count the
+            // reference location for the invocation while computing references count for the named type symbol. 
+            var isImplicitReference = _queriedSymbol.Kind == SymbolKind.NamedType &&
+                                      (definition as IMethodSymbol)?.MethodKind == MethodKind.Constructor;
+            return isImplicitlyDeclared ||
+                   isImplicitReference ||
+                   !reference.Location.IsInSource ||
+                   !definition.Locations.Any(loc => loc.IsInSource);
         }
 
         public void OnReferenceFound(ISymbol symbol, ReferenceLocation location)
         {
-            if (FilterReference(_queriedSymbol, symbol, location))
+            if (FilterReference(symbol, location))
             {
                 return;
             }
@@ -149,10 +151,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
             {
                 _aggregateCancellationTokenSource.Cancel();
             }
-        }
-
-        public void OnStarted()
-        {
         }
 
         public void ReportProgress(int current, int maximum)

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferenceService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferenceService.cs
@@ -33,10 +33,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
             }
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel == null)
-            {
-                return null;
-            }
 
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -92,10 +88,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
             }
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel == null)
-            {
-                return null;
-            }
 
             var langServices = document.GetLanguageService<ICodeLensDisplayInfoService>();
             if (langServices == null)
@@ -231,11 +223,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
             var document = solution.GetDocument(doc.Id);
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel == null)
-            {
-                return null;
-            }
-
             var fullName = GetEnclosingMethod(semanticModel, commonLocation)?.ToDisplayString(MethodDisplayFormat);
 
             return !string.IsNullOrEmpty(fullName) ? new ReferenceMethodDescriptor(fullName, document.FilePath) : null;
@@ -269,10 +256,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
             var document = solution.GetDocument(doc.Id);
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            if (semanticModel == null)
-            {
-                return null;
-            }
 
             return GetEnclosingMethod(semanticModel, commonLocation)?.ToDisplayString(MethodDisplayFormat);
         }

--- a/src/Features/Core/Portable/CodeLens/ICodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/ICodeLensReferencesService.cs
@@ -26,7 +26,13 @@ namespace Microsoft.CodeAnalysis.CodeLens
         /// <summary>
         /// Given a document and syntax node, returns a collection of locations of methods that refer to the located node.
         /// </summary>
-        Task<IEnumerable<ReferenceMethodDescriptor>> FindMethodReferenceLocationsAsync(Solution solution,
+        Task<IEnumerable<ReferenceMethodDescriptor>> FindReferenceMethodsAsync(Solution solution,
             DocumentId documentId, SyntaxNode syntaxNode, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Given a document and syntax node, returns the fully qualified name of the located node's declaration.
+        /// </summary>
+        Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -81,6 +81,7 @@
     <InternalsVisibleToTypeScript Include="Roslyn.Services.Editor.TypeScript.UnitTests" />
     <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.Alm.Shared.CodeAnalysisClient" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Shared\DesktopShim.cs">

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -82,6 +82,8 @@
     <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.Alm.Shared.CodeAnalysisClient" />
+    <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.ReferencesProvider" />
+    <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.TestsProvider" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Compilers\Shared\DesktopShim.cs">


### PR DESCRIPTION
This PR does three things:

* Makes the CodeLens API IVT to the VS CodeLens code (instead of making it public).
* Cleans up the code a little bit (for example, no need to do Distinct on a Set).
* Adds a missing API for CodeLens.

Can you look @heejaechang and @CyrusNajmabadi ?