### PR TITLE
Fix CodeLens references details window

### DIFF
--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -45,6 +45,7 @@
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.CSharp" />
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.CSharp.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Workspaces" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests2" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />

--- a/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
+++ b/src/Features/VisualBasic/Portable/BasicFeatures.vbproj
@@ -55,6 +55,7 @@
     <InternalsVisibleTo Include="Microsoft.CodeAnalysis.VisualBasic.InteractiveEditorFeatures" />
     <InternalsVisibleTo Include="Microsoft.VisualStudio.LanguageServices.VisualBasic" />
     <InternalsVisibleTo Include="MonoDevelop.VBNetBinding" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Workspaces" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.CSharp.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests" />
     <InternalsVisibleToTest Include="Roslyn.Services.Editor.UnitTests2" />

--- a/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
+++ b/src/Workspaces/Remote/Core/RemoteWorkspaces.csproj
@@ -19,6 +19,18 @@
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Features\Core\Portable\Features.csproj">
+      <Project>{edc68a0e-c68d-4a74-91b7-bf38ec909888}</Project>
+      <Name>Features</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Features\CSharp\Portable\CSharpFeatures.csproj">
+      <Project>{3973b09a-4fbf-44a5-8359-3d22ceb71f71}</Project>
+      <Name>CSharpFeatures</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Features\VisualBasic\Portable\BasicFeatures.vbproj">
+      <Project>{a1bcd0ce-6c2f-4f8c-9a48-d9d93928e26d}</Project>
+      <Name>BasicFeatures</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Core\Desktop\Workspaces.Desktop.csproj">
       <Project>{2e87fa96-50bb-4607-8676-46521599f998}</Project>
       <Name>Workspaces.Desktop</Name>

--- a/src/Workspaces/Remote/Core/Services/RoslynServices.cs
+++ b/src/Workspaces/Remote/Core/Services/RoslynServices.cs
@@ -14,7 +14,10 @@ namespace Microsoft.CodeAnalysis.Remote
     {
         // TODO: probably need to split this to private and public services
         public static readonly HostServices HostServices = MefHostServices.Create(
-            MefHostServices.DefaultAssemblies.Add(typeof(Host.TemporaryStorageServiceFactory.TemporaryStorageService).Assembly));
+            MefHostServices.DefaultAssemblies
+                .Add(typeof(Host.TemporaryStorageServiceFactory.TemporaryStorageService).Assembly)
+                .Add(typeof(CSharp.CodeLens.CSharpCodeLensDisplayInfoService).Assembly)
+                .Add(typeof(VisualBasic.CodeLens.VisualBasicDisplayInfoService).Assembly));
 
         public static readonly AssetService AssetService = new AssetService();
         public static readonly SolutionService SolutionService = new SolutionService();


### PR DESCRIPTION
When you click on the CodeLens "x references", you get a details window that shows you information about the references. That detail uses a language-specific service that the backend uses to format the text. On the remote host, we need to make sure those language-specific services are available, otherwise the window will fail to come up.

@heejaechang @srivatsn 