### PR TITLE
Add additional verification for process execution

### DIFF
--- a/src/Test/Utilities/Desktop/ProcessUtilities.cs
+++ b/src/Test/Utilities/Desktop/ProcessUtilities.cs
@@ -78,6 +78,8 @@ namespace Roslyn.Test.Utilities
 
                 process.WaitForExit();
 
+                Debug.Assert(process.HasExited);
+
                 return new ProcessResult(process.ExitCode, outputBuilder.ToString(), errorBuilder.ToString());
             }
         }

--- a/src/Test/Utilities/Desktop/ProcessUtilities.cs
+++ b/src/Test/Utilities/Desktop/ProcessUtilities.cs
@@ -78,6 +78,7 @@ namespace Roslyn.Test.Utilities
 
                 process.WaitForExit();
 
+                // Double check the process has actually exited
                 Debug.Assert(process.HasExited);
 
                 return new ProcessResult(process.ExitCode, outputBuilder.ToString(), errorBuilder.ToString());

--- a/src/Test/Utilities/Shared/TempFiles/DisposableFile.cs
+++ b/src/Test/Utilities/Shared/TempFiles/DisposableFile.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public void Dispose()
         {
-            if (Path != null && File.Exists(Path))
+            if (Path != null)
             {
                 try
                 {


### PR DESCRIPTION
Test failures seem to indicate that a file might be held by a still-running
process, but it doesn't appear that that is possible in the code. Verify
that the process is closed using an assert to double-check this assumption.

Hopefully helps with #13626