### PR TITLE
Catch exceptions when writing XML doc files in VB

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/DocumentationCommentCompiler.cs
@@ -88,9 +88,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     leaveOpen: true); // Don't close caller's stream.
             }
 
-            using (writer)
+            try
             {
-                try
+                using (writer)
                 {
                     var compiler = new DocumentationCommentCompiler(assemblyName ?? compilation.SourceAssembly.Name, compilation, writer, filterTree, filterSpanWithinTree,
                         processIncludes: true, isForSingleSymbol: false, diagnostics: diagnostics, cancellationToken: cancellationToken);
@@ -98,10 +98,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                     Debug.Assert(compiler._indentDepth == 0);
                     writer?.Flush();
                 }
-                catch (Exception e)
-                {
-                    diagnostics.Add(ErrorCode.ERR_DocFileGen, Location.None, e.Message);
-                }
+            }
+            catch (Exception e)
+            {
+                diagnostics.Add(ErrorCode.ERR_DocFileGen, Location.None, e.Message);
             }
 
             if (filterTree != null)

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1688,7 +1688,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_OptionMustBeAbsolutePath = 37257
         ERR_DocFileGen = 37258
 
-        ' available 37258
         ERR_TupleTooFewElements = 37259
         ERR_TupleReservedMemberNameAnyPosition = 37260
         ERR_TupleReservedMemberName = 37261

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1686,6 +1686,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_PeWritingFailure = 37256
 
         ERR_OptionMustBeAbsolutePath = 37257
+        ERR_DocFileGen = 37258
 
         ' available 37258
         ERR_TupleTooFewElements = 37259

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -2946,6 +2946,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Error writing to XML documentation file: {0}.
+        '''</summary>
+        Friend ReadOnly Property ERR_DocFileGen() As String
+            Get
+                Return ResourceManager.GetString("ERR_DocFileGen", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to &apos;{0}&apos; does not implement &apos;{1}&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_DoesntImplementAwaitInterface2() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5400,4 +5400,7 @@
   <data name="ERR_InvalidInstrumentationKind" xml:space="preserve">
     <value>Invalid instrumentation kind: {0}</value>
   </data>
+  <data name="ERR_DocFileGen" xml:space="preserve">
+    <value>Error writing to XML documentation file: {0}</value>
+  </data>
 </root>


### PR DESCRIPTION
This is the same fix as was implemented for C# in #13806, but for VB.

/cc @AlekseyTs @dotnet/roslyn-compiler 