### PR TITLE
Allow unexpected custom type info for instances of generic types

### DIFF
--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/CustomTypeInfoTypeArgumentMap.cs
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/Helpers/CustomTypeInfoTypeArgumentMap.cs
@@ -65,7 +65,10 @@ namespace Microsoft.CodeAnalysis.ExpressionEvaluator
             ReadOnlyCollection<byte> dynamicFlags;
             ReadOnlyCollection<string> tupleElementNames;
             CustomTypeInfo.Decode(typeInfo.PayloadTypeId, typeInfo.Payload, out dynamicFlags, out tupleElementNames);
-            Debug.Assert(dynamicFlags != null || tupleElementNames != null);
+            if (dynamicFlags == null && tupleElementNames == null)
+            {
+                return s_empty;
+            }
 
             var typeDefinition = type.GetGenericTypeDefinition();
             Debug.Assert(typeDefinition != null);


### PR DESCRIPTION
Fixes assert failure in DEBUG builds inspecting generic types.

Fixes #13715.