### PR TITLE
Revert an incorrect optimization in binary operator overload resolution

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -821,7 +821,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Is this applicable operator better than every other applicable method?
                 for (int j = 0; j < i; ++j)
                 {
-                    if (candidates[j].Kind != OperatorAnalysisResultKind.Applicable)
+                    if (candidates[j].Kind == OperatorAnalysisResultKind.Inapplicable)
                     {
                         continue;
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/BinaryOperatorOverloadResolution.cs
@@ -245,45 +245,25 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert((object)underlying != null);
             Debug.Assert(underlying.SpecialType != SpecialType.None);
 
-            NamedTypeSymbol nullableEnum = null;
-            NamedTypeSymbol nullableUnderlying = null;
-
-            // PERF: avoid instantiating nullable types in common simple cases.
-            var leftType = left.Type;
-            var rightType = right.Type;
-            var simpleCase = leftType?.IsValueType == true &&
-                             rightType?.IsValueType == true &&
-                             leftType.IsNullableType() == false &&
-                             rightType.IsNullableType() == false;
-
-            if (!simpleCase)
-            {
-                var nullable = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
-                nullableEnum = nullable.Construct(enumType);
-                nullableUnderlying = nullable.Construct(underlying);
-            }
+            var nullable = Compilation.GetSpecialType(SpecialType.System_Nullable_T);
+            var nullableEnum = nullable.Construct(enumType);
+            var nullableUnderlying = nullable.Construct(underlying);
 
             switch (kind)
             {
                 case BinaryOperatorKind.Addition:
                     operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingAddition, enumType, underlying, enumType));
                     operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UnderlyingAndEnumAddition, underlying, enumType, enumType));
-                    if (!simpleCase)
-                    {
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingAddition, nullableEnum, nullableUnderlying, nullableEnum));
-                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumAddition, nullableUnderlying, nullableEnum, nullableEnum));
-                    }
+                    operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingAddition, nullableEnum, nullableUnderlying, nullableEnum));
+                    operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumAddition, nullableUnderlying, nullableEnum, nullableEnum));
                     break;
                 case BinaryOperatorKind.Subtraction:
                     if (Strict)
                     {
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumSubtraction, enumType, enumType, underlying));
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingSubtraction, enumType, underlying, enumType));
-                        if (!simpleCase)
-                        {
-                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying));
-                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum));
-                        }
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying));
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum));
                     }
                     else
                     {
@@ -297,22 +277,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                         { Priority = 2 });
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.EnumAndUnderlyingSubtraction, enumType, underlying, enumType)
                         { Priority = isExactSubtraction ? 1 : 3 });
-                        if (!simpleCase)
-                        {
-                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying)
-                            { Priority = 12 });
-                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum)
-                            { Priority = isExactSubtraction ? 11 : 13 });
-                        }
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumSubtraction, nullableEnum, nullableEnum, nullableUnderlying)
+                        { Priority = 12 });
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedEnumAndUnderlyingSubtraction, nullableEnum, nullableUnderlying, nullableEnum)
+                        { Priority = isExactSubtraction ? 11 : 13 });
 
                         // Due to a bug, the native compiler allows "underlying - enum", so Roslyn does as well.
                         operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.UnderlyingAndEnumSubtraction, underlying, enumType, enumType)
                         { Priority = 4 });
-                        if (!simpleCase)
-                        {
-                            operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumSubtraction, nullableUnderlying, nullableEnum, nullableEnum)
-                            { Priority = 14 });
-                        }
+                        operators.Add(new BinaryOperatorSignature(BinaryOperatorKind.LiftedUnderlyingAndEnumSubtraction, nullableUnderlying, nullableEnum, nullableEnum)
+                        { Priority = 14 });
                     }
                     break;
                 case BinaryOperatorKind.Equal:
@@ -323,19 +297,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case BinaryOperatorKind.LessThanOrEqual:
                     var boolean = Compilation.GetSpecialType(SpecialType.System_Boolean);
                     operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Enum, enumType, enumType, boolean));
-                    if (!simpleCase)
-                    {
-                        operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, boolean));
-                    }
+                    operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, boolean));
                     break;
                 case BinaryOperatorKind.And:
                 case BinaryOperatorKind.Or:
                 case BinaryOperatorKind.Xor:
                     operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Enum, enumType, enumType, enumType));
-                    if (!simpleCase)
-                    {
-                        operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, nullableEnum));
-                    }
+                    operators.Add(new BinaryOperatorSignature(kind | BinaryOperatorKind.Lifted | BinaryOperatorKind.Enum, nullableEnum, nullableEnum, nullableEnum));
                     break;
             }
         }
@@ -843,7 +811,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // UNDONE: This is a naive quadratic algorithm; there is a linear algorithm that works. Consider using it.
             var candidates = result.Results;
-            for (int i = 0; i < candidates.Count; ++i)
+            for (int i = 1; i < candidates.Count; ++i)
             {
                 if (candidates[i].Kind != OperatorAnalysisResultKind.Applicable)
                 {
@@ -851,13 +819,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // Is this applicable operator better than every other applicable method?
-                for (int j = 0; j < candidates.Count; ++j)
+                for (int j = 0; j < i; ++j)
                 {
-                    if (i == j)
-                    {
-                        continue;
-                    }
-                    if (candidates[j].Kind == OperatorAnalysisResultKind.Inapplicable)
+                    if (candidates[j].Kind != OperatorAnalysisResultKind.Applicable)
                     {
                         continue;
                     }

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/Operators/UnaryOperatorOverloadResolution.cs
@@ -79,9 +79,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // SPEC: error occurs.
 
             // UNDONE: This is a naive quadratic algorithm; there is a linear algorithm that works. Consider using it.
-
             var candidates = result.Results;
-            for (int i = 0; i < candidates.Count; ++i)
+            for (int i = 1; i < candidates.Count; ++i)
             {
                 if (candidates[i].Kind != OperatorAnalysisResultKind.Applicable)
                 {
@@ -89,12 +88,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 // Is this applicable operator better than every other applicable method?
-                for (int j = 0; j < candidates.Count; ++j)
+                for (int j = 0; j < i; ++j)
                 {
-                    if (i == j)
-                    {
-                        continue;
-                    }
                     if (candidates[j].Kind == OperatorAnalysisResultKind.Inapplicable)
                     {
                         continue;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OverloadResolutionTests.cs
@@ -9037,5 +9037,36 @@ class Program
                 Diagnostic(ErrorCode.ERR_AmbigCall, "Method").WithArguments("Program.Method(Del1)", "Program.Method(Del2)").WithLocation(12, 9)
                 );
         }
+
+        [Fact, WorkItem(13380, "https://github.com/dotnet/roslyn/issues/13380")]
+        public void ImplicitNullableOperatorInEquality()
+        {
+            string source =
+@"public class Class1
+{
+    public static void Main(string[] args)
+    {
+        var a = default(Registration<Something>);
+        var x = (a == Something.Bad); //this line fails in VS2015.3
+        System.Console.WriteLine(x);
+    }
+}
+
+public struct Registration<T> where T : struct
+{
+    public static implicit operator T? (Registration<T> registration)
+    {
+        return null;
+    }
+}
+
+public enum Something
+{
+    Good,
+    Bad
+}";
+            // should be NO errors.
+            CompileAndVerify(source, expectedOutput: @"False");
+        }
     }
 }


### PR DESCRIPTION
from PR #9543; issue #13380 shows why the optimization is not correct.

@dotnet/roslyn-compiler Please review
/cc @VSadov @tmat @agocke @AlekseyTs
