### PR TITLE
Don't cause braces to become imbalanced when populating a switch statement

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/CrefCompletionProviderTests.cs
@@ -1015,6 +1015,11 @@ class C
             {
                 throw new NotImplementedException();
             }
+
+            public void AddFirstMissingCloseBrace(SyntaxNode root, SyntaxNode contextNode, out SyntaxNode newRoot, out SyntaxNode newContextNode)
+            {
+                throw new NotImplementedException();
+            }
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -895,6 +897,7 @@ namespace ConsoleApplication1
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsPopulateSwitch)]
+        [WorkItem(13455, "https://github.com/dotnet/roslyn/issues/13455")]
         public async Task AllMissingTokens()
         {
             await TestAsync(
@@ -928,7 +931,7 @@ class MyClass
                 break;
         }
     }
-");
+}", compareTokens: false);
         }
     }
 }

--- a/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
+++ b/src/EditorFeatures/CSharpTest/PopulateSwitch/PopulateSwitchTests_FixAllTests.cs
@@ -1,4 +1,6 @@
-﻿using Roslyn.Test.Utilities;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Roslyn.Test.Utilities;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/CrefCompletionProviderTests.vb
@@ -891,6 +891,10 @@ End Class]]></a>.Value.NormalizeLineEndings()
             Public Function ConvertToSingleLine(node As SyntaxNode, Optional useElasticTrivia As Boolean = False) As SyntaxNode Implements ISyntaxFactsService.ConvertToSingleLine
                 Throw New NotImplementedException()
             End Function
+
+            Public Sub AddFirstMissingCloseBrace(root As SyntaxNode, contextNode As SyntaxNode, ByRef newRoot As SyntaxNode, ByRef newContextNode As SyntaxNode) Implements ISyntaxFactsService.AddFirstMissingCloseBrace
+                Throw New NotImplementedException()
+            End Sub
         End Class
     End Class
 End Namespace

--- a/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
+++ b/src/Workspaces/Core/Portable/LanguageServices/SyntaxFactsService/ISyntaxFactsService.cs
@@ -185,6 +185,14 @@ namespace Microsoft.CodeAnalysis.LanguageServices
         /// that arguments name.
         /// </summary>
         string GetNameForArgument(SyntaxNode argument);
+
+        // Walks the tree, starting from contextNode, looking for the first construct
+        // with a missing close brace.  If found, the close brace will be added and the
+        // updates root will be returned.  The context node in that new tree will also
+        // be returned.
+        void AddFirstMissingCloseBrace(
+            SyntaxNode root, SyntaxNode contextNode, 
+            out SyntaxNode newRoot, out SyntaxNode newContextNode);
     }
 
     [Flags]

--- a/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
+++ b/src/Workspaces/VisualBasic/Portable/LanguageServices/VisualBasicSyntaxFactsService.vb
@@ -1456,5 +1456,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Return False
         End Function
+
+        Public Sub AddFirstMissingCloseBrace(root As SyntaxNode, contextNode As SyntaxNode, ByRef newRoot As SyntaxNode, ByRef newContextNode As SyntaxNode) Implements ISyntaxFactsService.AddFirstMissingCloseBrace
+            ' Nothing to be done.  VB doesn't have close braces
+            newRoot = root
+            newContextNode = contextNode
+        End Sub
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/13455
