### PR TITLE
Add System.Runtime.InteropServices.RuntimeInformation to list of Debugger dependencies

### DIFF
--- a/src/Setup/DevDivPackages/Debugger/project.json
+++ b/src/Setup/DevDivPackages/Debugger/project.json
@@ -9,7 +9,8 @@
     "System.Reflection.TypeExtensions": "4.1.0",
     "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.1.0",
-    "System.Threading.Thread": "4.0.0"
+    "System.Threading.Thread": "4.0.0",
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
   },
   "frameworks": {
     "net46": {}


### PR DESCRIPTION
We were missing one facade that the Debugger depends on.