### PR TITLE
Catch exceptions from writing the XML doc stream

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -1565,7 +1565,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Invalid operand for pattern match..
+        ///   Looks up a localized string similar to Invalid operand for pattern match; value required, but found &apos;{0}&apos;..
         /// </summary>
         internal static string ERR_BadIsPatternExpression {
             get {
@@ -3334,6 +3334,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_DllImportOnInvalidMethod {
             get {
                 return ResourceManager.GetString("ERR_DllImportOnInvalidMethod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error writing to XML documentation file: {0}.
+        /// </summary>
+        internal static string ERR_DocFileGen {
+            get {
+                return ResourceManager.GetString("ERR_DocFileGen", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -2503,6 +2503,9 @@ A catch() block after a catch (System.Exception e) block can catch non-CLS excep
   <data name="ERR_CantReadResource" xml:space="preserve">
     <value>Error reading resource '{0}' -- '{1}'</value>
   </data>
+  <data name="ERR_DocFileGen" xml:space="preserve">
+    <value>Error writing to XML documentation file: {0}</value>
+  </data>
   <data name="WRN_XMLParseError" xml:space="preserve">
     <value>XML comment has badly formed XML -- '{0}'</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -98,7 +98,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(compiler._indentDepth == 0);
                     writer?.Flush();
                 }
-                catch (IOException e)
+                catch (Exception e)
                 {
                     diagnostics.Add(ErrorCode.ERR_DocFileGen, Location.None, e.Message);
                 }

--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -90,10 +90,18 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             using (writer)
             {
-                var compiler = new DocumentationCommentCompiler(assemblyName ?? compilation.SourceAssembly.Name, compilation, writer, filterTree, filterSpanWithinTree,
-                    processIncludes: true, isForSingleSymbol: false, diagnostics: diagnostics, cancellationToken: cancellationToken);
-                compiler.Visit(compilation.SourceAssembly.GlobalNamespace);
-                Debug.Assert(compiler._indentDepth == 0);
+                try
+                {
+                    var compiler = new DocumentationCommentCompiler(assemblyName ?? compilation.SourceAssembly.Name, compilation, writer, filterTree, filterSpanWithinTree,
+                        processIncludes: true, isForSingleSymbol: false, diagnostics: diagnostics, cancellationToken: cancellationToken);
+                    compiler.Visit(compilation.SourceAssembly.GlobalNamespace);
+                    Debug.Assert(compiler._indentDepth == 0);
+                    writer?.Flush();
+                }
+                catch (IOException e)
+                {
+                    diagnostics.Add(ErrorCode.ERR_DocFileGen, Location.None, e.Message);
+                }
             }
 
             if (filterTree != null)

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -732,7 +732,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_CantHaveWin32ResAndIcon = 1565,
         ERR_CantReadResource = 1566,
         //ERR_AutoResGen = 1567,
-        //ERR_DocFileGen = 1569,
+        ERR_DocFileGen = 1569,
         WRN_XMLParseError = 1570,
         WRN_DuplicateParamTag = 1571,
         WRN_UnmatchedParamTag = 1572,


### PR DESCRIPTION
If an IO error occurs while writing the doc comment stream we currently
let the exception rise out of the compiler. We should instead catch the
exception and surface a diagnostic.

Fixes devdiv bug 217734