### PR TITLE
Make option page controls viewable in the xaml designer

### DIFF
--- a/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractOptionPageControl.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -19,11 +20,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
 
         public AbstractOptionPageControl(IServiceProvider serviceProvider)
         {
+            InitializeStyles();
+
+            if (DesignerProperties.GetIsInDesignMode(this))
+            {
+                return;
+            }
+
             var componentModel = (IComponentModel)serviceProvider.GetService(typeof(SComponentModel));
-
             var workspace = componentModel.GetService<VisualStudioWorkspace>();
-            this.OptionService = workspace.Services.GetService<IOptionService>();
+            this.OptionService = workspace.Services.GetService<IOptionService>();            
+        }
 
+        private void InitializeStyles()
+        {
             var groupBoxStyle = new System.Windows.Style(typeof(GroupBox));
             groupBoxStyle.Setters.Add(new Setter(GroupBox.PaddingProperty, new Thickness() { Left = 7, Right = 7, Top = 7 }));
             groupBoxStyle.Setters.Add(new Setter(GroupBox.MarginProperty, new Thickness() { Bottom = 3 }));


### PR DESCRIPTION
We were getting a null ref in the AbstractOptionPageControl, so now we
check to see if the constructor is running in the designer before using
the IServiceProvider parameter to get the IOptionService for the
VisualStudioWorkspace.
