### PR TITLE
Adjust heuristic to choose a set of best candidates for overload resolution failure.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Invocation.vb
@@ -1638,8 +1638,8 @@ ProduceBoundNode:
         ''' <summary>
         '''Figure out the set of best candidates in the following preference order:
         '''  1) Applicable
-        '''  2) TypeInferenceFailed
-        '''  3) ArgumentMismatch, GenericConstraintsViolated
+        '''  2) ArgumentMismatch, GenericConstraintsViolated
+        '''  3) TypeInferenceFailed
         '''  4) ArgumentCountMismatch
         '''  5) BadGenericArity
         '''  6) Ambiguous
@@ -1669,9 +1669,9 @@ ProduceBoundNode:
             Dim preference(OverloadResolution.CandidateAnalysisResultState.Count - 1) As Integer
 
             preference(Applicable) = 1
-            preference(TypeInferenceFailed) = 2
-            preference(ArgumentMismatch) = 3
-            preference(GenericConstraintsViolated) = 3
+            preference(ArgumentMismatch) = 2
+            preference(GenericConstraintsViolated) = 2
+            preference(TypeInferenceFailed) = 3
             preference(ArgumentCountMismatch) = 4
             preference(BadGenericArity) = 5
             preference(Ambiguous) = 6

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/ArrayLiteralTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/ArrayLiteralTests.vb
@@ -1513,10 +1513,20 @@ End Module
     ]]></file>
 </compilation>)
 
-            compilation.VerifyDiagnostics(Diagnostic(ERRID.ERR_TypeInferenceFailureAmbiguous2, "fooModules").WithArguments("Public Sub fooModules(Of T)(ParamArray z As T())"))
+            Dim expected =
+<expected>
+BC30311: Value of type 'String()' cannot be converted to 'String'.
+        fooModules({"1"}, {1})
+                   ~~~~~
+BC30311: Value of type 'Integer()' cannot be converted to 'String'.
+        fooModules({"1"}, {1})
+                          ~~~
+</expected>
+
+            AssertTheseDiagnostics(compilation, expected)
 
             compilation = compilation.WithOptions(_strictOn)
-            compilation.VerifyDiagnostics(Diagnostic(ERRID.ERR_TypeInferenceFailureAmbiguous2, "fooModules").WithArguments("Public Sub fooModules(Of T)(ParamArray z As T())"))
+            AssertTheseDiagnostics(compilation, expected)
         End Sub
 
         <WorkItem(544352, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/544352")>

--- a/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Semantics/OverloadResolution.vb
@@ -5619,16 +5619,6 @@ BC30456: 'GetWordsAsync' is not a member of 'Line'.
 BC30451: 'WordsKey' is not declared. It may be inaccessible due to its protection level.
                         If imax <= WordsKey Then Return
                                    ~~~~~~~~
-BC30518: Overload resolution failed because no accessible 'WhenAll' can be called with these arguments:
-    'Public Shared Overloads Function WhenAll(Of TResult)(tasks As IEnumerable(Of Task(Of TResult))) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-    'Public Shared Overloads Function WhenAll(Of TResult)(ParamArray tasks As Task(Of TResult)()) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-                        Await Task.WhenAll(WordTasks.ToArray())
-                                   ~~~~~~~
-BC30518: Overload resolution failed because no accessible 'WhenAll' can be called with these arguments:
-    'Public Shared Overloads Function WhenAll(Of TResult)(tasks As IEnumerable(Of Task(Of TResult))) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-    'Public Shared Overloads Function WhenAll(Of TResult)(ParamArray tasks As Task(Of TResult)()) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-                Await Task.WhenAll(SentenceTasks.ToArray())
-                           ~~~~~~~
 ]]></expected>)
         End Sub
 
@@ -5742,22 +5732,47 @@ BC30456: 'GetDeliveryWindowVendor9Async' is not a member of 'DeliveryWindowDepar
 BC30451: 'Vendor9Key' is not declared. It may be inaccessible due to its protection level.
                                                                                           If MaxDepth <= Vendor9Key Then
                                                                                                          ~~~~~~~~~~
-BC30518: Overload resolution failed because no accessible 'WhenAll' can be called with these arguments:
-    'Public Shared Overloads Function WhenAll(Of TResult)(tasks As IEnumerable(Of Task(Of TResult))) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-    'Public Shared Overloads Function WhenAll(Of TResult)(ParamArray tasks As Task(Of TResult)()) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-                                                                                          Await Task.WhenAll(Vendor9Tasks.ToArray())
-                                                                                                     ~~~~~~~
-BC30518: Overload resolution failed because no accessible 'WhenAll' can be called with these arguments:
-    'Public Shared Overloads Function WhenAll(Of TResult)(tasks As IEnumerable(Of Task(Of TResult))) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-    'Public Shared Overloads Function WhenAll(Of TResult)(ParamArray tasks As Task(Of TResult)()) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-                                             Await Task.WhenAll(DepartmentTasks.ToArray())
-                                                        ~~~~~~~
-BC30518: Overload resolution failed because no accessible 'WhenAll' can be called with these arguments:
-    'Public Shared Overloads Function WhenAll(Of TResult)(tasks As IEnumerable(Of Task(Of TResult))) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-    'Public Shared Overloads Function WhenAll(Of TResult)(ParamArray tasks As Task(Of TResult)()) As Task(Of TResult())': Type parameter 'TResult' cannot be inferred.
-        Await Task.WhenAll(VendorTasks.ToArray())
-                   ~~~~~~~
 ]]></expected>)
+        End Sub
+
+        <WorkItem(9341, "https://github.com/dotnet/roslyn/issues/9341")>
+        <Fact()>
+        Public Sub FailureDueToAnErrorInALambda_04()
+
+            Dim compilationDef =
+<compilation>
+    <file name="a.vb">
+Imports System
+
+Module Test
+    Sub Main()
+        Invoke(
+            Sub()
+                M1("error here")
+            End Sub)
+    End Sub
+
+    Sub M1()
+    End Sub
+
+    Public Sub Invoke(callback As Action)
+    End Sub
+
+    Function Invoke(Of TResult)(callback As Func(Of TResult)) As TResult
+        Return Nothing
+    End Function
+End Module
+    </file>
+</compilation>
+
+            Dim compilation = CompilationUtils.CreateCompilationWithMscorlibAndVBRuntime(compilationDef)
+
+            CompilationUtils.AssertTheseDiagnostics(compilation,
+<expected>
+BC30057: Too many arguments to 'Public Sub M1()'.
+                M1("error here")
+                   ~~~~~~~~~~~~
+</expected>)
         End Sub
 
     End Class

--- a/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateMethodCrossLanguageTests.vb
+++ b/src/EditorFeatures/Test2/Diagnostics/GenerateFromUsage/GenerateMethodCrossLanguageTests.vb
@@ -479,7 +479,7 @@ end class
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -493,7 +493,7 @@ using System.Threading.Tasks;
  
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : T
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : T
     {
     }
 }
@@ -511,7 +511,7 @@ public struct MyStruct<T>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of String)
@@ -534,7 +534,7 @@ End Module]]>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -548,7 +548,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : AAA, BBB
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : AAA, BBB
     {
     }
 }
@@ -581,7 +581,7 @@ public class CCC : AAA, BBB
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of CCC)
@@ -604,7 +604,7 @@ End Module]]>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -618,7 +618,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : AAA, BBB
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : AAA, BBB
     {
     }
 }
@@ -651,7 +651,7 @@ public class CCC : AAA, BBB
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of CCC)
@@ -674,7 +674,7 @@ End Module]]>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -688,7 +688,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
     {
     }
 }
@@ -731,7 +731,7 @@ public class derived2 : interface3
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of Object)
@@ -842,7 +842,7 @@ End Module]]>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -856,7 +856,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
     {
     }
 }
@@ -904,7 +904,7 @@ public class derived3 : derived1, interface3
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of derived3)
@@ -927,7 +927,7 @@ End Module]]>
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module
                 </Document>
@@ -941,7 +941,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : interface1, interface2, interface3
     {
     }
 }
@@ -996,7 +996,7 @@ public class outer
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of outer.inner.derived3)
@@ -1018,7 +1018,7 @@ End Module]]>
                 <Document>Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange($$foo())
+        list.AddRange1($$foo())
     End Sub
 End Module</Document>
             </Project>
@@ -1031,7 +1031,7 @@ using System.Threading.Tasks;
 
 public static class extensions
 {
-    public static void AddRange<T, U>(this List<T> list, MyStruct<U> items) where U : Base1<AAA>, inter1
+    public static void AddRange1<T, U>(this List<T> list, MyStruct<U> items) where U : Base1<AAA>, inter1
     {
     }
 }
@@ -1069,7 +1069,7 @@ public class FinalType<T> : Base1<T>, inter1 where T : AAA
 Module Program
     Sub Main(args As String())
         Dim list = New List(Of String)
-        list.AddRange(foo())
+        list.AddRange1(foo())
     End Sub
 
     Private Function foo() As MyStruct(Of FinalType(Of AAA))


### PR DESCRIPTION
Fixes #9341.

@dotnet/roslyn-compiler Please review.