### PR TITLE
MetadataVisitor should also visit constants (not just local variables)

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18044,7 +18044,7 @@ class C
 
         [Fact]
         [WorkItem(13767, "https://github.com/dotnet/roslyn/issues/13767")]
-        public void GenericConstantFromReferencedAssembly()
+        public void ConstantTypeFromReferencedAssembly()
         {
             var libSource = @" public class ReferencedType { } ";
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18024,30 +18024,6 @@ public interface I<in T>
 
         [Fact]
         [WorkItem(13767, "https://github.com/dotnet/roslyn/issues/13767")]
-        public void ValueTupleInConstant()
-        {
-            var source = @"
-class C<T> { }
-class C
-{
-    static void M()
-    {
-        const C<System.ValueTuple<int, int>> c = null;
-    }
-}
-";
-
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", references: s_valueTupleRefs);
-            comp.VerifyEmitDiagnostics(
-                // (7,46): warning CS0219: The variable 'c' is assigned but its value is never used
-                //         const C<System.ValueTuple<int, int>> c = null;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "c").WithArguments("c").WithLocation(7, 46)
-                );
-            // no assertion
-        }
-
-        [Fact]
-        [WorkItem(13767, "https://github.com/dotnet/roslyn/issues/13767")]
         public void TupleInConstant()
         {
             var source = @"
@@ -18059,56 +18035,11 @@ class C
         const C<(int, int)> c = null;
         System.Console.Write(c);
     }
-}
-";
+}";
 
             var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", references: s_valueTupleRefs);
-            comp.VerifyEmitDiagnostics(
-                );
-            // no assertion
-        }
-
-        [Fact]
-        [WorkItem(13767, "https://github.com/dotnet/roslyn/issues/13767")]
-        public void TupleInLocal()
-        {
-            var source = @"
-class C<T> { }
-class C
-{
-    static void M()
-    {
-        C<(int, int)> c = default(C<(int, int)>);
-        N(ref c);
-    }
-    static void N(ref C<(int, int)> x) { }
-}
-";
-
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", references: s_valueTupleRefs);
-            comp.VerifyEmitDiagnostics(
-                // (7,29): warning CS0219: The variable 'c' is assigned but its value is never used
-                //         const C<(int, int)> c = null;
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "c").WithArguments("c").WithLocation(7, 29)
-                );
-            // no assertion
-        }
-
-        [Fact]
-        [WorkItem(13767, "https://github.com/dotnet/roslyn/issues/13767")]
-        public void DeriveFromGenericWithTuple()
-        {
-            var source = @"
-class C<T> { }
-class C : C<(int, int)>
-{
-}
-";
-
-            var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", references: s_valueTupleRefs);
-            comp.VerifyEmitDiagnostics(
-                );
-            // no assertion
+            comp.VerifyEmitDiagnostics();
+            // no assertion in MetadataWriter
         }
 
         [Fact]
@@ -18123,6 +18054,7 @@ class C
     static void M()
     {
         const ReferencedType c = null;
+        System.Console.Write(c);
     }
 }";
 
@@ -18131,6 +18063,7 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, assemblyName: "comp", references: new[] { libComp.EmitToImageReference() });
             comp.VerifyEmitDiagnostics();
+            // no assertion in MetadataWriter
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -18045,7 +18046,12 @@ class C
 
             // emit with pdb
             comp.VerifyEmitDiagnostics();
-            CompileAndVerify(comp, expectedOutput: "");
+            CompileAndVerify(comp, expectedOutput: "", validator: (assembly) =>
+            {
+                var reader = assembly.GetMetadataReader();
+                AssertEx.SetEqual(new[] { "mscorlib 4.0", "System.ValueTuple 4.0" }, reader.DumpAssemblyReferences());
+                Assert.Contains("ValueTuple`2, System, System.ValueTuple", reader.DumpTypeReferences());
+            });
             // no assertion in MetadataWriter
         }
 
@@ -18076,6 +18082,7 @@ class C
                 {
                     var reader = assembly.GetMetadataReader();
                     AssertEx.SetEqual(new[] { "mscorlib 4.0", "lib 0.0" }, reader.DumpAssemblyReferences());
+                    Assert.Contains("ReferencedType, , lib", reader.DumpTypeReferences());
                 });
         }
     }

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/ReferenceManagerTests.cs
@@ -383,15 +383,9 @@ public class OKImpl : I
             CompileAndVerify(main, validator: (assembly) =>
             {
                 var reader = assembly.GetMetadataReader();
-                List<string> refs = new List<string>();
-                foreach (var assemblyRef in reader.AssemblyReferences)
-                {
-                    var row = reader.GetAssemblyReference(assemblyRef);
-                    refs.Add(reader.GetString(row.Name) + " " + row.Version.Major + "." + row.Version.Minor);
-                }
 
                 // Dev11 adds "Lib 1.0" to the references, we don't (see DevDiv #15580)
-                AssertEx.SetEqual(new[] { "mscorlib 4.0", "RefLibV1 1.0", "Lib 2.0", "X 2.0" }, refs);
+                AssertEx.SetEqual(new[] { "mscorlib 4.0", "RefLibV1 1.0", "Lib 2.0", "X 2.0" }, reader.DumpAssemblyReferences());
             },
             // PE verification would need .config file with Lib v1 -> Lib v2 binding redirect 
             verify: false);
@@ -1741,10 +1735,7 @@ public class C : I { }
             CompileAndVerify(main, validator: (pe) =>
             {
                 var reader = pe.GetMetadataReader();
-
-                var assemblyRef = reader.AssemblyReferences.AsEnumerable().Single();
-                var name = reader.GetString(reader.GetAssemblyReference(assemblyRef).Name);
-                Assert.Equal(name, "mscorlib");
+                AssertEx.SetEqual(new[] { "mscorlib 4.0" }, reader.DumpAssemblyReferences());
             },
             verify: false);
         }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
@@ -198,25 +198,5 @@ namespace Microsoft.CodeAnalysis
                 reader.StringComparer.Equals(typeDef.Name, typeName) &&
                 reader.StringComparer.Equals(typeDef.Namespace, namespaceName);
         }
-
-        internal static IEnumerable<string> DumpAssemblyReferences(this MetadataReader reader)
-        {
-            return reader.AssemblyReferences.Select(r => reader.GetAssemblyReference(r))
-                .Select(row => $"{reader.GetString(row.Name)} {row.Version.Major}.{row.Version.Minor}");
-        }
-
-        internal static IEnumerable<string> DumpTypeReferences(this MetadataReader reader)
-        {
-            return reader.TypeReferences
-                .Select(t => reader.GetTypeReference(t))
-                .Select(t =>
-                {
-                    var assemblyName = t.ResolutionScope.Kind == HandleKind.AssemblyReference
-                        ? reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)t.ResolutionScope).Name)
-                        : "";
-
-                    return $"{reader.GetString(t.Name)}, {reader.GetString(t.Namespace)}, {assemblyName}";
-                });
-        }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
@@ -204,5 +204,19 @@ namespace Microsoft.CodeAnalysis
             return reader.AssemblyReferences.Select(r => reader.GetAssemblyReference(r))
                 .Select(row => $"{reader.GetString(row.Name)} {row.Version.Major}.{row.Version.Minor}");
         }
+
+        internal static IEnumerable<string> DumpTypeReferences(this MetadataReader reader)
+        {
+            return reader.TypeReferences
+                .Select(t => reader.GetTypeReference(t))
+                .Select(t =>
+                {
+                    var assemblyName = t.ResolutionScope.Kind == HandleKind.AssemblyReference
+                        ? reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)t.ResolutionScope).Name)
+                        : "";
+
+                    return $"{reader.GetString(t.Name)}, {reader.GetString(t.Namespace)}, {assemblyName}";
+                });
+        }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 
@@ -195,6 +197,12 @@ namespace Microsoft.CodeAnalysis
             return (typeDef.Attributes & (TypeAttributes.Public | TypeAttributes.Interface)) == TypeAttributes.Public &&
                 reader.StringComparer.Equals(typeDef.Name, typeName) &&
                 reader.StringComparer.Equals(typeDef.Namespace, namespaceName);
+        }
+
+        internal static IEnumerable<string> DumpAssemblyReferences(this MetadataReader reader)
+        {
+            return reader.AssemblyReferences.Select(r => reader.GetAssemblyReference(r))
+                .Select(row => $"{reader.GetString(row.Name)} {row.Version.Major}.{row.Version.Minor}");
         }
     }
 }

--- a/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
+++ b/src/Compilers/Core/Portable/MetadataReader/MetadataReaderExtensions.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
-using System.Linq;
 using System.Reflection;
 using System.Reflection.Metadata;
 

--- a/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
+++ b/src/Compilers/Core/Portable/PEWriter/MetadataVisitor.cs
@@ -254,6 +254,11 @@ namespace Microsoft.Cci
 
         public virtual void Visit(IMethodBody methodBody)
         {
+            foreach (var scope in methodBody.LocalScopes)
+            {
+                this.Visit(scope.Constants);
+            }
+
             this.Visit(methodBody.LocalVariables);
             //this.Visit(methodBody.Operations);    //in Roslyn we don't break out each instruction as it's own operation.
             this.Visit(methodBody.ExceptionRegions);

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/ReferenceManagerTests.vb
@@ -559,14 +559,8 @@ End Class
             CompileAndVerify(main, verify:=False, validator:=
                 Sub(assembly)
                     Dim reader = assembly.GetMetadataReader()
-                    Dim refs As List(Of String) = New List(Of String)()
 
-                    For Each assemblyRef In reader.AssemblyReferences
-                        Dim row = reader.GetAssemblyReference(assemblyRef)
-                        refs.Add(reader.GetString(row.Name) & " " & row.Version.Major & "." & row.Version.Minor)
-                    Next
-
-                    AssertEx.SetEqual({"mscorlib 4.0", "RefLibV1 1.0", "Lib 2.0"}, refs)
+                    AssertEx.SetEqual({"mscorlib 4.0", "RefLibV1 1.0", "Lib 2.0"}, reader.DumpAssemblyReferences())
                 End Sub)
         End Sub
 

--- a/src/Test/Utilities/Shared/Metadata/MetadataReaderUtils.cs
+++ b/src/Test/Utilities/Shared/Metadata/MetadataReaderUtils.cs
@@ -245,5 +245,29 @@ namespace Roslyn.Test.Utilities
                 return EncodedStringText.Create(stream);
             }
         }
+
+        public static IEnumerable<string> DumpAssemblyReferences(this MetadataReader reader)
+        {
+            return reader.AssemblyReferences.Select(r => reader.GetAssemblyReference(r))
+                .Select(row => $"{reader.GetString(row.Name)} {row.Version.Major}.{row.Version.Minor}");
+        }
+
+        public static IEnumerable<string> DumpTypeReferences(this MetadataReader reader)
+        {
+            return reader.TypeReferences
+                .Select(t => reader.GetTypeReference(t))
+                .Select(t => $"{reader.GetString(t.Name)}, {reader.GetString(t.Namespace)}, {reader.Dump(t.ResolutionScope)}");
+        }
+
+        public static string Dump(this MetadataReader reader, EntityHandle handle)
+        {
+            switch (handle.Kind)
+            {
+                case HandleKind.AssemblyReference:
+                    return "AssemblyRef:" + reader.GetString(reader.GetAssemblyReference((AssemblyReferenceHandle)handle).Name);
+                default:
+                    return handle.Kind.ToString();
+            }
+        }
     }
 }

--- a/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
+++ b/src/Workspaces/CoreTest/SolutionTests/SolutionTests.cs
@@ -973,7 +973,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [Fact, Trait(Traits.Feature, Traits.Features.Workspace)]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13506"), Trait(Traits.Feature, Traits.Features.Workspace)]
+        [WorkItem(13506, "https://github.com/dotnet/roslyn/issues/13506")]
         public void TestRecoverableSyntaxTreeCSharp()
         {
             var pid = ProjectId.CreateNewId();


### PR DESCRIPTION
The code below was causing an assert.

First, some background from my investigation. `MetadataWriter.BuildMetadataAndIL` has four relevant steps:

1. `CreateIndices` which assigns an index/handle for every type reference and assembly reference (and more). It does so mainly by running a `ReferenceIndexer` (which is a `MetadataVisitor`) on all the parts (types, methods, etc)
2. It `SerializeMethodBodies`, which incidentally will also serialize some debug information into the pdb writer (`pdbWriterOpt?.SerializeDebugInfo`). This will need the handle for the type of the constant, which adds the type ref to the indices table (but without its assembly ref)
3. Once done, it locks the indices table (`_tableIndicesAreComplete = true;`)
4. Then it `PopulateTables` which adds the type and assembly ref from those tables into a `MetadataBuilder`. But we have a type ref without corresponding assembly ref, and it is to late to add it to the indices tables (we're supposed to be done updating indices). This is where the assert was getting hit.

I considered a few solutions, but the one that seems most reasonable to me is simply observing that the code inside `SerializeDebugInfo` (at step 3, calling `DefineScopeLocals`) enumerates both locals and constants, but the `MetadataVisitor` which discovers all the type refs at step 1 only enumerates locals.
So I'm having the `MetadataVisitor` also visit the constants.

```C#
class C
{
    static void M()
    {
        const ReferencedType c = null; // ReferencedType comes from an assembly reference
    }
}
```

Fixes https://github.com/dotnet/roslyn/issues/13767
CC @cston @dotnet/roslyn-compiler @tmat for review.