### PR TITLE
Remove an incorrect ContainsDiagnostics test in LanguageParser

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -6572,7 +6572,7 @@ tryAgain:
                 var close = this.EatToken(SyntaxKind.CloseParenToken);
                 var result = _syntaxFactory.TupleType(open, list, close);
 
-                if (!result.ContainsDiagnostics && list.Count < 2)
+                if (list.Count < 2)
                 {
                     result = this.AddError(result, ErrorCode.ERR_TupleTooFewElements);
                 }
@@ -10233,7 +10233,7 @@ tryAgain:
                 var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
                 var result = _syntaxFactory.TupleExpression(openParen, list, closeParen);
 
-                if (!result.ContainsDiagnostics && list.Count < 2)
+                if (list.Count < 2)
                 {
                     result = this.AddError(result, ErrorCode.ERR_TupleTooFewElements);
                 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -3555,45 +3555,45 @@ Lambda:
 namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
 ";
             CreateCompilationWithMscorlib(source, parseOptions: TestOptions.Regular).VerifyDiagnostics(
-    // (2,11): error CS7000: Unexpected use of an aliased name
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_UnexpectedAliasedName, "global::").WithLocation(2, 11),
-    // (2,19): error CS1001: Identifier expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(2, 19),
-    // (2,20): error CS8096: Tuple type must have at least two elements.
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(System.Linq.Expressions.Expression<System.Func<B>>)").WithLocation(2, 20),
-    // (2,76): error CS1026: ) expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_CloseParenExpected, "=>").WithLocation(2, 76),
-    // (2,79): error CS0116: A namespace cannot directly contain members such as fields or methods
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "B").WithLocation(2, 79),
-    // (2,19): error CS1514: { expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_LbraceExpected, "(").WithLocation(2, 19),
-    // (2,76): error CS1022: Type or namespace definition, or end-of-file expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_EOFExpected, "=>").WithLocation(2, 76),
-    // (2,81): error CS1022: Type or namespace definition, or end-of-file expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_EOFExpected, ")").WithLocation(2, 81),
-    // (2,84): error CS1520: Method must have a return type
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_MemberNeedsType, "Compile").WithLocation(2, 84),
-    // (2,93): error CS1002: ; expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(2, 93),
-    // (2,93): error CS8096: Tuple type must have at least two elements.
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(2, 93),
-    // (2,95): error CS1022: Type or namespace definition, or end-of-file expected
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_EOFExpected, "{").WithLocation(2, 95),
-    // (2,84): error CS0501: '<invalid-global-code>.Compile()' must declare a body because it is not marked abstract, extern, or partial
-    // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
-    Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "Compile").WithArguments(".<invalid-global-code>.Compile()").WithLocation(2, 84)
+                // (2,11): error CS7000: Unexpected use of an aliased name
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_UnexpectedAliasedName, "global::").WithLocation(2, 11),
+                // (2,19): error CS1001: Identifier expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, "(").WithLocation(2, 19),
+                // (2,20): error CS8124: Tuple must contain at least two elements.
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(System.Linq.Expressions.Expression<System.Func<B>>)").WithLocation(2, 20),
+                // (2,76): error CS1026: ) expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "=>").WithLocation(2, 76),
+                // (2,79): error CS0116: A namespace cannot directly contain members such as fields or methods
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_NamespaceUnexpected, "B").WithLocation(2, 79),
+                // (2,19): error CS1514: { expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_LbraceExpected, "(").WithLocation(2, 19),
+                // (2,76): error CS1022: Type or namespace definition, or end-of-file expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_EOFExpected, "=>").WithLocation(2, 76),
+                // (2,81): error CS1022: Type or namespace definition, or end-of-file expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_EOFExpected, ")").WithLocation(2, 81),
+                // (2,84): error CS1520: Method must have a return type
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "Compile").WithLocation(2, 84),
+                // (2,93): error CS1002: ; expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(2, 93),
+                // (2,93): error CS8124: Tuple must contain at least two elements.
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "()").WithLocation(2, 93),
+                // (2,95): error CS1022: Type or namespace definition, or end-of-file expected
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_EOFExpected, "{").WithLocation(2, 95),
+                // (2,84): error CS0501: '<invalid-global-code>.Compile()' must declare a body because it is not marked abstract, extern, or partial
+                // namespace global::((System.Linq.Expressions.Expression<System.Func<B>>)(() => B )).Compile()(){}
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "Compile").WithArguments(".<invalid-global-code>.Compile()").WithLocation(2, 84)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/CompilationAPITests.cs
@@ -493,25 +493,27 @@ namespace A.B {
              );
 
             comp.VerifyDiagnostics(
-    // (1,19): error CS1002: ; expected
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
-    // (1,20): error CS1031: Type expected
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.ERR_TypeExpected, "*").WithLocation(1, 20),
-    // (1,21): error CS1040: Preprocessor directives must appear as the first non-whitespace character on a line
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.ERR_BadDirectivePlacement, "#").WithLocation(1, 21),
-    // (1,61): error CS1026: ) expected
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 61),
-    // (1,14): error CS0430: The extern alias 'Alias' was not specified in a /reference option
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.ERR_BadExternAlias, "Alias").WithArguments("Alias").WithLocation(1, 14),
-    // (1,1): hidden CS8020: Unused extern alias.
-    // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
-    Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias Alias").WithLocation(1, 1)
-
+                // (1,19): error CS1002: ; expected
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
+                // (1,19): error CS8124: Tuple must contain at least two elements.
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithLocation(1, 19),
+                // (1,20): error CS1031: Type expected
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_TypeExpected, "*").WithLocation(1, 20),
+                // (1,21): error CS1040: Preprocessor directives must appear as the first non-whitespace character on a line
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_BadDirectivePlacement, "#").WithLocation(1, 21),
+                // (1,61): error CS1026: ) expected
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "").WithLocation(1, 61),
+                // (1,14): error CS0430: The extern alias 'Alias' was not specified in a /reference option
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_BadExternAlias, "Alias").WithArguments("Alias").WithLocation(1, 14),
+                // (1,1): hidden CS8020: Unused extern alias.
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.HDN_UnusedExternAlias, "extern alias Alias").WithLocation(1, 1)
                 );
         }
 
@@ -562,6 +564,9 @@ namespace A.B {
                 // (1,19): error CS1002: ; expected
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "(").WithLocation(1, 19),
+                // (1,19): error CS8124: Tuple must contain at least two elements.
+                // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithLocation(1, 19),
                 // (1,19): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 // extern alias Alias(*#$@^%*&); class D : Alias(*#$@^%*&).C {}
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(*#$@^%*&); class D : Alias(*#$@^%*&).C {}").WithArguments("tuples", "7").WithLocation(1, 19),


### PR DESCRIPTION
by which the presence of a nested warning could suppress
what should be an error. Also adds a test for #13719, which is
related.
Fixes #13667 

@VSadov @jcouv @dotnet/roslyn-compiler Please review
@jaredpar You might want to look at this too, since you were ***sooooo*** interested in the issue ;)
