### PR TITLE
Fix crash in overload resolution with tuple literals

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolutionResult.cs
@@ -970,9 +970,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 Debug.Assert(argument.Kind != BoundKind.OutDeconstructVarPendingInference);
                 Debug.Assert(argument.Kind != BoundKind.OutVarLocalPendingInference);
-
-                TypeSymbol argType = argument.Display as TypeSymbol;
-                Debug.Assert((object)argType != null);
+                Debug.Assert(argument.Display != null);
 
                 if (arguments.IsExtensionMethodThisArgument(arg))
                 {
@@ -986,7 +984,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ErrorCode.ERR_BadExtensionArgTypes,
                             location,
                             symbols,
-                            argType,
+                            argument.Display,
                             name,
                             method);
                     }
@@ -997,7 +995,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             ErrorCode.ERR_BadInstanceArgType,
                             sourceLocation,
                             symbols,
-                            argType,
+                            argument.Display,
                             name,
                             method,
                             parameter);
@@ -1010,22 +1008,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // object that contains both values, so we have to construct our own.
                     // NOTE: since this is a symbol, it will use the SymbolDisplay options for parameters (i.e. will
                     // have the same format as the display value of the parameter).
-                    SignatureOnlyParameterSymbol displayArg = new SignatureOnlyParameterSymbol(
-                        argType,
-                        ImmutableArray<CustomModifier>.Empty,
-                        isParams: false,
-                        refKind: refArg);
+                    var argType = argument.Display as TypeSymbol;
+                    if (argType != null)
+                    {
+                        SignatureOnlyParameterSymbol displayArg = new SignatureOnlyParameterSymbol(
+                            argType,
+                            ImmutableArray<CustomModifier>.Empty,
+                            isParams: false,
+                            refKind: refArg);
 
-                    SymbolDistinguisher distinguisher = new SymbolDistinguisher(compilation, displayArg, UnwrapIfParamsArray(parameter));
+                        SymbolDistinguisher distinguisher = new SymbolDistinguisher(compilation, displayArg, UnwrapIfParamsArray(parameter));
 
-                    // CS1503: Argument {0}: cannot convert from '{1}' to '{2}'
-                    diagnostics.Add(
-                        ErrorCode.ERR_BadArgType,
-                        sourceLocation,
-                        symbols,
-                        arg + 1,
-                        distinguisher.First,
-                        distinguisher.Second);
+                        // CS1503: Argument {0}: cannot convert from '{1}' to '{2}'
+                        diagnostics.Add(
+                            ErrorCode.ERR_BadArgType,
+                            sourceLocation,
+                            symbols,
+                            arg + 1,
+                            distinguisher.First,
+                            distinguisher.Second);
+                    }
+                    else
+                    {
+                        diagnostics.Add(
+                            ErrorCode.ERR_BadArgType,
+                            sourceLocation,
+                            symbols,
+                            arg + 1,
+                            argument.Display,
+                            UnwrapIfParamsArray(parameter));
+                    }
                 }
             }
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -17887,5 +17887,49 @@ class Program
             Assert.Equal(newText.ToString(), finalText);
             // no crash
         }
+
+        [Fact]
+        [WorkItem(258853, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/258853")]
+        public void BadOverloadWithTupleLiteralWithNaturalType()
+        {
+            var source = @"
+class Program
+{
+    static void M(int i) { } 
+    static void M(string i) { } 
+
+    static void Main() 
+    {
+        M((1, 2));
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (9,11): error CS1503: Argument 1: cannot convert from '(int, int)' to 'int'
+                //         M((1, 2));
+                Diagnostic(ErrorCode.ERR_BadArgType, "(1, 2)").WithArguments("1", "(int, int)", "int").WithLocation(9, 11));
+        }
+
+        [Fact]
+        [WorkItem(258853, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/258853")]
+        public void BadOverloadWithTupleLiteralWithNoNaturalType()
+        {
+            var source = @"
+class Program
+{
+    static void M(int i) { } 
+    static void M(string i) { } 
+
+    static void Main() 
+    {
+        M((1, null));
+    }
+}";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (9,11): error CS1503: Argument 1: cannot convert from '(int, <null>)' to 'int'
+                //         M((1, null));
+                Diagnostic(ErrorCode.ERR_BadArgType, "(1, null)").WithArguments("1", "(int, <null>)", "int").WithLocation(9, 11));
+        }
     }
 }

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -7182,10 +7182,14 @@ End Module
 </compilation>, additionalRefs:=s_valueTupleRefs)
 
 
-            compilation.VerifyDiagnostics(
-                    Diagnostic(ERRID.ERR_NoCallableOverloadCandidates2, "M").WithArguments("M", "
+            compilation.AssertTheseDiagnostics(
+<errors>
+    BC30518: Overload resolution failed because no accessible 'M' can be called with these arguments:
     'Public Sub M(x As Integer)': Value of type '(Integer, Integer)' cannot be converted to 'Integer'.
-    'Public Sub M(x As String)': Value of type '(Integer, Integer)' cannot be converted to 'String'.").WithLocation(8, 9))
+    'Public Sub M(x As String)': Value of type '(Integer, Integer)' cannot be converted to 'String'.
+        M((1, 2))
+        ~
+</errors>)
         End Sub
 
         <Fact>
@@ -7209,10 +7213,45 @@ End Module
 </compilation>, additionalRefs:=s_valueTupleRefs)
 
 
-            compilation.VerifyDiagnostics(
-                    Diagnostic(ERRID.ERR_NoCallableOverloadCandidates2, "M").WithArguments("M", "
+            compilation.AssertTheseDiagnostics(
+<errors>
+    BC30518: Overload resolution failed because no accessible 'M' can be called with these arguments:
     'Public Sub M(x As Integer)': Value of type '(Integer, Object)' cannot be converted to 'Integer'.
-    'Public Sub M(x As String)': Value of type '(Integer, Object)' cannot be converted to 'String'.").WithLocation(8, 9))
+    'Public Sub M(x As String)': Value of type '(Integer, Object)' cannot be converted to 'String'.
+        M((1, Nothing))
+        ~
+</errors>)
+        End Sub
+
+        <Fact>
+        <WorkItem(258853, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/258853")>
+        Public Sub BadOverloadWithTupleLiteralWithAddressOf()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Module C
+    Sub M(x As Integer)
+    End Sub
+    Sub M(x As String)
+    End Sub
+
+    Sub Main()
+        M((1, AddressOf Main))
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+
+            compilation.AssertTheseDiagnostics(
+<errors>
+    BC30518: Overload resolution failed because no accessible 'M' can be called with these arguments:
+    'Public Sub M(x As Integer)': Expression does not produce a value.
+    'Public Sub M(x As String)': Expression does not produce a value.
+        M((1, AddressOf Main))
+        ~
+</errors>)
         End Sub
     End Class
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -7161,6 +7161,59 @@ additionalReferences:=s_valueTupleRefs)
                        Sub(t) Assert.Equal(SpecialType.System_Int32, t.SpecialType))
         End Sub
 
+        <Fact>
+        <WorkItem(258853, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/258853")>
+        Public Sub BadOverloadWithTupleLiteralWithNaturalType()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Module C
+    Sub M(x As Integer)
+    End Sub
+    Sub M(x As String)
+    End Sub
+
+    Sub Main()
+        M((1, 2))
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+
+            compilation.VerifyDiagnostics(
+                    Diagnostic(ERRID.ERR_NoCallableOverloadCandidates2, "M").WithArguments("M", "
+    'Public Sub M(x As Integer)': Value of type '(Integer, Integer)' cannot be converted to 'Integer'.
+    'Public Sub M(x As String)': Value of type '(Integer, Integer)' cannot be converted to 'String'.").WithLocation(8, 9))
+        End Sub
+
+        <Fact>
+        <WorkItem(258853, "https://devdiv.visualstudio.com/DevDiv/_workitems/edit/258853")>
+        Public Sub BadOverloadWithTupleLiteralWithNothing()
+            Dim compilation = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Module C
+    Sub M(x As Integer)
+    End Sub
+    Sub M(x As String)
+    End Sub
+
+    Sub Main()
+        M((1, Nothing))
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+
+            compilation.VerifyDiagnostics(
+                    Diagnostic(ERRID.ERR_NoCallableOverloadCandidates2, "M").WithArguments("M", "
+    'Public Sub M(x As Integer)': Value of type '(Integer, Object)' cannot be converted to 'Integer'.
+    'Public Sub M(x As String)': Value of type '(Integer, Object)' cannot be converted to 'String'.").WithLocation(8, 9))
+        End Sub
     End Class
 
 End Namespace


### PR DESCRIPTION
The overload resolution code had a bad dependency on `BoundExpression.Display` being a `TypeSymbol`.  That member appears to be added specifically for the opposite case.  Essentially `BoundExpression` values which can't possibly produce a valid `TypeSymbol`: null literals, method groups, etc ... Over time it's also become a place for `BoundExpression` nodes to customize their display.

The bad dependency has gone unnoticed up until now because of previous error handling in overload resolution.  All of the `BoundExpression` which can't produce a type were special cased in one formm or another earlier on.

Our work in tuple litercals exposed this bug though.  It added an override for `BoundExpression.Display` which is a `string` (completely valid) and no previous special casing existed for this type and it ended up hitting the code with the bad dependency.

Fix is to properly handle the case wherce the value is a not a `TypeSymbol`.

This addresses DevDiv 258853 (Watson bug)