### PR TITLE
Don't include the Git SHA if the ref file isn't present

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -80,7 +80,7 @@
             <DotGitDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)../../.git'))</DotGitDir>
             <HeadFileContent Condition="Exists('$(DotGitDir)/HEAD')">$([System.IO.File]::ReadAllText('$(DotGitDir)/HEAD').Trim())</HeadFileContent>
             <RefPath Condition="$(HeadFileContent.StartsWith('ref: '))">$(DotGitDir)/$(HeadFileContent.Substring(5))</RefPath>
-            <GitHeadSha Condition="'$(RefPath)' != ''">$([System.IO.File]::ReadAllText('$(RefPath)').Trim())</GitHeadSha>
+            <GitHeadSha Condition="'$(RefPath)' != '' and Exists('$(RefPath)')">$([System.IO.File]::ReadAllText('$(RefPath)').Trim())</GitHeadSha>
             <GitHeadSha Condition="'$(HeadFileContent)' != '' and
                                    '$(RefPath)' == ''">$(HeadFileContent)</GitHeadSha>
           </PropertyGroup>


### PR DESCRIPTION

/cc @jasonmalinowski @CyrusNajmabadi @jaredpar @dotnet/roslyn-infrastructure 