### PR TITLE
Retargeting on VB tuple should retarget the underlying type

### DIFF
--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -211,7 +211,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             If format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName) AndAlso
-            String.IsNullOrEmpty(symbolName) Then
+                String.IsNullOrEmpty(symbolName) Then
 
                 symbolName = StringConstants.NamedSymbolErrorName
             Else

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -210,8 +210,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 symbol = symbol.TupleUnderlyingType
             End If
 
-                If format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName) AndAlso
-                String.IsNullOrEmpty(symbolName) Then
+            If format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName) AndAlso
+            String.IsNullOrEmpty(symbolName) Then
 
                 symbolName = StringConstants.NamedSymbolErrorName
             Else

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -149,7 +149,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Private Function RetargetNamedTypeDefinition(type As NamedTypeSymbol, options As RetargetOptions) As NamedTypeSymbol
                 Debug.Assert(type Is type.OriginalDefinition)
 
-                ' Before we do anything else, check if we need to do special retargeting
+                If (type.IsTupleType) Then
+                    Return DirectCast(type, TupleTypeSymbol).WithUnderlyingType(Retarget(type.TupleUnderlyingType, options))
+                End If
+
+                ' Check if we need to do special retargeting
                 ' for primitive type references encoded with enum values in metadata signatures.
                 If (options = RetargetOptions.RetargetPrimitiveTypesByTypeCode) Then
                     Dim typeCode As PrimitiveTypeCode = type.PrimitiveTypeCode

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -149,8 +149,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
             Private Function RetargetNamedTypeDefinition(type As NamedTypeSymbol, options As RetargetOptions) As NamedTypeSymbol
                 Debug.Assert(type Is type.OriginalDefinition)
 
-                If (type.IsTupleType) Then
-                    Return DirectCast(type, TupleTypeSymbol).WithUnderlyingType(Retarget(type.TupleUnderlyingType, options))
+                If type.IsTupleType Then
+                    Dim newUnderlyingType = Retarget(type.TupleUnderlyingType, options)
+
+                    If newUnderlyingType.IsTupleOrCompatibleWithTupleOfCardinality(type.TupleElementTypes.Length) Then
+                        Return DirectCast(type, TupleTypeSymbol).WithUnderlyingType(newUnderlyingType)
+                    Else
+                        Return newUnderlyingType
+                    End If
                 End If
 
                 ' Check if we need to do special retargeting

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -4828,7 +4828,7 @@ End Namespace
 
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/13305")>
+        <Fact>
         Public Sub MultipleDefinitionsOfValueTuple()
 
             Dim source1 =
@@ -4875,14 +4875,30 @@ End Class
 </file>
 </compilation>
 
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source, additionalRefs:={comp1.ToMetadataReference(), comp2.ToMetadataReference()})
-            comp.AssertTheseDiagnostics(
+            Dim comp3 = CreateCompilationWithMscorlibAndVBRuntime(source, additionalRefs:={comp1.ToMetadataReference(), comp2.ToMetadataReference()})
+            comp3.AssertTheseDiagnostics(
 <errors>
+BC30521: Overload resolution failed because no accessible 'Extension' is most specific for these arguments:
+    Extension method 'Public Sub Extension(y As (Integer, Integer))' defined in 'M1': Not most specific.
+    Extension method 'Public Sub Extension(y As (Integer, Integer))' defined in 'M2': Not most specific.
+        x.Extension((1, 1))
+          ~~~~~~~~~
+BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'comp.dll' failed.
+        x.Extension((1, 1))
+                    ~~~~~~
 </errors>)
-            ' Crashes in SubstituteNamedType.MakeDeclaredBase
 
-            Dim verifier = CompileAndVerify(source, additionalRefs:={comp1.ToMetadataReference()}, expectedOutput:=<![CDATA[M1.Extension]]>)
-            verifier.VerifyDiagnostics()
+            Dim comp4 = CreateCompilationWithMscorlibAndVBRuntime(source,
+                            additionalRefs:={comp1.ToMetadataReference()},
+                            options:=TestOptions.DebugExe)
+
+            comp4.AssertTheseDiagnostics(
+<errors>
+BC40056: Namespace or type specified in the Imports 'M2' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
+Imports M2
+        ~~
+</errors>)
+            CompileAndVerify(comp4, expectedOutput:=<![CDATA[M1.Extension]]>)
 
         End Sub
 


### PR DESCRIPTION
The tuple type should not go through normal retargeting logic, instead its underlying type should be retargeted and used.

@dotnet/roslyn-compiler for review.

Fixes crashing issue https://github.com/dotnet/roslyn/issues/13305
Relates to [this C# change ](https://github.com/dotnet/roslyn/pull/11047/files)