### PR TITLE
Enable compiler server by default in NuGet package

### DIFF
--- a/build/Targets/Microsoft.Net.Compilers.props
+++ b/build/Targets/Microsoft.Net.Compilers.props
@@ -28,8 +28,6 @@
              AssemblyFile="$(ToolsetCompilerPath)\Microsoft.Build.Tasks.CodeAnalysis.dll"
              />
   <PropertyGroup>
-    <!-- By default don't use the compiler server in Visual Studio. -->
-    <UseSharedCompilation Condition="'$(UseSharedCompilation)' == ''">false</UseSharedCompilation>
     <CSharpCoreTargetsPath>$(ToolsetCompilerPath)\Microsoft.CSharp.Core.targets</CSharpCoreTargetsPath>
     <VisualBasicCoreTargetsPath>$(ToolsetCompilerPath)\Microsoft.VisualBasic.Core.targets</VisualBasicCoreTargetsPath>
   </PropertyGroup>


### PR DESCRIPTION
This changes the targets inserted by our NuGet package to use the compiler server by default.  This is the same default as the compiler inserted via MSBuild / Visual Studio.

Originally we pushed for the server to be off by default due to NuGet.  When the compiler server is running it will lock the DLLs in memory and hence makes it impossible to delete NuGet packages.  In practice though this is the case even without the compiler server due to MSBuild and node reuse locking our task.  The compiler server has a much shorter lifetime than MSBuild hence it's not contributing to the problem here.

The downside of leaving this off by default is that it slows down build times for customers as every bulid requires a full JIT.

closes #12360