### PR TITLE
Deconstruction into dynamic array and dynamic indexer

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3044,5 +3044,156 @@ class C
             var comp = CompileAndVerify(source, expectedOutput: "0 10 ", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics();
         }
+
+        [Fact]
+        public void TupleDeconstructionIntoDynamicArrayIndexer()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic x = new string[] { """", """" };
+        M(x);
+        System.Console.WriteLine($""{x[0]} {x[1]}"");
+    }
+
+    static void M(dynamic x)
+    {
+        (x[0], x[1]) = (""hello"", ""world"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "hello world", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void IntTupleDeconstructionIntoDynamicArrayIndexer()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic x = new int[] { 1, 2 };
+        M(x);
+        System.Console.WriteLine($""{x[0]} {x[1]}"");
+    }
+
+    static void M(dynamic x)
+    {
+        (x[0], x[1]) = (3, 4);
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "3 4", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DeconstructionIntoDynamicArrayIndexer()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic x = new string[] { """", """" };
+        M(x);
+        System.Console.WriteLine($""{x[0]} {x[1]}"");
+    }
+
+    static void M(dynamic x)
+    {
+        (x[0], x[1]) = new C();
+    }
+
+    public void Deconstruct(out string a, out string b)
+    {
+        a = ""hello"";
+        b = ""world"";
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "hello world", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void TupleDeconstructionIntoDynamicArray()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic[] x = new string[] { """", """" };
+        M(x);
+        System.Console.WriteLine($""{x[0]} {x[1]}"");
+    }
+
+    static void M(dynamic[] x)
+    {
+        (x[0], x[1]) = (""hello"", ""world"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "hello world", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DeconstructionIntoDynamicArray()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic[] x = new string[] { """", """" };
+        M(x);
+        System.Console.WriteLine($""{x[0]} {x[1]}"");
+    }
+
+    static void M(dynamic[] x)
+    {
+        (x[0], x[1]) = new C();
+    }
+
+    public void Deconstruct(out string a, out string b)
+    {
+        a = ""hello"";
+        b = ""world"";
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "hello world", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void DeconstructionIntoDynamicMember()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic x = System.ValueTuple.Create(1, 2);
+        (x.Item1, x.Item2) = new C();
+        System.Console.WriteLine($""{x.Item1} {x.Item2}"");
+    }
+
+    public void Deconstruct(out int a, out int b)
+    {
+        a = 3;
+        b = 4;
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "3 4", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -13966,6 +13966,26 @@ class C
 ");
         }
 
+        [Fact]
+        public void CompoundAssignment()
+        {
+            string source = @"
+class C
+{
+    static void Main()
+    {
+        dynamic[] x = new string[] { ""hello"" };
+        x[0] += ""!"";
+        System.Console.Write(x[0]);
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "hello!", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
+            comp.VerifyDiagnostics();
+            // No runtime failure (System.ArrayTypeMismatchException: Attempted to access an element as a type incompatible with the array.)
+            // because of the special handling for dynamic in LocalRewriter.TransformCompoundAssignmentLHS
+        }
+
         #endregion
 
         #region Object And Collection Initializers


### PR DESCRIPTION
The deconstruction lowering uses `TransformCompoundAssignmentLHS` to capture the side-effects of left-hand-side variables and get symbols back for writing into those references. But we were always passing `isDynamicAssignment` as `false`.
It turns out that is a bug and I added some tests that hit that case. Before this fix, those tests produce code that fails at runtime with `System.ArrayTypeMismatchException: Attempted to access an element as a type incompatible with the array.`

In this process, I found out that lowering of some of the assignment steps (that are part of the deconstruction) would fail because they would would not switch on the proper `Kind` in `VisitAssignmentOperator`. It would switch on the kind of the unlowered left (ie the kind of the placeholder), instead of the proper kind `DynamicIndexerAccess`.
After this fix, lowering of the assignment step directly makes lowered assignment nodes with `MakeAssignmentOperator` instead of calling `VisitExpression` on the un-lowered assignment node.

Fixes https://github.com/dotnet/roslyn/issues/12398

@AlekseyTs @dotnet/roslyn-compiler for review.