### PR TITLE
Add an Init.cmd file to the VS toolset package

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -908,6 +908,15 @@ Public Class BuildDevDivInsertionFiles
         ' No duplicates are allowed
         filesToInsert.GroupBy(Function(x) x).All(Function(g) g.Count() = 1)
 
+        Dim fileContents = "@echo off
+
+set RoslynToolsRoot=%~dp0
+set DEVPATH=%RoslynToolsRoot%;%DEVPATH%"
+
+        File.WriteAllText(
+            Path.Combine(_binDirectory, "Init.cmd"),
+            fileContents)
+
         Dim xml = <?xml version="1.0" encoding="utf-8"?>
                   <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
                       <metadata>
@@ -918,6 +927,7 @@ Public Class BuildDevDivInsertionFiles
                           <version>0.0</version>
                       </metadata>
                       <files>
+                          <file src="Init.cmd"/>
                           <%= filesToInsert.
                               OrderBy(Function(f) f).
                               Select(Function(f) <file src=<%= f %> xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd"/>) %>

--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -908,6 +908,11 @@ Public Class BuildDevDivInsertionFiles
         ' No duplicates are allowed
         filesToInsert.GroupBy(Function(x) x).All(Function(g) g.Count() = 1)
 
+        ' Write an Init.cmd that sets DEVPATH to the toolset location. This overrides
+        ' assembly loading during the VS build to always look in the Roslyn toolset
+        ' first. This is necessary because there are various incompatible versions
+        ' of Roslyn littered throughout the DEVPATH already and this one should always
+        ' take precedence.
         Dim fileContents = "@echo off
 
 set RoslynToolsRoot=%~dp0


### PR DESCRIPTION
To get the right environment variables set up for the VS build we need
to run a script when the Razzle environment is created. This Init script
will be run during the initial CoreXT Init to set up that variable.

/cc @jaredpar @natidea @dotnet/roslyn-infrastructure 