### PR TITLE
Implement EnC distance function for deconstruction

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/ActiveStatementTests.cs
@@ -8189,15 +8189,15 @@ class C
         }
 
         [Fact]
-        public void MethodUpdate_VarDeconstruction()
+        public void MethodUpdate_VarDeconstructionInForLoop()
         {
             string src1 = @"
 class C
 {
     static void F(object o1, object o2)
     {
-        <AS:0>Console.WriteLine(1);</AS:0>
         for (var (x, y) = o1; ; ) { }
+        <AS:0>Console.WriteLine(1);</AS:0>
     }
 }
 ";
@@ -8206,8 +8206,8 @@ class C
 {
     static void F(object o1, object o2)
     {
-        <AS:0>Console.WriteLine(1);</AS:0>
         for (var (x, y) = o2; ; ) { }
+        <AS:0>Console.WriteLine(1);</AS:0>
     }
 }
 ";
@@ -8219,7 +8219,7 @@ class C
         }
 
         [Fact]
-        public void MethodUpdate_TypedDeconstruction()
+        public void MethodUpdate_TypedDeconstructionInForLoop()
         {
             string src1 = @"
 class C

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -7170,6 +7170,32 @@ foreach(var (x1, x2) in new[] { (30, 40) }) { Console.Write(50); }
         }
 
         [Fact]
+        public void ForEachAndForEachComponentStatement()
+        {
+            string src1 = @"
+foreach(var (x1, x2) in F()) { Console.Write(1); }
+";
+
+            string src2 = @"
+foreach(var (x3, x4) in new[] { (1, 2) }) { Console.Write(1); }
+foreach(var x1 in F()) { Console.Write(50); }
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "foreach(var (x1, x2) in F()) { Console.Write(1); }", "foreach(var x1 in F()) { Console.Write(50); }" },
+                { "{ Console.Write(1); }", "{ Console.Write(50); }" },
+                { "Console.Write(1);", "Console.Write(1);" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
         public void ForWithDeconstruction()
         {
             string src1 = @"

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -7118,6 +7118,32 @@ var (x1, x2) = (30, 40);
         }
 
         [Fact]
+        public void ForEachStatement()
+        {
+            string src1 = @"
+foreach(var x1 in new[] { 1 }) { Console.Write(1); }
+";
+
+            string src2 = @"
+foreach(var x3 in new[] { 1 }) { Console.Write(1); }
+foreach(var x1 in new[] { 30 }) { Console.Write(50); }
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "foreach(var x1 in new[] { 1 }) { Console.Write(1); }", "foreach(var x1 in new[] { 30 }) { Console.Write(50); }" },
+                { "{ Console.Write(1); }", "{ Console.Write(50); }" },
+                { "Console.Write(1);", "Console.Write(1);" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
         public void ForEachComponentStatement()
         {
             string src1 = @"
@@ -7198,7 +7224,7 @@ for (var x1 = 30; ; ) { Console.Write(50); }
             expected.AssertEqual(actual);
         }
 
-        [Fact]
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/13904")]
         [WorkItem(13904, "https://github.com/dotnet/roslyn/issues/13904")]
         public void Assignment()
         {
@@ -7215,9 +7241,9 @@ var x1 = 100;
             // https://github.com/dotnet/roslyn/issues/13904
             var expected = new MatchingPairs
             {
-                { "var x1 = 1;", "var x3 = 1;" },
-                { "var x1 = 1", "var x3 = 1" },
-                { "x1 = 1", "x3 = 1" }
+                { "var x1 = 1;", "var x1 = 1;" },
+                { "var x1 = 1", "var x1 = 1" },
+                { "x1 = 1", "x1 = 1" }
             };
 
             var match = GetMethodMatch(src1, src2);

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/RudeEditStatementTests.cs
@@ -7089,5 +7089,143 @@ class C
         }
 
         #endregion
+
+        #region C# 7
+
+        [Fact]
+        public void DeconstructionStatement()
+        {
+            string src1 = @"
+var (x1, x2) = (1, 2);
+";
+
+            string src2 = @"
+var (x3, x4) = (1, 2);
+var (x1, x2) = (30, 40);
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "var (x1, x2) = (1, 2);", "var (x1, x2) = (30, 40);" },
+                { "var (x1, x2) = (1, 2)", "var (x1, x2) = (30, 40)" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void ForEachComponentStatement()
+        {
+            string src1 = @"
+foreach(var (x1, x2) in new[] { (1, 2) }) { Console.Write(1); }
+";
+
+            string src2 = @"
+foreach(var (x3, x4) in new[] { (1, 2) }) { Console.Write(1); }
+foreach(var (x1, x2) in new[] { (30, 40) }) { Console.Write(50); }
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "foreach(var (x1, x2) in new[] { (1, 2) }) { Console.Write(1); }", "foreach(var (x1, x2) in new[] { (30, 40) }) { Console.Write(50); }" },
+                { "{ Console.Write(1); }", "{ Console.Write(50); }" },
+                { "Console.Write(1);", "Console.Write(1);" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void ForWithDeconstruction()
+        {
+            string src1 = @"
+for (var (x1, x2) = (1, 2); ; ) { Console.Write(1); }
+";
+
+            string src2 = @"
+for (var (x3, x4) = (1, 2); ; ) { Console.Write(1); }
+for (var (x1, x2) = (30, 40); ; ) { Console.Write(50); }
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "for (var (x1, x2) = (1, 2); ; ) { Console.Write(1); }", "for (var (x1, x2) = (30, 40); ; ) { Console.Write(50); }" },
+                { "var (x1, x2) = (1, 2)", "var (x1, x2) = (30, 40)" },
+                { "{ Console.Write(1); }", "{ Console.Write(50); }" },
+                { "Console.Write(1);", "Console.Write(1);" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        public void For()
+        {
+            string src1 = @"
+for (var x1 = 1; ; ) { Console.Write(1); }
+";
+
+            string src2 = @"
+for (var x3 = 1; ; ) { Console.Write(1); }
+for (var x1 = 30; ; ) { Console.Write(50); }
+";
+
+            // variable names weight more in matching
+            var expected = new MatchingPairs
+            {
+                { "for (var x1 = 1; ; ) { Console.Write(1); }", "for (var x1 = 30; ; ) { Console.Write(50); }" },
+                { "var x1 = 1", "var x1 = 30" },
+                { "x1 = 1", "x1 = 30" },
+                { "{ Console.Write(1); }", "{ Console.Write(50); }" },
+                { "Console.Write(1);", "Console.Write(1);" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        [Fact]
+        [WorkItem(13904, "https://github.com/dotnet/roslyn/issues/13904")]
+        public void Assignment()
+        {
+            string src1 = @"
+var x1 = 1;
+";
+
+            string src2 = @"
+var x3 = 1;
+var x1 = 100;
+";
+
+            // This matching seems wrong, as it doesn't give more weight to names of locals
+            // https://github.com/dotnet/roslyn/issues/13904
+            var expected = new MatchingPairs
+            {
+                { "var x1 = 1;", "var x3 = 1;" },
+                { "var x1 = 1", "var x3 = 1" },
+                { "x1 = 1", "x3 = 1" }
+            };
+
+            var match = GetMethodMatch(src1, src2);
+            var actual = ToMatchingPairs(match);
+
+            expected.AssertEqual(actual);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
As one of the steps in the computation of an edit script (list of steps to transform a tree into a new one), EnC computes pairs of nodes that best match. This rests on a distance computation. In the default case, that is a syntactic distance, but additional weight is given to the names of declared locals.

Strangely, this logic is missing for plain local declaration statements, but it exists for other statements (for, foreach, using, ...). Filed issue https://github.com/dotnet/roslyn/issues/13904 to track that.

@tmat @dotnet/roslyn-compiler for review.

Relates to https://github.com/dotnet/roslyn/issues/12379 (umbrella issue for EnC with C# 7)
