### PR TITLE
Fix a crash in declaration pattern binding when the expression is bad.

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4837,7 +4837,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
     <value>It is not legal to use nullable type '{0}' in a pattern; use the underlying type '{1}' instead.</value>
   </data>
   <data name="ERR_BadIsPatternExpression" xml:space="preserve">
-    <value>Invalid operand for pattern match.</value>
+    <value>Invalid operand for pattern match; value required, but found '{0}'.</value>
   </data>
   <data name="ERR_PeWritingFailure" xml:space="preserve">
     <value>An error occurred while writing the output file: {0}.</value>


### PR DESCRIPTION
Fixes #13383 

@dotnet/roslyn-compiler Can I please have a couple of reviews of this small bug fix?
