### PR TITLE
Issue #10428: Formatting of empty loops now respects CSharp spacing options

### DIFF
--- a/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/FormattingTests.cs
@@ -6795,6 +6795,32 @@ class Program
 {
     void Main()
     {
+        for ( ;;)
+        {
+        }
+    }
+}";
+            var expected = @"
+class Program
+{
+    void Main()
+    {
+        for (; ; )
+        {
+        }
+    }
+}";
+            await AssertFormatAsync(expected, code);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SpacingForForStatementInfiniteLoopWithNoSpaces()
+        {
+            var code = @"
+class Program
+{
+    void Main()
+    {
         for ( ; ; )
         {
         }
@@ -6810,7 +6836,75 @@ class Program
         }
     }
 }";
-            await AssertFormatAsync(expected, code);
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.SpaceAfterSemicolonsInForStatement, false },
+            };
+
+            await AssertFormatAsync(expected, code, changedOptionSet: optionSet);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SpacingForForStatementInfiniteLoopWithSpacesBefore()
+        {
+            var code = @"
+class Program
+{
+    void Main()
+    {
+        for (;; )
+        {
+        }
+    }
+}";
+            var expected = @"
+class Program
+{
+    void Main()
+    {
+        for ( ; ;)
+        {
+        }
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.SpaceBeforeSemicolonsInForStatement, true },
+                { CSharpFormattingOptions.SpaceAfterSemicolonsInForStatement, false },
+            };
+
+            await AssertFormatAsync(expected, code, changedOptionSet: optionSet);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task SpacingForForStatementInfiniteLoopWithSpacesBeforeAndAfter()
+        {
+            var code = @"
+class Program
+{
+    void Main()
+    {
+        for (;;)
+        {
+        }
+    }
+}";
+            var expected = @"
+class Program
+{
+    void Main()
+    {
+        for ( ; ; )
+        {
+        }
+    }
+}";
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { CSharpFormattingOptions.SpaceBeforeSemicolonsInForStatement, true },
+            };
+
+            await AssertFormatAsync(expected, code, changedOptionSet: optionSet);
         }
 
         [WorkItem(4421, "https://github.com/dotnet/roslyn/issues/4421")]
@@ -7434,7 +7528,7 @@ switch (o)
 
         private Task AssertFormatBodyAsync(string expected, string input)
         {
-            Func<string, string> transform = s => 
+            Func<string, string> transform = s =>
             {
                 var lines = s.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
                 for (int i = 0; i < lines.Length; i++)


### PR DESCRIPTION
Hi there as a long-time C# dev I would love to make a contribution to Roslyn!

This PR updates the formatting rules for empty for loops to respect the options governing non-empty for loops; thus resolving Issue #10428. (I hope!) I've added tests to cover all four variations of the two options. The removal of trailing whitespace @ line 7392 I think is a result of running the codeformatter tool.

Fixes #10428