### PR TITLE
Properly handle expression variable declared within VariableDeclaratorSyntax.ArgumentList in field declarations.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4202,7 +4202,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers..
+        ///   Looks up a localized string similar to Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers..
         /// </summary>
         internal static string ERR_ExpressionVariableInConstructorOrFieldInitializer {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4948,6 +4948,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>Deconstruction is not supported for an 'out' argument.</value>
   </data>
   <data name="ERR_ExpressionVariableInConstructorOrFieldInitializer" xml:space="preserve">
-    <value>Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.</value>
+    <value>Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.</value>
   </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceFixedFieldSymbol.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                             ExpressionSyntax sizeExpression = arguments[0].Expression;
 
                             BinderFactory binderFactory = this.DeclaringCompilation.GetBinderFactory(SyntaxTree);
-                            Binder binder = binderFactory.GetBinder(sizeExpression);
+                            Binder binder = new ExpressionVariableBinder(sizeExpression, binderFactory.GetBinder(sizeExpression));
 
                             TypeSymbol intType = binder.GetSpecialType(SpecialType.System_Int32, diagnostics, sizeExpression);
                             BoundExpression boundSizeExpression = binder.GenerateConversionForAssignment(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceLocalSymbol.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Roslyn.Utilities;
@@ -153,7 +154,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(
                 nodeToBind.Kind() == SyntaxKind.CasePatternSwitchLabel ||
                 nodeToBind.Kind() == SyntaxKind.ArgumentList && nodeToBind.Parent is ConstructorInitializerSyntax ||
-                nodeToBind.Kind() == SyntaxKind.VariableDeclarator ||
+                nodeToBind.Kind() == SyntaxKind.VariableDeclarator && 
+                    new[] { SyntaxKind.LocalDeclarationStatement, SyntaxKind.ForStatement, SyntaxKind.UsingStatement, SyntaxKind.FixedStatement }.
+                        Contains(nodeToBind.Ancestors().OfType<StatementSyntax>().First().Kind()) ||
                 nodeToBind is ExpressionSyntax);
             return typeSyntax.IsVar
                 ? new LocalSymbolWithEnclosingContext(containingSymbol, scopeBinder, nodeBinder, typeSyntax, identifierToken, kind, nodeToBind, forbiddenZone)

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -2950,34 +2950,34 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (9,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(TakeOutParam(3, out int x3) && x3 > 0)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(9, 36),
                 // (13,16): error CS0841: Cannot use local variable 'x4' before it is declared
                 //         : this(x4 && TakeOutParam(4, out int x4))
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(13, 16),
-                // (13,42): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,42): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(x4 && TakeOutParam(4, out int x4))
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(13, 42),
-                // (17,37): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (17,37): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(17, 37),
-                // (18,37): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (18,37): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(18, 37),
                 // (18,41): error CS0128: A local variable named 'x5' is already defined in this scope
                 //                TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(18, 41),
-                // (23,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (23,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(TakeOutParam(6, out int x6) && x6 > 0, 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 36),
-                // (24,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (24,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                TakeOutParam(6, out int x6) && x6 > 0) // 2
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(24, 36),
                 // (24,40): error CS0128: A local variable named 'x6' is already defined in this scope
                 //                TakeOutParam(6, out int x6) && x6 > 0) // 2
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(24, 40),
-                // (27,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (27,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(TakeOutParam(7, out int x7) && x7 > 0)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(27, 36),
                 // (30,16): error CS0103: The name 'x7' does not exist in the current context
@@ -3073,34 +3073,34 @@ public class Y
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (9,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(TakeOutParam(3, out int x3) && x3 > 0)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(9, 36),
                 // (13,16): error CS0841: Cannot use local variable 'x4' before it is declared
                 //         : base(x4 && TakeOutParam(4, out int x4))
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(13, 16),
-                // (13,42): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,42): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(x4 && TakeOutParam(4, out int x4))
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(13, 42),
-                // (17,37): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (17,37): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(17, 37),
-                // (18,37): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (18,37): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(18, 37),
                 // (18,41): error CS0128: A local variable named 'x5' is already defined in this scope
                 //                TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(18, 41),
-                // (23,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (23,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(TakeOutParam(6, out int x6) && x6 > 0, 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 36),
-                // (24,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (24,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                TakeOutParam(6, out int x6) && x6 > 0) // 2
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(24, 36),
                 // (24,40): error CS0128: A local variable named 'x6' is already defined in this scope
                 //                TakeOutParam(6, out int x6) && x6 > 0) // 2
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(24, 40),
-                // (27,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (27,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(TakeOutParam(7, out int x7) && x7 > 0)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(27, 36),
                 // (30,16): error CS0103: The name 'x7' does not exist in the current context
@@ -3178,7 +3178,7 @@ class D
                 // (15,27): error CS0103: The name 'x' does not exist in the current context
                 //         Console.WriteLine(x);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x").WithArguments("x").WithLocation(15, 27),
-                // (13,51): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,51): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     public D(object o) : this(TakeOutParam(o, out int x) && x >= 5) 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(13, 51)
                 );
@@ -3222,7 +3222,7 @@ class C
                 // (15,27): error CS0103: The name 'x' does not exist in the current context
                 //         Console.WriteLine(x);
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x").WithArguments("x").WithLocation(15, 27),
-                // (13,51): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,51): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     public D(object o) : base(TakeOutParam(o, out int x) && x >= 5) 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(13, 51)
                 );
@@ -4617,31 +4617,31 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (8,38): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (8,38): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test3 = TakeOutParam(3, out int x3) && x3 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 38),
                 // (10,18): error CS0841: Cannot use local variable 'x4' before it is declared
                 //     bool Test4 = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 18),
-                // (10,44): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (10,44): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test4 = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 44),
-                // (12,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test5 = TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 39),
-                // (13,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                  TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 39),
                 // (13,43): error CS0128: A local variable named 'x5' is already defined in this scope
                 //                  TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(13, 43),
-                // (16,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 39),
-                // (16,87): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,87): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 87),
-                // (18,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (18,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test71 = TakeOutParam(7, out int x7) && x7 > 0; 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 39),
                 // (19,25): error CS0103: The name 'x7' does not exist in the current context
@@ -4719,13 +4719,13 @@ class Test
                 // (6,13): error CS0841: Cannot use local variable 'x4' before it is declared
                 //     Test4 = x4 && TakeOutParam(4, out int x4) ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(6, 13),
-                // (6,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (6,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test4 = x4 && TakeOutParam(4, out int x4) ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(6, 39),
-                // (8,34): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (8,34): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test5 = TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(8, 34),
-                // (9,34): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,34): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //             TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(9, 34),
                 // (9,38): error CS0128: A local variable named 'x5' is already defined in this scope
@@ -4736,19 +4736,19 @@ class Test
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, @"TakeOutParam(51, out int x5) && 
             TakeOutParam(52, out int x5) && 
             x5 > 0 ? 1 : 0").WithArguments("X.Test5").WithLocation(8, 13),
-                // (12,34): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,34): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test61 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(12, 34),
                 // (12,14): error CS0133: The expression being assigned to 'X.Test61' must be constant
                 //     Test61 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, "TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0").WithArguments("X.Test61").WithLocation(12, 14),
-                // (12,90): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,90): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test61 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(12, 90),
                 // (12,70): error CS0133: The expression being assigned to 'X.Test62' must be constant
                 //     Test61 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0,
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, "TakeOutParam(6, out int x6) && x6 > 0 ? 1 : 0").WithArguments("X.Test62").WithLocation(12, 70),
-                // (14,34): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (14,34): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test71 = TakeOutParam(7, out int x7) && x7 > 0 ? 1 : 0, 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(14, 34),
                 // (14,14): error CS0133: The expression being assigned to 'X.Test71' must be constant
@@ -4757,7 +4757,7 @@ class Test
                 // (15,14): error CS0103: The name 'x7' does not exist in the current context
                 //     Test72 = x7, 
                 Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(15, 14),
-                // (4,33): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (4,33): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     Test3 = TakeOutParam(3, out int x3) ? x3 : 0,
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(4, 33),
                 // (4,13): error CS0133: The expression being assigned to 'X.Test3' must be constant
@@ -4831,7 +4831,7 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (8,44): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (8,44): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test3 = TakeOutParam(3, out int x3) && x3 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 44),
                 // (8,24): error CS0133: The expression being assigned to 'X.Test3' must be constant
@@ -4840,13 +4840,13 @@ public class X
                 // (10,24): error CS0841: Cannot use local variable 'x4' before it is declared
                 //     const bool Test4 = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 24),
-                // (10,50): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (10,50): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test4 = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 50),
-                // (12,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test5 = TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 45),
-                // (13,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                        TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 45),
                 // (13,49): error CS0128: A local variable named 'x5' is already defined in this scope
@@ -4857,19 +4857,19 @@ public class X
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, @"TakeOutParam(51, out int x5) && 
                        TakeOutParam(52, out int x5) && 
                        x5 > 0").WithArguments("X.Test5").WithLocation(12, 24),
-                // (16,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 45),
                 // (16,25): error CS0133: The expression being assigned to 'X.Test61' must be constant
                 //     const bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, "TakeOutParam(6, out int x6) && x6 > 0").WithArguments("X.Test61").WithLocation(16, 25),
-                // (16,93): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,93): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 93),
                 // (16,73): error CS0133: The expression being assigned to 'X.Test62' must be constant
                 //     const bool Test61 = TakeOutParam(6, out int x6) && x6 > 0, Test62 = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_NotConstantExpression, "TakeOutParam(6, out int x6) && x6 > 0").WithArguments("X.Test62").WithLocation(16, 73),
-                // (18,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (18,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     const bool Test71 = TakeOutParam(7, out int x7) && x7 > 0; 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 45),
                 // (18,25): error CS0133: The expression being assigned to 'X.Test71' must be constant
@@ -4948,7 +4948,7 @@ public class X
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (9,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 = TakeOutParam(1, out int x1) && Dummy(x1); 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(9, 45)
                 );
@@ -4989,7 +4989,7 @@ public class X
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (9,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 = TakeOutParam(1, out int x1) && Dummy(() => x1); 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(9, 45)
                 );
@@ -9939,31 +9939,31 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
             compilation.VerifyDiagnostics(
-                // (8,45): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (8,45): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test3 {get;} = TakeOutParam(3, out int x3) && x3 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 45),
                 // (10,25): error CS0841: Cannot use local variable 'x4' before it is declared
                 //     bool Test4 {get;} = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 25),
-                // (10,51): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (10,51): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test4 {get;} = x4 && TakeOutParam(4, out int x4);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 51),
-                // (12,46): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,46): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test5 {get;} = TakeOutParam(51, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 46),
-                // (13,39): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,39): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                  TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 39),
                 // (13,43): error CS0128: A local variable named 'x5' is already defined in this scope
                 //                  TakeOutParam(52, out int x5) && 
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(13, 43),
-                // (16,46): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,46): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test61 {get;} = TakeOutParam(6, out int x6) && x6 > 0; bool Test62 {get;} = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 46),
-                // (16,106): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,106): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test61 {get;} = TakeOutParam(6, out int x6) && x6 > 0; bool Test62 {get;} = TakeOutParam(6, out int x6) && x6 > 0;
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 106),
-                // (18,46): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (18,46): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test71 {get;} = TakeOutParam(7, out int x7) && x7 > 0; 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 46),
                 // (19,32): error CS0103: The name 'x7' does not exist in the current context
@@ -10039,7 +10039,7 @@ public class X
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (9,52): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,52): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 {get;} = TakeOutParam(1, out int x1) && Dummy(x1); 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(9, 52)
                 );
@@ -16474,7 +16474,7 @@ public class Cls
             CompileAndVerify(compilation, expectedOutput: @"123").VerifyDiagnostics();
 #else
             compilation.VerifyDiagnostics(
-                // (25,26): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (25,26): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(Test1(out var x1), x1)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var x1").WithLocation(25, 26)
                 );
@@ -16531,7 +16531,7 @@ public class Cls
             CompileAndVerify(compilation, expectedOutput: @"123").VerifyDiagnostics();
 #else
             compilation.VerifyDiagnostics(
-                // (29,26): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (29,26): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(Test1(out var x1), x1)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var x1").WithLocation(29, 26)
                 );
@@ -16572,7 +16572,7 @@ public class Cls
                                                             parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (16,20): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (16,20): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : this(out var x1)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var x1").WithLocation(16, 20)
                 );
@@ -16615,7 +16615,7 @@ public class Cls
                                                             parseOptions: TestOptions.Regular);
 
             compilation.VerifyDiagnostics(
-                // (20,20): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (20,20): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //         : base(out var x1)
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "var x1").WithLocation(20, 20)
                 );

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -260,7 +260,7 @@ False";
             var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
 #else
             compilation.VerifyDiagnostics(
-                // (13,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (13,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     public D(object o) : this(o is int x && x >= 5) {}
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(13, 36)
                 );
@@ -345,13 +345,13 @@ False for 1.2";
             }
 #else
             compilation.VerifyDiagnostics(
-                // (7,35): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (7,35): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool b1 = M(o1, (o1 is int x && x >= 5)),
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(7, 35),
-                // (8,35): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (8,35): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                 b2 = M(o2, (o2 is int x && x >= 5)),
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(8, 35),
-                // (9,35): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,35): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //                 b3 = M(o3, (o3 is int x && x >= 5));
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(9, 35)
                 );
@@ -4083,7 +4083,7 @@ public class X
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (9,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 = 1 is int x1 && Dummy(x1); 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(9, 30)
                 );
@@ -4125,10 +4125,10 @@ True
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (14,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (14,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 = 1 is int x1 && Dummy(() => x1);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(14, 30),
-                // (15,23): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (15,23): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     bool Test2 = 2 is int x1 && Dummy(() => x1);
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(15, 23)
                 );
@@ -4165,31 +4165,31 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (8,23): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (8,23): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test3 = 3 is int x3 && x3 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 23),
     // (10,18): error CS0841: Cannot use local variable 'x4' before it is declared
     //     bool Test4 = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 18),
-    // (10,29): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (10,29): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test4 = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 29),
-    // (12,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (12,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test5 = 51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 24),
-    // (13,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //                  52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 24),
     // (13,28): error CS0128: A local variable named 'x5' is already defined in this scope
     //                  52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(13, 28),
-    // (16,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 24),
-    // (16,56): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,56): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 56),
-    // (18,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (18,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test71 = 7 is int x7 && x7 > 0; 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 24),
     // (19,25): error CS0103: The name 'x7' does not exist in the current context
@@ -4258,31 +4258,31 @@ public enum X
     // (6,13): error CS0841: Cannot use local variable 'x4' before it is declared
     //     Test4 = x4 && 4 is int x4 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(6, 13),
-    // (6,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (6,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test4 = x4 && 4 is int x4 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(6, 24),
-    // (8,19): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (8,19): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test5 = 51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(8, 19),
-    // (9,19): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (9,19): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //             52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(9, 19),
     // (9,23): error CS0128: A local variable named 'x5' is already defined in this scope
     //             52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(9, 23),
-    // (12,19): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (12,19): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test61 = 6 is int x6 && x6 > 0 ? 1 : 0, Test62 = 6 is int x6 && x6 > 0 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(12, 19),
     // (12,14): error CS0133: The expression being assigned to 'X.Test61' must be constant
     //     Test61 = 6 is int x6 && x6 > 0 ? 1 : 0, Test62 = 6 is int x6 && x6 > 0 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_NotConstantExpression, "6 is int x6 && x6 > 0 ? 1 : 0").WithArguments("X.Test61").WithLocation(12, 14),
-    // (12,59): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (12,59): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test61 = 6 is int x6 && x6 > 0 ? 1 : 0, Test62 = 6 is int x6 && x6 > 0 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(12, 59),
     // (12,54): error CS0133: The expression being assigned to 'X.Test62' must be constant
     //     Test61 = 6 is int x6 && x6 > 0 ? 1 : 0, Test62 = 6 is int x6 && x6 > 0 ? 1 : 0,
     Diagnostic(ErrorCode.ERR_NotConstantExpression, "6 is int x6 && x6 > 0 ? 1 : 0").WithArguments("X.Test62").WithLocation(12, 54),
-    // (14,19): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (14,19): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test71 = 7 is int x7 && x7 > 0 ? 1 : 0, 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(14, 19),
     // (14,14): error CS0133: The expression being assigned to 'X.Test71' must be constant
@@ -4291,7 +4291,7 @@ public enum X
     // (15,14): error CS0103: The name 'x7' does not exist in the current context
     //     Test72 = x7, 
     Diagnostic(ErrorCode.ERR_NameNotInContext, "x7").WithArguments("x7").WithLocation(15, 14),
-    // (4,18): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (4,18): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     Test3 = 3 is int x3 ? x3 : 0,
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(4, 18),
     // (4,13): error CS0133: The expression being assigned to 'X.Test3' must be constant
@@ -4360,7 +4360,7 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (8,29): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (8,29): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test3 = 3 is int x3 && x3 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 29),
     // (8,24): error CS0133: The expression being assigned to 'X.Test3' must be constant
@@ -4369,31 +4369,31 @@ public class X
     // (10,24): error CS0841: Cannot use local variable 'x4' before it is declared
     //     const bool Test4 = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 24),
-    // (10,35): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (10,35): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test4 = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 35),
-    // (12,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (12,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test5 = 51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 30),
-    // (13,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //                        52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 30),
     // (13,34): error CS0128: A local variable named 'x5' is already defined in this scope
     //                        52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(13, 34),
-    // (16,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 30),
     // (16,25): error CS0133: The expression being assigned to 'X.Test61' must be constant
     //     const bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_NotConstantExpression, "6 is int x6 && x6 > 0").WithArguments("X.Test61").WithLocation(16, 25),
-    // (16,62): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,62): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 62),
     // (16,57): error CS0133: The expression being assigned to 'X.Test62' must be constant
     //     const bool Test61 = 6 is int x6 && x6 > 0, Test62 = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_NotConstantExpression, "6 is int x6 && x6 > 0").WithArguments("X.Test62").WithLocation(16, 57),
-    // (18,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (18,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     const bool Test71 = 7 is int x7 && x7 > 0; 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 30),
     // (18,25): error CS0133: The expression being assigned to 'X.Test71' must be constant
@@ -4466,7 +4466,7 @@ public class X
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (9,37): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (9,37): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     static bool Test1 {get;} = 1 is int x1 && Dummy(x1); 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(9, 37)
                 );
@@ -4503,31 +4503,31 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (8,30): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (8,30): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test3 {get;} = 3 is int x3 && x3 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(8, 30),
     // (10,25): error CS0841: Cannot use local variable 'x4' before it is declared
     //     bool Test4 {get;} = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(10, 25),
-    // (10,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (10,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test4 {get;} = x4 && 4 is int x4;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(10, 36),
-    // (12,31): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (12,31): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test5 {get;} = 51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(12, 31),
-    // (13,24): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,24): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //                  52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(13, 24),
     // (13,28): error CS0128: A local variable named 'x5' is already defined in this scope
     //                  52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(13, 28),
-    // (16,31): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,31): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test61 {get;} = 6 is int x6 && x6 > 0; bool Test62 {get;} = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 31),
-    // (16,75): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (16,75): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test61 {get;} = 6 is int x6 && x6 > 0; bool Test62 {get;} = 6 is int x6 && x6 > 0;
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(16, 75),
-    // (18,31): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (18,31): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     bool Test71 {get;} = 7 is int x7 && x7 > 0; 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(18, 31),
     // (19,32): error CS0103: The name 'x7' does not exist in the current context
@@ -4894,34 +4894,34 @@ public class X
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (9,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (9,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(3 is int x3 && x3 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(9, 21),
     // (13,16): error CS0841: Cannot use local variable 'x4' before it is declared
     //         : this(x4 && 4 is int x4)
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(13, 16),
-    // (13,27): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,27): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(x4 && 4 is int x4)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(13, 27),
-    // (17,22): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (17,22): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(17, 22),
-    // (18,22): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (18,22): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //                52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(18, 22),
     // (18,26): error CS0128: A local variable named 'x5' is already defined in this scope
     //                52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(18, 26),
-    // (23,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (23,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 21),
-    // (23,44): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (23,44): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 44),
     // (23,48): error CS0128: A local variable named 'x6' is already defined in this scope
     //         : this(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(23, 48),
-    // (27,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (27,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : this(7 is int x7 && x7 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(27, 21),
     // (30,16): error CS0103: The name 'x7' does not exist in the current context
@@ -5011,34 +5011,34 @@ public class Y
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
             compilation.VerifyDiagnostics(
-    // (9,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (9,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(3 is int x3 && x3 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x3").WithLocation(9, 21),
     // (13,16): error CS0841: Cannot use local variable 'x4' before it is declared
     //         : base(x4 && 4 is int x4)
     Diagnostic(ErrorCode.ERR_VariableUsedBeforeDeclaration, "x4").WithArguments("x4").WithLocation(13, 16),
-    // (13,27): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,27): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(x4 && 4 is int x4)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x4").WithLocation(13, 27),
-    // (17,22): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (17,22): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(51 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(17, 22),
-    // (18,22): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (18,22): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //                52 is int x5 && 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x5").WithLocation(18, 22),
     // (18,26): error CS0128: A local variable named 'x5' is already defined in this scope
     //                52 is int x5 && 
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x5").WithArguments("x5").WithLocation(18, 26),
-    // (23,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (23,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 21),
-    // (23,44): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (23,44): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x6").WithLocation(23, 44),
     // (23,48): error CS0128: A local variable named 'x6' is already defined in this scope
     //         : base(6 is int x6 && x6 > 0, 6 is int x6 && x6 > 0)
     Diagnostic(ErrorCode.ERR_LocalDuplicate, "x6").WithArguments("x6").WithLocation(23, 48),
-    // (27,21): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (27,21): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //         : base(7 is int x7 && x7 > 0)
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x7").WithLocation(27, 21),
     // (30,16): error CS0103: The name 'x7' does not exist in the current context
@@ -5110,7 +5110,7 @@ class D
     // (15,27): error CS0103: The name 'x' does not exist in the current context
     //         Console.WriteLine(x);
     Diagnostic(ErrorCode.ERR_NameNotInContext, "x").WithArguments("x").WithLocation(15, 27),
-    // (13,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     public D(object o) : this(o is int x && x >= 5) 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(13, 36)
                 );
@@ -5148,7 +5148,7 @@ class C
     // (15,27): error CS0103: The name 'x' does not exist in the current context
     //         Console.WriteLine(x);
     Diagnostic(ErrorCode.ERR_NameNotInContext, "x").WithArguments("x").WithLocation(15, 27),
-    // (13,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+    // (13,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
     //     public D(object o) : base(o is int x && x >= 5) 
     Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x").WithLocation(13, 36)
                 );
@@ -5201,10 +5201,10 @@ True
 True");
 #else
             compilation.VerifyDiagnostics(
-                // (12,36): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (12,36): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     public D(object o) : base(2 is int x1 && Dummy(x1)) 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(12, 36),
-                // (17,28): error CS8200: Out variable or pattern variable declarations are not allowed within constructor/field/auto-implemented property initializers.
+                // (17,28): error CS8200: Out variable and pattern variable declarations are not allowed within constructor initializers, field initializers, or property initializers.
                 //     public D() : this(1 is int x1 && Dummy(x1)) 
                 Diagnostic(ErrorCode.ERR_ExpressionVariableInConstructorOrFieldInitializer, "int x1").WithLocation(17, 28)
                 );


### PR DESCRIPTION
Related to #12597 and # 13417.
Also fixes #13528.

@dotnet/roslyn-compiler, @gafter Please review.