### PR TITLE
 Suggestion tag improvements.

### DIFF
--- a/src/EditorFeatures/Core/EditorFeatures.csproj
+++ b/src/EditorFeatures/Core/EditorFeatures.csproj
@@ -645,6 +645,7 @@
     <Compile Include="IRefactorNotifyService.cs" />
     <Compile Include="Shared\IImageMonikerService.cs" />
     <Compile Include="Shared\DefaultImageMonikerService.cs" />
+    <Compile Include="Shared\Tagging\EventSources\TaggerEventSources.EditorFormatMapChangedEventSource.cs" />
     <Compile Include="Shared\Tagging\EventSources\TaggerEventSources.ViewSpanChangedEventSource.cs" />
     <Compile Include="Shared\Utilities\SynchronizationContextTaskScheduler.cs" />
     <Compile Include="Tagging\AbstractAsynchronousTaggerProvider.Tagger.cs" />

--- a/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.Designer.cs
@@ -1468,6 +1468,15 @@ namespace Microsoft.CodeAnalysis.Editor {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Suggestion ellipses (…).
+        /// </summary>
+        internal static string Suggestion_ellipses {
+            get {
+                return ResourceManager.GetString("Suggestion_ellipses", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;symbol&apos; cannot be a namespace..
         /// </summary>
         internal static string symbol_cannot_be_a_namespace {

--- a/src/EditorFeatures/Core/EditorFeaturesResources.resx
+++ b/src/EditorFeatures/Core/EditorFeaturesResources.resx
@@ -748,4 +748,7 @@ Do you want to proceed?</value>
   <data name="Navigating" xml:space="preserve">
     <value>Navigating...</value>
   </data>
+  <data name="Suggestion_ellipses" xml:space="preserve">
+    <value>Suggestion ellipses (…)</value>
+  </data>
 </root>

--- a/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Windows.Media;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 
@@ -11,31 +13,53 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
     /// </summary>
     internal abstract class GraphicsTag : ITag
     {
-        protected static SolidColorBrush VerticalRuleBrush;
-        protected static Color VerticalRuleColor;
+        private IEditorFormatMapService _editorFormatMapService;
+        private IEditorFormatMap _editorFormatMap;
 
-        protected virtual void Initialize(IWpfTextView view)
+        protected virtual void Initialize(IWpfTextView view, 
+            ref Brush graphicsTagBrush,
+            ref Color graphicsTagColor)
         {
-            if (VerticalRuleBrush != null)
+            if (graphicsTagBrush != null)
             {
                 return;
             }
 
+            Debug.Assert(_editorFormatMap == null);
+            _editorFormatMap = _editorFormatMapService.GetEditorFormatMap("text");
+            _editorFormatMap.FormatMappingChanged += OnFormatMappingChanged;
+
             // TODO: Refresh this when the user changes fonts and colors
 
-            // TODO: Get from resources
-            var lightGray = Color.FromRgb(0xE0, 0xE0, 0xE0);
+            // If we can't get the color for some reason, fall back to a hardcoded value
+            // the editor has for outlining.
+            var lightGray = Color.FromRgb(0xA5, 0xA5, 0xA5);
 
-            var outliningForegroundBrush = view.VisualElement.TryFindResource("outlining.verticalrule.foreground") as SolidColorBrush;
-            var color = outliningForegroundBrush?.Color ?? lightGray;
+            var color = this.GetColor(view, _editorFormatMap) ?? lightGray;
 
-            VerticalRuleColor = color;
-            VerticalRuleBrush = new SolidColorBrush(VerticalRuleColor);
+            graphicsTagColor = color;
+            graphicsTagBrush = new SolidColorBrush(graphicsTagColor);
         }
+
+        protected abstract Color? GetColor(IWpfTextView view, IEditorFormatMap editorFormatMap);
+
+        private void OnFormatMappingChanged(object sender, FormatItemsEventArgs e)
+        {
+            _editorFormatMap.FormatMappingChanged -= OnFormatMappingChanged;
+            _editorFormatMap = null;
+            this.ClearCachedFormatData();
+        }
+
+        protected abstract void ClearCachedFormatData();
 
         /// <summary>
         /// This method allows corresponding adornment manager to ask for a graphical glyph.
         /// </summary>
         public abstract GraphicsResult GetGraphics(IWpfTextView view, Geometry bounds);
+
+        internal void RegisterService(IEditorFormatMapService editorFormatMapService)
+        {
+            _editorFormatMapService = editorFormatMapService;
+        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
     /// </summary>
     internal abstract class GraphicsTag : ITag
     {
-        private IEditorFormatMap _editorFormatMap;
+        private readonly IEditorFormatMap _editorFormatMap;
         protected Brush _graphicsTagBrush;
         protected Color _graphicsTagColor;
 
@@ -46,10 +46,5 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
         /// This method allows corresponding adornment manager to ask for a graphical glyph.
         /// </summary>
         public abstract GraphicsResult GetGraphics(IWpfTextView view, Geometry bounds);
-
-        internal void RegisterFormatMap(IEditorFormatMap editorFormatMap)
-        {
-            _editorFormatMap = editorFormatMap;
-        }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
@@ -28,8 +28,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
                 return;
             }
 
-            // TODO: Refresh this when the user changes fonts and colors
-
             // If we can't get the color for some reason, fall back to a hardcoded value
             // the editor has for outlining.
             var lightGray = Color.FromRgb(0xA5, 0xA5, 0xA5);

--- a/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Adornments/GraphicsTag.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Diagnostics;
 using System.Windows.Media;
 using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
@@ -13,21 +12,21 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
     /// </summary>
     internal abstract class GraphicsTag : ITag
     {
-        private IEditorFormatMapService _editorFormatMapService;
         private IEditorFormatMap _editorFormatMap;
+        protected Brush _graphicsTagBrush;
+        protected Color _graphicsTagColor;
 
-        protected virtual void Initialize(IWpfTextView view, 
-            ref Brush graphicsTagBrush,
-            ref Color graphicsTagColor)
+        protected GraphicsTag(IEditorFormatMap editorFormatMap)
         {
-            if (graphicsTagBrush != null)
+            _editorFormatMap = editorFormatMap;
+        }
+
+        protected virtual void Initialize(IWpfTextView view)
+        {
+            if (_graphicsTagBrush != null)
             {
                 return;
             }
-
-            Debug.Assert(_editorFormatMap == null);
-            _editorFormatMap = _editorFormatMapService.GetEditorFormatMap("text");
-            _editorFormatMap.FormatMappingChanged += OnFormatMappingChanged;
 
             // TODO: Refresh this when the user changes fonts and colors
 
@@ -37,29 +36,20 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Adornments
 
             var color = this.GetColor(view, _editorFormatMap) ?? lightGray;
 
-            graphicsTagColor = color;
-            graphicsTagBrush = new SolidColorBrush(graphicsTagColor);
+            _graphicsTagColor = color;
+            _graphicsTagBrush = new SolidColorBrush(_graphicsTagColor);
         }
 
         protected abstract Color? GetColor(IWpfTextView view, IEditorFormatMap editorFormatMap);
-
-        private void OnFormatMappingChanged(object sender, FormatItemsEventArgs e)
-        {
-            _editorFormatMap.FormatMappingChanged -= OnFormatMappingChanged;
-            _editorFormatMap = null;
-            this.ClearCachedFormatData();
-        }
-
-        protected abstract void ClearCachedFormatData();
 
         /// <summary>
         /// This method allows corresponding adornment manager to ask for a graphical glyph.
         /// </summary>
         public abstract GraphicsResult GetGraphics(IWpfTextView view, Geometry bounds);
 
-        internal void RegisterService(IEditorFormatMapService editorFormatMapService)
+        internal void RegisterFormatMap(IEditorFormatMap editorFormatMap)
         {
-            _editorFormatMapService = editorFormatMapService;
+            _editorFormatMap = editorFormatMap;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.TaggerProvider.cs
@@ -63,9 +63,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 // We act as a source of events ourselves.  When the diagnostics service tells
                 // us about new diagnostics, we'll use that to kick of the asynchronous tagging
                 // work.
-                return TaggerEventSources.Compose(
+                
+                var eventSource = TaggerEventSources.Compose(
                     TaggerEventSources.OnWorkspaceRegistrationChanged(subjectBuffer, TaggerDelay.Medium),
                     this);
+
+                // See if our owner has any additional events for us to listen to.
+                var ownerEventSource = _owner.GetTaggerEventSource();
+                return ownerEventSource == null
+                    ? eventSource
+                    : TaggerEventSources.Compose(ownerEventSource, eventSource);
             }
 
             protected override Task ProduceTagsAsync(TaggerContext<TTag> context, DocumentSnapshotSpan spanToTag, int? caretPosition)
@@ -163,6 +170,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 // taken cared by the external service (diagnostic service).
                 this.Changed?.Invoke(this, new TaggerEventArgs(TaggerDelay.NearImmediate));
             }
+        }
+
+        protected virtual ITaggerEventSource GetTaggerEventSource()
+        {
+            return null;
         }
     }
 }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
@@ -6,6 +6,8 @@ using System.Collections.Immutable;
 using System.ComponentModel.Composition;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
+using Microsoft.CodeAnalysis.Editor.Shared.Tagging;
+using Microsoft.CodeAnalysis.Editor.Tagging;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
@@ -24,7 +26,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
     {
         private static readonly IEnumerable<Option<bool>> s_tagSourceOptions =
             ImmutableArray.Create(EditorComponentOnOffOptions.Tagger, InternalFeatureOnOffOptions.Squiggles, ServiceComponentOnOffOptions.DiagnosticProvider);
+
+        private readonly IEditorFormatMap _editorFormatMap;
+
         protected internal override IEnumerable<Option<bool>> Options => s_tagSourceOptions;
+
+        private readonly object _suggestionTagGate = new object();
+        private SuggestionTag _suggestionTag;
 
         [ImportingConstructor]
         public DiagnosticsSuggestionTaggerProvider(
@@ -34,7 +42,23 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> listeners)
             : base(diagnosticService, notificationService, listeners)
         {
-            SuggestionTag.Instance.RegisterService(editorFormatMapService);
+            _editorFormatMap = editorFormatMapService.GetEditorFormatMap("text");
+            _editorFormatMap.FormatMappingChanged += OnFormatMappingChanged;
+            _suggestionTag = new SuggestionTag(_editorFormatMap);
+        }
+
+        private void OnFormatMappingChanged(object sender, FormatItemsEventArgs e)
+        {
+            lock (_suggestionTagGate)
+            {
+                _suggestionTag = new SuggestionTag(_editorFormatMap);
+            }
+        }
+
+        protected override ITaggerEventSource GetTaggerEventSource()
+        {
+            return TaggerEventSources.OnEditorFormatMapChanged(
+                _editorFormatMap, TaggerDelay.NearImmediate);
         }
 
         protected internal override bool IncludeDiagnostic(DiagnosticData diagnostic)
@@ -44,7 +68,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
         protected override SuggestionTag CreateTag(DiagnosticData diagnostic)
         {
-            return SuggestionTag.Instance;
+            lock(_suggestionTagGate)
+            {
+                return _suggestionTag;
+            }
         }
 
         protected override SnapshotSpan AdjustSnapshotSpan(SnapshotSpan snapshotSpan, int minimumLength)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/DiagnosticsSuggestionTaggerProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
 
@@ -27,11 +28,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
         [ImportingConstructor]
         public DiagnosticsSuggestionTaggerProvider(
+            IEditorFormatMapService editorFormatMapService,
             IDiagnosticService diagnosticService,
             IForegroundNotificationService notificationService,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> listeners)
             : base(diagnosticService, notificationService, listeners)
         {
+            SuggestionTag.Instance.RegisterService(editorFormatMapService);
         }
 
         protected internal override bool IncludeDiagnostic(DiagnosticData diagnostic)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 return;
             }
 
-            var color = Color.FromArgb(100, VerticalRuleColor.R, VerticalRuleColor.G, VerticalRuleColor.B);
+            var color = Color.FromArgb(200, VerticalRuleColor.R, VerticalRuleColor.G, VerticalRuleColor.B);
             s_pen = new Pen
             {
                 Brush = new SolidColorBrush(color),

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
@@ -1,32 +1,69 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+using System.ComponentModel.Composition;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using Microsoft.CodeAnalysis.Editor.Implementation.Adornments;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 {
+    [Export(typeof(EditorFormatDefinition))]
+    [Name(SuggestionTagFormat.ResourceName)]
+    [UserVisible(true)]
+    internal sealed class SuggestionTagFormat : EditorFormatDefinition
+    {
+        public const string ResourceName = "SuggestionTagFormat";
+
+        public SuggestionTagFormat()
+        {
+            this.ForegroundColor = Color.FromArgb(200, 0xA5, 0xA5, 0xA5);
+            this.BackgroundCustomizable = false;
+            this.DisplayName = EditorFeaturesResources.Suggestion_ellipses;
+        }
+    }
+
     /// <summary>
     /// Tag that specifies line separator.
     /// </summary>
     internal class SuggestionTag : GraphicsTag
     {
+        private static Brush s_graphicsTagBrush;
+        private static Color s_graphicsTagColor;
+        private static Pen s_graphicsTagPen;
+
         public static readonly SuggestionTag Instance = new SuggestionTag();
 
-        private static Pen s_pen;
-
-        protected override void Initialize(IWpfTextView view)
+        protected override Color? GetColor(
+            IWpfTextView view, IEditorFormatMap editorFormatMap)
         {
-            base.Initialize(view);
+            var property = editorFormatMap.GetProperties(SuggestionTagFormat.ResourceName)["ForegroundColor"];
+            return property as Color?;
+        }
 
-            if (s_pen != null)
+        protected override void ClearCachedFormatData()
+        {
+            s_graphicsTagBrush = null;
+            s_graphicsTagColor = default(Color);
+            s_graphicsTagPen = null;
+        }
+
+        protected override void Initialize(IWpfTextView view, 
+            ref Brush graphicsTagBrush, 
+            ref Color graphicsTagColor)
+        {
+            base.Initialize(view, ref graphicsTagBrush, ref graphicsTagColor);
+
+            if (s_graphicsTagPen != null)
             {
                 return;
             }
 
-            var color = Color.FromArgb(200, VerticalRuleColor.R, VerticalRuleColor.G, VerticalRuleColor.B);
-            s_pen = new Pen
+            var color = graphicsTagColor;
+            s_graphicsTagPen = new Pen
             {
                 Brush = new SolidColorBrush(color),
                 DashStyle = DashStyles.Dot,
@@ -37,7 +74,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
         public override GraphicsResult GetGraphics(IWpfTextView view, Geometry geometry)
         {
-            Initialize(view);
+            Initialize(view, ref s_graphicsTagBrush, ref s_graphicsTagColor);
 
             // We clip off a bit off the start of the line to prevent a half-square being
             // drawn.
@@ -47,17 +84,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             var line = new Line
             {
                 X1 = geometry.Bounds.Left,
-                Y1 = geometry.Bounds.Bottom - s_pen.Thickness,
+                Y1 = geometry.Bounds.Bottom - s_graphicsTagPen.Thickness,
                 X2 = geometry.Bounds.Right,
-                Y2 = geometry.Bounds.Bottom - s_pen.Thickness,
+                Y2 = geometry.Bounds.Bottom - s_graphicsTagPen.Thickness,
                 Clip = new RectangleGeometry { Rect = clipRectangle }
             };
             // RenderOptions.SetEdgeMode(line, EdgeMode.Aliased);
 
-            ApplyPen(line, s_pen);
+            ApplyPen(line, s_graphicsTagPen);
 
             // Shift the line over to offset the clipping we did.
-            line.RenderTransform = new TranslateTransform(-s_pen.Thickness, 0);
+            line.RenderTransform = new TranslateTransform(-s_graphicsTagPen.Thickness, 0);
             return new GraphicsResult(line, null);
         }
 

--- a/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTag.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTag.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
     /// </summary>
     internal class LineSeparatorTag : GraphicsTag
     {
-        private static Brush s_graphicsTagBrush;
-        private static Color s_graphicsTagColor;
-
-        public static readonly LineSeparatorTag Instance = new LineSeparatorTag();
+        public LineSeparatorTag(IEditorFormatMap editorFormatMap)
+            : base(editorFormatMap)
+        {
+        }
 
         protected override Color? GetColor(
             IWpfTextView view, IEditorFormatMap editorFormatMap)
@@ -27,21 +27,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
             return brush?.Color;
         }
 
-        protected override void ClearCachedFormatData()
-        {
-            s_graphicsTagBrush = null;
-            s_graphicsTagColor = default(Color);
-        }
-
         /// <summary>
         /// Creates a very long line at the bottom of bounds.
         /// </summary>
         public override GraphicsResult GetGraphics(IWpfTextView view, Geometry bounds)
         {
-            Initialize(view, ref s_graphicsTagBrush, ref s_graphicsTagColor);
+            Initialize(view);
 
             var border = new Border();
-            border.BorderBrush = s_graphicsTagBrush;
+            border.BorderBrush = _graphicsTagBrush;
             border.BorderThickness = new Thickness(0, 0, 0, bottom: 1);
             border.Height = 1;
             border.Width = view.ViewportWidth;

--- a/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTag.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTag.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using Microsoft.CodeAnalysis.Editor.Implementation.Adornments;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
@@ -14,17 +15,33 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
     /// </summary>
     internal class LineSeparatorTag : GraphicsTag
     {
+        private static Brush s_graphicsTagBrush;
+        private static Color s_graphicsTagColor;
+
         public static readonly LineSeparatorTag Instance = new LineSeparatorTag();
+
+        protected override Color? GetColor(
+            IWpfTextView view, IEditorFormatMap editorFormatMap)
+        {
+            var brush = view.VisualElement.TryFindResource("outlining.verticalrule.foreground") as SolidColorBrush;
+            return brush?.Color;
+        }
+
+        protected override void ClearCachedFormatData()
+        {
+            s_graphicsTagBrush = null;
+            s_graphicsTagColor = default(Color);
+        }
 
         /// <summary>
         /// Creates a very long line at the bottom of bounds.
         /// </summary>
         public override GraphicsResult GetGraphics(IWpfTextView view, Geometry bounds)
         {
-            Initialize(view);
+            Initialize(view, ref s_graphicsTagBrush, ref s_graphicsTagColor);
 
             var border = new Border();
-            border.BorderBrush = VerticalRuleBrush;
+            border.BorderBrush = s_graphicsTagBrush;
             border.BorderThickness = new Thickness(0, 0, 0, bottom: 1);
             border.Height = 1;
             border.Width = view.ViewportWidth;

--- a/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/LineSeparators/LineSeparatorTaggerProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
@@ -34,13 +35,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.LineSeparators
 
         [ImportingConstructor]
         public LineSeparatorTaggerProvider(
+            IEditorFormatMapService editorFormatMapService,
             IForegroundNotificationService notificationService,
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
                 : base(new AggregateAsynchronousOperationListener(asyncListeners, FeatureAttribute.LineSeparators), notificationService)
         {
+            LineSeparatorTag.Instance.RegisterService(editorFormatMapService);
         }
 
-        protected override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
+        protected override ITaggerEventSource CreateEventSource(
+            ITextView textView, ITextBuffer subjectBuffer)
         {
             return TaggerEventSources.OnTextChanged(subjectBuffer, TaggerDelay.NearImmediate);
         }

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.EditorFormatMapChangedEventSource.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.EditorFormatMapChangedEventSource.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.Editor.Tagging;
+using Microsoft.VisualStudio.Text.Classification;
+
+namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
+{
+    internal partial class TaggerEventSources
+    {
+        private class EditorFormatMapChangedEventSource : AbstractTaggerEventSource
+        {
+            private readonly IEditorFormatMap _editorFormatMap;
+
+            public EditorFormatMapChangedEventSource(IEditorFormatMap editorFormatMap, TaggerDelay delay)
+                : base(delay)
+            {
+                _editorFormatMap = editorFormatMap;
+            }
+
+            public override void Connect()
+            {
+                _editorFormatMap.FormatMappingChanged += OnEditorFormatMapChanged;
+            }
+
+            public override void Disconnect()
+            {
+                _editorFormatMap.FormatMappingChanged -= OnEditorFormatMapChanged;
+            }
+
+            private void OnEditorFormatMapChanged(object sender, FormatItemsEventArgs e)
+            {
+                this.RaiseChanged();
+            }
+        }
+    }
+}

--- a/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
+++ b/src/EditorFeatures/Core/Shared/Tagging/EventSources/TaggerEventSources.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Notification;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Roslyn.Utilities;
 
@@ -107,6 +108,12 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Tagging
         public static ITaggerEventSource OnViewSpanChanged(ITextView textView, TaggerDelay textChangeDelay, TaggerDelay scrollChangeDelay)
         {
             return new ViewSpanChangedEventSource(textView, textChangeDelay, scrollChangeDelay);
+        }
+
+        public static ITaggerEventSource OnEditorFormatMapChanged(
+            IEditorFormatMap editorFormatMap, TaggerDelay delay)
+        {
+            return new EditorFormatMapChangedEventSource(editorFormatMap, delay);
         }
     }
 }

--- a/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Tagging/AbstractAsynchronousTaggerProvider.cs
@@ -109,9 +109,12 @@ namespace Microsoft.CodeAnalysis.Editor.Tagging
             }
 
             var tagSource = GetOrCreateTagSource(textViewOpt, subjectBuffer);
-            return tagSource == null
-                ? null
-                : new Tagger(_asyncListener, _notificationService, tagSource, subjectBuffer) as IAccurateTagger<T>;
+            if (tagSource == null)
+            {
+                return null;
+            }
+
+            return new Tagger(_asyncListener, _notificationService, tagSource, subjectBuffer) as IAccurateTagger<T>;
         }
 
         private TagSource GetOrCreateTagSource(ITextView textViewOpt, ITextBuffer subjectBuffer)

--- a/src/EditorFeatures/Test/LineSeparators/AdornmentManagerTests.cs
+++ b/src/EditorFeatures/Test/LineSeparators/AdornmentManagerTests.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Classification;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Formatting;
 using Microsoft.VisualStudio.Text.Tagging;
@@ -26,6 +27,15 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.LineSeparators
     {
         internal class Tag : GraphicsTag
         {
+            public Tag(IEditorFormatMap editorFormatMap) : base(editorFormatMap)
+            {
+            }
+
+            protected override Color? GetColor(IWpfTextView view, IEditorFormatMap editorFormatMap)
+            {
+                return Colors.Black;
+            }
+
             public override GraphicsResult GetGraphics(IWpfTextView textView, Geometry bounds)
             {
                 return new GraphicsResult(null, null);
@@ -120,7 +130,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.LineSeparators
 
                 _aggregator.Setup(a => a.GetTags(It.IsAny<SnapshotSpan>())).Returns(new[] { mappingTagSpan.Object });
                 mappingTagSpan.SetupGet(mts => mts.Span).Returns(_mappingSpan.Object);
-                mappingTagSpan.SetupGet(mts => mts.Tag).Returns(new Tag());
+                mappingTagSpan.SetupGet(mts => mts.Tag).Returns(new Tag(null));
 
                 _mappingSpan.Setup(ms => ms.GetSpans(It.IsAny<ITextSnapshot>())).Returns(new NormalizedSnapshotSpanCollection(MySnapshotSpan));
             }


### PR DESCRIPTION
1. Increase opacity
2. Support user configuration of the suggestion tag color.
3. Refresh the color when the user changes fonts and colors.

Fixes https://github.com/dotnet/roslyn/issues/13496