### PR TITLE
Fix for incorrect async capture analysis when 32+ variables and branches are involved

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -345,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             public PendingBranch(BoundNode branch, LocalState state)
             {
                 this.Branch = branch;
-                this.State = state;
+                this.State = state.Clone();
             }
         }
 
@@ -829,7 +829,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var result = new SavedPending(ref _pendingBranches, ref _labelsSeen);
             if (_trackExceptions)
             {
-                _pendingBranches.Add(new PendingBranch(null, this.State.Clone()));
+                _pendingBranches.Add(new PendingBranch(null, this.State));
             }
 
             return result;
@@ -2005,7 +2005,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
         {
             VisitRvalue(node.Expression);
-            _pendingBranches.Add(new PendingBranch(node, this.State.Clone()));
+            _pendingBranches.Add(new PendingBranch(node, this.State));
             if (_trackExceptions) NotePossibleException(node);
             return null;
         }
@@ -2445,7 +2445,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitYieldReturnStatement(BoundYieldReturnStatement node)
         {
             VisitRvalue(node.Expression);
-            _pendingBranches.Add(new PendingBranch(node, this.State.Clone()));
+            _pendingBranches.Add(new PendingBranch(node, this.State));
             return null;
         }
 
@@ -2539,7 +2539,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitConditionalGoto(BoundConditionalGoto node)
         {
             VisitRvalue(node.Condition);
-            _pendingBranches.Add(new PendingBranch(node, this.State.Clone()));
+            _pendingBranches.Add(new PendingBranch(node, this.State));
             return null;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -75,6 +75,80 @@ class Test
         }
 
         [Fact]
+        [WorkItem(13867, "https://github.com/dotnet/roslyn/issues/13867")]
+        public void AsyncWithLotsLocals()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {
+        static void Main()
+        {
+            DoItAsync().Wait();
+        }
+
+        public static async Task DoItAsync()
+        {
+            var var1 = 0;
+            var var2 = 0;
+            var var3 = 0;
+            var var4 = 0;
+            var var5 = 0;
+            var var6 = 0;
+            var var7 = 0;
+            var var8 = 0;
+            var var9 = 0;
+            var var10 = 0;
+            var var11 = 0;
+            var var12 = 0;
+            var var13 = 0;
+            var var14 = 0;
+            var var15 = 0;
+            var var16 = 0;
+            var var17 = 0;
+            var var18 = 0;
+            var var19 = 0;
+            var var20 = 0;
+            var var21 = 0;
+            var var22 = 0;
+            var var23 = 0;
+            var var24 = 0;
+            var var25 = 0;
+            var var26 = 0;
+            var var27 = 0;
+            var var28 = 0;
+            var var29 = 0;
+            var var30 = 0;
+            var var31 = 0;
+
+            string s;
+            if (true)
+            {
+                s = ""a"";
+                await Task.Yield();
+            }
+            else
+            {
+                s = ""b"";
+            }
+
+            Console.WriteLine(s ?? ""null"");  // should be ""a"" always, somehow is ""null""
+        }
+    }
+}";
+            var expected = @"
+a
+";
+            CompileAndVerify(source, options: TestOptions.ReleaseExe, expectedOutput: expected);
+            CompileAndVerify(source, options: TestOptions.DebugExe, expectedOutput: expected);
+
+        }
+
+        [Fact]
         public void AsyncWithParam()
         {
             var source = @"

--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.NestedTypes.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.NestedTypes.vb
@@ -103,7 +103,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Public Sub New(branch As BoundStatement, state As LocalState, nesting As BlockNesting)
                 Me.Branch = branch
-                Me.State = state
+                Me.State = state.Clone()
                 Me.Nesting = nesting
             End Sub
         End Class

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenAsyncTests.vb
@@ -244,6 +244,132 @@ End Module
         End Sub
 
         <Fact()>
+        <WorkItem(13867, "https://github.com/dotnet/roslyn/issues/13867")>
+        Public Sub Simple_Test_ManyLocals()
+            Dim c = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Module1
+    Sub Main()
+        DoItAsync().Wait()
+    End Sub
+
+    public async Function DoItAsync() as Task
+        Dim var1 = 0
+        Dim var2 = 0
+        Dim var3 = 0
+        Dim var4 = 0
+        Dim var5 = 0
+        Dim var6 = 0
+        Dim var7 = 0
+        Dim var8 = 0
+        Dim var9 = 0
+        Dim var10 = 0
+        Dim var11 = 0
+        Dim var12 = 0
+        Dim var13 = 0
+        Dim var14 = 0
+        Dim var15 = 0
+        Dim var16 = 0
+        Dim var17 = 0
+        Dim var18 = 0
+        Dim var19 = 0
+        Dim var20 = 0
+        Dim var21 = 0
+        Dim var22 = 0
+        Dim var23 = 0
+        Dim var24 = 0
+        Dim var25 = 0
+        Dim var26 = 0
+        Dim var27 = 0
+        Dim var28 = 0
+        Dim var29 = 0
+        Dim var30 = 0
+        Dim var31 = 0
+
+        Dim s as string
+        if true
+            s = "a"
+            await Task.Yield()
+        else
+            s = "b"
+        end if
+
+        Console.WriteLine(if(s , "null"))  ' should be "a" always, somehow is "null"
+    end Function 
+End Module
+    </file>
+</compilation>, useLatestFramework:=True, options:=TestOptions.DebugExe, expectedOutput:="a")
+        End Sub
+
+        <Fact()>
+        <WorkItem(13867, "https://github.com/dotnet/roslyn/issues/13867")>
+        Public Sub Simple_Test_ManyLocals_Rel()
+            Dim c = CompileAndVerify(
+<compilation>
+    <file name="a.vb">
+Imports System
+Imports System.Threading
+Imports System.Threading.Tasks
+
+Module Module1
+    Sub Main()
+        DoItAsync().Wait()
+    End Sub
+
+    public async Function DoItAsync() as Task
+        Dim var1 = 0
+        Dim var2 = 0
+        Dim var3 = 0
+        Dim var4 = 0
+        Dim var5 = 0
+        Dim var6 = 0
+        Dim var7 = 0
+        Dim var8 = 0
+        Dim var9 = 0
+        Dim var10 = 0
+        Dim var11 = 0
+        Dim var12 = 0
+        Dim var13 = 0
+        Dim var14 = 0
+        Dim var15 = 0
+        Dim var16 = 0
+        Dim var17 = 0
+        Dim var18 = 0
+        Dim var19 = 0
+        Dim var20 = 0
+        Dim var21 = 0
+        Dim var22 = 0
+        Dim var23 = 0
+        Dim var24 = 0
+        Dim var25 = 0
+        Dim var26 = 0
+        Dim var27 = 0
+        Dim var28 = 0
+        Dim var29 = 0
+        Dim var30 = 0
+        Dim var31 = 0
+
+        Dim s as string
+        if true
+            s = "a"
+            await Task.Yield()
+        else
+            s = "b"
+        end if
+
+        Console.WriteLine(if(s , "null"))  ' should be "a" always, somehow is "null"
+    end Function 
+End Module
+    </file>
+</compilation>, useLatestFramework:=True, options:=TestOptions.ReleaseExe, expectedOutput:="a")
+        End Sub
+
+        <Fact()>
         Public Sub Simple_Task()
             CompileAndVerify(
 <compilation>


### PR DESCRIPTION
Fix for incorrect capture analysis when 32+ variables and branches are involved

When pending a branch, the mutable state must be cloned. Otherwise we might continue mutating the state after pending it.

Cloning of control flow state is a no-op since it is a struct.
For data flow states cloning is a no-op for small states with <32 locals since the first 31 locals are tracked "inline".
Cloning large ones is observable because the extra bits are stored in a lazy allocated array, forgetting to clone results in unwanted sharing of those bits across various pended and actual states.

Fixes: https://github.com/dotnet/roslyn/issues/13867