### PR TITLE
Never offer to remove an unboxing cast, as it can cause an exception.

### DIFF
--- a/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/RemoveUnnecessaryCast/RemoveUnnecessaryCastTests.cs
@@ -3856,5 +3856,36 @@ class Program
             parseOptions: TestOptions.Regular,
             withScriptOption: true);
         }
+
+        [WorkItem(12572, "https://github.com/dotnet/roslyn/issues/12572")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsRemoveUnnecessaryCast)]
+        public async Task DontRemoveCastThatUnboxes()
+        {
+            // The cast below can't be removed because it could throw a null ref exception.
+            await TestMissingAsync(
+            @"
+using System;
+
+class Program
+{
+    static void Main()
+    {
+        object i = null;
+        switch ([|(int)i|])
+        {
+            case 0:
+                Console.WriteLine(0);
+                break;
+            case 1:
+                Console.WriteLine(1);
+                break;
+            case 2:
+                Console.WriteLine(2);
+                break;
+        }
+    }
+}
+");
+        }
     }
 }

--- a/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/CastExpressionSyntaxExtensions.cs
@@ -383,6 +383,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 // Explicit reference conversions can cause an exception or data loss, hence can never be removed.
                 return false;
             }
+            else if (expressionToCastType.IsExplicit && expressionToCastType.IsUnboxing)
+            {
+                // Unboxing conversions can cause a null ref exception, hence can never be removed.
+                return false;
+            }
             else if (expressionToCastType.IsExplicit && expressionToCastType.IsNumeric)
             {
                 // Don't remove any explicit numeric casts.


### PR DESCRIPTION
Fixes #12572 
Fixes #10306

It turns out the underlying bug has nothing to do with pattern-matching, or anything in the compiler.

@DustinCampbell @mavasani Can you please review this?
@dotnet/roslyn-compiler Any additional reviews are welcome.
