### PR TITLE
make VS not crash when service hub failed to launch

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -113,7 +113,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                     try
                     {
                         instanceTask.Wait(_shutdownCancellationTokenSource.Token);
-                        instanceTask.Result.Shutdown();
+
+                        // result can be null if service hub failed to launch
+                        instanceTask.Result?.Shutdown();
                     }
                     catch (OperationCanceledException)
                     {
@@ -151,6 +153,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                 // if we reached here, IRemoteHostClientFactory must exist.
                 // this will make VS.Next dll to be loaded
                 var instance = await _workspace.Services.GetRequiredService<IRemoteHostClientFactory>().CreateAsync(_workspace, cancellationToken).ConfigureAwait(false);
+                if (instance == null)
+                {
+                    return null;
+                }
+
                 instance.ConnectionChanged += OnConnectionChanged;
 
                 return instance;

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         public const string OptionName = "FeatureManager/Features";
 
         [ExportOption]
-        public static readonly Option<bool> RemoteHost = new Option<bool>(OptionName, nameof(RemoteHost), defaultValue: false);
+        public static readonly Option<bool> RemoteHost = new Option<bool>(OptionName, nameof(RemoteHost), defaultValue: true);
 
         [ExportOption]
         public static readonly Option<int> SolutionChecksumMonitorBackOffTimeSpanInMS = new Option<int>(OptionName, nameof(SolutionChecksumMonitorBackOffTimeSpanInMS), defaultValue: 10000);

--- a/src/VisualStudio/Core/Next/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/Core/Next/Remote/RemoteHostClientFactory.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host.Mef;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Remote
 {
@@ -13,8 +14,18 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     {
         public Task<RemoteHostClient> CreateAsync(Workspace workspace, CancellationToken cancellationToken)
         {
-            // this is the point where we can create different kind of remote host client in future (cloud or etc)
-            return ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken);
+            try
+            {
+                // this is the point where we can create different kind of remote host client in future (cloud or etc)
+                return ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken);
+            }
+            catch
+            {
+                // currently there is so many moving parts that cause, in some branch/drop,
+                // service hub not to work. in such places (ex, Jenkins), rather than crashing VS
+                // right away, let VS run without service hub enabled.
+                return SpecializedTasks.Default<RemoteHostClient>();
+            }
         }
     }
 }

--- a/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
+++ b/src/VisualStudio/RemoteHostClientMock/Remote/RemoteHostClientFactory.cs
@@ -15,13 +15,20 @@ namespace Roslyn.VisualStudio.DiagnosticsWindow.Remote
     {
         public Task<RemoteHostClient> CreateAsync(Workspace workspace, CancellationToken cancellationToken)
         {
-            // this is the point where we can create different kind of remote host client in future (cloud or etc)
-            if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
+            try
             {
-                return InProcRemoteHostClient.CreateAsync(workspace, cancellationToken);
-            }
+                // this is the point where we can create different kind of remote host client in future (cloud or etc)
+                if (workspace.Options.GetOption(RemoteHostClientFactoryOptions.RemoteHost_InProc))
+                {
+                    return InProcRemoteHostClient.CreateAsync(workspace, cancellationToken);
+                }
 
-            return ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken);
+                return ServiceHubRemoteHostClient.CreateAsync(workspace, cancellationToken);
+            }
+            catch
+            {
+                return Task.FromResult<RemoteHostClient>(null);
+            }
         }
     }
 }


### PR DESCRIPTION
this done so that roslyn with remote host on by default can run in any branch. otherwise, we either can't turn on remote host by default or it only works on certain branch.