### PR TITLE
Remove the facades used by the compiler build task

### DIFF
--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -51,10 +51,8 @@
     <SystemRuntimeLoaderVersion>4.0.0</SystemRuntimeLoaderVersion>
     <SystemRuntimeNumericsVersion>4.0.1</SystemRuntimeNumericsVersion>
     <SystemSecurityAccessControlVersion>4.0.0</SystemSecurityAccessControlVersion>
-    <SystemSecurityClaimsVersion>4.0.1</SystemSecurityClaimsVersion>
     <SystemSecurityCryptographyAlgorithmsVersion>4.2.0</SystemSecurityCryptographyAlgorithmsVersion>
     <SystemSecurityCryptographyEncodingVersion>4.0.0</SystemSecurityCryptographyEncodingVersion>
-    <SystemSecurityCryptographyPrimitivesVersion>4.0.0</SystemSecurityCryptographyPrimitivesVersion>
     <SystemSecurityCryptographyX509CertificatesVersion>4.1.0</SystemSecurityCryptographyX509CertificatesVersion>
     <SystemSecurityPrincipalWindowsVersion>4.0.0</SystemSecurityPrincipalWindowsVersion>
     <SystemTextEncodingVersion>4.0.11</SystemTextEncodingVersion>

--- a/src/Setup/DevDivPackages/Roslyn/project.json
+++ b/src/Setup/DevDivPackages/Roslyn/project.json
@@ -8,19 +8,9 @@
     "ManagedEsent": "1.9.4",
     "System.AppContext": "4.1.0",
     "System.Console": "4.0.0",
-    "System.Diagnostics.Process": "4.1.0",
     "System.Diagnostics.StackTrace": "4.0.1",
-    "System.IO.Pipes": "4.0.0",
     "System.IO.FileSystem": "4.0.1",
-    "System.IO.FileSystem.DriveInfo": "4.0.0",
     "System.IO.FileSystem.Primitives": "4.0.1",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
-    "System.Security.AccessControl": "4.0.0",
-    "System.Security.Claims": "4.0.1",
-    "System.Security.Cryptography.Algorithms": "4.2.0",
-    "System.Security.Cryptography.Primitives": "4.0.0",
-    "System.Security.Principal.Windows": "4.0.0",
-    "System.Threading.Thread": "4.0.0"
   },
   "frameworks": {
     "net46": {}

--- a/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
+++ b/src/Setup/DevDivVsix/PortableFacades/PortableFacades.swr
@@ -1,7 +1,7 @@
 use vs
 
 package name=PortableFacades
-        version=1.0.0.0
+        version=1.1.0.0
 
 folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.AppContext\4.1.0\lib\net46\System.AppContext.dll" vs.file.ngen=yes
@@ -9,17 +9,12 @@ folder InstallDir:\Common7\IDE\PrivateAssemblies
     file source="$(NuGetPackageRoot)\System.Diagnostics.Process\4.1.0\runtimes\win\lib\net46\System.Diagnostics.Process.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Diagnostics.StackTrace\4.0.1\lib\net46\System.Diagnostics.StackTrace.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.IO.FileSystem\4.0.1\lib\net46\System.IO.FileSystem.dll" vs.file.ngen=yes
-    file source="$(NuGetPackageRoot)\System.IO.FileSystem.DriveInfo\4.0.0\runtimes\win\lib\net46\System.IO.FileSystem.DriveInfo.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.IO.FileSystem.Primitives\4.0.1\lib\net46\System.IO.FileSystem.Primitives.dll" vs.file.ngen=yes
-    file source="$(NuGetPackageRoot)\System.IO.Pipes\4.0.0\runtimes\win\lib\net46\System.IO.Pipes.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Net.Security\4.0.0\runtimes\win\lib\net46\System.Net.Security.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Net.Sockets\4.1.0\lib\net46\System.Net.Sockets.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Reflection.TypeExtensions\4.1.0\lib\net46\System.Reflection.TypeExtensions.dll" vs.file.ngen=yes
-    file source="$(NuGetPackageRoot)\System.Security.AccessControl\4.0.0\runtimes\win\lib\net46\System.Security.AccessControl.dll" vs.file.ngen=yes
-    file source="$(NuGetPackageRoot)\System.Security.Claims\4.0.1\lib\net46\System.Security.Claims.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Algorithms\4.2.0\runtimes\win\lib\net46\System.Security.Cryptography.Algorithms.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Encoding\4.0.0\runtimes\win\lib\net46\System.Security.Cryptography.Encoding.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.Primitives\4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Security.Cryptography.X509Certificates\4.1.0\runtimes\win\lib\net46\System.Security.Cryptography.X509Certificates.dll" vs.file.ngen=yes
-    file source="$(NuGetPackageRoot)\System.Security.Principal.Windows\4.0.0\runtimes\win\lib\net46\System.Security.Principal.Windows.dll" vs.file.ngen=yes
     file source="$(NuGetPackageRoot)\System.Threading.Thread\4.0.0\lib\net46\System.Threading.Thread.dll" vs.file.ngen=yes


### PR DESCRIPTION
These facades only need to be present next to the build task, which is
in the MSBuild/Compiler authoring. They were incorrectly being included 
in the PrivateAssemblies authoring.
