### PR TITLE
Adjust suggestion tag clipping to prevent seeing errant pixels drawn on the screen

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/SuggestionTag.cs
@@ -71,7 +71,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             // We clip off a bit off the start of the line to prevent a half-square being
             // drawn.
             var clipRectangle = geometry.Bounds;
-            clipRectangle.Offset(1, 0);
+            clipRectangle.Offset(2, 0);
 
             var line = new Line
             {


### PR DESCRIPTION
Before.  Faint, but it's there:

![image](https://cloud.githubusercontent.com/assets/4564579/18619940/48d713cc-7dbd-11e6-9379-d675d906aabe.png)

After:

![image](https://cloud.githubusercontent.com/assets/4564579/18619944/53fcfd70-7dbd-11e6-8a1b-d0bc27cf0449.png)

