### PR TITLE
Adding tests to close #13661 and #12802

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18098,5 +18098,26 @@ class C
                 });
             // no assertion in MetadataWriter
         }
+
+        [Fact]
+        [WorkItem(13661, "https://github.com/dotnet/roslyn/issues/13661")]
+        public void LongTupleWithPartialNames_Bug13661()
+        {
+            var source = @"
+using System;
+class C
+{
+    static void Main()
+    {
+        var o = (A: 1, 2, C: 3, D: 4, E: 5, F: 6, G: 7, 8, I: 9);
+        Console.Write(o.I);
+    }
+}
+";
+            CompileAndVerify(source,
+                additionalRefs: s_valueTupleRefs,
+                parseOptions: TestOptions.Regular, expectedOutput: @"9");
+            // no assert hit
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18117,7 +18117,20 @@ class C
             CompileAndVerify(source,
                 additionalRefs: s_valueTupleRefs,
                 options: TestOptions.DebugExe,
-                expectedOutput: @"9");
+                expectedOutput: @"9",
+                sourceSymbolValidator: (module) =>
+                {
+                    var sourceModule = (SourceModuleSymbol)module;
+                    var compilation = sourceModule.DeclaringCompilation;
+                    var tree = compilation.SyntaxTrees.First();
+                    var model = compilation.GetSemanticModel(tree);
+                    var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
+
+                    var x = nodes.OfType<VariableDeclaratorSyntax>().First();
+                    var xSymbol = ((SourceLocalSymbol)model.GetDeclaredSymbol(x)).Type;
+                    AssertEx.SetEqual(xSymbol.GetMembers().OfType<FieldSymbol>().Select(f => f.Name),
+                        "A", "C", "D", "E", "F", "G", "I", "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9", "Rest");
+                });
             // no assert hit
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -18116,7 +18116,8 @@ class C
 ";
             CompileAndVerify(source,
                 additionalRefs: s_valueTupleRefs,
-                parseOptions: TestOptions.Regular, expectedOutput: @"9");
+                options: TestOptions.DebugExe,
+                expectedOutput: @"9");
             // no assert hit
         }
     }

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -8198,6 +8198,26 @@ End Module
 
         End Sub
 
+        <Fact>
+        <WorkItem(13661, "https://github.com/dotnet/roslyn/issues/13661")>
+        Public Sub LongTupleWithPartialNames_Bug13661()
+
+            Dim verifier = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim t = (A:=1, B:=2, C:=3, D:=4, E:=5, F:=6, G:=7, 8, I:=9)
+        System.Console.Write($"{t.I}")
+    End Sub
+End Module
+
+    </file>
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:="9")
+            ' No assert hit
+
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -8207,14 +8207,27 @@ End Module
     <file name="a.vb">
 Module C
     Sub Main()
-        Dim t = (A:=1, B:=2, C:=3, D:=4, E:=5, F:=6, G:=7, 8, I:=9)
+        Dim t = (A:=1, 2, C:=3, D:=4, E:=5, F:=6, G:=7, 8, I:=9)
         System.Console.Write($"{t.I}")
     End Sub
 End Module
 
     </file>
 </compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef},
-options:=TestOptions.DebugExe, expectedOutput:="9")
+                options:=TestOptions.DebugExe, expectedOutput:="9",
+                sourceSymbolValidator:=
+                    Sub(m As ModuleSymbol)
+                        Dim compilation = m.DeclaringCompilation
+                        Dim tree = compilation.SyntaxTrees.First()
+                        Dim model = compilation.GetSemanticModel(tree)
+                        Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
+
+                        Dim t = nodes.OfType(Of VariableDeclaratorSyntax)().Single().Names(0)
+                        Dim xSymbol = DirectCast(model.GetDeclaredSymbol(t), LocalSymbol).Type
+
+                        AssertEx.SetEqual(xSymbol.GetMembers().OfType(Of FieldSymbol)().Select(Function(f) f.Name),
+                            "A", "C", "D", "E", "F", "G", "I", "Item1", "Item2", "Item3", "Item4", "Item5", "Item6", "Item7", "Item8", "Item9", "Rest")
+                    End Sub)
             ' No assert hit
 
         End Sub

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -8213,7 +8213,8 @@ Module C
 End Module
 
     </file>
-</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef}, expectedOutput:="9")
+</compilation>, additionalRefs:={ValueTupleRef, SystemRuntimeFacadeRef},
+options:=TestOptions.DebugExe, expectedOutput:="9")
             ' No assert hit
 
         End Sub

--- a/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/InlineTemporary/InlineTemporaryTests.cs
@@ -4071,5 +4071,47 @@ class C
 
             await TestAsync(code, expected, index: 0);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsInlineTemporary)]
+        [WorkItem(12802, "https://github.com/dotnet/roslyn/issues/12802")]
+        public async Task Deconstruction2()
+        {
+            var code = @"
+class Program
+{
+    static void Main()
+    {
+        var [||]kvp = KVP.Create(42, ""hello"");
+        var(x1, x2) = kvp;
+    }
+}
+public static class KVP
+{
+    public static KVP<T1, T2> Create<T1, T2>(T1 item1, T2 item2) { return null; }
+}
+public class KVP<T1, T2>
+{
+    public void Deconstruct(out T1 item1, out T2 item2) { item1 = default(T1); item2 = default(T2); }
+}";
+
+            var expected = @"
+class Program
+{
+    static void Main()
+    {
+        var(x1, x2) = KVP.Create(42, ""hello"");
+    }
+}
+public static class KVP
+{
+    public static KVP<T1, T2> Create<T1, T2>(T1 item1, T2 item2) { return null; }
+}
+public class KVP<T1, T2>
+{
+    public void Deconstruct(out T1 item1, out T2 item2) { item1 = default(T1); item2 = default(T2); }
+}";
+
+            await TestAsync(code, expected, index: 0);
+        }
     }
 }


### PR DESCRIPTION
Both issues no longer repro.

Chuck noticed an assertion with long tuples with missing names, such as `var o = (A: 1, 2, C: 3, D: 4, E: 5, F: 6, G: 7, 8, I: 9);`. This is issue #13661. This was fixed by Vlad's preview 5 fix to rationalize `TupleTypeSymbol.CreateMembers` and align it between C# and VB.

I'd noticed a refactoring problem with decontruction, #12802. The generated code was not simplified far enough. This no longer repros.

@dotnet/roslyn-compiler for review.