### PR TITLE
Fix crash on "is type" operator with typeless tuple expression.

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2550,6 +2550,20 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
 
                     return true;
+
+                default:
+                    if ((object)operand.Type == null && !operand.IsLiteralNull())
+                    {
+                        if (!operand.HasAnyErrors)
+                        {
+                            // Operator 'is' cannot be applied to operand of type '(int, <null>)'
+                            diagnostics.Add(ErrorCode.ERR_BadUnaryOp, node.Location, "is", operand.Display);
+                        }
+
+                        return true;
+                    }
+
+                    break;
             }
 
             return operand.HasAnyErrors;

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -2557,7 +2557,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         if (!operand.HasAnyErrors)
                         {
                             // Operator 'is' cannot be applied to operand of type '(int, <null>)'
-                            diagnostics.Add(ErrorCode.ERR_BadUnaryOp, node.Location, "is", operand.Display);
+                            Error(diagnostics, ErrorCode.ERR_BadUnaryOp, node, SyntaxFacts.GetText(SyntaxKind.IsKeyword), operand.Display);
                         }
 
                         return true;

--- a/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/SwitchBinder.cs
@@ -472,7 +472,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             if (!switchExpression.HasAnyErrors)
             {
                 Debug.Assert((object)switchExpression.Type == null || switchExpression.Type.SpecialType == SpecialType.System_Void);
-                diagnostics.Add(ErrorCode.ERR_PatternValueExpected, node.Location, switchExpression.Display);
+                diagnostics.Add(ErrorCode.ERR_SwitchExpressionValueExpected, node.Location, switchExpression.Display);
             }
 
             return new BoundBadExpression(node, LookupResultKind.Empty, ImmutableArray<Symbol>.Empty, ImmutableArray.Create<BoundNode>(switchExpression), switchGoverningType ?? CreateErrorType());

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1565,7 +1565,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid operand for pattern match..
+        ///   Looks up a localized string similar to Invalid operand for pattern match; value required, but found &apos;{0}&apos;..
         /// </summary>
         internal static string ERR_BadIsPatternExpression {
             get {
@@ -7415,15 +7415,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The switch expression must be a value; found {0}..
-        /// </summary>
-        internal static string ERR_PatternValueExpected {
-            get {
-                return ResourceManager.GetString("ERR_PatternValueExpected", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to An expression of type {0} cannot be handled by a pattern of type {1}..
         /// </summary>
         internal static string ERR_PatternWrongType {
@@ -8635,6 +8626,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_SubexpressionNotInNameof {
             get {
                 return ResourceManager.GetString("ERR_SubexpressionNotInNameof", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The switch expression must be a value; found {0}..
+        /// </summary>
+        internal static string ERR_SwitchExpressionValueExpected {
+            get {
+                return ResourceManager.GetString("ERR_SwitchExpressionValueExpected", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4866,7 +4866,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_DeconstructRequiresExpression" xml:space="preserve">
     <value>Deconstruct assignment requires an expression with a type on the right-hand-side.</value>
   </data>
-  <data name="ERR_PatternValueExpected" xml:space="preserve">
+  <data name="ERR_SwitchExpressionValueExpected" xml:space="preserve">
     <value>The switch expression must be a value; found {0}.</value>
   </data>
   <data name="ERR_PatternIsSubsumed" xml:space="preserve">

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1356,7 +1356,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         #region diagnostics for pattern-matching introduced in C# 7
         ERR_PatternNullableType = 8116,
         ERR_BadIsPatternExpression = 8117,
-        ERR_PatternValueExpected = 8119,
+        ERR_SwitchExpressionValueExpected = 8119,
         ERR_PatternIsSubsumed = 8120,
         ERR_PatternWrongType = 8121,
         ERR_ExpressionTreeContainsIsMatch = 8122,

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -1,18 +1,18 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
 using Xunit;
-using System.Threading;
-using System.Linq;
-using System.Collections.Generic;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
+    [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternMatchingTests : CSharpTestBase
     {
         [Fact]
@@ -14624,6 +14624,7 @@ unsafe struct S
         }
 
         [Fact, WorkItem(13723, "https://github.com/dotnet/roslyn/issues/13723")]
+        [CompilerTrait(CompilerFeature.Tuples)]
         public void ExpressionWithoutAType()
         {
             var source =
@@ -14678,6 +14679,7 @@ public class Vec
         }
 
         [Fact, WorkItem(13746, "https://github.com/dotnet/roslyn/issues/13746")]
+        [CompilerTrait(CompilerFeature.Tuples)]
         public void ExpressionWithoutAType02()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -14617,9 +14617,86 @@ unsafe struct S
                 // (8,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //             if ((1, object.Equals) is()) {}
                 Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, object.Equals)").WithArguments("System.ValueTuple`2").WithLocation(8, 17),
-                // (8,17): error CS8117: Invalid operand for pattern match; value required, but found '(int, method group)'.
+                // (8,17): error CS0023: Operator 'is' cannot be applied to operand of type '(int, method group)'
                 //             if ((1, object.Equals) is()) {}
-                Diagnostic(ErrorCode.ERR_BadIsPatternExpression, "(1, object.Equals)").WithArguments("(int, method group)").WithLocation(8, 17)
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "(1, object.Equals) is()").WithArguments("is", "(int, method group)").WithLocation(8, 17)
+                );
+        }
+
+        [Fact, WorkItem(13723, "https://github.com/dotnet/roslyn/issues/13723")]
+        public void ExpressionWithoutAType()
+        {
+            var source =
+@"
+public class Vec
+{
+    public static void Main()
+    {
+        if (null is 1) {}
+        if (Main is 2) {}
+        if (delegate {} is 3) {}
+        if ((1, null) is 4) {}
+        if (null is var x1) {}
+        if (Main is var x2) {}
+        if (delegate {} is var x3) {}
+        if ((1, null) is var x4) {}
+    }
+}
+";
+            CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe).VerifyDiagnostics(
+                // (6,13): error CS8117: Invalid operand for pattern match; value required, but found '<null>'.
+                //         if (null is 1) {}
+                Diagnostic(ErrorCode.ERR_BadIsPatternExpression, "null").WithArguments("<null>").WithLocation(6, 13),
+                // (7,13): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
+                //         if (Main is 2) {}
+                Diagnostic(ErrorCode.ERR_LambdaInIsAs, "Main is 2").WithLocation(7, 13),
+                // (8,13): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
+                //         if (delegate {} is 3) {}
+                Diagnostic(ErrorCode.ERR_LambdaInIsAs, "delegate {} is 3").WithLocation(8, 13),
+                // (9,13): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         if ((1, null) is 4) {}
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, null)").WithArguments("System.ValueTuple`2").WithLocation(9, 13),
+                // (9,13): error CS0023: Operator 'is' cannot be applied to operand of type '(int, <null>)'
+                //         if ((1, null) is 4) {}
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "(1, null) is 4").WithArguments("is", "(int, <null>)").WithLocation(9, 13),
+                // (10,13): error CS8117: Invalid operand for pattern match; value required, but found '<null>'.
+                //         if (null is var x1) {}
+                Diagnostic(ErrorCode.ERR_BadIsPatternExpression, "null").WithArguments("<null>").WithLocation(10, 13),
+                // (11,13): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
+                //         if (Main is var x2) {}
+                Diagnostic(ErrorCode.ERR_LambdaInIsAs, "Main is var x2").WithLocation(11, 13),
+                // (12,13): error CS0837: The first operand of an 'is' or 'as' operator may not be a lambda expression, anonymous method, or method group.
+                //         if (delegate {} is var x3) {}
+                Diagnostic(ErrorCode.ERR_LambdaInIsAs, "delegate {} is var x3").WithLocation(12, 13),
+                // (13,13): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         if ((1, null) is var x4) {}
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, null)").WithArguments("System.ValueTuple`2").WithLocation(13, 13),
+                // (13,13): error CS0023: Operator 'is' cannot be applied to operand of type '(int, <null>)'
+                //         if ((1, null) is var x4) {}
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "(1, null) is var x4").WithArguments("is", "(int, <null>)").WithLocation(13, 13)
+                );
+        }
+
+        [Fact, WorkItem(13746, "https://github.com/dotnet/roslyn/issues/13746")]
+        public void ExpressionWithoutAType02()
+        {
+            var source =
+@"
+public class Program
+{
+    public static void Main()
+    {
+        if ((1, null) is Program) {}
+    }
+}
+";
+            CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe).VerifyDiagnostics(
+                // (6,13): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
+                //         if ((1, null) is Program) {}
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, null)").WithArguments("System.ValueTuple`2").WithLocation(6, 13),
+                // (6,13): error CS0023: Operator 'is' cannot be applied to operand of type '(int, <null>)'
+                //         if ((1, null) is Program) {}
+                Diagnostic(ErrorCode.ERR_BadUnaryOp, "(1, null) is Program").WithArguments("is", "(int, <null>)").WithLocation(6, 13)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
 using Roslyn.Test.Utilities;
-using System.Linq;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
+    [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternSwitchTests : CSharpTestBase
     {
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SwitchTests.cs
@@ -478,17 +478,17 @@ class T
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found <null>.
                 //         switch(null)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found <null>.
                 //         switch(null)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found <null>.
                 //         switch(null)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "null").WithArguments("<null>").WithLocation(6, 16)
                 );
         }
 
@@ -513,17 +513,17 @@ class T
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found void.
                 //         switch(M())
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found void.
                 //         switch(M())
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found void.
                 //         switch(M())
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M()").WithArguments("void").WithLocation(6, 16)
                 );
         }
 
@@ -548,17 +548,17 @@ class T
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found method group
                 //         switch(M)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found method group
                 //         switch(M)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
                 );
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found method group.
                 //         switch(M)
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "M").WithArguments("method group").WithLocation(6, 16)
                 );
         }
 
@@ -581,15 +581,15 @@ class T
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found lambda expression
                 //         switch(() => {})
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
             CreateCompilationWithMscorlib(text, parseOptions: TestOptions.Regular6WithV7SwitchBinder).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found lambda expression
                 //         switch(() => {})
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,16): error CS8119: The switch expression must be a value; found lambda expression
                 //         switch(() => {})
-                Diagnostic(ErrorCode.ERR_PatternValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
+                Diagnostic(ErrorCode.ERR_SwitchExpressionValueExpected, "() => {}").WithArguments("lambda expression").WithLocation(6, 16));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/PatternParsingTests.cs
@@ -1,15 +1,12 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Linq;
-using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
-using Roslyn.Test.Utilities;
-using Xunit;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 {
+    [CompilerTrait(CompilerFeature.Patterns)]
     public class PatternParsingTexts : CSharpTestBase
     {
         [Fact]

--- a/src/Test/Utilities/Shared/Traits/CompilerFeature.cs
+++ b/src/Test/Utilities/Shared/Traits/CompilerFeature.cs
@@ -18,5 +18,6 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         Tuples,
         RefLocalsReturns,
         OutVar,
+        Patterns,
     }
 }


### PR DESCRIPTION
Add tests for non-reproducible issue #13723
Fixes #13746 
Also rename an error code for clarity.

@VSadov @jcouv Please review
@dotnet/roslyn-compiler More reviews welcome!
