### PR TITLE
Do not cache the classification service we use.  It is not safe to do so.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationUtilities.cs
@@ -18,8 +18,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 {
     internal static class SemanticClassificationUtilities
     {
-        public static async Task ProduceTagsAsync(TaggerContext<IClassificationTag> context, DocumentSnapshotSpan spanToTag,
-            IEditorClassificationService classificationService, ClassificationTypeMap typeMap)
+        public static async Task ProduceTagsAsync(
+            TaggerContext<IClassificationTag> context,
+            DocumentSnapshotSpan spanToTag,
+            IEditorClassificationService classificationService,
+            ClassificationTypeMap typeMap)
         {
             var document = spanToTag.Document;
             if (document == null)
@@ -37,8 +40,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             await ClassifySpansAsync(context, spanToTag, classificationService, typeMap).ConfigureAwait(false);
         }
 
-        private static async Task<bool> TryClassifyContainingMemberSpan(TaggerContext<IClassificationTag> context, DocumentSnapshotSpan spanToTag,
-            IEditorClassificationService classificationService, ClassificationTypeMap typeMap)
+        private static async Task<bool> TryClassifyContainingMemberSpan(
+            TaggerContext<IClassificationTag> context,
+            DocumentSnapshotSpan spanToTag,
+            IEditorClassificationService classificationService,
+            ClassificationTypeMap typeMap)
         {
             var range = context.TextChangeRange;
             if (range == null)
@@ -49,6 +55,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
 
             // there was top level edit, check whether that edit updated top level element
             var document = spanToTag.Document;
+            if (!document.SupportsSyntaxTree)
+            {
+                return false;
+            }
+
             var cancellationToken = context.CancellationToken;
 
             var lastSemanticVersion = (VersionStamp?)context.State;

--- a/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Classification/SemanticClassificationViewTaggerProvider.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
         protected override TaggerTextChangeBehavior TextChangeBehavior => TaggerTextChangeBehavior.TrackTextChanges;
         protected override IEnumerable<Option<bool>> Options => SpecializedCollections.SingletonEnumerable(InternalFeatureOnOffOptions.SemanticColorizer);
 
-        private IEditorClassificationService _classificationService;
-
         [ImportingConstructor]
         public SemanticClassificationViewTaggerProvider(
             IForegroundNotificationService notificationService,
@@ -95,18 +93,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Classification
             // Attempt to get a classification service which will actually produce the results.
             // If we can't (because we have no Document, or because the language doesn't support
             // this service), then bail out immediately.
-            if (_classificationService == null)
-            {
-                var document = spanToTag.Document;
-                _classificationService = document?.Project.LanguageServices.GetService<IEditorClassificationService>();
-            }
+            var document = spanToTag.Document;
+            var classificationService = document?.Project.LanguageServices.GetService<IEditorClassificationService>();
 
-            if (_classificationService == null)
+            if (classificationService == null)
             {
                 return SpecializedTasks.EmptyTask;
             }
 
-            return SemanticClassificationUtilities.ProduceTagsAsync(context, spanToTag, _classificationService, _typeMap);
+            return SemanticClassificationUtilities.ProduceTagsAsync(context, spanToTag, classificationService, _typeMap);
         }
     }
 }

--- a/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
+++ b/src/EditorFeatures/Test2/Classification/ClassificationTests.vb
@@ -1,0 +1,86 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports System.Composition
+Imports System.Threading
+Imports System.Threading.Tasks
+Imports Microsoft.CodeAnalysis.Classification
+Imports Microsoft.CodeAnalysis.Editor.Implementation.Classification
+Imports Microsoft.CodeAnalysis.Editor.Shared.Utilities
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
+Imports Microsoft.CodeAnalysis.Host.Mef
+Imports Microsoft.CodeAnalysis.Notification
+Imports Microsoft.CodeAnalysis.Shared.TestHooks
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.VisualStudio.Text
+Imports Microsoft.VisualStudio.Text.Tagging
+Imports Roslyn.Utilities
+
+Namespace Microsoft.CodeAnalysis.Editor.UnitTests.Classification
+    Public Class ClassificationTests
+        <WpfFact, WorkItem(13753, "https://github.com/dotnet/roslyn/issues/13753")>
+        Public Async Function TestSemanticClassificationWithoutSyntaxTree() As Task
+            Dim workspaceDefinition =
+            <Workspace>
+                <Project Language="NoCompilation" AssemblyName="TestAssembly" CommonReferencesPortable="true">
+                    <Document>
+                        var x = {}; // e.g., TypeScript code or anything else that doesn't support compilations
+                    </Document>
+                </Project>
+            </Workspace>
+
+            Dim exportProvider = MinimalTestExportProvider.CreateExportProvider(
+                TestExportProvider.CreateAssemblyCatalogWithCSharpAndVisualBasic().WithParts(
+                    GetType(NoCompilationEditorClassificationService)))
+
+            Using workspace = Await TestWorkspace.CreateAsync(workspaceDefinition, exportProvider:=exportProvider)
+                Dim waiter = New AsynchronousOperationListener()
+                Dim provider = New SemanticClassificationViewTaggerProvider(
+                    workspace.GetService(Of IForegroundNotificationService),
+                    workspace.GetService(Of ISemanticChangeNotificationService),
+                    workspace.GetService(Of ClassificationTypeMap),
+                    SpecializedCollections.SingletonEnumerable(
+                        New Lazy(Of IAsynchronousOperationListener, FeatureMetadata)(
+                            Function() waiter, New FeatureMetadata(New Dictionary(Of String, Object)() From {{"FeatureName", FeatureAttribute.Classification}}))))
+
+                Dim buffer = workspace.Documents.First().GetTextBuffer()
+                Dim tagger = provider.CreateTagger(Of IClassificationTag)(
+                    workspace.Documents.First().GetTextView(),
+                    buffer)
+
+                Using edit = buffer.CreateEdit()
+                    edit.Insert(0, " ")
+                    edit.Apply()
+                End Using
+
+                Using DirectCast(tagger, IDisposable)
+                    Await waiter.CreateWaitTask()
+
+                    ' Note: we don't actually care what results we get back.  We're just
+                    ' verifying that we don't crash because the SemanticViewTagger ends up
+                    ' calling SyntaxTree/SemanticModel code.
+                    tagger.GetTags(New NormalizedSnapshotSpanCollection(
+                        New SnapshotSpan(buffer.CurrentSnapshot, New Span(0, 1))))
+                End Using
+            End Using
+        End Function
+
+        <ExportLanguageService(GetType(IEditorClassificationService), "NoCompilation"), [Shared]>
+        Private Class NoCompilationEditorClassificationService
+            Implements IEditorClassificationService
+
+            Public Sub AddLexicalClassifications(text As SourceText, textSpan As TextSpan, result As List(Of ClassifiedSpan), cancellationToken As CancellationToken) Implements IEditorClassificationService.AddLexicalClassifications
+            End Sub
+
+            Public Function AddSemanticClassificationsAsync(document As Document, textSpan As TextSpan, result As List(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IEditorClassificationService.AddSemanticClassificationsAsync
+                Return SpecializedTasks.EmptyTask
+            End Function
+
+            Public Function AddSyntacticClassificationsAsync(document As Document, textSpan As TextSpan, result As List(Of ClassifiedSpan), cancellationToken As CancellationToken) As Task Implements IEditorClassificationService.AddSyntacticClassificationsAsync
+                Return SpecializedTasks.EmptyTask
+            End Function
+
+            Public Function AdjustStaleClassification(text As SourceText, classifiedSpan As ClassifiedSpan) As ClassifiedSpan Implements IEditorClassificationService.AdjustStaleClassification
+            End Function
+        End Class
+    End Class
+End Namespace

--- a/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
+++ b/src/EditorFeatures/Test2/EditorServicesTest2.vbproj
@@ -135,6 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CallHierarchy\CallHierarchyTests.vb" />
+    <Compile Include="Classification\ClassificationTests.vb" />
     <Compile Include="Diagnostics\InMemoryAssemblyLoader.vb" />
     <Compile Include="Diagnostics\NamingStyles\NamingStyleTests.IdentifierCreation.Compliance.vb" />
     <Compile Include="Diagnostics\NamingStyles\NamingStyleTests.IdentifierCreation.ComplexTests.vb" />


### PR DESCRIPTION
The problem is that the SemanticClassificationViewTaggerProvider is essentially a singleton.  We have a single ViewTaggerProvider that acts as the "data source" for all the unique taggers created.  These individual taggers can have cached state, but the ViewTaggerProvider itself cannot. 

This ended up breaking TypeScript because we would cache the IEditorClassificationService for the first document we saw (in the repro case, that was C#) but that classification service would fail when passed a TS document.

We never had a problem with this in C#/VB roslyn because we effectively have the same Classification Service for both those languages (for Semantic Classification at least).  So the cache value would work fine on either language.  

This broke recently because F# wanted to use this service.  So we changed the service from being exported only for Vb/C# and made it exported for all Roslyn languages.  This was not caught during testing because TypeScript worked fine in isolation.  It was only if you had a mixed C#+TS world that you'd get a problem.