### PR TITLE
Fix for "Some tests fail due to non-standard cultural settings" (#10362)

### DIFF
--- a/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/AnonymousTypesSymbolTests.cs
@@ -1297,7 +1297,7 @@ class Query
         {
             // test AnonymousType.ToString()
             var currCulture = System.Threading.Thread.CurrentThread.CurrentCulture;
-            System.Threading.Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("en-US");
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
             try
             {
                 var source = @"

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/AnonymousTypesCodeGenTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/AnonymousTypesCodeGenTests.vb
@@ -368,7 +368,7 @@ expectedOutput:="VB$AnonymousType_0`1[T0]")
         Public Sub TestAnonymousType_ToString()
             ' test AnonymousType_ToString() itself
             Dim currCulture = System.Threading.Thread.CurrentThread.CurrentCulture
-            System.Threading.Thread.CurrentThread.CurrentCulture = New System.Globalization.CultureInfo("en-US")
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture
             Try
 
                 CompileAndVerify(
@@ -734,7 +734,7 @@ expectedOutput:=<![CDATA[
         Public Sub TestAnonymousType_LocalAsNewWith()
             ' AnonymousType ToString
             Dim currCulture = System.Threading.Thread.CurrentThread.CurrentCulture
-            System.Threading.Thread.CurrentThread.CurrentCulture = New System.Globalization.CultureInfo("en-US")
+            System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture
             Try
 
                 CompileAndVerify(

--- a/src/Compilers/VisualBasic/Test/Emit/Semantics/StaticLocalsSemanticTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Semantics/StaticLocalsSemanticTests.vb
@@ -346,7 +346,7 @@ End Class
             ' test late bind
             ' call ToString() on object defeat the purpose
             Dim currCulture = Threading.Thread.CurrentThread.CurrentCulture
-            Threading.Thread.CurrentThread.CurrentCulture = New System.Globalization.CultureInfo("en-US")
+            Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture
             Try
                 'Declare static local which is late bound
                 Dim compilationDef = CreateCompilationWithMscorlibAndVBRuntime(

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/BinaryOperators.vb
@@ -19,6 +19,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
         <Fact>
         Public Sub Test1()
 
+            Dim currCulture = System.Threading.Thread.CurrentThread.CurrentCulture
+            System.Threading.Thread.CurrentThread.CurrentCulture = New System.Globalization.CultureInfo("en-US", useUserOverride:=False)
+
+            Try
+
             Dim compilationDef =
 <compilation name="VBBinaryOperators1">
     <file name="lib.vb">
@@ -40,6 +45,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.Semantics
             Assert.False(compilation.Options.CheckOverflow)
 
             CompileAndVerify(compilation, expectedOutput:=My.Resources.Resource.BinaryOperatorsTestBaseline1)
+
+            Catch ex As Exception
+                Assert.Null(ex)
+            Finally
+                System.Threading.Thread.CurrentThread.CurrentCulture = currCulture
+            End Try
 
         End Sub
 


### PR DESCRIPTION
This pull request fixes #10362 by using the invariant culture instead of the English one in the five tests failing on my system.