### PR TITLE
Properly handle expression variable declared within VariableDeclaratorSyntax.ArgumentList in ‘fixed’, ‘for’ and ‘using’ statements.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -954,7 +954,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundLocalDeclaration(associatedSyntaxNode, localSymbol, boundDeclType, initializerOpt, arguments, hasErrors);
         }
 
-        private ImmutableArray<BoundExpression> BindDeclaratorArguments(VariableDeclaratorSyntax declarator, DiagnosticBag diagnostics)
+        internal ImmutableArray<BoundExpression> BindDeclaratorArguments(VariableDeclaratorSyntax declarator, DiagnosticBag diagnostics)
         {
             // It is possible that we have a bracketed argument list, like "int x[];" or "int x[123];" 
             // in a non-fixed-size-array declaration . This is a common error made by C++ programmers. 

--- a/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/FixedStatementBinder.cs
@@ -30,10 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     locals.Add(MakeLocal(_syntax.Declaration, declarator, LocalDeclarationKind.FixedVariable));
 
-                    if (declarator.Initializer != null)
-                    {
-                        ExpressionVariableFinder.FindExpressionVariables(this, locals, declarator.Initializer.Value);
-                    }
+                    // also gather expression-declared variables from the bracketed argument lists and the initializers
+                    ExpressionVariableFinder.FindExpressionVariables(this, locals, declarator);
                 }
 
                 return locals.ToImmutable();

--- a/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ForLoopBinder.cs
@@ -40,7 +40,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     var localSymbol = MakeLocal(_syntax.Declaration, vdecl, LocalDeclarationKind.ForInitializerVariable);
                     locals.Add(localSymbol);
-                    ExpressionVariableFinder.FindExpressionVariables(this, locals, vdecl.Initializer?.Value);
+
+                    // also gather expression-declared variables from the bracketed argument lists and the initializers
+                    ExpressionVariableFinder.FindExpressionVariables(this, locals, vdecl);
                 }
             }
             else

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -360,10 +360,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (VariableDeclaratorSyntax declarator in declarationSyntax.Variables)
                 {
-                    if (declarator.Initializer != null)
-                    {
-                        Visit(declarator.Initializer.Value, usingBinder);
-                    }
+                    Visit(declarator, usingBinder);
                 }
             }
 
@@ -401,10 +398,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (var variable in declaration.Variables)
                 {
-                    if (variable.Initializer != null)
-                    {
-                        Visit(variable.Initializer.Value, binder);
-                    }
+                    Visit(variable, binder);
                 }
             }
             else
@@ -478,10 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 foreach (VariableDeclaratorSyntax declarator in node.Declaration.Variables)
                 {
-                    if (declarator.Initializer != null)
-                    {
-                        Visit(declarator.Initializer.Value, binder);
-                    }
+                    Visit(declarator, binder);
                 }
             }
 
@@ -651,12 +642,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             foreach (var decl in node.Declaration.Variables)
             {
-                var value = decl.Initializer?.Value;
-                if (value != null)
-                {
-                    Visit(value, _enclosing);
-                }
+                Visit(decl);
             }
+        }
+
+        public override void VisitVariableDeclarator(VariableDeclaratorSyntax node)
+        {
+            Visit(node.ArgumentList);
+            Visit(node.Initializer?.Value);
         }
 
         public override void VisitDeconstructionDeclarationStatement(DeconstructionDeclarationStatementSyntax node)

--- a/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/UsingStatementBinder.cs
@@ -40,10 +40,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     locals.Add(MakeLocal(declarationSyntax, declarator, LocalDeclarationKind.UsingVariable));
 
-                    if (declarator.Initializer != null)
-                    {
-                        ExpressionVariableFinder.FindExpressionVariables(this, locals, declarator.Initializer.Value);
-                    }
+                    // also gather expression-declared variables from the bracketed argument lists and the initializers
+                    ExpressionVariableFinder.FindExpressionVariables(this, locals, declarator);
                 }
 
                 return locals.ToImmutableAndFree();

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1660,7 +1660,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            Debug.Assert(localsOpt.Where(l => l.DeclarationKind != LocalDeclarationKind.PatternVariable).All(_usedVariables.Contains));
+            Debug.Assert(localsOpt.Where(l => l.DeclarationKind == LocalDeclarationKind.UsingVariable).All(_usedVariables.Contains));
 
             return result;
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -752,23 +752,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // This occurs, for example, in
                         // int x, y[out var Z, 1 is int I];
                         // for (int x, y[out var Z, 1 is int I]; ;) {}
-                        var declarator = (VariableDeclaratorSyntax)_nodeToBind;
-                        if (declarator.ArgumentList != null)
-                        {
-                            foreach (var arg in declarator.ArgumentList.Arguments)
-                            {
-                                var expression = arg.Expression;
-                                if (expression.Kind() == SyntaxKind.DeclarationExpression)
-                                {
-                                    this.SetType(_nodeBinder.CreateErrorType("var"));
-                                    // no error is necessary, as they would be dropped on the floor by the caller
-                                }
-                                else
-                                {
-                                    _nodeBinder.BindExpression(expression, diagnostics);
-                                }
-                            }
-                        }
+                        _nodeBinder.BindDeclaratorArguments((VariableDeclaratorSyntax)_nodeToBind, diagnostics);
                         break;
                     default:
                         _nodeBinder.BindExpression((ExpressionSyntax)_nodeToBind, diagnostics);


### PR DESCRIPTION
Related to #12597.
Fixes #13459, #13460.

I will open an issue for cloning new tests to target pattern variables.
@dotnet/roslyn-compiler, @gafter Please review. 