### PR TITLE
New error code for missing well-known ValueTuple type

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Compilation_WellKnownMembers.cs
@@ -111,7 +111,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (type.IsValueTupleType())
                     {
                         result = new MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(this.Assembly.Modules[0], ref emittedName,
-                                        CreateValueTupleTypeNotFoundError(emittedName), type);
+                                           new CSDiagnosticInfo(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, emittedName.FullName), type);
                     }
                     else
                     {
@@ -134,14 +134,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return _lazyWellKnownTypes[index];
-        }
-
-        private CSDiagnosticInfo CreateValueTupleTypeNotFoundError(MetadataTypeName name)
-        {
-            return new CSDiagnosticInfo(
-                ErrorCode.ERR_PredefinedValueTupleTypeNotFound,
-                name.FullName
-            );
         }
 
         internal bool IsAttributeType(TypeSymbol type)

--- a/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MissingMetadataTypeSymbol.cs
@@ -281,23 +281,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 get
                 {
-                    switch (this.TypeId)
+                    if (this.TypeId != (int)SpecialType.None)
                     {
-                        case (int)SpecialType.None:
-                            break;
-
-                        case (int)WellKnownType.System_ValueTuple_T1:
-                        case (int)WellKnownType.System_ValueTuple_T2:
-                        case (int)WellKnownType.System_ValueTuple_T3:
-                        case (int)WellKnownType.System_ValueTuple_T4:
-                        case (int)WellKnownType.System_ValueTuple_T5:
-                        case (int)WellKnownType.System_ValueTuple_T6:
-                        case (int)WellKnownType.System_ValueTuple_T7:
-                        case (int)WellKnownType.System_ValueTuple_TRest:
-                            return new CSDiagnosticInfo(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, MetadataHelpers.BuildQualifiedName(_namespaceName, MetadataName));
-
-                        default:
-                            return new CSDiagnosticInfo(ErrorCode.ERR_PredefinedTypeNotFound, MetadataHelpers.BuildQualifiedName(_namespaceName, MetadataName));
+                        return new CSDiagnosticInfo(ErrorCode.ERR_PredefinedTypeNotFound, MetadataHelpers.BuildQualifiedName(_namespaceName, MetadataName));
                     }
 
                     return base.ErrorInfo;
@@ -353,6 +339,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
 
             public TopLevelWithCustomErrorInfo(ModuleSymbol module, ref MetadataTypeName emittedName, DiagnosticInfo errorInfo, SpecialType typeId)
+                : base(module, ref emittedName, typeId)
+            {
+                Debug.Assert(errorInfo != null);
+                _errorInfo = errorInfo;
+            }
+
+            public TopLevelWithCustomErrorInfo(ModuleSymbol module, ref MetadataTypeName emittedName, DiagnosticInfo errorInfo, WellKnownType typeId)
                 : base(module, ref emittedName, typeId)
             {
                 Debug.Assert(errorInfo != null);

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/MissingSpecialMember.cs
@@ -567,6 +567,24 @@ namespace System
                         continue;
                 }
 
+                switch (wkt)
+                {
+                    case WellKnownType.System_ValueTuple_T1:
+                    case WellKnownType.System_ValueTuple_T2:
+                    case WellKnownType.System_ValueTuple_T3:
+                    case WellKnownType.System_ValueTuple_T4:
+                    case WellKnownType.System_ValueTuple_T5:
+                    case WellKnownType.System_ValueTuple_T6:
+                    case WellKnownType.System_ValueTuple_T7:
+                    case WellKnownType.System_ValueTuple_TRest:
+                        Assert.True(wkt.IsValueTupleType());
+                        break;
+
+                    default:
+                        Assert.False(wkt.IsValueTupleType());
+                        break;
+                }
+
                 var symbol = comp.GetWellKnownType(wkt);
                 Assert.NotNull(symbol);
                 Assert.NotEqual(SymbolKind.ErrorType, symbol.Kind);

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -591,7 +591,7 @@ namespace Microsoft.CodeAnalysis
         public static bool IsValueTupleType(this WellKnownType typeId)
         {
             Debug.Assert(typeId != WellKnownType.ExtSentinel);
-            return typeId >= WellKnownType.System_ValueTuple_T1 && typeId < WellKnownType.System_ValueTuple_TRest;
+            return typeId >= WellKnownType.System_ValueTuple_T1 && typeId <= WellKnownType.System_ValueTuple_TRest;
         }
 
         public static bool IsValid(this WellKnownType typeId)

--- a/src/Compilers/Core/Portable/WellKnownTypes.cs
+++ b/src/Compilers/Core/Portable/WellKnownTypes.cs
@@ -588,6 +588,12 @@ namespace Microsoft.CodeAnalysis
             return typeId >= WellKnownType.First && typeId < WellKnownType.NextAvailable;
         }
 
+        public static bool IsValueTupleType(this WellKnownType typeId)
+        {
+            Debug.Assert(typeId != WellKnownType.ExtSentinel);
+            return typeId >= WellKnownType.System_ValueTuple_T1 && typeId < WellKnownType.System_ValueTuple_TRest;
+        }
+
         public static bool IsValid(this WellKnownType typeId)
         {
             return typeId >= WellKnownType.First && typeId < WellKnownType.NextAvailable && typeId != WellKnownType.ExtSentinel;

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1698,7 +1698,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_SourceLinkRequiresPortablePdb = 37264
         ERR_CannotEmbedWithoutPdb = 37265
 
-        ERR_InvalidInstrumentationKind = 37265
+        ERR_InvalidInstrumentationKind = 37266
+
+        ERR_ValueTupleTypeRefResolutionError = 37267
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/MissingMetadataTypeSymbol.vb
@@ -232,6 +232,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Me._errorInfo = errorInfo
             End Sub
 
+            Public Sub New(moduleSymbol As ModuleSymbol, ByRef emittedName As MetadataTypeName, delayedErrorInfo As Func(Of TopLevelWithCustomErrorInfo, DiagnosticInfo))
+                MyBase.New(moduleSymbol, emittedName)
+
+                Debug.Assert(delayedErrorInfo IsNot Nothing)
+                Me._errorInfo = delayedErrorInfo(Me)
+            End Sub
+
             Friend Overrides ReadOnly Property ErrorInfo As DiagnosticInfo
                 Get
                     Return _errorInfo

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -361,7 +361,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 If result Is Nothing Then
                     Dim emittedName As MetadataTypeName = MetadataTypeName.FromFullName(mdName, useCLSCompliantNameArityEncoding:=True)
-                    result = New MissingMetadataTypeSymbol.TopLevel(Assembly.Modules(0), emittedName)
+
+                    If type.IsValueTupleType() Then
+                        result = New MissingMetadataTypeSymbol.TopLevelWithCustomErrorInfo(Assembly.Modules(0), emittedName,
+                                       Function(t) ErrorFactory.ErrorInfo(ERRID.ERR_ValueTupleTypeRefResolutionError, t))
+                    Else
+                        result = New MissingMetadataTypeSymbol.TopLevel(Assembly.Modules(0), emittedName)
+                    End If
                 End If
 
                 If (Interlocked.CompareExchange(_lazyWellKnownTypes(index), result, Nothing) IsNot Nothing) Then

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -11299,7 +11299,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Import of type &apos;{0}&apos; failed..
+        '''  Looks up a localized string similar to Predefined type &apos;{0}&apos; is not defined or imported..
         '''</summary>
         Friend ReadOnly Property ERR_ValueTupleTypeRefResolutionError() As String
             Get

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -11299,6 +11299,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Import of type &apos;{0}&apos; failed..
+        '''</summary>
+        Friend ReadOnly Property ERR_ValueTupleTypeRefResolutionError() As String
+            Get
+                Return ResourceManager.GetString("ERR_ValueTupleTypeRefResolutionError", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &apos;{4}&apos; cannot be converted to &apos;{5}&apos; because &apos;{0}&apos; is not derived from &apos;{1}&apos;, as required for the &apos;In&apos; generic parameter &apos;{2}&apos; in &apos;{3}&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_VarianceConversionFailedIn6() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -1996,7 +1996,7 @@
     <value>Import of type '{0}' from assembly or module '{1}' failed.</value>
   </data>
   <data name="ERR_ValueTupleTypeRefResolutionError" xml:space="preserve">
-    <value>Import of type '{0}' failed.</value>
+    <value>Predefined type '{0}' is not defined or imported.</value>
   </data>
   <data name="ERR_ParamArrayWrongType" xml:space="preserve">
     <value>ParamArray parameters must have an array type.</value>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -1995,6 +1995,9 @@
   <data name="ERR_TypeRefResolutionError3" xml:space="preserve">
     <value>Import of type '{0}' from assembly or module '{1}' failed.</value>
   </data>
+  <data name="ERR_ValueTupleTypeRefResolutionError" xml:space="preserve">
+    <value>Import of type '{0}' failed.</value>
+  </data>
   <data name="ERR_ParamArrayWrongType" xml:space="preserve">
     <value>ParamArray parameters must have an array type.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -124,19 +124,19 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t as (Integer, Integer)
                  ~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t as (Integer, Integer)
                  ~~~~~~~~~~~~~~~~~~
 BC30389: '(Integer, Integer).Item1' is not accessible in this context because it is 'Private'.
         console.writeline(t.Item1)
                           ~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30389: '(A As Integer, B As Integer).Item1' is not accessible in this context because it is 'Private'.
@@ -203,7 +203,7 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t = (Nothing, Nothing)
                 ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3155,34 +3155,34 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of )' is not defined or imported.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of )' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
-        Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
-                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of )' failed.
+BC37267: Predefined type 'ValueTuple(Of )' is not defined or imported.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
+        Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
+                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC37267: Predefined type 'ValueTuple(Of )' is not defined or imported.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of )' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of )' is not defined or imported.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of )' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3210,16 +3210,16 @@ End Module
 BC37258: Tuple member names must all be provided, if any one is provided.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                  ~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                  ~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                  ~~~~~~~~~~~~~~~~~~~~~~
 BC37258: Tuple member names must all be provided, if any one is provided.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                                           ~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                                           ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3843,13 +3843,13 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim x As (Integer, String) = (1, "hello")
                  ~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim x As (Integer, String) = (1, "hello")
                  ~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim x As (Integer, String) = (1, "hello")
                                      ~~~~~~~~~~~~
 </errors>)
@@ -4263,13 +4263,13 @@ BC30389: '(first As Integer, second As Boolean).first' is not accessible in this
 BC30389: '(first As Integer, second As Boolean).second' is not accessible in this context because it is 'Private'.
         System.Console.Write($"{x.first} {x.second}")
                                           ~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
     Public Shared Function M(Of T1, T2)() As (first As T1, second As T2)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
     Public Shared Function M(Of T1, T2)() As (first As T1, second As T2)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         return (Nothing, Nothing)
                ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -4347,10 +4347,10 @@ End Namespace
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
     Function M(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)() As (T1, T2, T3, T4, T5, T6, T7, T8, T9)
                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
     Function M(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)() As (T1, T2, T3, T4, T5, T6, T7, T8, T9)
                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -4883,7 +4883,7 @@ BC30521: Overload resolution failed because no accessible 'Extension' is most sp
     Extension method 'Public Sub Extension(y As (Integer, Integer))' defined in 'M2': Not most specific.
         x.Extension((1, 1))
           ~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'comp.dll' failed.
+BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         x.Extension((1, 1))
                     ~~~~~~
 </errors>)
@@ -5935,13 +5935,13 @@ BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer,
 BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)' cannot be converted to '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8 )
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30452: Operator '=' is not defined for types '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)' and '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30198: ')' expected.
@@ -5959,13 +5959,13 @@ BC30451: 'oopsss' is not declared. It may be inaccessible due to its protection 
 BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)' cannot be converted to '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to 'Integer'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, (1, 1, 1), 10)
                                              ~~~~~~~~~
-BC37267: Import of type 'ValueTuple(Of ,,)' failed.
+BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, (1, 1, 1), 10)
                                              ~~~~~~~~~
 </errors>)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -124,19 +124,19 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim t as (Integer, Integer)
                  ~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim t as (Integer, Integer)
                  ~~~~~~~~~~~~~~~~~~
 BC30389: '(Integer, Integer).Item1' is not accessible in this context because it is 'Private'.
         console.writeline(t.Item1)
                           ~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30389: '(A As Integer, B As Integer).Item1' is not accessible in this context because it is 'Private'.
@@ -203,7 +203,7 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim t = (Nothing, Nothing)
                 ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3155,34 +3155,34 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of )' from assembly or module 'NoTuples.dll' failed.
-        Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
-                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of )' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of )' failed.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
-                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of )' from assembly or module 'NoTuples.dll' failed.
-        Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
-                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC37267: Import of type 'ValueTuple(Of )' failed.
+        Dim x As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = ("Alice", 2, 3, 4, 5, 6, 7, 8)
+                                                                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of )' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of )' failed.
+        Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,,,,,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of )' failed.
         Dim y As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8)
                                                                                             ~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3207,19 +3207,19 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                 ~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                 ~~~~~~~~~~~~~~~~~~~~~~
 BC37258: Tuple member names must all be provided, if any one is provided.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                  ~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
+        Dim x As (Integer, A As String) = (1, "hello", C:=2)
+                 ~~~~~~~~~~~~~~~~~~~~~~
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
+        Dim x As (Integer, A As String) = (1, "hello", C:=2)
+                 ~~~~~~~~~~~~~~~~~~~~~~
+BC37258: Tuple member names must all be provided, if any one is provided.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                                           ~~~~~~~~~~~~~~~~~~
-BC37258: Tuple member names must all be provided, if any one is provided.
+BC37267: Import of type 'ValueTuple(Of ,,)' failed.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                                           ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -3843,13 +3843,13 @@ End Module
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim x As (Integer, String) = (1, "hello")
                  ~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim x As (Integer, String) = (1, "hello")
                  ~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         Dim x As (Integer, String) = (1, "hello")
                                      ~~~~~~~~~~~~
 </errors>)
@@ -4263,13 +4263,13 @@ BC30389: '(first As Integer, second As Boolean).first' is not accessible in this
 BC30389: '(first As Integer, second As Boolean).second' is not accessible in this context because it is 'Private'.
         System.Console.Write($"{x.first} {x.second}")
                                           ~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
     Public Shared Function M(Of T1, T2)() As (first As T1, second As T2)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
     Public Shared Function M(Of T1, T2)() As (first As T1, second As T2)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,)' from assembly or module 'NoTuples.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,)' failed.
         return (Nothing, Nothing)
                ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -5935,13 +5935,13 @@ BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer,
 BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)' cannot be converted to '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8 )
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,)' from assembly or module 'comp.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,,)' failed.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8,
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30452: Operator '=' is not defined for types '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)' and '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,)' from assembly or module 'comp.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,,)' failed.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30198: ')' expected.
@@ -5959,13 +5959,13 @@ BC30451: 'oopsss' is not declared. It may be inaccessible due to its protection 
 BC30311: Value of type '((Integer, Integer), Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)' cannot be converted to '(x0 As (Integer, Integer), x1 As Integer, x2 As Integer, x3 As Integer, x4 As Integer, x5 As Integer, x6 As Integer, x7 As Integer, x8 As Integer, x9 As Integer, x10 As Integer)'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,)' from assembly or module 'comp.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,,)' failed.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, 9)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30311: Value of type '(Integer, Integer, Integer)' cannot be converted to 'Integer'.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, (1, 1, 1), 10)
                                              ~~~~~~~~~
-BC31091: Import of type 'ValueTuple(Of ,,)' from assembly or module 'comp.dll' failed.
+BC37267: Import of type 'ValueTuple(Of ,,)' failed.
         x = ((0, 0), 1, 2, 3, 4, 5, 6, 7, 8, (1, 1, 1), 10)
                                              ~~~~~~~~~
 </errors>)


### PR DESCRIPTION
This is a re-work of PR https://github.com/dotnet/roslyn/pull/13542.
Aleksey pointed out that the new error should only appear when looking up the ValueTuple well-known types, not for other missing references to ValueTuple. This simplifies the logic, both for C# and VB.


The purpose is to report a distinct error code so that Cyrus's code fixer can trigger easily and recommend to add the ValueTuple nuget package.

@dotnet/roslyn-compiler for review.
FYI for @CyrusNajmabadi 
Relates to #13375