### PR TITLE
No accessibility error on error tuple fields

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -67,7 +67,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         Public Sub New(container As NamedTypeSymbol, name As String, tupleFieldId As Integer, location As Location, type As TypeSymbol, useSiteDiagnosticInfo As DiagnosticInfo)
-            MyBase.New(container, container, type, name)
+            MyBase.New(container, container, type, name, Accessibility.Public)
             Debug.Assert(name <> Nothing)
             Me._locations = If((location Is Nothing), ImmutableArray(Of Location).Empty, ImmutableArray.Create(Of Location)(location))
             Me._useSiteDiagnosticInfo = useSiteDiagnosticInfo

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -130,21 +130,12 @@ BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
 BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t as (Integer, Integer)
                  ~~~~~~~~~~~~~~~~~~
-BC30389: '(Integer, Integer).Item1' is not accessible in this context because it is 'Private'.
-        console.writeline(t.Item1)
-                          ~~~~~~~
 BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
         Dim t1 as (A As Integer, B As Integer)
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC30389: '(A As Integer, B As Integer).Item1' is not accessible in this context because it is 'Private'.
-        console.writeline(t1.Item1)
-                          ~~~~~~~~
-BC30389: '(A As Integer, B As Integer).A' is not accessible in this context because it is 'Private'.
-        console.writeline(t1.A)
-                          ~~~~
 </errors>)
 
         End Sub
@@ -4257,12 +4248,6 @@ End Class
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC30389: '(first As Integer, second As Boolean).first' is not accessible in this context because it is 'Private'.
-        System.Console.Write($"{x.first} {x.second}")
-                                ~~~~~~~
-BC30389: '(first As Integer, second As Boolean).second' is not accessible in this context because it is 'Private'.
-        System.Console.Write($"{x.first} {x.second}")
-                                          ~~~~~~~~
 BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
     Public Shared Function M(Of T1, T2)() As (first As T1, second As T2)
                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
One liner fix to align VB implementation to C#. The `TupleErrorFieldSymbol` should have public accessibility, which avoids un-necessary diagnostics.

@dotnet/roslyn-compiler for review.

Fixes https://github.com/dotnet/roslyn/issues/13302