### PR TITLE
Fix for tuple field locations and IsImplicitlyDeclared

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -604,7 +604,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (srcType.IsTupleType)
             {
-                srcElementFields = ((TupleTypeSymbol)srcType).TupleElementFields;
+                srcElementFields = ((TupleTypeSymbol)srcType).TupleDefaultElementFields;
             }
             else
             {
@@ -615,7 +615,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // PERF: if allocations here become nuisance, consider caching the TupleTypeSymbol
                 //       in the type symbols that can actually be tuple compatible
-                srcElementFields = TupleTypeSymbol.Create((NamedTypeSymbol)srcType).TupleElementFields;
+                srcElementFields = TupleTypeSymbol.Create((NamedTypeSymbol)srcType).TupleDefaultElementFields;
             }
 
             var fieldAccessorsBuilder = ArrayBuilder<BoundExpression>.GetInstance(numElements);

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -618,7 +618,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 tupleTypeSymbol = TupleTypeSymbol.Create((NamedTypeSymbol)srcType);
             }
 
-            var srcElementFields = ((TupleTypeSymbol)srcType).TupleDefaultElementFields;
+            var srcElementFields = tupleTypeSymbol.TupleDefaultElementFields;
             var fieldAccessorsBuilder = ArrayBuilder<BoundExpression>.GetInstance(numElements);
 
             BoundAssignmentOperator assignmentToTemp;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -599,12 +599,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             var destElementTypes = rewrittenType.GetElementTypesOfTupleOrCompatible();
             var numElements = destElementTypes.Length;
 
-            ImmutableArray<FieldSymbol> srcElementFields;
             TypeSymbol srcType = rewrittenOperand.Type;
 
+            TupleTypeSymbol tupleTypeSymbol;
             if (srcType.IsTupleType)
             {
-                srcElementFields = ((TupleTypeSymbol)srcType).TupleDefaultElementFields;
+                tupleTypeSymbol = (TupleTypeSymbol)srcType;
             }
             else
             {
@@ -615,9 +615,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 // PERF: if allocations here become nuisance, consider caching the TupleTypeSymbol
                 //       in the type symbols that can actually be tuple compatible
-                srcElementFields = TupleTypeSymbol.Create((NamedTypeSymbol)srcType).TupleDefaultElementFields;
+                tupleTypeSymbol = TupleTypeSymbol.Create((NamedTypeSymbol)srcType);
             }
 
+            var srcElementFields = ((TupleTypeSymbol)srcType).TupleDefaultElementFields;
             var fieldAccessorsBuilder = ArrayBuilder<BoundExpression>.GetInstance(numElements);
 
             BoundAssignmentOperator assignmentToTemp;

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_DeconstructionAssignmentOperator.cs
@@ -173,7 +173,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             temps.Add(savedTuple.LocalSymbol);
 
             // list the tuple fields accessors
-            var fields = tupleType.TupleElementFields;
+            var fields = tupleType.TupleDefaultElementFields;
 
             for (int i = 0; i < numElements; i++)
             {

--- a/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/FieldSymbol.cs
@@ -387,7 +387,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Returns True when field symbol is not mapped directly to a field in the underlying tuple struct.
         /// </summary>
-        internal virtual bool IsVirtualTupleField
+        public virtual bool IsVirtualTupleField
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this is a field representing a Default element like Item1, Item2...
+        /// </summary>
+        public virtual bool IsDefaultTupleElement
         {
             get
             {
@@ -411,7 +422,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// If this is a field representing a tuple element,
         /// returns the index of the element (zero-based).
-        /// Otherwise, a negative number.
+        /// Otherwise returns -1
         /// </summary>
         public virtual int TupleElementIndex
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -50,9 +50,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this field represents a tuple element, 
-        /// id is an index of the element (zero-based).
-        /// Otherwise, (-1 - [index in members array]);
+        /// If this is a field representing a tuple element,
+        /// returns the index of the element (zero-based).
+        /// Otherwise returns -1
         /// </summary>
         public override int TupleElementIndex
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -16,8 +16,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly TypeSymbol _type;
 
         /// <summary>
-        /// If this field represents a tuple element (including the name match), 
-        /// id is an index of the element (zero-based).
+        /// If this field represents a tuple element with index X
+        /// - 2X      if this field represents Default-named element
+        /// - 2X + 1  if this field represents Friendly-named element
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
         private readonly int _tupleElementIndex;
@@ -44,15 +45,29 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this field represents a tuple element (including the name match), 
+        /// If this field represents a tuple element, 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
-        /// </summary>
+        /// </summary>i
         public override int TupleElementIndex
         {
             get
             {
-                return _tupleElementIndex;
+                if (_tupleElementIndex < 0)
+                {
+                    return -1;
+                }
+
+                return _tupleElementIndex >> 1;
+            }
+        }
+
+        public override bool IsDefaultTupleElement
+        {
+            get
+            {
+                // not negative and even
+                return (_tupleElementIndex & ((1 << 31) | 1)) == 0;
             }
         }
 
@@ -126,8 +141,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             return (object)other != null &&
                 _tupleElementIndex == other._tupleElementIndex &&
-                ContainingType == other.ContainingType &&
-                Name == other.Name;
+                ContainingType == other.ContainingType;
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If this field represents a tuple element, 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
-        /// </summary>i
+        /// </summary>
         public override int TupleElementIndex
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -26,7 +26,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         private readonly ImmutableArray<Location> _locations;
         private readonly DiagnosticInfo _useSiteDiagnosticInfo;
 
-        public TupleErrorFieldSymbol(NamedTypeSymbol container, string name, int tupleElementIndex, Location location, TypeSymbol type, DiagnosticInfo useSiteDiagnosticInfo)
+        // default tuple elements like Item1 or Item20 could be provided by the user or
+        // otherwise implicitly declared by compiler
+        private readonly bool _isImplicitlyDeclared;
+
+        public TupleErrorFieldSymbol(NamedTypeSymbol container, string name, int tupleElementIndex, Location location, TypeSymbol type, DiagnosticInfo useSiteDiagnosticInfo, bool isImplicitlyDeclared)
             : base(container, name, isPublic:true, isReadOnly:false, isStatic:false)
         {
             Debug.Assert(name != null);
@@ -34,6 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create(location);
             _useSiteDiagnosticInfo = useSiteDiagnosticInfo;
             _tupleElementIndex = tupleElementIndex;
+            _isImplicitlyDeclared = isImplicitlyDeclared;
         }
 
         public override bool IsTupleField
@@ -92,7 +97,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations);
+                return _isImplicitlyDeclared ?
+                    ImmutableArray<SyntaxReference>.Empty :
+                    GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations);
             }
         }
 
@@ -100,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return false;
+                return _isImplicitlyDeclared;
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleErrorFieldSymbol.cs
@@ -17,8 +17,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// If this field represents a tuple element with index X
-        /// - 2X      if this field represents Default-named element
-        /// - 2X + 1  if this field represents Friendly-named element
+        ///  2X      if this field represents Default-named element
+        ///  2X + 1  if this field represents Friendly-named element
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
         private readonly int _tupleElementIndex;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -147,10 +147,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly ImmutableArray<Location> _locations;
 
-        public TupleElementFieldSymbol(TupleTypeSymbol container, FieldSymbol underlyingField, int tupleElementIndex, Location location)
+        // default tuple elements like Item1 or Item20 could be provided by the user or
+        // otherwise implicitly declared by compiler
+        private readonly bool _isImplicitlyDeclared;
+
+        public TupleElementFieldSymbol(TupleTypeSymbol container, FieldSymbol underlyingField, int tupleElementIndex, Location location, bool isImplicitlyDeclared)
             : base(container, underlyingField, tupleElementIndex)
         {
             _locations = location == null ? ImmutableArray<Location>.Empty : ImmutableArray.Create(location);
+            _isImplicitlyDeclared = isImplicitlyDeclared;
         }
 
         public override ImmutableArray<Location> Locations
@@ -165,7 +170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations);
+                return _isImplicitlyDeclared ? 
+                    ImmutableArray<SyntaxReference>.Empty : 
+                    GetDeclaringSyntaxReferenceHelper<CSharpSyntaxNode>(_locations);
             }
         }
 
@@ -173,7 +180,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return false;
+                return _isImplicitlyDeclared;
             }
         }
 
@@ -223,8 +230,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private readonly string _name;
 
-        public TupleVirtualElementFieldSymbol(TupleTypeSymbol container, FieldSymbol underlyingField, string name, int tupleElementIndex, Location location)
-            : base(container, underlyingField, tupleElementIndex, location)
+        public TupleVirtualElementFieldSymbol(TupleTypeSymbol container, FieldSymbol underlyingField, string name, int tupleElementIndex, Location location, bool isImplicitlyDeclared)
+            : base(container, underlyingField, tupleElementIndex, location, isImplicitlyDeclared)
         {
             Debug.Assert(name != null);
             Debug.Assert(name != underlyingField.Name || !container.UnderlyingNamedType.Equals(underlyingField.ContainingType, TypeCompareKind.IgnoreDynamicAndTupleNames),

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -41,9 +41,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// If this field represents a tuple element, 
-        /// id is an index of the element (zero-based).
-        /// Otherwise, (-1 - [index in members array]);
+        /// If this is a field representing a tuple element,
+        /// returns the index of the element (zero-based).
+        /// Otherwise returns -1
         /// </summary>
         public override int TupleElementIndex
         {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -15,8 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         protected readonly TupleTypeSymbol _containingTuple;
 
         /// <summary>
-        /// If this field represents a tuple element, 
-        /// id is an index of the element (zero-based).
+        /// If this field represents a tuple element with index X
+        /// - 2X      if this field represents Default-named element
+        /// - 2X + 1  if this field represents Friendly-named element
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
         private readonly int _tupleElementIndex;
@@ -48,7 +49,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get
             {
-                return _tupleElementIndex;
+                if (_tupleElementIndex < 0)
+                {
+                    return -1;
+                }
+
+                return _tupleElementIndex >> 1;
+            }
+        }
+
+        public override bool IsDefaultTupleElement
+        {
+            get
+            {
+                // not negative and even
+                return (_tupleElementIndex & ((1<<31) | 1)) == 0 ;
             }
         }
 
@@ -103,9 +118,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public override sealed int GetHashCode()
         {
-            return Hash.Combine(
-                Hash.Combine(_containingTuple.GetHashCode(), _tupleElementIndex.GetHashCode()),
-                this.Name.GetHashCode());
+            return Hash.Combine(_containingTuple.GetHashCode(), _tupleElementIndex.GetHashCode());
         }
 
         public override sealed bool Equals(object obj)
@@ -121,9 +134,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // in nameless tuple there could be fields that differ only by index
             // and in named tupoles there could be fields that differ only by name
             return (object)other != null &&
-                _tupleElementIndex == other.TupleElementIndex &&
-                _containingTuple == other._containingTuple &&
-                this.Name == other.Name;
+                _tupleElementIndex == other._tupleElementIndex &&
+                _containingTuple == other._containingTuple;
         }
     }
 
@@ -245,7 +257,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        internal override bool IsVirtualTupleField
+        public override bool IsVirtualTupleField
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If this field represents a tuple element, 
         /// id is an index of the element (zero-based).
         /// Otherwise, (-1 - [index in members array]);
-        /// </summary>i
+        /// </summary>
         public override int TupleElementIndex
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleFieldSymbol.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         /// <summary>
         /// If this field represents a tuple element with index X
-        /// - 2X      if this field represents Default-named element
-        /// - 2X + 1  if this field represents Friendly-named element
+        ///  2X      if this field represents Default-named element
+        ///  2X + 1  if this field represents Friendly-named element
         /// Otherwise, (-1 - [index in members array]);
         /// </summary>
         private readonly int _tupleElementIndex;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -720,7 +720,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         /// <summary>
-        /// Get the fields for the tuple's elements (in order and cached).
+        /// Get the default fields for the tuple's elements (in order and cached).
         /// </summary>
         public override ImmutableArray<FieldSymbol> TupleDefaultElementFields
         {
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<Symbol> CreateMembers()
         {
-            var elementsMatchedByFields = new bool[_elementTypes.Length];
+            var elementsMatchedByFields = ArrayBuilder<bool>.GetInstance(_elementTypes.Length, false);
             var members = ArrayBuilder<Symbol>.GetInstance(Math.Max(_elementTypes.Length, _underlyingType.OriginalDefinition.GetMembers().Length));
 
             NamedTypeSymbol currentUnderlying = _underlyingType;
@@ -926,8 +926,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             currentFieldsForElements.Free();
 
-            // At the end, add remaining virtual fields
-            for (int i = 0; i < elementsMatchedByFields.Length; i++)
+            // At the end, add unmatched fields as error symbols
+            for (int i = 0; i < elementsMatchedByFields.Count; i++)
             {
                 if (!elementsMatchedByFields[i])
                 {
@@ -964,6 +964,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
             }
 
+            elementsMatchedByFields.Free();
             return members.ToImmutableAndFree();
         }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -845,10 +845,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                                 if (defaultImplicitlyDeclared && providedName != null)
                                 {
-                                        // The name given doesn't match the default name Item8, etc.
-                                        // Add a virtual field with the given name
-                                        // tupleFieldIndex << 1 + 1, because this is not a default element
-                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared: false));
+                                    // The name given doesn't match the default name Item8, etc.
+                                    // Add a virtual field with the given name
+                                    // tupleFieldIndex << 1 + 1, because this is not a default element
+                                    members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared: false));
                                 }
 
                                 elementsMatchedByFields[tupleFieldIndex] = true; // mark as handled
@@ -937,7 +937,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     // Add default element field. 
                     // i << 1 because this is a default element
-                    members.Add(new TupleErrorFieldSymbol(this, defaultName, i << 1, defaultImplicitlyDeclared ? null: location, _elementTypes[i], diagnosticInfo, defaultImplicitlyDeclared));
+                    members.Add(new TupleErrorFieldSymbol(this, defaultName, i << 1, defaultImplicitlyDeclared ? null : location, _elementTypes[i], diagnosticInfo, defaultImplicitlyDeclared));
 
 
                     if (defaultImplicitlyDeclared && providedName != null)

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -737,7 +737,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<FieldSymbol> CollectTupleElementFields()
         {
-            var builder = ArrayBuilder<FieldSymbol>.GetInstance(_elementTypes.Length, null);
+            var builder = ArrayBuilder<FieldSymbol>.GetInstance(_elementTypes.Length, fillWithValue: null);
 
             foreach (var member in GetMembers())
             {
@@ -777,7 +777,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<Symbol> CreateMembers()
         {
-            var elementsMatchedByFields = ArrayBuilder<bool>.GetInstance(_elementTypes.Length, false);
+            var elementsMatchedByFields = ArrayBuilder<bool>.GetInstance(_elementTypes.Length, fillWithValue: false);
             var members = ArrayBuilder<Symbol>.GetInstance(Math.Max(_elementTypes.Length, _underlyingType.OriginalDefinition.GetMembers().Length));
 
             NamedTypeSymbol currentUnderlying = _underlyingType;

--- a/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Tuples/TupleTypeSymbol.cs
@@ -747,10 +747,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 var field = (FieldSymbol)member;
-                var index = field.TupleElementIndex;
 
                 if (field.IsDefaultTupleElement)
                 {
+                    var index = field.TupleElementIndex;
                     Debug.Assert((object)builder[index] == null);
                     builder[index] = field;
                 }
@@ -821,49 +821,34 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                 var location = _elementLocations.IsDefault ? null : _elementLocations[tupleFieldIndex];
                                 var defaultName = TupleMemberName(tupleFieldIndex + 1);
                                 // if provided name does not match the default one, 
-                                // then default element as declared implicitly
+                                // then default element is declared implicitly
                                 var defaultImplicitlyDeclared = providedName != defaultName;
 
                                 var fieldSymbol = field.AsMember(currentUnderlying);
 
+                                // Add a field with default name. It should be present regardless.
                                 if (currentNestingLevel != 0)
                                 {
                                     // This is a matching field, but it is in the extension tuple
-
-                                    // Add a field with default name. It should be present regardless.
                                     // Make it virtual since we are not at the top level
                                     // tupleFieldIndex << 1 because this is a default element
                                     members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, defaultName, tupleFieldIndex << 1, location, defaultImplicitlyDeclared));
-
-                                    if (defaultImplicitlyDeclared && providedName != null)
-                                    {
-                                        // The name given doesn't match default name Item8, etc.
-                                        // Add a field with the given name
-                                        // tupleFieldIndex << 1 + 1, because this is not a default element
-                                        members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared: false));
-                                    }
                                 }
-                                else if (defaultImplicitlyDeclared)
+                                else
                                 {
                                     Debug.Assert(fieldSymbol.Name == defaultName, "top level underlying field must match default name");
 
                                     // Add the underlying field as an element. It should have the default name.
                                     // tupleFieldIndex << 1 because this is a default element
                                     members.Add(new TupleElementFieldSymbol(this, fieldSymbol, tupleFieldIndex << 1, location, defaultImplicitlyDeclared));
+                                }
 
-                                    if (providedName != null)
-                                    {
-                                        // Add a field with the given name
+                                if (defaultImplicitlyDeclared && providedName != null)
+                                {
+                                        // The name given doesn't match the default name Item8, etc.
+                                        // Add a virtual field with the given name
                                         // tupleFieldIndex << 1 + 1, because this is not a default element
                                         members.Add(new TupleVirtualElementFieldSymbol(this, fieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared: false));
-                                    }
-                                }
-                                else
-                                {
-                                    Debug.Assert(fieldSymbol.Name == defaultName, "top level underlying field must match default name");
-
-                                    // tupleFieldIndex << 1 because this is a default element
-                                    members.Add(new TupleElementFieldSymbol(this, fieldSymbol, tupleFieldIndex << 1, location, isImplicitlyDeclared: false));
                                 }
 
                                 elementsMatchedByFields[tupleFieldIndex] = true; // mark as handled
@@ -947,7 +932,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     var location = _elementLocations.IsDefault ? null : _elementLocations[i];
                     var defaultName = TupleMemberName(i + 1);
                     // if provided name does not match the default one, 
-                    // then default element as declared implicitly
+                    // then default element is declared implicitly
                     var defaultImplicitlyDeclared = providedName != defaultName;
 
                     // Add default element field. 
@@ -957,7 +942,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                     if (defaultImplicitlyDeclared && providedName != null)
                     {
-                        // Add frieldly named element field. 
+                        // Add friendly named element field. 
                         // (i << 1) + 1, because this is not a default element
                         members.Add(new TupleErrorFieldSymbol(this, providedName, (i << 1) + 1, location, _elementTypes[i], diagnosticInfo, isImplicitlyDeclared: false));
                     }

--- a/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/TypeSymbol.cs
@@ -626,7 +626,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// If this symbol represents a tuple type, get the fields for the tuple's elements.
         /// Otherwise, returns default.
         /// </summary>
-        public virtual ImmutableArray<FieldSymbol> TupleElementFields => default(ImmutableArray<FieldSymbol>);
+        public virtual ImmutableArray<FieldSymbol> TupleDefaultElementFields => default(ImmutableArray<FieldSymbol>);
 
         /// <summary>
         /// Is this type a managed type (false for everything but enum, pointer, and

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3966,7 +3966,7 @@ namespace System
             Assert.True(mItem1.GetAttributes().IsEmpty);
             Assert.Equal("error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
                          mItem1.GetUseSiteDiagnostic().ToString());
-            Assert.False(mItem1.Locations.IsDefaultOrEmpty);
+            Assert.True(mItem1.Locations.IsDefaultOrEmpty);
             Assert.Equal("string", mItem1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.False(mItem1.IsImplicitlyDeclared);
             Assert.Null(mItem1.TypeLayoutOffset);
@@ -9098,7 +9098,7 @@ class C
             Assert.True(m4Item8.CustomModifiers.IsEmpty);
             Assert.True(m4Item8.GetAttributes().IsEmpty);
             Assert.Null(m4Item8.GetUseSiteDiagnostic());
-            Assert.True(m4Item8.Locations.IsDefaultOrEmpty);
+            Assert.False(m4Item8.Locations.IsDefaultOrEmpty);
             Assert.Equal("Item1", m4Item8.TupleUnderlyingField.Name);
             Assert.False(m4Item8.IsImplicitlyDeclared);
             Assert.Null(m4Item8.TypeLayoutOffset);
@@ -9717,7 +9717,7 @@ class C
             Assert.True(m8Item8.CustomModifiers.IsEmpty);
             Assert.True(m8Item8.GetAttributes().IsEmpty);
             Assert.Null(m8Item8.GetUseSiteDiagnostic());
-            Assert.True(m8Item8.Locations.IsDefaultOrEmpty);
+            Assert.False(m8Item8.Locations.IsDefaultOrEmpty);
             Assert.Equal("Item1", m8Item8.TupleUnderlyingField.Name);
             Assert.False(m8Item8.IsImplicitlyDeclared);
             Assert.Null(m8Item8.TypeLayoutOffset);
@@ -9934,7 +9934,7 @@ class C
             Assert.True(m2Item1.GetAttributes().IsEmpty);
             Assert.Null(m2Item1.GetUseSiteDiagnostic());
             Assert.False(m2Item1.Locations.IsDefaultOrEmpty);
-            Assert.Equal("Item1", m2Item1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.Equal("a2", m2Item1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("Item1", m2Item1.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
             Assert.False(m2Item1.IsImplicitlyDeclared);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3292,7 +3292,7 @@ class C
             Assert.True(mItem1.GetAttributes().IsEmpty);
             Assert.Null(mItem1.GetUseSiteDiagnostic());
             Assert.True(mItem1.Locations.IsEmpty);
-            Assert.False(mItem1.IsImplicitlyDeclared);
+            Assert.True(mItem1.IsImplicitlyDeclared);
             Assert.Null(mItem1.TypeLayoutOffset);
         }
 
@@ -3967,8 +3967,8 @@ namespace System
             Assert.Equal("error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
                          mItem1.GetUseSiteDiagnostic().ToString());
             Assert.True(mItem1.Locations.IsDefaultOrEmpty);
-            Assert.Equal("string", mItem1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
-            Assert.False(mItem1.IsImplicitlyDeclared);
+            Assert.True(mItem1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.True(mItem1.IsImplicitlyDeclared);
             Assert.Null(mItem1.TypeLayoutOffset);
 
             AssertTestDisplayString(mTuple.GetMembers(),
@@ -8658,9 +8658,9 @@ class C
             Assert.True(m1Item1.GetAttributes().IsEmpty);
             Assert.Null(m1Item1.GetUseSiteDiagnostic());
             Assert.False(m1Item1.Locations.IsDefaultOrEmpty);
-            Assert.Equal("int", m1Item1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(m1Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
             Assert.Equal("Item1", m1Item1.TupleUnderlyingField.Name);
-            Assert.False(m1Item1.IsImplicitlyDeclared);
+            Assert.True(m1Item1.IsImplicitlyDeclared);
             Assert.Null(m1Item1.TypeLayoutOffset);
 
             Assert.True(m2Item1.IsTupleField);
@@ -8676,8 +8676,10 @@ class C
             Assert.False(m2Item1.Locations.IsDefaultOrEmpty);
             Assert.Equal("Item1", m2Item1.Name);
             Assert.Equal("Item1", m2Item1.TupleUnderlyingField.Name);
-            Assert.Equal(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
-            Assert.False(m2Item1.IsImplicitlyDeclared);
+            Assert.NotEqual(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
+            Assert.Equal("MetadataFile(System.ValueTuple.dll)", m2Item1.TupleUnderlyingField.Locations.Single().ToString());
+            Assert.Equal("SourceFile([826..828))", m2Item1.Locations.Single().ToString());
+            Assert.True(m2Item1.IsImplicitlyDeclared);
             Assert.Null(m2Item1.TypeLayoutOffset);
 
             Assert.True(m2a2.IsTupleField);
@@ -8905,9 +8907,9 @@ class C
             Assert.True(m3Item8.GetAttributes().IsEmpty);
             Assert.Null(m3Item8.GetUseSiteDiagnostic());
             Assert.False(m3Item8.Locations.IsDefaultOrEmpty);
-            Assert.Equal("int", m3Item8.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(m3Item8.DeclaringSyntaxReferences.IsDefaultOrEmpty);
             Assert.Equal("Item1", m3Item8.TupleUnderlyingField.Name);
-            Assert.False(m3Item8.IsImplicitlyDeclared);
+            Assert.True(m3Item8.IsImplicitlyDeclared);
             Assert.Null(m3Item8.TypeLayoutOffset);
 
             var m3TupleRestTuple = (NamedTypeSymbol)((FieldSymbol)m3Tuple.GetMembers("Rest").Single()).Type;
@@ -9100,7 +9102,7 @@ class C
             Assert.Null(m4Item8.GetUseSiteDiagnostic());
             Assert.False(m4Item8.Locations.IsDefaultOrEmpty);
             Assert.Equal("Item1", m4Item8.TupleUnderlyingField.Name);
-            Assert.False(m4Item8.IsImplicitlyDeclared);
+            Assert.True(m4Item8.IsImplicitlyDeclared);
             Assert.Null(m4Item8.TypeLayoutOffset);
 
             var m4h4 = (FieldSymbol)m4Tuple.GetMembers("h4").Single();
@@ -9719,7 +9721,7 @@ class C
             Assert.Null(m8Item8.GetUseSiteDiagnostic());
             Assert.False(m8Item8.Locations.IsDefaultOrEmpty);
             Assert.Equal("Item1", m8Item8.TupleUnderlyingField.Name);
-            Assert.False(m8Item8.IsImplicitlyDeclared);
+            Assert.True(m8Item8.IsImplicitlyDeclared);
             Assert.Null(m8Item8.TypeLayoutOffset);
 
             var m8Item1 = (FieldSymbol)m8Tuple.GetMembers("Item1").Last();
@@ -9918,9 +9920,9 @@ class C
             Assert.True(m1Item1.GetAttributes().IsEmpty);
             Assert.Null(m1Item1.GetUseSiteDiagnostic());
             Assert.False(m1Item1.Locations.IsDefaultOrEmpty);
-            Assert.Equal("1", m1Item1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(m1Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
             Assert.Equal("Item1", m1Item1.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
-            Assert.False(m1Item1.IsImplicitlyDeclared);
+            Assert.True(m1Item1.IsImplicitlyDeclared);
             Assert.Null(m1Item1.TypeLayoutOffset);
 
             Assert.True(m2Item1.IsTupleField);
@@ -9934,10 +9936,12 @@ class C
             Assert.True(m2Item1.GetAttributes().IsEmpty);
             Assert.Null(m2Item1.GetUseSiteDiagnostic());
             Assert.False(m2Item1.Locations.IsDefaultOrEmpty);
-            Assert.Equal("a2", m2Item1.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
+            Assert.True(m2Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
             Assert.Equal("Item1", m2Item1.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
-            Assert.Equal(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
-            Assert.False(m2Item1.IsImplicitlyDeclared);
+            Assert.NotEqual(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
+            Assert.Equal("SourceFile([891..896))", m2Item1.TupleUnderlyingField.Locations.Single().ToString());
+            Assert.Equal("SourceFile([196..198))", m2Item1.Locations.Single().ToString());
+            Assert.True(m2Item1.IsImplicitlyDeclared);
             Assert.Null(m2Item1.TypeLayoutOffset);
 
             Assert.True(m2a2.IsTupleField);

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3272,7 +3272,7 @@ class C
             Assert.True(mFirst.CustomModifiers.IsEmpty);
             Assert.True(mFirst.GetAttributes().IsEmpty);
             Assert.Null(mFirst.GetUseSiteDiagnostic());
-            Assert.False(mFirst.Locations.IsDefaultOrEmpty);
+            Assert.False(mFirst.Locations.IsEmpty);
             Assert.Equal("first", mFirst.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.False(mFirst.IsImplicitlyDeclared);
             Assert.Null(mFirst.TypeLayoutOffset);
@@ -3966,8 +3966,8 @@ namespace System
             Assert.True(mItem1.GetAttributes().IsEmpty);
             Assert.Equal("error CS8128: Member 'Item1' was not found on type 'ValueTuple<T1, T2>' from assembly 'comp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null'.",
                          mItem1.GetUseSiteDiagnostic().ToString());
-            Assert.True(mItem1.Locations.IsDefaultOrEmpty);
-            Assert.True(mItem1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.True(mItem1.Locations.IsEmpty);
+            Assert.True(mItem1.DeclaringSyntaxReferences.IsEmpty);
             Assert.True(mItem1.IsImplicitlyDeclared);
             Assert.Null(mItem1.TypeLayoutOffset);
 
@@ -8657,8 +8657,8 @@ class C
             Assert.True(m1Item1.CustomModifiers.IsEmpty);
             Assert.True(m1Item1.GetAttributes().IsEmpty);
             Assert.Null(m1Item1.GetUseSiteDiagnostic());
-            Assert.False(m1Item1.Locations.IsDefaultOrEmpty);
-            Assert.True(m1Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.False(m1Item1.Locations.IsEmpty);
+            Assert.True(m1Item1.DeclaringSyntaxReferences.IsEmpty);
             Assert.Equal("Item1", m1Item1.TupleUnderlyingField.Name);
             Assert.True(m1Item1.IsImplicitlyDeclared);
             Assert.Null(m1Item1.TypeLayoutOffset);
@@ -8673,7 +8673,7 @@ class C
             Assert.True(m2Item1.CustomModifiers.IsEmpty);
             Assert.True(m2Item1.GetAttributes().IsEmpty);
             Assert.Null(m2Item1.GetUseSiteDiagnostic());
-            Assert.False(m2Item1.Locations.IsDefaultOrEmpty);
+            Assert.False(m2Item1.Locations.IsEmpty);
             Assert.Equal("Item1", m2Item1.Name);
             Assert.Equal("Item1", m2Item1.TupleUnderlyingField.Name);
             Assert.NotEqual(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
@@ -8692,7 +8692,7 @@ class C
             Assert.True(m2a2.CustomModifiers.IsEmpty);
             Assert.True(m2a2.GetAttributes().IsEmpty);
             Assert.Null(m2a2.GetUseSiteDiagnostic());
-            Assert.False(m2a2.Locations.IsDefaultOrEmpty);
+            Assert.False(m2a2.Locations.IsEmpty);
             Assert.Equal("a2", m2a2.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("Item1", m2a2.TupleUnderlyingField.Name);
             Assert.False(m2a2.IsImplicitlyDeclared);
@@ -8906,8 +8906,8 @@ class C
             Assert.True(m3Item8.CustomModifiers.IsEmpty);
             Assert.True(m3Item8.GetAttributes().IsEmpty);
             Assert.Null(m3Item8.GetUseSiteDiagnostic());
-            Assert.False(m3Item8.Locations.IsDefaultOrEmpty);
-            Assert.True(m3Item8.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.False(m3Item8.Locations.IsEmpty);
+            Assert.True(m3Item8.DeclaringSyntaxReferences.IsEmpty);
             Assert.Equal("Item1", m3Item8.TupleUnderlyingField.Name);
             Assert.True(m3Item8.IsImplicitlyDeclared);
             Assert.Null(m3Item8.TypeLayoutOffset);
@@ -9100,7 +9100,7 @@ class C
             Assert.True(m4Item8.CustomModifiers.IsEmpty);
             Assert.True(m4Item8.GetAttributes().IsEmpty);
             Assert.Null(m4Item8.GetUseSiteDiagnostic());
-            Assert.False(m4Item8.Locations.IsDefaultOrEmpty);
+            Assert.False(m4Item8.Locations.IsEmpty);
             Assert.Equal("Item1", m4Item8.TupleUnderlyingField.Name);
             Assert.True(m4Item8.IsImplicitlyDeclared);
             Assert.Null(m4Item8.TypeLayoutOffset);
@@ -9119,7 +9119,7 @@ class C
             Assert.True(m4h4.CustomModifiers.IsEmpty);
             Assert.True(m4h4.GetAttributes().IsEmpty);
             Assert.Null(m4h4.GetUseSiteDiagnostic());
-            Assert.False(m4h4.Locations.IsDefaultOrEmpty);
+            Assert.False(m4h4.Locations.IsEmpty);
             Assert.Equal("h4", m4h4.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("Item1", m4h4.TupleUnderlyingField.Name);
             Assert.False(m4h4.IsImplicitlyDeclared);
@@ -9349,7 +9349,7 @@ class C
             Assert.True(m5Item8.CustomModifiers.IsEmpty);
             Assert.True(m5Item8.GetAttributes().IsEmpty);
             Assert.Null(m5Item8.GetUseSiteDiagnostic());
-            Assert.False(m5Item8.Locations.IsDefaultOrEmpty);
+            Assert.False(m5Item8.Locations.IsEmpty);
             Assert.Equal("Item8", m5Item8.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("Item1", m5Item8.TupleUnderlyingField.Name);
             Assert.False(m5Item8.IsImplicitlyDeclared);
@@ -9719,7 +9719,7 @@ class C
             Assert.True(m8Item8.CustomModifiers.IsEmpty);
             Assert.True(m8Item8.GetAttributes().IsEmpty);
             Assert.Null(m8Item8.GetUseSiteDiagnostic());
-            Assert.False(m8Item8.Locations.IsDefaultOrEmpty);
+            Assert.False(m8Item8.Locations.IsEmpty);
             Assert.Equal("Item1", m8Item8.TupleUnderlyingField.Name);
             Assert.True(m8Item8.IsImplicitlyDeclared);
             Assert.Null(m8Item8.TypeLayoutOffset);
@@ -9739,7 +9739,7 @@ class C
             Assert.True(m8Item1.CustomModifiers.IsEmpty);
             Assert.True(m8Item1.GetAttributes().IsEmpty);
             Assert.Null(m8Item1.GetUseSiteDiagnostic());
-            Assert.False(m8Item1.Locations.IsDefaultOrEmpty);
+            Assert.False(m8Item1.Locations.IsEmpty);
             Assert.Equal("Item1", m8Item1.Name);
             Assert.Equal("Item1", m8Item1.TupleUnderlyingField.Name);
             Assert.NotEqual(m8Item1.Locations.Single(), m8Item1.TupleUnderlyingField.Locations.Single());
@@ -9919,8 +9919,8 @@ class C
             Assert.True(m1Item1.CustomModifiers.IsEmpty);
             Assert.True(m1Item1.GetAttributes().IsEmpty);
             Assert.Null(m1Item1.GetUseSiteDiagnostic());
-            Assert.False(m1Item1.Locations.IsDefaultOrEmpty);
-            Assert.True(m1Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.False(m1Item1.Locations.IsEmpty);
+            Assert.True(m1Item1.DeclaringSyntaxReferences.IsEmpty);
             Assert.Equal("Item1", m1Item1.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.True(m1Item1.IsImplicitlyDeclared);
             Assert.Null(m1Item1.TypeLayoutOffset);
@@ -9935,8 +9935,8 @@ class C
             Assert.True(m2Item1.CustomModifiers.IsEmpty);
             Assert.True(m2Item1.GetAttributes().IsEmpty);
             Assert.Null(m2Item1.GetUseSiteDiagnostic());
-            Assert.False(m2Item1.Locations.IsDefaultOrEmpty);
-            Assert.True(m2Item1.DeclaringSyntaxReferences.IsDefaultOrEmpty);
+            Assert.False(m2Item1.Locations.IsEmpty);
+            Assert.True(m2Item1.DeclaringSyntaxReferences.IsEmpty);
             Assert.Equal("Item1", m2Item1.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.NotEqual(m2Item1.Locations.Single(), m2Item1.TupleUnderlyingField.Locations.Single());
             Assert.Equal("SourceFile([891..896))", m2Item1.TupleUnderlyingField.Locations.Single().ToString());
@@ -9954,7 +9954,7 @@ class C
             Assert.True(m2a2.CustomModifiers.IsEmpty);
             Assert.True(m2a2.GetAttributes().IsEmpty);
             Assert.Null(m2a2.GetUseSiteDiagnostic());
-            Assert.False(m2a2.Locations.IsDefaultOrEmpty);
+            Assert.False(m2a2.Locations.IsEmpty);
             Assert.Equal("a2", m2a2.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.Equal("Item1", m2a2.TupleUnderlyingField.DeclaringSyntaxReferences.Single().GetSyntax().ToString());
             Assert.False(m2a2.IsImplicitlyDeclared);
@@ -9980,7 +9980,7 @@ class C
             Assert.Null(m1ToString.GetUseSiteDiagnostic());
             Assert.Equal("System.String System.ValueType.ToString()",
                          m1ToString.OverriddenMethod.ToTestDisplayString());
-            Assert.False(m1ToString.Locations.IsDefaultOrEmpty);
+            Assert.False(m1ToString.Locations.IsEmpty);
             Assert.Equal("public override string ToString()", m1ToString.DeclaringSyntaxReferences.Single().GetSyntax().ToString().Substring(0, 33));
             Assert.Equal(m1ToString.Locations.Single(), m1ToString.TupleUnderlyingMethod.Locations.Single());
         }

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -135,11 +135,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim destElementTypes = destinationType.GetElementTypesOfTupleOrCompatible()
             Dim numElements = destElementTypes.Length
 
-            Dim srcElementFields As ImmutableArray(Of FieldSymbol)
             Dim srcType As TypeSymbol = rewrittenOperand.Type
+            Dim tupleTypeSymbol As TupleTypeSymbol
 
-            If (srcType.IsTupleType) Then
-                srcElementFields = DirectCast(srcType, TupleTypeSymbol).TupleDefaultElementFields
+            If srcType.IsTupleType Then
+                tupleTypeSymbol = DirectCast(srcType, TupleTypeSymbol)
             Else
                 ' The following codepath should be very uncommon (if reachable at all)
                 ' we should generally not see tuple compatible types in bound trees and 
@@ -148,8 +148,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' PERF: if allocations here become nuisance, consider caching the TupleTypeSymbol
                 '       in the type symbols that can actually be tuple compatible
-                srcElementFields = TupleTypeSymbol.Create(DirectCast(srcType, NamedTypeSymbol)).TupleDefaultElementFields
+                tupleTypeSymbol = TupleTypeSymbol.Create(DirectCast(srcType, NamedTypeSymbol))
             End If
+
+            Dim srcElementFields = tupleTypeSymbol.TupleDefaultElementFields
 
             Dim fieldAccessorsBuilder = ArrayBuilder(Of BoundExpression).GetInstance(numElements)
             Dim assignmentToTemp As BoundExpression = Nothing

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -139,7 +139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim srcType As TypeSymbol = rewrittenOperand.Type
 
             If (srcType.IsTupleType) Then
-                srcElementFields = DirectCast(srcType, TupleTypeSymbol).TupleElementFields
+                srcElementFields = DirectCast(srcType, TupleTypeSymbol).TupleDefaultElementFields
             Else
                 ' The following codepath should be very uncommon (if reachable at all)
                 ' we should generally not see tuple compatible types in bound trees and 
@@ -148,7 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' PERF: if allocations here become nuisance, consider caching the TupleTypeSymbol
                 '       in the type symbols that can actually be tuple compatible
-                srcElementFields = TupleTypeSymbol.Create(DirectCast(srcType, NamedTypeSymbol)).TupleElementFields
+                srcElementFields = TupleTypeSymbol.Create(DirectCast(srcType, NamedTypeSymbol)).TupleDefaultElementFields
             End If
 
             Dim fieldAccessorsBuilder = ArrayBuilder(Of BoundExpression).GetInstance(numElements)

--- a/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/FieldSymbol.vb
@@ -336,6 +336,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
+        ''' Returns True when field symbol is not mapped directly to a field in the underlying tuple struct.
+        ''' </summary>
+        Public Overridable ReadOnly Property IsVirtualTupleField As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' Returns true if this is a field representing a Default element like Item1, Item2...
+        ''' </summary>
+        Public Overridable ReadOnly Property IsDefaultTupleElement As Boolean
+            Get
+                Return False
+            End Get
+        End Property
+
+        ''' <summary>
         ''' If this is a field of a tuple type, return corresponding underlying field from the
         ''' tuple underlying type. Otherwise, Nothing. In case of a malformed underlying type
         ''' the corresponding underlying field might be missing, return Nothing in this case too.
@@ -343,6 +361,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Public Overridable ReadOnly Property TupleUnderlyingField() As FieldSymbol
             Get
                 Return Nothing
+            End Get
+        End Property
+
+        ''' <summary>
+        ''' If this is a field representing a tuple element,
+        ''' returns the index of the element (zero-based).
+        ''' Otherwise returns -1
+        ''' </summary>
+        Public Overridable ReadOnly Property TupleElementIndex As Integer
+            Get
+                Return -1
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -36,9 +36,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
-        ''' If this field represents a tuple element (including the name match), 
-        ''' id is an index of the element (zero-based).
-        ''' Otherwise, (-1 - [index in members array]);
+        ''' If this is a field representing a tuple element,
+        ''' returns the index of the element (zero-based).
+        ''' Otherwise returns -1
         ''' </summary>
         Public Overrides ReadOnly Property TupleElementIndex As Integer
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -83,12 +83,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Sub New(container As NamedTypeSymbol, name As String, tupleFieldId As Integer, location As Location, type As TypeSymbol, useSiteDiagnosticInfo As DiagnosticInfo, isImplicitlyDeclared As Boolean)
+        Public Sub New(container As NamedTypeSymbol, name As String, tupleElementIndex As Integer, location As Location, type As TypeSymbol, useSiteDiagnosticInfo As DiagnosticInfo, isImplicitlyDeclared As Boolean)
             MyBase.New(container, container, type, name, Accessibility.Public)
             Debug.Assert(name <> Nothing)
             Me._locations = If((location Is Nothing), ImmutableArray(Of Location).Empty, ImmutableArray.Create(Of Location)(location))
             Me._useSiteDiagnosticInfo = useSiteDiagnosticInfo
-            Me._tupleElementIndex = tupleFieldId
+            Me._tupleElementIndex = tupleElementIndex
             Me._isImplicitlyDeclared = isImplicitlyDeclared
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleErrorFieldSymbol.vb
@@ -15,15 +15,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Inherits SynthesizedFieldSymbol
 
         ''' <summary>
-        ''' If this field represents a tuple element (including the name match), 
-        ''' id is an index of the element (zero-based).
+        ''' If this field represents a tuple element with index X, the field contains
+        '''  2X      if this field represents a Default-named element
+        '''  2X + 1  if this field represents a Friendly-named element
         ''' Otherwise, (-1 - [index in members array]);
         ''' </summary>
-        Private ReadOnly _tupleFieldId As Integer
+        Private ReadOnly _tupleElementIndex As Integer
 
         Private ReadOnly _locations As ImmutableArray(Of Location)
-
         Private ReadOnly _useSiteDiagnosticInfo As DiagnosticInfo
+
+        ' default tuple elements like Item1 Or Item20 could be provided by the user or
+        ' otherwise implicitly declared by compiler
+        Private ReadOnly _isImplicitlyDeclared As Boolean
 
         Public Overrides ReadOnly Property IsTupleField As Boolean
             Get
@@ -36,9 +40,20 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' id is an index of the element (zero-based).
         ''' Otherwise, (-1 - [index in members array]);
         ''' </summary>
-        Public ReadOnly Property TupleFieldId As Integer
+        Public Overrides ReadOnly Property TupleElementIndex As Integer
             Get
-                Return Me._tupleFieldId
+                If _tupleElementIndex < 0 Then
+                    Return -1
+                End If
+
+                Return _tupleElementIndex >> 1
+            End Get
+        End Property
+
+        Public Overrides ReadOnly Property IsDefaultTupleElement As Boolean
+            Get
+                ' not negative and even
+                Return (_tupleElementIndex And ((1 << 31) Or 1)) = 0
             End Get
         End Property
 
@@ -56,22 +71,25 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overrides ReadOnly Property DeclaringSyntaxReferences As ImmutableArray(Of SyntaxReference)
             Get
-                Return Symbol.GetDeclaringSyntaxReferenceHelper(Of VisualBasicSyntaxNode)(Me._locations)
+                Return If(_isImplicitlyDeclared,
+                    ImmutableArray(Of SyntaxReference).Empty,
+                    GetDeclaringSyntaxReferenceHelper(Of VisualBasicSyntaxNode)(_locations))
             End Get
         End Property
 
         Public Overrides ReadOnly Property IsImplicitlyDeclared As Boolean
             Get
-                Return False
+                Return _isImplicitlyDeclared
             End Get
         End Property
 
-        Public Sub New(container As NamedTypeSymbol, name As String, tupleFieldId As Integer, location As Location, type As TypeSymbol, useSiteDiagnosticInfo As DiagnosticInfo)
+        Public Sub New(container As NamedTypeSymbol, name As String, tupleFieldId As Integer, location As Location, type As TypeSymbol, useSiteDiagnosticInfo As DiagnosticInfo, isImplicitlyDeclared As Boolean)
             MyBase.New(container, container, type, name, Accessibility.Public)
             Debug.Assert(name <> Nothing)
             Me._locations = If((location Is Nothing), ImmutableArray(Of Location).Empty, ImmutableArray.Create(Of Location)(location))
             Me._useSiteDiagnosticInfo = useSiteDiagnosticInfo
-            Me._tupleFieldId = tupleFieldId
+            Me._tupleElementIndex = tupleFieldId
+            Me._isImplicitlyDeclared = isImplicitlyDeclared
         End Sub
 
         Public Overrides ReadOnly Property Type As TypeSymbol
@@ -85,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Public Overrides Function GetHashCode() As Integer
-            Return Hash.Combine(Me.ContainingType.GetHashCode(), Me._tupleFieldId.GetHashCode())
+            Return Hash.Combine(Me.ContainingType.GetHashCode(), Me._tupleElementIndex.GetHashCode())
         End Function
 
         Public Overrides Function Equals(obj As Object) As Boolean
@@ -94,7 +112,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overloads Function Equals(other As TupleErrorFieldSymbol) As Boolean
             Return other Is Me OrElse
-                (other IsNot Nothing AndAlso Me._tupleFieldId = other._tupleFieldId AndAlso Me.ContainingType = other.ContainingType)
+                (other IsNot Nothing AndAlso Me._tupleElementIndex = other._tupleElementIndex AndAlso Me.ContainingType = other.ContainingType)
         End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -36,9 +36,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Property
 
         ''' <summary>
-        ''' If this field represents a tuple element (including the name match), 
-        ''' id is an index of the element (zero-based).
-        ''' Otherwise, (-1 - [index in members array]);
+        ''' If this is a field representing a tuple element,
+        ''' returns the index of the element (zero-based).
+        ''' Otherwise returns -1
         ''' </summary>
         Public Overrides ReadOnly Property TupleElementIndex As Integer
             Get

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -175,8 +175,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Sub New(container As TupleTypeSymbol, underlyingField As FieldSymbol, tupleFieldId As Integer, location As Location, isImplicitlyDeclared As Boolean)
-            MyBase.New(container, underlyingField, tupleFieldId)
+        Public Sub New(container As TupleTypeSymbol, underlyingField As FieldSymbol, tupleElementIndex As Integer, location As Location, isImplicitlyDeclared As Boolean)
+            MyBase.New(container, underlyingField, tupleElementIndex)
             Me._locations = If((location Is Nothing), ImmutableArray(Of Location).Empty, ImmutableArray.Create(Of Location)(location))
             Me._isImplicitlyDeclared = isImplicitlyDeclared
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleFieldSymbol.vb
@@ -17,8 +17,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         ''' <summary>
         ''' If this field represents a tuple element with index X, the field contains
-        ''' - 2X      if this field represents a Default-named element
-        ''' - 2X + 1  if this field represents a Friendly-named element
+        '''  2X      if this field represents a Default-named element
+        '''  2X + 1  if this field represents a Friendly-named element
         ''' Otherwise, (-1 - [index in members array]);
         ''' </summary>
         Private _tupleElementIndex As Integer

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -682,7 +682,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     Dim defaultName As String = TupleMemberName(tupleFieldIndex + 1)
 
                                     ' Add a field with default name regardless
-                                    members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, defaultName, -members.Count - 1, Nothing))
+                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, defaultName, -members.Count - 1, Nothing))
 
                                     If Not IdentifierComparison.Equals(namesOfVirtualFields(tupleFieldIndex), defaultName) Then
                                         ' The name given doesn't match default name ItemTupleTypeSymbol.RestPosition, etc.
@@ -692,7 +692,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                         If IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
                                             members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex, location))
                                         Else
-                                            members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex, location))
+                                            members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex, location))
                                         End If
                                     End If
                                 ElseIf IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
@@ -703,7 +703,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                     members.Add(New TupleFieldSymbol(Me, FieldSymbol, -members.Count - 1))
 
                                     ' Add a field with the given name
-                                    members.Add(New TupleRenamedElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex,
+                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex,
                                                                                             If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))))
                                 End If
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -85,7 +85,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public ReadOnly Property TupleElementFields As ImmutableArray(Of FieldSymbol)
+        ''' <summary>
+        ''' Get the default fields for the tuple's elements (in order and cached).
+        ''' </summary>
+        Public ReadOnly Property TupleDefaultElementFields As ImmutableArray(Of FieldSymbol)
             Get
                 Dim isDefault As Boolean = Me._lazyFields.IsDefault
                 If isDefault Then
@@ -613,16 +616,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Continue For
                 End If
 
-                Dim index = If(TryCast(member, TupleFieldSymbol)?.TupleFieldId,
-                                DirectCast(member, TupleErrorFieldSymbol).TupleFieldId)
+                Dim field = DirectCast(member, FieldSymbol)
+                Dim index = field.TupleElementIndex
 
-                If index >= 0 Then
+                If field.IsDefaultTupleElement Then
                     Debug.Assert(builder(index) Is Nothing)
-                    builder(index) = DirectCast(member, FieldSymbol)
+                    builder(index) = field
                 End If
             Next
 
-            Debug.Assert(builder.All(Function(symbol) symbol IsNot Nothing))
+            Debug.Assert(builder.All(Function(s) s IsNot Nothing))
 
             Return builder.ToImmutableAndFree()
         End Function
@@ -636,16 +639,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Function CreateMembers() As ImmutableArray(Of Symbol)
-            Dim namesOfVirtualFields = ArrayBuilder(Of String).GetInstance(_elementTypes.Length)
-
-            If _elementNames.IsDefault Then
-                For i As Integer = 1 To _elementTypes.Length
-                    namesOfVirtualFields.Add(TupleMemberName(i))
-                Next
-            Else
-                namesOfVirtualFields.AddRange(_elementNames)
-            End If
-
+            Dim elementsMatchedByFields = ArrayBuilder(Of Boolean).GetInstance(_elementTypes.Length, False)
             Dim members = ArrayBuilder(Of Symbol).GetInstance(Math.Max(_elementTypes.Length, _underlyingType.OriginalDefinition.GetMembers().Length))
 
             Dim currentUnderlying As NamedTypeSymbol = _underlyingType
@@ -671,44 +665,56 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                             Dim tupleFieldIndex = currentFieldsForElements.IndexOf(field, ReferenceEqualityComparer.Instance)
                             If tupleFieldIndex >= 0 Then
-                                ' This Is a tuple backing field
+                                ' This is a tuple backing field
+
+                                ' adjust tuple index for nesting
+                                If currentNestingLevel <> 0 Then
+                                    tupleFieldIndex += (RestPosition - 1) * currentNestingLevel
+                                End If
+
+                                Dim providedName = If(_elementNames.IsDefault, Nothing, _elementNames(tupleFieldIndex))
+                                Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))
+                                Dim defaultName = TupleMemberName(tupleFieldIndex + 1)
+                                ' if provided name does not match the default one, 
+                                ' then default element as declared implicitly
+                                Dim defaultImplicitlyDeclared = Not IdentifierComparison.Equals(providedName, defaultName)
+
                                 Dim FieldSymbol = field.AsMember(currentUnderlying)
 
                                 If currentNestingLevel <> 0 Then
                                     ' This is a matching field, but it is in the extension tuple
-                                    tupleFieldIndex += (RestPosition - 1) * currentNestingLevel
 
+                                    ' Add a field with default name. It should be present regardless.
+                                    ' Make it virtual since we are not at the top level
+                                    ' tupleFieldIndex << 1 because this is a default element
+                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, defaultName, tupleFieldIndex << 1, location, defaultImplicitlyDeclared))
 
-                                    Dim defaultName As String = TupleMemberName(tupleFieldIndex + 1)
-
-                                    ' Add a field with default name regardless
-                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, defaultName, -members.Count - 1, Nothing))
-
-                                    If Not IdentifierComparison.Equals(namesOfVirtualFields(tupleFieldIndex), defaultName) Then
-                                        ' The name given doesn't match default name ItemTupleTypeSymbol.RestPosition, etc.
+                                    If defaultImplicitlyDeclared AndAlso providedName IsNot Nothing Then
+                                        ' The name given doesn't match default name Item8, etc.
                                         ' Add a field with the given name
-                                        Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))
-
-                                        If IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
-                                            members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex, location))
-                                        Else
-                                            members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex, location))
-                                        End If
+                                        ' tupleFieldIndex << 1 + 1, because this is not a default element
+                                        members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared:=False))
                                     End If
-                                ElseIf IdentifierComparison.Equals(field.Name, namesOfVirtualFields(tupleFieldIndex)) Then
-                                    members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex,
-                                                                                    If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))))
-                                Else
-                                    ' Add a field with default name
-                                    members.Add(New TupleFieldSymbol(Me, FieldSymbol, -members.Count - 1))
+                                ElseIf defaultImplicitlyDeclared Then
+                                    Debug.Assert(IdentifierComparison.Equals(FieldSymbol.Name, defaultName), "top level underlying field must match default name")
 
-                                    ' Add a field with the given name
-                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, namesOfVirtualFields(tupleFieldIndex), tupleFieldIndex,
-                                                                                            If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))))
+                                    ' Add the underlying field as an element. It should have the default name.
+                                    ' tupleFieldIndex << 1 because this is a default element
+                                    members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex << 1, location, defaultImplicitlyDeclared))
+
+                                    If providedName IsNot Nothing Then
+                                        ' Add a field with the given name
+                                        ' tupleFieldIndex << 1 + 1, because this is not a default element
+                                        members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared:=False))
+                                    End If
+                                Else
+                                    Debug.Assert(IdentifierComparison.Equals(FieldSymbol.Name, defaultName), "top level underlying field must match default name")
+
+                                    ' tupleFieldIndex << 1 because this is a default element
+                                    members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex << 1, location, isImplicitlyDeclared:=False))
                                 End If
 
-                                namesOfVirtualFields(tupleFieldIndex) = Nothing ' mark as handled
-
+                                elementsMatchedByFields(tupleFieldIndex) = True ' mark as handled
                             ElseIf currentNestingLevel = 0 Then
                                 ' field at the top level didn't match a tuple backing field, simply add.
                                 members.Add(New TupleFieldSymbol(Me, field.AsMember(currentUnderlying), -members.Count - 1))
@@ -754,12 +760,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             currentFieldsForElements.Free()
 
-            ' At the end, add remaining virtual fields
-            For i As Integer = 0 To namesOfVirtualFields.Count - 1
-                Dim Name As String = namesOfVirtualFields(i)
-                If Name IsNot Nothing Then
-                    ' We couldn't find a backing field for this vitual field. It will be an error to access it. 
-                    Dim fieldRemainder As Integer ' one - based
+            ' At the end, add unmatched fields as error symbols
+            For i As Integer = 0 To elementsMatchedByFields.Count - 1
+                If Not elementsMatchedByFields(i) Then
+                    ' We couldn't find a backing field for this element. It will be an error to access it. 
+                    Dim fieldRemainder As Integer ' one-based
                     Dim fieldChainLength = NumberOfValueTuples(i + 1, fieldRemainder)
                     Dim container As NamedTypeSymbol = GetNestedTupleUnderlyingType(_underlyingType, fieldChainLength - 1).OriginalDefinition
 
@@ -768,16 +773,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                           ErrorFactory.ErrorInfo(ERRID.ERR_MissingRuntimeHelper,
                                                                                container.Name & "." & TupleMemberName(fieldRemainder)))
 
-                    Dim defaultName As String = TupleMemberName(i + 1)
-                    ' Add a field with default name if the given name Is different
-                    If Name <> defaultName Then
-                        members.Add(New TupleErrorFieldSymbol(Me, defaultName, -members.Count - 1, Nothing, _elementTypes(i), diagnosticInfo))
-                    End If
+                    Dim providedName = If(_elementNames.IsDefault, Nothing, _elementNames(i))
+                    Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(i))
+                    Dim defaultName = TupleMemberName(i + 1)
+                    ' if provided name does not match the default one, 
+                    ' then default element as declared implicitly
+                    Dim defaultImplicitlyDeclared = Not IdentifierComparison.Equals(providedName, defaultName)
 
-                    members.Add(New TupleErrorFieldSymbol(Me, Name, i,
-                                                      If(_elementLocations.IsDefault, Nothing, _elementLocations(i)),
-                                                      _elementTypes(i),
-                                                      diagnosticInfo))
+                    ' Add default element field. 
+                    ' i << 1 because this is a default element
+                    members.Add(New TupleErrorFieldSymbol(Me, defaultName, i << 1, If(defaultImplicitlyDeclared, Nothing, location), _elementTypes(i), diagnosticInfo, defaultImplicitlyDeclared))
+
+
+                    If defaultImplicitlyDeclared AndAlso providedName IsNot Nothing Then
+                        ' Add frieldly named element field. 
+                        ' (i << 1) + 1, because this is not a default element
+                        members.Add(New TupleErrorFieldSymbol(Me, providedName, (i << 1) + 1, location, _elementTypes(i), diagnosticInfo, isImplicitlyDeclared:=False))
+                    End If
                 End If
             Next
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -609,7 +609,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Function CollectTupleElementFields() As ImmutableArray(Of FieldSymbol)
-            Dim builder = ArrayBuilder(Of FieldSymbol).GetInstance(_elementTypes.Length, Nothing)
+            Dim builder = ArrayBuilder(Of FieldSymbol).GetInstance(_elementTypes.Length, fillWithValue:=Nothing)
 
             For Each member In GetMembers()
                 If member.Kind <> SymbolKind.Field Then
@@ -639,7 +639,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         End Function
 
         Private Function CreateMembers() As ImmutableArray(Of Symbol)
-            Dim elementsMatchedByFields = ArrayBuilder(Of Boolean).GetInstance(_elementTypes.Length, False)
+            Dim elementsMatchedByFields = ArrayBuilder(Of Boolean).GetInstance(_elementTypes.Length, fillWithValue:=False)
             Dim members = ArrayBuilder(Of Symbol).GetInstance(Math.Max(_elementTypes.Length, _underlyingType.OriginalDefinition.GetMembers().Length))
 
             Dim currentUnderlying As NamedTypeSymbol = _underlyingType

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -617,9 +617,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End If
 
                 Dim field = DirectCast(member, FieldSymbol)
-                Dim index = field.TupleElementIndex
 
                 If field.IsDefaultTupleElement Then
+                    Dim index = field.TupleElementIndex
                     Debug.Assert(builder(index) Is Nothing)
                     builder(index) = field
                 End If
@@ -676,42 +676,30 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(tupleFieldIndex))
                                 Dim defaultName = TupleMemberName(tupleFieldIndex + 1)
                                 ' if provided name does not match the default one, 
-                                ' then default element as declared implicitly
+                                ' then default element is declared implicitly
                                 Dim defaultImplicitlyDeclared = Not IdentifierComparison.Equals(providedName, defaultName)
 
                                 Dim FieldSymbol = field.AsMember(currentUnderlying)
 
+                                ' Add a field with default name. It should be present regardless.
                                 If currentNestingLevel <> 0 Then
                                     ' This is a matching field, but it is in the extension tuple
-
-                                    ' Add a field with default name. It should be present regardless.
                                     ' Make it virtual since we are not at the top level
                                     ' tupleFieldIndex << 1 because this is a default element
                                     members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, defaultName, tupleFieldIndex << 1, location, defaultImplicitlyDeclared))
-
-                                    If defaultImplicitlyDeclared AndAlso providedName IsNot Nothing Then
-                                        ' The name given doesn't match default name Item8, etc.
-                                        ' Add a field with the given name
-                                        ' tupleFieldIndex << 1 + 1, because this is not a default element
-                                        members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared:=False))
-                                    End If
-                                ElseIf defaultImplicitlyDeclared Then
+                                Else
                                     Debug.Assert(IdentifierComparison.Equals(FieldSymbol.Name, defaultName), "top level underlying field must match default name")
 
                                     ' Add the underlying field as an element. It should have the default name.
                                     ' tupleFieldIndex << 1 because this is a default element
                                     members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex << 1, location, defaultImplicitlyDeclared))
+                                End If
 
-                                    If providedName IsNot Nothing Then
-                                        ' Add a field with the given name
-                                        ' tupleFieldIndex << 1 + 1, because this is not a default element
-                                        members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared:=False))
-                                    End If
-                                Else
-                                    Debug.Assert(IdentifierComparison.Equals(FieldSymbol.Name, defaultName), "top level underlying field must match default name")
-
-                                    ' tupleFieldIndex << 1 because this is a default element
-                                    members.Add(New TupleElementFieldSymbol(Me, FieldSymbol, tupleFieldIndex << 1, location, isImplicitlyDeclared:=False))
+                                If defaultImplicitlyDeclared AndAlso providedName IsNot Nothing Then
+                                    ' The name given doesn't match the default name Item8, etc.
+                                    ' Add a virtual field with the given name
+                                    ' tupleFieldIndex << 1 + 1, because this is not a default element
+                                    members.Add(New TupleVirtualElementFieldSymbol(Me, FieldSymbol, providedName, (tupleFieldIndex << 1) + 1, location, isImplicitlyDeclared:=False))
                                 End If
 
                                 elementsMatchedByFields(tupleFieldIndex) = True ' mark as handled
@@ -777,7 +765,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Dim location = If(_elementLocations.IsDefault, Nothing, _elementLocations(i))
                     Dim defaultName = TupleMemberName(i + 1)
                     ' if provided name does not match the default one, 
-                    ' then default element as declared implicitly
+                    ' then default element is declared implicitly
                     Dim defaultImplicitlyDeclared = Not IdentifierComparison.Equals(providedName, defaultName)
 
                     ' Add default element field. 
@@ -786,7 +774,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 
                     If defaultImplicitlyDeclared AndAlso providedName IsNot Nothing Then
-                        ' Add frieldly named element field. 
+                        ' Add friendly named element field. 
                         ' (i << 1) + 1, because this is not a default element
                         members.Add(New TupleErrorFieldSymbol(Me, providedName, (i << 1) + 1, location, _elementTypes(i), diagnosticInfo, isImplicitlyDeclared:=False))
                     End If

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -4293,7 +4293,7 @@ BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
             Assert.True(mFirst.CustomModifiers.IsEmpty)
             Assert.True(mFirst.GetAttributes().IsEmpty)
             'Assert.Null(mFirst.GetUseSiteDiagnostic())
-            Assert.False(mFirst.Locations.IsDefaultOrEmpty)
+            Assert.False(mFirst.Locations.IsEmpty)
             Assert.Equal("first", mFirst.DeclaringSyntaxReferences.Single().GetSyntax().ToString())
             Assert.False(mFirst.IsImplicitlyDeclared)
             Assert.Null(mFirst.TypeLayoutOffset)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -4313,7 +4313,7 @@ BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
             Assert.True(mItem1.GetAttributes().IsEmpty)
             'Assert.Null(mItem1.GetUseSiteDiagnostic())
             Assert.True(mItem1.Locations.IsEmpty)
-            Assert.False(mItem1.IsImplicitlyDeclared)
+            Assert.True(mItem1.IsImplicitlyDeclared)
             Assert.Null(mItem1.TypeLayoutOffset)
 
         End Sub

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -208,7 +208,16 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 // Get the source symbol if possible
                 var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
 
-                if (sourceSymbol.IsImplicitlyDeclared || !sourceSymbol.Locations.All(loc => loc.IsInSource))
+                if (sourceSymbol.Kind == SymbolKind.Field && 
+                    ((IFieldSymbol)sourceSymbol).ContainingType.IsTupleType &&
+                    sourceSymbol.IsImplicitlyDeclared)
+                {
+                    // should not rename Item1, Item2...
+                    // when user did not declare them in source.
+                    return TriggerIdentifierKind.NotRenamable;
+                }
+
+                if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
                 {
                     return TriggerIdentifierKind.NotRenamable;
                 }

--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -208,7 +208,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                 // Get the source symbol if possible
                 var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
 
-                if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
+                if (sourceSymbol.IsImplicitlyDeclared || !sourceSymbol.Locations.All(loc => loc.IsInSource))
                 {
                     return TriggerIdentifierKind.NotRenamable;
                 }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1219,6 +1219,27 @@ class C
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameImplicitTupleFieldVB()
+        {
+            var code = @"
+class C
+    Sub M()
+        Dim x as (Integer, Integer) = (1, 2)
+        Dim y = x.Item1$$
+    End Sub
+End Class
+";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+                await state.AssertNoTag();
+                Assert.Empty(await state.GetDocumentDiagnosticsAsync());
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
         public async Task RenameImplicitTupleFieldExtended()
         {
             var code = @"
@@ -1240,6 +1261,26 @@ class C
             }
         }
 
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameImplicitTupleFieldExtendedVB()
+        {
+            var code = @"
+Class C
+    Sub M()
+        Dim x as (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+        Dim y = x.Item9$$
+    End Sub
+End Class
+";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+                await state.AssertNoTag();
+                Assert.Empty(await state.GetDocumentDiagnosticsAsync());
+            }
+        }
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
@@ -1278,6 +1319,102 @@ class C
 
         [WpfFact]
         [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleFieldVB()
+        {
+            var code = @"
+class C
+    Sub M()
+        Dim x as (Item1 as integer, int Item2 as integer) = (1, 2)
+        Dim y = x.Item1$$
+    End Sub
+End Class";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+
+                await state.AssertTag("Item1", "Ite", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+    Sub M()
+        Dim x as (Ite as integer, int Item2 as integer) = (1, 2)
+        Dim y = x.Ite
+    End Sub
+End Class";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
+
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleField01()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        (int Ite, int) x = (1, 2);
+        var y = x.Ite$$;
+    }
+}";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("m1");
+
+                await state.AssertTag("Ite", "Item1", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void M()
+    {
+        (int Item1, int) x = (1, 2);
+        var y = x.Item1;
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleField01VB()
+        {
+            var code = @"
+class C
+    Sub M()
+        Dim x as (Ite as Integer, Item2 as Integer) = (1, 2)
+        var y = x.Ite$$
+    End Sub
+End Class";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.InsertText("m1");
+
+                await state.AssertTag("Ite", "Item1", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+    Sub M()
+        Dim x as (Item1 as Integer, Item2 as Integer) = (1, 2)
+        var y = x.Item1
+    End Sub
+End Class";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
         public async Task RenameExplicitTupleFieldExtended()
         {
             var code = @"
@@ -1306,6 +1443,37 @@ class C
         var y = x.Ite;
     }
 }";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleFieldExtendedVB()
+        {
+            var code = @"
+class C
+    Sub M()
+        Dim x as (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Item9 As Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var y = x.Item9$$;
+    End Sub
+End Class";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.VisualBasic))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+
+                await state.AssertTag("Item9", "Ite", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+    Sub M()
+        Dim x as (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Ite As Integer, Integer) = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var y = x.Ite;
+    End Sub
+End Class";
                 Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
                 await state.AssertNoTag();
             }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1194,5 +1194,121 @@ class C
                 Assert.NotEmpty(await state.GetDocumentDiagnosticsAsync());
             }
         }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameImplicitTupleField()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        (int, int) x = (1, 2);
+        var y = x.Item1$$;
+    }
+}";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+                await state.AssertNoTag();
+                Assert.Empty(await state.GetDocumentDiagnosticsAsync());
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameImplicitTupleFieldExtended()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        (int, int, int, int, int, int, int, int, int, int) x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var y = x.Item9$$;
+    }
+}
+";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+                await state.AssertNoTag();
+                Assert.Empty(await state.GetDocumentDiagnosticsAsync());
+            }
+        }
+
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleField()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        (int Item1, int) x = (1, 2);
+        var y = x.Item1$$;
+    }
+}";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+
+                await state.AssertTag("Item1", "Ite", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void M()
+    {
+        (int Ite, int) x = (1, 2);
+        var y = x.Ite;
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        public async Task RenameExplicitTupleFieldExtended()
+        {
+            var code = @"
+class C
+{
+    void M()
+    {
+        (int, int, int, int, int, int, int, int, int Item9, int) x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var y = x.Item9$$;
+    }
+}";
+            using (var state = await RenameTrackingTestState.CreateAsync(code, LanguageNames.CSharp))
+            {
+                state.EditorOperations.Backspace();
+                state.EditorOperations.Backspace();
+
+                await state.AssertTag("Item9", "Ite", invokeAction: true);
+
+                // Make sure the rename completed            
+                var expectedCode = @"
+class C
+{
+    void M()
+    {
+        (int, int, int, int, int, int, int, int, int Ite, int) x = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        var y = x.Ite;
+    }
+}";
+                Assert.Equal(expectedCode, state.HostDocument.TextBuffer.CurrentSnapshot.GetText());
+                await state.AssertNoTag();
+            }
+        }
     }
 }


### PR DESCRIPTION
We had several inconsistencies in presenting tuple element field locations and implementation of IsImplicitlyDeclared/DeclaringSyntaxReferences. 
And that got worse when partially named tuples were allowed, while the API behavior was not adjusted sufficiently.

One result of the API inconsistencies is inability of IDE to avoid crashes like in https://github.com/dotnet/roslyn/issues/13696
(trying to edit names of synthesized fields like "Item10" or "Item1" at the use site leads to a crash)

Fixes: https://github.com/dotnet/roslyn/issues/13696
Fixes: https://github.com/dotnet/roslyn/issues/13502

Also some improvements to the implementation of tuple element id which made field equality not relying on string compares.