### PR TITLE
Conditionally skip tests when fonts corrupted on the machine

### DIFF
--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/MyTemplateTests.vb
@@ -139,8 +139,7 @@ End Module
 
         End Sub
 
-        ' <Fact()>
-        ' Disabling due to flakeyness: https://github.com/dotnet/roslyn/issues/13404
+        <ConditionalFact(GetType(HasValidFonts))>
         Public Sub MyWinformApp()
             Dim sources = <compilation>
                               <file name="c.vb"><![CDATA[

--- a/src/Test/Utilities/Desktop/ConditionalFactAttribute.cs
+++ b/src/Test/Utilities/Desktop/ConditionalFactAttribute.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.Drawing;
 using System.IO;
 using Microsoft.CodeAnalysis.Test.Utilities;
 using Microsoft.Win32;
@@ -101,5 +102,32 @@ namespace Roslyn.Test.Utilities
     public sealed class OSVersion
     {
         public static readonly bool IsWin8 = System.Environment.OSVersion.Version.Build >= 9200;
+    }
+
+    public class HasValidFonts : ExecutionCondition
+    {
+        public override bool ShouldSkip
+        {
+            get
+            {
+                try
+                {
+                    var unused = SystemFonts.DefaultFont;
+                    return unused == null;
+                }
+                catch
+                {
+                    // Motivating issue: https://github.com/dotnet/roslyn/issues/11278
+                    //
+                    // On a small percentage of Jenkins runs we see that fonts are corrupted on the machine.  That causes any
+                    // font based test to fail with no reasonable way to recover (other than manually re-installing fonts). 
+                    //
+                    // This at least gives us a mechanism for skipping those tests when fonts are in a bad state.
+                    return true;
+                }
+            }
+        }
+
+        public override string SkipReason => "Fonts are unavailable";
     }
 }

--- a/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
+++ b/src/Test/Utilities/Desktop/TestUtilities.Desktop.csproj
@@ -77,6 +77,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>


### PR DESCRIPTION
A rare but persistent test failure source involves our inability to access `SystemFonts.Default` on Jenkins machines.  All of the documentation we can find on this problem indicates that fonts are corrupted on the machine.  That seems unlikely given the tests we run and if true there is no reasonable action we can take in the test to recover from it.

Considered a lot of options for this bug:

- Fixing the problem: not really possible.  It's an issue creating a system level font.  There are no reflection tricks or hacks I can do to "fudge" the value in case of an error.
- Deleting the test: it's a valid scenario that we don't want to regress.  The particular scenario is not well known to developers hence chance of regression is decent.
- try / catch ignore: that would make failures completely invisible to the system.

Eventually I settled on this approach of conditionally disabling the test.  It's not much better than try / catch ignore but at least the data is trackable as skipped tests will show up in logs.

closes #11278