### PR TITLE
Add tuple handling in variance check

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -246,8 +246,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return IsVarianceUnsafe(((ArrayTypeSymbol)type).ElementType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
+                    var namedType = type.IsTupleType ? type.TupleUnderlyingType : (NamedTypeSymbol)type;
                     // 3) (see IsVarianceUnsafe(NamedTypeSymbol))
-                    return IsVarianceUnsafe((NamedTypeSymbol)type, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
+                    return IsVarianceUnsafe(namedType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 default:
                     return false;
             }

--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return IsVarianceUnsafe(((ArrayTypeSymbol)type).ElementType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
-                    var namedType = type.IsTupleType ? type.TupleUnderlyingType : (NamedTypeSymbol)type;
+                    var namedType = type.TupleUnderlyingTypeOrSelf();
                     // 3) (see IsVarianceUnsafe(NamedTypeSymbol))
                     return IsVarianceUnsafe(namedType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 default:

--- a/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/VarianceSafety.cs
@@ -246,7 +246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     return IsVarianceUnsafe(((ArrayTypeSymbol)type).ElementType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 case SymbolKind.ErrorType:
                 case SymbolKind.NamedType:
-                    var namedType = type.TupleUnderlyingTypeOrSelf();
+                    var namedType = (NamedTypeSymbol)type.TupleUnderlyingTypeOrSelf();
                     // 3) (see IsVarianceUnsafe(NamedTypeSymbol))
                     return IsVarianceUnsafe(namedType, requireOutputSafety, requireInputSafety, context, locationProvider, locationArg, diagnostics);
                 default:

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17886,5 +17886,39 @@ class Program
             Assert.Equal(newText.ToString(), finalText);
             // no crash
         }
+
+        [Fact, WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")]
+        public static void TupleVariance()
+        {
+            var source = @"
+public interface I<out T>
+{
+    System.ValueTuple<bool, T> M();
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp1.VerifyDiagnostics(
+                // (4,5): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'I<T>.M()'. 'T' is covariant.
+                //     System.ValueTuple<bool, T> M();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "System.ValueTuple<bool, T>").WithArguments("I<T>.M()", "T", "covariant", "invariantly").WithLocation(4, 5)
+                );
+        }
+
+        [Fact, WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")]
+        public static void TupleVariance2()
+        {
+            var source = @"
+public interface I<out T>
+{
+    (bool, T)[] M();
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp1.VerifyDiagnostics(
+                // (4,5): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'I<T>.M()'. 'T' is covariant.
+                //     (bool, T)[] M();
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "(bool, T)[]").WithArguments("I<T>.M()", "T", "covariant", "invariantly").WithLocation(4, 5)
+                );
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17888,7 +17888,7 @@ class Program
         }
 
         [Fact, WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")]
-        public static void TupleVariance()
+        public static void TupleCoVariance()
         {
             var source = @"
 public interface I<out T>
@@ -17905,7 +17905,7 @@ public interface I<out T>
         }
 
         [Fact, WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")]
-        public static void TupleVariance2()
+        public static void TupleCoVariance2()
         {
             var source = @"
 public interface I<out T>
@@ -17918,6 +17918,23 @@ public interface I<out T>
                 // (4,5): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'I<T>.M()'. 'T' is covariant.
                 //     (bool, T)[] M();
                 Diagnostic(ErrorCode.ERR_UnexpectedVariance, "(bool, T)[]").WithArguments("I<T>.M()", "T", "covariant", "invariantly").WithLocation(4, 5)
+                );
+        }
+
+        [Fact, WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")]
+        public static void TupleContraVariance()
+        {
+            var source = @"
+public interface I<in T>
+{
+    void M((bool, T)[] x);
+}
+";
+            var comp1 = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp1.VerifyDiagnostics(
+                // (4,12): error CS1961: Invalid variance: The type parameter 'T' must be invariantly valid on 'I<T>.M((bool, T)[])'. 'T' is contravariant.
+                //     void M((bool, T)[] x);
+                Diagnostic(ErrorCode.ERR_UnexpectedVariance, "(bool, T)[]").WithArguments("I<T>.M((bool, T)[])", "T", "contravariant", "invariantly").WithLocation(4, 12)
                 );
         }
     }

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMemberContainerTypeSymbol.vb
@@ -823,7 +823,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                                                   diagnostics)
 
                 Case SymbolKind.NamedType
-                    Dim namedType = DirectCast(type, NamedTypeSymbol)
+                    Dim namedType = DirectCast(type.GetTupleUnderlyingTypeOrSelf(), NamedTypeSymbol)
 
                     If Not namedType.IsGenericType Then
                         Return

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -7161,6 +7161,66 @@ additionalReferences:=s_valueTupleRefs)
                        Sub(t) Assert.Equal(SpecialType.System_Int32, t.SpecialType))
         End Sub
 
+        <Fact()>
+        <WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")>
+        Public Sub TupleCoVariance()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb"><![CDATA[
+Interface I(Of Out T)
+    Function M() As System.ValueTuple(Of Integer, T)
+End Interface
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC36726: Type 'T' cannot be used for the 'T2' in 'System.ValueTuple(Of T1, T2)' in this context because 'T' is an 'Out' type parameter.
+    Function M() As System.ValueTuple(Of Integer, T)
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</errors>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")>
+        Public Sub TupleCoVariance2()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb"><![CDATA[
+Interface I(Of Out T)
+    Function M() As (Integer, T)
+End Interface
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC36726: Type 'T' cannot be used for the 'T2' in 'System.ValueTuple(Of T1, T2)' in this context because 'T' is an 'Out' type parameter.
+    Function M() As (Integer, T)
+                    ~~~~~~~~~~~~
+</errors>)
+        End Sub
+
+        <Fact()>
+        <WorkItem(13705, "https://github.com/dotnet/roslyn/issues/13705")>
+        Public Sub TupleContraVariance()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb"><![CDATA[
+Interface I(Of In T)
+    Sub M(x As (Boolean, T))
+End Interface
+]]></file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef})
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC36727: Type 'T' cannot be used for the 'T2' in 'System.ValueTuple(Of T1, T2)' in this context because 'T' is an 'In' type parameter.
+    Sub M(x As (Boolean, T))
+               ~~~~~~~~~~~~
+</errors>)
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Bug https://github.com/dotnet/roslyn/issues/13705 was reported showing that tuples symbols aren't handled properly in variance safety checks.
Seems I missed this in my previous [scrub](https://github.com/dotnet/roslyn/pull/13024).

@dotnet/roslyn-compiler for review. Thanks