### PR TITLE
Only declare Hidden Descriptors for SimplifyTypeName/QualifyMemberAccess

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
@@ -16,32 +16,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.QualifyMemberAccess
 
         private static readonly LocalizableString s_qualifyMembersTitle = new LocalizableResourceString(nameof(FeaturesResources.Add_this_or_Me_qualification), FeaturesResources.ResourceManager, typeof(FeaturesResources));
 
-        private static readonly DiagnosticDescriptor s_descriptorQualifyMemberAccessInfo = new DiagnosticDescriptor(IDEDiagnosticIds.AddQualificationDiagnosticId,
+        private static readonly DiagnosticDescriptor s_descriptorQualifyMemberAccess = new DiagnosticDescriptor(IDEDiagnosticIds.AddQualificationDiagnosticId,
                                                                     s_qualifyMembersTitle,
                                                                     s_shouldBeQualifiedMessage,
                                                                     DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Info,
-                                                                    isEnabledByDefault: true,
-                                                                    customTags: DiagnosticCustomTags.Unnecessary);
-        private static readonly DiagnosticDescriptor s_descriptorQualifyMemberAccessWarning = new DiagnosticDescriptor(IDEDiagnosticIds.AddQualificationDiagnosticId,
-                                                                    s_qualifyMembersTitle,
-                                                                    s_shouldBeQualifiedMessage,
-                                                                    DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Warning,
-                                                                    isEnabledByDefault: true,
-                                                                    customTags: DiagnosticCustomTags.Unnecessary);
-        private static readonly DiagnosticDescriptor s_descriptorQualifyMemberAccessError = new DiagnosticDescriptor(IDEDiagnosticIds.AddQualificationDiagnosticId,
-                                                                    s_qualifyMembersTitle,
-                                                                    s_shouldBeQualifiedMessage,
-                                                                    DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Error,
+                                                                    DiagnosticSeverity.Hidden,
                                                                     isEnabledByDefault: true,
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(
-            s_descriptorQualifyMemberAccessInfo,
-            s_descriptorQualifyMemberAccessWarning,
-            s_descriptorQualifyMemberAccessError);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptorQualifyMemberAccess);
 
         public bool RunInProcess => true;
 
@@ -90,27 +73,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.QualifyMemberAccess
             var isQualificationPresent = IsAlreadyQualifiedMemberAccess(memberReference.Instance.Syntax);
             if (shouldOptionBePresent && !isQualificationPresent)
             {
-                DiagnosticDescriptor descriptor;
-                switch (optionValue.Notification.Value)
+                var severity = optionValue.Notification.Value;
+                if (severity != DiagnosticSeverity.Hidden)
                 {
-                    case DiagnosticSeverity.Hidden:
-                        descriptor = null;
-                        break;
-                    case DiagnosticSeverity.Info:
-                        descriptor = s_descriptorQualifyMemberAccessInfo;
-                        break;
-                    case DiagnosticSeverity.Warning:
-                        descriptor = s_descriptorQualifyMemberAccessWarning;
-                        break;
-                    case DiagnosticSeverity.Error:
-                        descriptor = s_descriptorQualifyMemberAccessError;
-                        break;
-                    default:
-                        throw ExceptionUtilities.Unreachable;
-                }
+                    var descriptor = new DiagnosticDescriptor(
+                        IDEDiagnosticIds.AddQualificationDiagnosticId,
+                        s_qualifyMembersTitle,
+                        s_shouldBeQualifiedMessage,
+                        DiagnosticCategory.Style,
+                        severity,
+                        isEnabledByDefault: true,
+                        customTags: DiagnosticCustomTags.Unnecessary);
 
-                if (descriptor != null)
-                {
                     context.ReportDiagnostic(Diagnostic.Create(descriptor, context.Operation.Syntax.GetLocation()));
                 }
             }

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -35,35 +35,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
 
         private static readonly LocalizableString s_localizableTitleRemoveThisOrMe = new LocalizableResourceString(nameof(FeaturesResources.Remove_qualification), FeaturesResources.ResourceManager, typeof(FeaturesResources));
-        private static readonly DiagnosticDescriptor s_descriptorRemoveThisOrMeHidden = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveQualificationDiagnosticId,
+        private static readonly DiagnosticDescriptor s_descriptorRemoveThisOrMe = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveQualificationDiagnosticId,
                                                                     s_localizableTitleRemoveThisOrMe,
                                                                     s_localizableMessage,
                                                                     DiagnosticCategory.Style,
                                                                     DiagnosticSeverity.Hidden,
                                                                     isEnabledByDefault: true,
                                                                     customTags: DiagnosticCustomTags.Unnecessary);
-        private static readonly DiagnosticDescriptor s_descriptorRemoveThisOrMeInfo = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveQualificationDiagnosticId,
-                                                                    s_localizableTitleRemoveThisOrMe,
-                                                                    s_localizableMessage,
-                                                                    DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Info,
-                                                                    isEnabledByDefault: true,
-                                                                    customTags: DiagnosticCustomTags.Unnecessary);
-        private static readonly DiagnosticDescriptor s_descriptorRemoveThisOrMeWarning = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveQualificationDiagnosticId,
-                                                                    s_localizableTitleRemoveThisOrMe,
-                                                                    s_localizableMessage,
-                                                                    DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Warning,
-                                                                    isEnabledByDefault: true,
-                                                                    customTags: DiagnosticCustomTags.Unnecessary);
-        private static readonly DiagnosticDescriptor s_descriptorRemoveThisOrMeError = new DiagnosticDescriptor(IDEDiagnosticIds.RemoveQualificationDiagnosticId,
-                                                                    s_localizableTitleRemoveThisOrMe,
-                                                                    s_localizableMessage,
-                                                                    DiagnosticCategory.Style,
-                                                                    DiagnosticSeverity.Error,
-                                                                    isEnabledByDefault: true,
-                                                                    customTags: DiagnosticCustomTags.Unnecessary);
-
+        
         private static readonly DiagnosticDescriptor s_descriptorPreferIntrinsicTypeInDeclarations = new DiagnosticDescriptor(IDEDiagnosticIds.PreferIntrinsicPredefinedTypeInDeclarationsDiagnosticId,
                                                             s_localizableTitleSimplifyNames,
                                                             s_localizableMessage,
@@ -87,10 +66,7 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
                 return ImmutableArray.Create(
                     s_descriptorSimplifyNames,
                     s_descriptorSimplifyMemberAccess,
-                    s_descriptorRemoveThisOrMeHidden,
-                    s_descriptorRemoveThisOrMeInfo,
-                    s_descriptorRemoveThisOrMeWarning,
-                    s_descriptorRemoveThisOrMeError,
+                    s_descriptorRemoveThisOrMe,
                     s_descriptorPreferIntrinsicTypeInDeclarations,
                     s_descriptorPreferIntrinsicTypeInMemberAccess);
             }
@@ -196,19 +172,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
 
             var applicableOption = QualifyMemberAccessDiagnosticAnalyzerBase<TLanguageKindEnum>.GetApplicableOptionFromSymbolKind(symbolInfo.Symbol.Kind);
             var optionValue = optionSet.GetOption(applicableOption, GetLanguageName());
-            switch (optionValue.Notification.Value)
-            {
-                case DiagnosticSeverity.Hidden:
-                    return s_descriptorRemoveThisOrMeHidden;
-                case DiagnosticSeverity.Info:
-                    return s_descriptorRemoveThisOrMeInfo;
-                case DiagnosticSeverity.Warning:
-                    return s_descriptorRemoveThisOrMeWarning;
-                case DiagnosticSeverity.Error:
-                    return s_descriptorRemoveThisOrMeError;
-                default:
-                    throw ExceptionUtilities.Unreachable;
-            }
+            var severity = optionValue.Notification.Value;
+
+            return new DiagnosticDescriptor(
+                IDEDiagnosticIds.RemoveQualificationDiagnosticId,
+                s_localizableTitleRemoveThisOrMe,
+                s_localizableMessage,
+                DiagnosticCategory.Style,
+                severity,
+                isEnabledByDefault: true,
+                customTags: DiagnosticCustomTags.Unnecessary);
         }
 
         public DiagnosticAnalyzerCategory GetAnalyzerCategory()


### PR DESCRIPTION
Fixes #12714

Both SimplifyTypeName and QualifyMemberAccess were declaring one
DiagnosticDescriptor per DiagnosticSeverity level. After this change,
they only initially report DiagnosticSeverity.Hidden in the 
SupportedDiagnostics, which prevents them from running on closed files.

There are longer-term plans to allow these to run on closed files but
under closer control of the user.