### PR TITLE
Fix assertion problem with incremental parsing of deconstruction

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8451,7 +8451,6 @@ tryAgain:
                     {
                         return deconstruction;
                     }
-
                 }
                 finally
                 {

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -163,6 +163,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     {
                         // forget anything after and including any slot not holding a token
                         _tokenCount = i;
+                        if (_tokenCount == _tokenOffset)
+                        {
+                            FetchCurrentToken();
+                        }
                         break;
                     }
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17877,7 +17877,8 @@ class Program
             var startTree = SyntaxFactory.ParseSyntaxTree(text);
             var finalString = startTree.GetCompilationUnitRoot().ToFullString();
 
-            var newText = text.WithChanges(new TextChange(new TextSpan(80, 0), " ")); // add space before closing-paren
+            var pos = source1.IndexOf("var(a,  )") + 8;
+            var newText = text.WithChanges(new TextChange(new TextSpan(pos, 0), " ")); // add space before closing-paren
             var newTree = startTree.WithChangedText(newText);
             var finalText = newTree.GetCompilationUnitRoot().ToFullString();
             Assert.Equal(newText.ToString(), finalText);


### PR DESCRIPTION
The scenario is incremental parsing of `var (x,    )`, adding a space before the closing-paren. This currently hits an assertion in `SyntaxParser.Reset`. This is because when parsing a deconstruction, it is possible that we'll do two resets in a row.

The `_tokenCount` keeps track of how many token are usable in the `_blendedTokens` array. The `_tokenOffset` points to the one we're currently interested in.
The problem is that in a blending scenario the `Reset` may set `_tokenOffset` to `_tokenCount`, which prevents another call to `Reset` with the same offset.
This problem is not normally hit because any calls to `CurrentToken` will call `FetchCurrentToken()` which handles the situation. It puts more tokens in the `_blendedTokens` array and increments `_tokenCount` before the next attempt to `Reset`.

@mattwar @dotnet/roslyn-compiler for review.

Fixes https://github.com/dotnet/roslyn/issues/13494