### PR TITLE
Don't offer completion in a possible deconstruction declaration

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -277,6 +277,7 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        <WorkItem(13527, "https://github.com/dotnet/roslyn/issues/13527")>
         Public Async Function TestDeconstructionDeclaration4() As Task
             Using state = TestState.CreateCSharpTestState(
                   <Document><![CDATA[
@@ -291,6 +292,7 @@ class C
                 state.SendTypeChars("i")
                 Await state.WaitForAsynchronousOperationsAsync()
                 Await state.AssertSelectedCompletionItem(displayText:="int", isSoftSelected:=True)
+                ' We'd prefer hard-selection here, but only with ':' not acting as commit character
             End Using
         End Function
 

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -226,6 +226,75 @@ class C
         End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Foo()
+    {
+       var ($$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration2() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Foo()
+    {
+       var (a, $$
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration3() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Foo()
+    {
+       var ($$) = (1, 2);
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.AssertNoCompletionSession()
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TestDeconstructionDeclaration4() As Task
+            Using state = TestState.CreateCSharpTestState(
+                  <Document><![CDATA[
+class C
+{
+    public void Foo()
+    {
+        ($$)
+    }
+}]]></Document>)
+
+                state.SendTypeChars("i")
+                Await state.WaitForAsynchronousOperationsAsync()
+                Await state.AssertSelectedCompletionItem(displayText:="int", isSoftSelected:=True)
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(543268, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543268")>
         Public Async Function TestTypePreselection1() As Task
             Using state = TestState.CreateCSharpTestState(

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.Designer.cs
@@ -108,6 +108,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Autoselect disabled due to possible tuple type element creation..
+        /// </summary>
+        internal static string Autoselect_disabled_due_to_possible_tuple_type_element_creation {
+            get {
+                return ResourceManager.GetString("Autoselect_disabled_due_to_possible_tuple_type_element_creation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Autoselect disabled due to potential implicit array creation..
         /// </summary>
         internal static string Autoselect_disabled_due_to_potential_implicit_array_creation {
@@ -284,6 +293,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string Do_not_change_this_code_Put_cleanup_code_in_Dispose_bool_disposing_above {
             get {
                 return ResourceManager.GetString("Do_not_change_this_code_Put_cleanup_code_in_Dispose_bool_disposing_above", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;element name&gt; : .
+        /// </summary>
+        internal static string element_name {
+            get {
+                return ResourceManager.GetString("element_name", resourceCulture);
             }
         }
         

--- a/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
+++ b/src/Features/CSharp/Portable/CSharpFeaturesResources.resx
@@ -153,6 +153,12 @@
   <data name="Autoselect_disabled_due_to_possible_explicitly_named_anonymous_type_member_creation" xml:space="preserve">
     <value>Autoselect disabled due to possible explicitly named anonymous type member creation.</value>
   </data>
+  <data name="element_name" xml:space="preserve">
+    <value>&lt;element name&gt; : </value>
+  </data>
+  <data name="Autoselect_disabled_due_to_possible_tuple_type_element_creation" xml:space="preserve">
+    <value>Autoselect disabled due to possible tuple type element creation.</value>
+  </data>
   <data name="range_variable" xml:space="preserve">
     <value>&lt;range variable&gt;</value>
   </data>

--- a/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/SuggestionMode/CSharpSuggestionModeCompletionProvider.cs
@@ -44,9 +44,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.SuggestionMode
                 {
                     return CreateSuggestionModeItem(CSharpFeaturesResources.lambda_expression, CSharpFeaturesResources.Autoselect_disabled_due_to_potential_lambda_declaration);
                 }
-                else if (IsAnonymousObjectCreation(token) || IsPossibleTupleExpression(token))
+                else if (IsAnonymousObjectCreation(token))
                 {
                     return CreateSuggestionModeItem(CSharpFeaturesResources.member_name, CSharpFeaturesResources.Autoselect_disabled_due_to_possible_explicitly_named_anonymous_type_member_creation);
+                }
+                else if (IsPossibleTupleExpression(token))
+                {
+                    return CreateSuggestionModeItem(CSharpFeaturesResources.element_name, CSharpFeaturesResources.Autoselect_disabled_due_to_possible_tuple_type_element_creation);
                 }
                 else if (token.IsPreProcessorExpressionContext())
                 {

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -464,23 +464,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
             }
 
-            // var( |
-            // var(expr, |
-            // Those are more likely to be deconstruction-declarations being typed than invocations a method "var"
-            if (targetToken.IsInvocationOfVarExpression())
-            {
-                return false;
-            }
 
             if (targetToken.Kind() == SyntaxKind.OpenParenToken ||
                 targetToken.Kind() == SyntaxKind.CommaToken)
             {
                 if (targetToken.Parent.IsKind(SyntaxKind.ArgumentList))
                 {
-                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) ||
-                        targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
+                    if (targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.BaseConstructorInitializer) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.ThisConstructorInitializer))
+                    {
+                        return true;
+                    }
+
+                    // var( |
+                    // var(expr, |
+                    // Those are more likely to be deconstruction-declarations being typed than invocations a method "var"
+                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) && !targetToken.IsInvocationOfVarExpression())
                     {
                         return true;
                     }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -464,19 +464,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
             }
 
+            // var( |
+            // var(expr, |
+            // Those are more likely to be deconstruction-declarations being typed than invocations a method "var"
+            if (targetToken.IsInvocationOfVarExpression())
+            {
+                return false;
+            }
+
             if (targetToken.Kind() == SyntaxKind.OpenParenToken ||
                 targetToken.Kind() == SyntaxKind.CommaToken)
             {
                 if (targetToken.Parent.IsKind(SyntaxKind.ArgumentList))
                 {
-                    if (targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
+                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) ||
+                        targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.BaseConstructorInitializer) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.ThisConstructorInitializer))
-                    {
-                        return true;
-                    }
-                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) &&
-                        ((InvocationExpressionSyntax)targetToken.Parent.Parent).Expression.ToString() != "var")
                     {
                         return true;
                     }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -469,10 +469,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             {
                 if (targetToken.Parent.IsKind(SyntaxKind.ArgumentList))
                 {
-                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) ||
-                        targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
+                    if (targetToken.Parent.IsParentKind(SyntaxKind.ObjectCreationExpression) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.BaseConstructorInitializer) ||
                         targetToken.Parent.IsParentKind(SyntaxKind.ThisConstructorInitializer))
+                    {
+                        return true;
+                    }
+                    if (targetToken.Parent.IsParentKind(SyntaxKind.InvocationExpression) &&
+                        ((InvocationExpressionSyntax)targetToken.Parent.Parent).Expression.ToString() != "var")
                     {
                         return true;
                     }

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1883,7 +1883,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // var(|
             // var(id, |
             // Those are more likely to be deconstruction-declarations being typed than invocations a method "var"
-            if (token.IsInvocationOfVarExpression())
+            if (token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken) &&
+                token.IsInvocationOfVarExpression())
             {
                 return false;
             }
@@ -2184,14 +2185,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
         public static bool IsInvocationOfVarExpression(this SyntaxToken token)
         {
-            if (token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
+                ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
             {
-                if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
-                    ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
-                {
-                    return true;
-                }
+                return true;
             }
+
             return false;
         }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1882,13 +1882,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
             // var(|
             // var(id, |
-            if (token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            // Those are more likely to be deconstruction-declarations being typed than invocations a method "var"
+            if (token.IsInvocationOfVarExpression())
             {
-                if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
-                    ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
-                {
-                    return false;
-                }
+                return false;
             }
 
             // Foo(|
@@ -2182,6 +2179,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                     && ((InterpolationSyntax)token.Parent).OpenBraceToken == token;
             }
 
+            return false;
+        }
+
+        public static bool IsInvocationOfVarExpression(this SyntaxToken token)
+        {
+            if (token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            {
+                if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
+                    ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
+                {
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -1880,6 +1880,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 }
             }
 
+            // var(|
+            // var(id, |
+            if (token.IsKind(SyntaxKind.OpenParenToken, SyntaxKind.CommaToken))
+            {
+                if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
+                    ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
+                {
+                    return false;
+                }
+            }
+
             // Foo(|
             // Foo(expr, |
             // this[|

--- a/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2185,13 +2185,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
 
         public static bool IsInvocationOfVarExpression(this SyntaxToken token)
         {
-            if (token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
-                ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var")
-            {
-                return true;
-            }
-
-            return false;
+            return token.Parent.Parent.IsKind(SyntaxKind.InvocationExpression) &&
+                ((InvocationExpressionSyntax)token.Parent.Parent).Expression.ToString() == "var";
         }
 
         public static bool IsNameOfContext(this SyntaxTree syntaxTree, int position, SemanticModel semanticModelOpt = null, CancellationToken cancellationToken = default(CancellationToken))


### PR DESCRIPTION
The parser treats `var(x, y)` as a method invocation until an equal sign is added, as in `var (x, y) =`.
So tweaking the completion behavior for deconstruction has some negative side-effect on completion in a method invocation where the method is called "var". I think that is ok, because I expect methods called "var" would be quite rare.

With this change, no completions are available, just like there are no completions when typing `var $$`.

Also, I added a test that capture that `($$)` currently only offers soft selections ~~because it is a possible lambda~~.

Also updated the tooltip when in tuple context.

@CyrusNajmabadi @dotnet/roslyn-ide for review.

Fixes https://github.com/dotnet/roslyn/issues/13342