### PR TITLE
Add S.C.I and srm to toolset

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -911,6 +911,8 @@ Public Class BuildDevDivInsertionFiles
                           <version>0.0</version>
                       </metadata>
                       <files>
+                          <file src="System.Collections.Immutable.dll"/>
+                          <file src="System.Reflection.Metadata.dll"/>
                           <%= filesToInsert.
                               OrderBy(Function(f) f).
                               Distinct().

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -404,7 +404,11 @@ Public Class BuildDevDivInsertionFiles
         Next
 
         ' Add just the compiler files to a separate compiler nuspec
-        GenerateRoslynCompilerNuSpec(CompilerFiles)
+        ' (with the Immutable collections and System.Reflection.Metadata, which
+        '  are normally inserted separately)
+        Dim allCompilerFiles = CompilerFiles.Concat({
+            "System.Collections.Immutable.dll", "System.Reflection.Metadata.dll"})
+        GenerateRoslynCompilerNuSpec(allCompilerFiles)
 
         ' Copy over the files in the NetFX20 subdirectory (identical, except for references and Authenticode signing).
         ' These are for msvsmon, whose setup authoring is done by the debugger.
@@ -898,8 +902,11 @@ Public Class BuildDevDivInsertionFiles
         Return fileName.StartsWith("Microsoft.VisualStudio.LanguageServices.")
     End Function
 
-    Private Sub GenerateRoslynCompilerNuSpec(filesToInsert As String())
+    Private Sub GenerateRoslynCompilerNuSpec(filesToInsert As IEnumerable(Of String))
         Const PackageName As String = "VS.Tools.Roslyn"
+
+        ' No duplicates are allowed
+        filesToInsert.GroupBy(Function(x) x).All(Function(g) g.Count() = 1)
 
         Dim xml = <?xml version="1.0" encoding="utf-8"?>
                   <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
@@ -911,11 +918,8 @@ Public Class BuildDevDivInsertionFiles
                           <version>0.0</version>
                       </metadata>
                       <files>
-                          <file src="System.Collections.Immutable.dll"/>
-                          <file src="System.Reflection.Metadata.dll"/>
                           <%= filesToInsert.
                               OrderBy(Function(f) f).
-                              Distinct().
                               Select(Function(f) <file src=<%= f %> xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"/>) %>
                       </files>
                   </package>


### PR DESCRIPTION
S.Collections.Immutable and System.Reflection.Metadata are seemingly
special: they're not inserted as Roslyn binaries and they're not
inserted as corefx packages. This means they won't get added to the
toolset package via either of the two previous mechanisms. Since
we don't have to worry about insertion into VS and things like binding
redirects, this change will just grab the binaries out of the output
of the build and place them directly in the output package.