### PR TITLE
Update OOP analyzers to calculate OpenFileOnly based on options

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpPreferFrameworkTypeDiagnosticAnalyzer.cs
@@ -23,5 +23,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.Analyzers
 
         protected override bool IsInMemberAccessOrCrefReferenceContext(ExpressionSyntax node) =>
             node.IsInMemberAccessContext() || node.InsideCrefReference();
+
+        protected override string GetLanguageName() => LanguageNames.CSharp;
     }
 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Diagnostics.QualifyMemberAccess;
 
@@ -8,6 +9,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.QualifyMemberAccess
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class CSharpQualifyMemberAccessDiagnosticAnalyzer : QualifyMemberAccessDiagnosticAnalyzerBase<SyntaxKind>
     {
+        protected override string GetLanguageName()
+        {
+            return LanguageNames.CSharp;
+        }
+
         protected override bool IsAlreadyQualifiedMemberAccess(SyntaxNode node)
         {
             return node.IsKind(SyntaxKind.ThisExpression);

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.State.cs
@@ -12,7 +12,7 @@ using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
-    internal partial class CSharpTypeStyleDiagnosticAnalyzerBase
+    internal abstract partial class CSharpTypeStyleDiagnosticAnalyzerBase
     {
         internal class State
         {

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -10,6 +10,9 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.CodeStyle;
+using Microsoft.CodeAnalysis.CodeStyle;
+using System;
 
 namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
 {
@@ -38,7 +41,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(CreateDiagnosticDescriptor(DiagnosticSeverity.Hidden));
 
         public DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
-        public bool OpenFileOnly(Workspace workspace) => true;
+
+        public bool OpenFileOnly(Workspace workspace)
+        {
+            var forIntrinsicTypesOption = workspace.Options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeForIntrinsicTypes).Notification;
+            var whereApparentOption = workspace.Options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWhereApparent).Notification;
+            var wherePossibleOption = workspace.Options.GetOption(CSharpCodeStyleOptions.UseImplicitTypeWherePossible).Notification;
+
+            return !(forIntrinsicTypesOption == NotificationOption.Warning || forIntrinsicTypesOption == NotificationOption.Error ||
+                     whereApparentOption == NotificationOption.Warning || whereApparentOption == NotificationOption.Error ||
+                     wherePossibleOption == NotificationOption.Warning || wherePossibleOption == NotificationOption.Error);
+        }
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -45,7 +45,18 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
         private PerLanguageOption<CodeStyleOption<bool>> GetOptionForMemberAccessContext =>
             CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess;
 
-        public bool OpenFileOnly(Workspace workspace) => true;
+        public bool OpenFileOnly(Workspace workspace)
+        {
+            var preferTypeKeywordInDeclarationOption = workspace.Options.GetOption(
+                CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, GetLanguageName()).Notification;
+            var preferTypeKeywordInMemberAccessOption = workspace.Options.GetOption(
+                CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, GetLanguageName()).Notification;
+
+            return !(preferTypeKeywordInDeclarationOption == NotificationOption.Warning || preferTypeKeywordInDeclarationOption == NotificationOption.Error ||
+                     preferTypeKeywordInMemberAccessOption == NotificationOption.Warning || preferTypeKeywordInMemberAccessOption == NotificationOption.Error);
+        }
+
+        protected abstract string GetLanguageName();
 
         public DiagnosticAnalyzerCategory GetAnalyzerCategory() => DiagnosticAnalyzerCategory.SemanticSpanAnalysis;
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/QualifyMemberAccessDiagnosticAnalyzerBase.cs
@@ -26,7 +26,20 @@ namespace Microsoft.CodeAnalysis.Diagnostics.QualifyMemberAccess
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_descriptorQualifyMemberAccess);
 
-        public bool OpenFileOnly(Workspace workspace) => true;
+        public bool OpenFileOnly(Workspace workspace)
+        {
+            var qualifyFieldAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyFieldAccess, GetLanguageName()).Notification;
+            var qualifyPropertyAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyPropertyAccess, GetLanguageName()).Notification;
+            var qualifyMethodAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyMethodAccess, GetLanguageName()).Notification;
+            var qualifyEventAccessOption = workspace.Options.GetOption(CodeStyleOptions.QualifyEventAccess, GetLanguageName()).Notification;
+
+            return !(qualifyFieldAccessOption == NotificationOption.Warning || qualifyFieldAccessOption == NotificationOption.Error ||
+                     qualifyPropertyAccessOption == NotificationOption.Warning || qualifyPropertyAccessOption == NotificationOption.Error ||
+                     qualifyMethodAccessOption == NotificationOption.Warning || qualifyMethodAccessOption == NotificationOption.Error ||
+                     qualifyEventAccessOption == NotificationOption.Warning || qualifyEventAccessOption == NotificationOption.Error);
+        }
+
+        protected abstract string GetLanguageName();
 
         protected abstract bool IsAlreadyQualifiedMemberAccess(SyntaxNode node);
 

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -72,7 +72,16 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
             }
         }
 
-        public bool OpenFileOnly(Workspace workspace) => true;
+        public bool OpenFileOnly(Workspace workspace)
+        {
+            var preferTypeKeywordInDeclarationOption = workspace.Options.GetOption(
+                CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInDeclaration, GetLanguageName()).Notification;
+            var preferTypeKeywordInMemberAccessOption = workspace.Options.GetOption(
+                CodeStyleOptions.PreferIntrinsicPredefinedTypeKeywordInMemberAccess, GetLanguageName()).Notification;
+
+            return !(preferTypeKeywordInDeclarationOption == NotificationOption.Warning || preferTypeKeywordInDeclarationOption == NotificationOption.Error ||
+                     preferTypeKeywordInMemberAccessOption == NotificationOption.Warning || preferTypeKeywordInMemberAccessOption == NotificationOption.Error);
+        }
 
         protected abstract void AnalyzeNode(SyntaxNodeAnalysisContext context);
 

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicPreferFrameworkTypeDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicPreferFrameworkTypeDiagnosticAnalyzer.vb
@@ -26,6 +26,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Diagnostics.Analyzers
             Return Not KeywordMatchesTypeName(node.Keyword.Kind())
         End Function
 
+        Protected Overrides Function GetLanguageName() As String
+            Return LanguageNames.VisualBasic
+        End Function
+
         ''' <summary>
         ''' Returns true, if the VB language keyword for predefined type matches its
         ''' actual framework type name.

--- a/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
+++ b/src/Features/VisualBasic/Portable/Diagnostics/Analyzers/VisualBasicQualifyMemberAccessDiagnosticAnalyzer.vb
@@ -9,6 +9,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.QualifyMemberAccess
     Friend NotInheritable Class VisualBasicQualifyMemberAccessDiagnosticAnalyzer
         Inherits QualifyMemberAccessDiagnosticAnalyzerBase(Of SyntaxKind)
 
+        Protected Overrides Function GetLanguageName() As String
+            Return LanguageNames.VisualBasic
+        End Function
+
         Protected Overrides Function IsAlreadyQualifiedMemberAccess(node As SyntaxNode) As Boolean
             Return node.IsKind(SyntaxKind.MeExpression)
         End Function

--- a/src/Workspaces/Core/Portable/CodeStyle/NotificationOption.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/NotificationOption.cs
@@ -9,6 +9,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
     /// <remarks>
     /// This also supports various properties for databinding.
     /// </remarks>
+    /// <completionlist cref="NotificationOption"/>
     public class NotificationOption
     {
         public string Name { get; set; }


### PR DESCRIPTION
Only Error- and Warning-level Code Style options will run on closed files.
Suggestions will only run on open files.

This will help with perf (I believe), and is part of @heejaechang 's larger effort for OOP.