### PR TITLE
VB tuples: support partial names

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -8819,15 +8819,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tuple member names must all be provided, if any one is provided..
-        /// </summary>
-        internal static string ERR_TupleExplicitNamesOnAllMembersOrNone {
-            get {
-                return ResourceManager.GetString("ERR_TupleExplicitNamesOnAllMembersOrNone", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Tuple member name &apos;{0}&apos; is only allowed at position {1}..
         /// </summary>
         internal static string ERR_TupleReservedMemberName {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4845,9 +4845,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TupleDuplicateMemberName" xml:space="preserve">
     <value>Tuple member names must be unique.</value>
   </data>
-  <data name="ERR_TupleExplicitNamesOnAllMembersOrNone" xml:space="preserve">
-    <value>Tuple member names must all be provided, if any one is provided.</value>
-  </data>
   <data name="ERR_TupleReservedMemberName" xml:space="preserve">
     <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>

--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -827,9 +827,6 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Returns a new INamedTypeSymbol with the given element types and (optional) element names.
         /// </summary>
-        /// <remarks>
-        /// Since VB doesn't support tuples yet, this call will fail in a VB compilation.
-        /// </remarks>
         public INamedTypeSymbol CreateTupleTypeSymbol(ImmutableArray<ITypeSymbol> elementTypes, ImmutableArray<string> elementNames = default(ImmutableArray<string>))
         {
             return CommonCreateTupleTypeSymbol(elementTypes, elementNames);

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Expressions.vb
@@ -326,7 +326,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim elementLocations = ArrayBuilder(Of Location).GetInstance(arguments.Count)
 
             Dim elementNames As ArrayBuilder(Of String) = Nothing
-            Dim countOfExplicitNames = 0
 
             ' prepare and check element names and types
             For i As Integer = 0 To numElements - 1
@@ -339,7 +338,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     name = nameSyntax.Identifier.ValueText
                     elementLocations.Add(nameSyntax.GetLocation)
 
-                    countOfExplicitNames += 1
                     If Not CheckTupleMemberName(name, i, argumentSyntax.NameColonEquals.Name, diagnostics, uniqueFieldNames) Then
                         hasErrors = True
                     End If
@@ -359,11 +357,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 elementTypes.Add(elementType)
             Next
-
-            If countOfExplicitNames <> 0 AndAlso countOfExplicitNames <> elementTypes.Count Then
-                hasErrors = True
-                ReportDiagnostic(diagnostics, node, ERRID.ERR_TupleExplicitNamesOnAllMembersOrNone)
-            End If
 
             Dim elementNamesArray = If(elementNames Is Nothing, Nothing, elementNames.ToImmutableAndFree())
 
@@ -442,12 +435,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' names would typically all be there or none at all
             ' but in case we need to handle this in error cases
             If elementNames IsNot Nothing Then
-                elementNames.Add(If(name, TupleTypeSymbol.TupleMemberName(position)))
+                elementNames.Add(name)
             Else
                 If name IsNot Nothing Then
                     elementNames = ArrayBuilder(Of String).GetInstance(tupleSize)
                     For j As Integer = 1 To position - 1
-                        elementNames.Add(TupleTypeSymbol.TupleMemberName(j))
+                        elementNames.Add(Nothing)
                     Next
                     elementNames.Add(name)
                 End If

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Symbols.vb
@@ -695,7 +695,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' set of names already used
                 Dim uniqueFieldNames = New HashSet(Of String)(IdentifierComparison.Comparer)
-                Dim countOfExplicitNames As Integer = 0
 
                 For i As Integer = 0 To numElements - 1
                     Dim argumentSyntax = syntax.Elements(i)
@@ -714,7 +713,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                         name = nameSyntax.Identifier.ValueText
 
                         ' validate name if we have one
-                        countOfExplicitNames += 1
                         Binder.CheckTupleMemberName(name, i, nameSyntax, diagnostics, uniqueFieldNames)
                         locations.Add(nameSyntax.GetLocation)
                     Else
@@ -723,10 +721,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                     Binder.CollectTupleFieldMemberNames(name, i + 1, numElements, elementNames)
                 Next
-
-                If countOfExplicitNames <> 0 AndAlso countOfExplicitNames <> numElements Then
-                    Binder.ReportDiagnostic(diagnostics, syntax, ERRID.ERR_TupleExplicitNamesOnAllMembersOrNone)
-                End If
 
                 Dim typesArray As ImmutableArray(Of TypeSymbol) = types.ToImmutableAndFree()
                 Dim locationsArray As ImmutableArray(Of Location) = locations.ToImmutableAndFree()

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1687,7 +1687,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         ERR_OptionMustBeAbsolutePath = 37257
 
-        ERR_TupleExplicitNamesOnAllMembersOrNone = 37258
+        ' available 37258
         ERR_TupleTooFewElements = 37259
         ERR_TupleReservedMemberNameAnyPosition = 37260
         ERR_TupleReservedMemberName = 37261

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -10380,15 +10380,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Tuple member names must all be provided, if any one is provided..
-        '''</summary>
-        Friend ReadOnly Property ERR_TupleExplicitNamesOnAllMembersOrNone() As String
-            Get
-                Return ResourceManager.GetString("ERR_TupleExplicitNamesOnAllMembersOrNone", resourceCulture)
-            End Get
-        End Property
-        
-        '''<summary>
         '''  Looks up a localized string similar to Tuple member name &apos;{0}&apos; is only allowed at position {1}..
         '''</summary>
         Friend ReadOnly Property ERR_TupleReservedMemberName() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5382,9 +5382,6 @@
   <data name="ERR_TupleDuplicateMemberName" xml:space="preserve">
     <value>Tuple member names must be unique.</value>
   </data>
-  <data name="ERR_TupleExplicitNamesOnAllMembersOrNone" xml:space="preserve">
-    <value>Tuple member names must all be provided, if any one is provided.</value>
-  </data>
   <data name="ERR_TupleReservedMemberName" xml:space="preserve">
     <value>Tuple member name '{0}' is only allowed at position {1}.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -3191,7 +3191,7 @@ BC37267: Predefined type 'ValueTuple(Of ,,,,,,,)' is not defined or imported.
         Public Sub TupleTypeWithLateDiscoveredName()
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
-<compilation name="NoTuples">
+<compilation name="Tuples">
     <file name="a.vb"><![CDATA[
 Imports System
 Module C
@@ -3201,23 +3201,12 @@ Module C
 End Module
 
 ]]></file>
-</compilation>)
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC37258: Tuple member names must all be provided, if any one is provided.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                 ~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                 ~~~~~~~~~~~~~~~~~~~~~~
-BC37267: Predefined type 'ValueTuple(Of ,)' is not defined or imported.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                 ~~~~~~~~~~~~~~~~~~~~~~
-BC37258: Tuple member names must all be provided, if any one is provided.
-        Dim x As (Integer, A As String) = (1, "hello", C:=2)
-                                          ~~~~~~~~~~~~~~~~~~
-BC37267: Predefined type 'ValueTuple(Of ,,)' is not defined or imported.
+BC30311: Value of type '(Integer, String, C As Integer)' cannot be converted to '(Integer, A As String)'.
         Dim x As (Integer, A As String) = (1, "hello", C:=2)
                                           ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -5038,6 +5027,28 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub CreateTupleTypeSymbol_WithSomeNames()
+
+            Dim comp = VisualBasicCompilation.Create("test", references:={MscorlibRef}) ' no ValueTuple
+            Dim intType As TypeSymbol = comp.GetSpecialType(SpecialType.System_Int32)
+            Dim stringType As TypeSymbol = comp.GetSpecialType(SpecialType.System_String)
+
+            Dim vt3 = comp.GetWellKnownType(WellKnownType.System_ValueTuple_T3).Construct(intType, stringType, intType)
+
+            Dim tupleWithSomeNames = comp.CreateTupleTypeSymbol(vt3, ImmutableArray.Create(Nothing, "Item2", "Charlie"))
+
+            Assert.True(tupleWithSomeNames.IsTupleType)
+            Assert.Equal(SymbolKind.ErrorType, tupleWithSomeNames.TupleUnderlyingType.Kind)
+            Assert.Equal("(System.Int32, Item2 As System.String, Charlie As System.Int32)", tupleWithSomeNames.ToTestDisplayString())
+            Assert.Equal(New String() {Nothing, "Item2", "Charlie"}, tupleWithSomeNames.TupleElementNames)
+            Assert.Equal(New String() {"System.Int32", "System.String", "System.Int32"},
+                         tupleWithSomeNames.TupleElementTypes.Select(Function(t) t.ToTestDisplayString()))
+
+            Assert.Equal(SymbolKind.NamedType, tupleWithSomeNames.Kind)
+
+        End Sub
+
+        <Fact>
         Public Sub CreateTupleTypeSymbol_WithBadNames()
 
             Dim comp = VisualBasicCompilation.Create("test", references:={MscorlibRef}) ' no ValueTuple
@@ -5144,6 +5155,30 @@ End Class
                          tuple9WithNames.ToTestDisplayString())
 
             Assert.Equal(New String() {"Alice1", "Alice2", "Alice3", "Alice4", "Alice5", "Alice6", "Alice7", "Alice8", "Alice9"}, tuple9WithNames.TupleElementNames)
+
+            Assert.Equal(New String() {"System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32"},
+                         tuple9WithNames.TupleElementTypes.Select(Function(t) t.ToTestDisplayString()))
+
+        End Sub
+
+        <Fact>
+        Public Sub CreateTupleTypeSymbol_Tuple9WithDefaultNames()
+
+            Dim comp = VisualBasicCompilation.Create("test", references:={MscorlibRef}) ' no ValueTuple
+            Dim intType As TypeSymbol = comp.GetSpecialType(SpecialType.System_Int32)
+            Dim stringType As TypeSymbol = comp.GetSpecialType(SpecialType.System_String)
+
+            Dim vt9 = comp.GetWellKnownType(WellKnownType.System_ValueTuple_TRest).
+                Construct(intType, stringType, intType, stringType, intType, stringType, intType,
+                                       comp.GetWellKnownType(WellKnownType.System_ValueTuple_T2).Construct(stringType, intType))
+
+            Dim tuple9WithNames = comp.CreateTupleTypeSymbol(vt9, ImmutableArray.Create("Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9"))
+
+            Assert.True(tuple9WithNames.IsTupleType)
+            Assert.Equal("(Item1 As System.Int32, Item2 As System.String, Item3 As System.Int32, Item4 As System.String, Item5 As System.Int32, Item6 As System.String, Item7 As System.Int32, Item8 As System.String, Item9 As System.Int32)",
+                         tuple9WithNames.ToTestDisplayString())
+
+            Assert.Equal(New String() {"Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9"}, tuple9WithNames.TupleElementNames)
 
             Assert.Equal(New String() {"System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32", "System.String", "System.Int32"},
                          tuple9WithNames.TupleElementTypes.Select(Function(t) t.ToTestDisplayString()))
@@ -7253,6 +7288,26 @@ End Module
         ~
 </errors>)
         End Sub
+
+        <Fact>
+        Public Sub TupleLiteralWithOnlySomeNames()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Module C
+    Sub Main()
+        Dim t As (Integer, String, Integer) = (1, b:="hello", Item3:=3)
+        console.write($"{t.Item1} {t.Item2} {t.Item3}")
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:="1 hello 3")
+
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/ExtractMethod/ExtractMethodTests.vb
@@ -329,5 +329,67 @@ End Namespace")
 
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)>
+        <WorkItem(11196, "https://github.com/dotnet/roslyn/issues/11196")>
+        Public Async Function TestTupleDeclarationWithNames() As Task
+
+            Await TestAsync(
+"Class Program
+    Sub Main(args As String())
+        [|Dim x As (a As Integer, b As Integer) = (1, 2)|]
+        System.Console.WriteLine(x.a)
+    End Sub
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace",
+"Class Program
+    Sub Main(args As String())
+        Dim x As (a As Integer, b As Integer) = {|Rename:NewMethod|}()
+        System.Console.WriteLine(x.a)
+    End Sub
+    Private Shared Function NewMethod() As (a As Integer, b As Integer)
+        Return (1, 2)
+    End Function
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace")
+
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsExtractMethod), Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.Tuples)>
+        <WorkItem(11196, "https://github.com/dotnet/roslyn/issues/11196")>
+        Public Async Function TestTupleDeclarationWithSomeNames() As Task
+
+            Await TestAsync(
+"Class Program
+    Sub Main(args As String())
+        [|Dim x As (a As Integer, Integer) = (1, 2)|]
+        System.Console.WriteLine(x.a)
+    End Sub
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace",
+"Class Program
+    Sub Main(args As String())
+        Dim x As (a As Integer, Integer) = {|Rename:NewMethod|}()
+        System.Console.WriteLine(x.a)
+    End Sub
+    Private Shared Function NewMethod() As (a As Integer, Integer)
+        Return (1, 2)
+    End Function
+End Class
+Namespace System
+    Structure ValueTuple(Of T1, T2)
+    End Structure
+End Namespace")
+
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateMethod/GenerateMethodTests.vb
@@ -2310,6 +2310,69 @@ Class C
 End Class</text>.Value.Replace(vbLf, vbCrLf))
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        Public Async Function MethodWithTuple() As Task
+            Await TestAsync(
+"Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (Integer, String) = [|NewMethod|]((1, ""hello""))
+    End Sub
+End Class",
+"Imports System
+
+Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (Integer, String) = NewMethod((1, ""hello""))
+    End Sub
+
+    Private Shared Function NewMethod(p As (Integer, String)) As (Integer, String)
+        Throw New NotImplementedException()
+    End Function
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        Public Async Function MethodWithTupleWithNames() As Task
+            Await TestAsync(
+"Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (a As Integer, b As String) = [|NewMethod|]((c:=1, d:=""hello""))
+    End Sub
+End Class",
+"Imports System
+
+Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (a As Integer, b As String) = NewMethod((c:=1, d:=""hello""))
+    End Sub
+
+    Private Shared Function NewMethod(p As (c As Integer, d As String)) As (a As Integer, b As String)
+        Throw New NotImplementedException()
+    End Function
+End Class")
+        End Function
+
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateMethod)>
+        Public Async Function MethodWithTupleWithOneName() As Task
+            Await TestAsync(
+"Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (a As Integer, String) = [|NewMethod|]((c:=1, ""hello""))
+    End Sub
+End Class",
+"Imports System
+
+Class Program
+    Private Shared Async Sub Main(args As String())
+        Dim d As (a As Integer, String) = NewMethod((c:=1, ""hello""))
+    End Sub
+
+    Private Shared Function NewMethod(p As (c As Integer, String)) As (a As Integer, String)
+        Throw New NotImplementedException()
+    End Function
+End Class")
+        End Function
+
         Public Class GenerateConversionTests
             Inherits AbstractVisualBasicDiagnosticProviderBasedUserDiagnosticTest
 
@@ -2594,6 +2657,7 @@ Class Digit
 End Class
 </text>.Value.Replace(vbLf, vbCrLf), compareTokens:=False)
             End Function
+
         End Class
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateVariable/GenerateVariableTests.vb
@@ -974,5 +974,34 @@ NewLines("Class [Class] \n Private Sub Method(i As Integer) \n [|foo|] = Functio
 NewLines("Class [Class] \n Private Sub Method(i As Integer)\n        Dim foo As System.Func(Of Integer)\n        foo = Function() \n Return 2 \n End Function \n End Sub \n End Class"),
 index:=2)
         End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TupleRead() As Task
+            Await TestAsync(
+NewLines("Class [Class] \n Private Sub Method(i As (Integer, String)) \n Method([|tuple|]) \n End Sub \n End Class"),
+NewLines("Class [Class] \n Private tuple As (Integer, String) \n  Private Sub Method(i As (Integer, String))\n Method(tuple) \n End Sub \n End Class"))
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TupleWithOneNameRead() As Task
+            Await TestAsync(
+NewLines("Class [Class] \n Private Sub Method(i As (a As Integer, String)) \n Method([|tuple|]) \n End Sub \n End Class"),
+NewLines("Class [Class] \n Private tuple As (a As Integer, String) \n  Private Sub Method(i As (a As Integer, String))\n Method(tuple) \n End Sub \n End Class"))
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TupleWrite() As Task
+            Await TestAsync(
+NewLines("Class [Class] \n Private Sub Method() \n [|tuple|] = (1, ""hello"") \n End Sub \n End Class"),
+NewLines("Class [Class] \n Private tuple As (Integer, String) \n  Private Sub Method()\n tuple = (1, ""hello"") \n End Sub \n End Class"))
+        End Function
+
+        <Fact(), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateVariable)>
+        Public Async Function TupleWithOneNameWrite() As Task
+            Await TestAsync(
+NewLines("Class [Class] \n Private Sub Method() \n [|tuple|] = (a:=1, ""hello"") \n End Sub \n End Class"),
+NewLines("Class [Class] \n Private tuple As (a As Integer, String) \n  Private Sub Method()\n tuple = (a:=1, ""hello"") \n End Sub \n End Class"))
+        End Function
+
     End Class
 End Namespace

--- a/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/TypeSyntaxGeneratorVisitor.vb
@@ -130,7 +130,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
 
             Return SyntaxFactory.TupleType(SyntaxFactory.SeparatedList(
                 types.Select(Function(t, i) SyntaxFactory.TupleElement(
-                    If(hasNames, SyntaxFactory.IdentifierName(names(i)), Nothing), t.GenerateTypeSyntax()))))
+                    If(hasNames AndAlso names(i) IsNot Nothing, SyntaxFactory.IdentifierName(names(i)), Nothing),
+                    If(hasNames AndAlso names(i) IsNot Nothing, SyntaxFactory.Token(SyntaxKind.AsKeyword), Nothing),
+                    t.GenerateTypeSyntax()))))
         End Function
 
         Public Overrides Function VisitNamedType(symbol As INamedTypeSymbol) As TypeSyntax


### PR DESCRIPTION
Opening a new PR against preview-5.

Vlad's porting of tuples to VB already picked up much code after C# already supported partial names (`CreateTupleTypeSymbol` API, metadata loading), so the remaining code to be updated was limited: binding tuple type and binding tuple expression shouldn't report an error, and some refactoring code had to be updated (in `TypeSyntaxGeneratorVisitor.vb`).

Fixes https://github.com/dotnet/roslyn/issues/13662

@VSadov @dotnet/roslyn-compiler for review

Here are the corresponding changes in C#:
- [Partial names in C#](https://github.com/dotnet/roslyn/pull/12602/files) (ported all the logic and most tests)
- [Extract method refactoring in presence of partial names](https://github.com/dotnet/roslyn/commit/bcc8af40e7616c06c04f2c9ee3c2c30257fe79ef) (ported fix from `CreateTupleTypeSyntax` method)

The old PR was https://github.com/dotnet/roslyn/pull/13768