### PR TITLE
Make RegisterSymbolAction work on Parameters

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -1657,15 +1657,13 @@ public partial class C33 { }
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InConstructor()
+        public void TestParametersAnalyzer_InConstructor()
         {
             string source = @"
 public class C
 {
     public C(int a, int b)
     {
-        int c = 0, d = 0;
-        System.Console.WriteLine(c + d);
     }
 }
 ";
@@ -1673,24 +1671,20 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "a").WithLocation(4, 18),
-                    Diagnostic("Parameter_ID", "b").WithLocation(4, 25),
-                    Diagnostic("Local_ID", "c").WithLocation(6, 13),
-                    Diagnostic("Local_ID", "d").WithLocation(6, 20));
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 25));
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InRegularMethod()
+        public void TestParametersAnalyzer_InRegularMethod()
         {
             string source = @"
 public class C
 {
     void M1(string a, string b)
     {
-        C c = null;
-        System.Console.WriteLine(c);
     }
 }
 ";
@@ -1698,15 +1692,36 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "a").WithLocation(4, 20),
-                    Diagnostic("Parameter_ID", "b").WithLocation(4, 30),
-                    Diagnostic("Local_ID", "c").WithLocation(6, 11));
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 30));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestParametersAnalyzer_InIndexers()
+        {
+            string source = @"
+public class C
+{
+    public int this[int index]
+    {
+        get { return 0; }
+        set { }
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "index").WithLocation(4, 25));
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_Lambdas()
+        public void TestParametersAnalyzer_Lambdas()
         {
             string source = @"
 public class C
@@ -1721,7 +1736,7 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Local_ID", "x").WithLocation(6, 36),
                     Diagnostic("Parameter_ID", "a").WithLocation(6, 45),
@@ -1729,7 +1744,7 @@ public class C
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InAnonymousMethods()
+        public void TestParametersAnalyzer_InAnonymousMethods()
         {
             string source = @"
 public class C
@@ -1746,7 +1761,7 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                         Diagnostic("Parameter_ID", "a").WithLocation(9, 37),
                         Diagnostic("Parameter_ID", "x").WithLocation(6, 26),
@@ -1754,29 +1769,7 @@ public class C
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InIndexers()
-        {
-            string source = @"
-public class C
-{
-    public int this[int index]
-    {
-        get { return 0; }
-        set { }
-    }
-}
-";
-            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
-            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
-            compilation.VerifyDiagnostics();
-
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
-            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
-                    Diagnostic("Parameter_ID", "index").WithLocation(4, 25));
-        }
-
-        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InDelegateTypes()
+        public void TestParametersAnalyzer_InDelegateTypes()
         {
             string source = @"
 public class C
@@ -1788,14 +1781,14 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "x").WithLocation(4, 25),
                     Diagnostic("Parameter_ID", "y").WithLocation(4, 35));
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InOperators()
+        public void TestParametersAnalyzer_InOperators()
         {
             string source = @"
 public class C
@@ -1807,13 +1800,13 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "c").WithLocation(4, 44));
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InExplicitInterfaceImplementations()
+        public void TestParametersAnalyzer_InExplicitInterfaceImplementations()
         {
             string source = @"
 interface I
@@ -1830,7 +1823,7 @@ public class C : I
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "c").WithLocation(9, 18),
                     Diagnostic("Parameter_ID", "d").WithLocation(9, 25),
@@ -1839,7 +1832,7 @@ public class C : I
         }
 
         [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InExtensionMethods()
+        public void TestParametersAnalyzer_InExtensionMethods()
         {
             string source = @"
 public static class C
@@ -1851,14 +1844,14 @@ public static class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "x").WithLocation(4, 28),
                     Diagnostic("Parameter_ID", "y").WithLocation(4, 35));
         }
 
         [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
-        public void TestLocalsAndParametersAnalyzer_InLocalFunctions()
+        public void TestParametersAnalyzer_InLocalFunctions()
         {
             string source = @"
 public class C
@@ -1877,7 +1870,7 @@ public class C
             var compilation = CreateCompilationWithMscorlib45(new[] { tree });
             compilation.VerifyDiagnostics();
 
-            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForParameters() };
             compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
                     Diagnostic("Parameter_ID", "a").WithLocation(4, 18), // ctor
                     Diagnostic("Parameter_ID", "b").WithLocation(4, 25),

--- a/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.cs
@@ -1655,5 +1655,240 @@ public partial class C33 { }
                 Diagnostic("UniqueTextFileDiagnostic").WithArguments("Source3_File5.designer.cs").WithLocation(1, 1),
                 Diagnostic("NumberOfUniqueTextFileDescriptor").WithArguments("3").WithLocation(1, 1));
         }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InConstructor()
+        {
+            string source = @"
+public class C
+{
+    public C(int a, int b)
+    {
+        int c = 0, d = 0;
+        System.Console.WriteLine(c + d);
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "a").WithLocation(4, 18),
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 25),
+                    Diagnostic("Local_ID", "c").WithLocation(6, 13),
+                    Diagnostic("Local_ID", "d").WithLocation(6, 20));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InRegularMethod()
+        {
+            string source = @"
+public class C
+{
+    void M1(string a, string b)
+    {
+        C c = null;
+        System.Console.WriteLine(c);
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "a").WithLocation(4, 20),
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 30),
+                    Diagnostic("Local_ID", "c").WithLocation(6, 11));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_Lambdas()
+        {
+            string source = @"
+public class C
+{
+    void M2()
+    {
+        System.Func<int, int, int> x = (int a, int b) => b;
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Local_ID", "x").WithLocation(6, 36),
+                    Diagnostic("Parameter_ID", "a").WithLocation(6, 45),
+                    Diagnostic("Parameter_ID", "b").WithLocation(6, 52));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InAnonymousMethods()
+        {
+            string source = @"
+public class C
+{
+    void M3()
+    {
+        M4(delegate (int x, int y) { });
+    }
+
+    void M4(System.Action<int, int> a) { }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                        Diagnostic("Parameter_ID", "a").WithLocation(9, 37),
+                        Diagnostic("Parameter_ID", "x").WithLocation(6, 26),
+                        Diagnostic("Parameter_ID", "y").WithLocation(6, 33));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InIndexers()
+        {
+            string source = @"
+public class C
+{
+    public int this[int index]
+    {
+        get { return 0; }
+        set { }
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "index").WithLocation(4, 25));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InDelegateTypes()
+        {
+            string source = @"
+public class C
+{
+    delegate void D(int x, string y);
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "x").WithLocation(4, 25),
+                    Diagnostic("Parameter_ID", "y").WithLocation(4, 35));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InOperators()
+        {
+            string source = @"
+public class C
+{
+    public static implicit operator int (C c) { return 0; }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "c").WithLocation(4, 44));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InExplicitInterfaceImplementations()
+        {
+            string source = @"
+interface I
+{
+    void M(int a, int b);
+}
+
+public class C : I
+{
+    void I.M(int c, int d) { }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "c").WithLocation(9, 18),
+                    Diagnostic("Parameter_ID", "d").WithLocation(9, 25),
+                    Diagnostic("Parameter_ID", "a").WithLocation(4, 16),
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 23));
+        }
+
+        [Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InExtensionMethods()
+        {
+            string source = @"
+public static class C
+{
+    static void M(this int x, int y) { }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "x").WithLocation(4, 28),
+                    Diagnostic("Parameter_ID", "y").WithLocation(4, 35));
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14061"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")]
+        public void TestLocalsAndParametersAnalyzer_InLocalFunctions()
+        {
+            string source = @"
+public class C
+{
+    void M1() 
+    { 
+        M2(1, 2);
+
+        void M2(int a, int b)
+        {
+        }
+    }
+}
+";
+            var tree = CSharpSyntaxTree.ParseText(source, path: "Source.cs");
+            var compilation = CreateCompilationWithMscorlib45(new[] { tree });
+            compilation.VerifyDiagnostics();
+
+            var analyzers = new DiagnosticAnalyzer[] { new AnalyzerForLocalsAndParameters() };
+            compilation.VerifyAnalyzerDiagnostics(analyzers, null, null, true,
+                    Diagnostic("Parameter_ID", "a").WithLocation(4, 18), // ctor
+                    Diagnostic("Parameter_ID", "b").WithLocation(4, 25),
+                    Diagnostic("Local_ID", "c").WithLocation(6, 13),
+                    Diagnostic("Local_ID", "d").WithLocation(6, 20),
+                    Diagnostic("Parameter_ID", "a").WithLocation(10, 20), // M1
+                    Diagnostic("Parameter_ID", "b").WithLocation(10, 30),
+                    Diagnostic("Local_ID", "c").WithLocation(12, 11),
+                    Diagnostic("Local_ID", "x").WithLocation(18, 36), // M2
+                    Diagnostic("Parameter_ID", "a").WithLocation(26, 37), // M4
+                    Diagnostic("Parameter_ID", "index").WithLocation(28, 25)); // indexer
+        }
     }
 }

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -1200,8 +1200,6 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
 
-        internal Func<Diagnostic, bool> IsSupportedDiagnostic => _isSupportedDiagnostic;
-
         public OperationAnalysisContext(IOperation operation, ISymbol containingSymbol, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
         {
             _operation = operation;

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticAnalysisContext.cs
@@ -701,6 +701,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// </summary>
         public CancellationToken CancellationToken { get { return _cancellationToken; } }
 
+        internal Func<Diagnostic, bool> IsSupportedDiagnostic => _isSupportedDiagnostic;
+
         public SymbolAnalysisContext(ISymbol symbol, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
         {
             _symbol = symbol;
@@ -1197,6 +1199,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
         /// Token to check for requested cancellation of the analysis.
         /// </summary>
         public CancellationToken CancellationToken => _cancellationToken;
+
+        internal Func<Diagnostic, bool> IsSupportedDiagnostic => _isSupportedDiagnostic;
 
         public OperationAnalysisContext(IOperation operation, ISymbol containingSymbol, Compilation compilation, AnalyzerOptions options, Action<Diagnostic> reportDiagnostic, Func<Diagnostic, bool> isSupportedDiagnostic, CancellationToken cancellationToken)
         {

--- a/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
+++ b/src/Compilers/Core/Portable/DiagnosticAnalyzer/DiagnosticStartAnalysisScope.cs
@@ -609,27 +609,10 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             this.GetOrCreateAnalyzerActions(analyzer).AddSymbolAction(analyzerAction);
             _symbolActions = _symbolActions.Add(analyzerAction);
 
-            // The SymbolAnalyzerAction does not handle SymbolKind.Local or SymbolKind.Parameter
-            // because the compiler does not make CompilationEvents for them. As a workaround,
-            // handle them specially by registering further OperationActions (for 
-            // VariableDeclarations) or SymbolActions (for Methods) and utilize the results of
-            // those to construct the necessary SymbolAnalysisContexts.
-
-            if (symbolKinds.Contains(SymbolKind.Local))
-            {
-                RegisterOperationAction(analyzer, opContext =>
-                {
-                    var varDecl = (IVariableDeclaration)opContext.Operation;
-                    action(new SymbolAnalysisContext(
-                        varDecl.Variable,
-                        opContext.Compilation,
-                        opContext.Options,
-                        opContext.ReportDiagnostic,
-                        opContext.IsSupportedDiagnostic,
-                        opContext.CancellationToken));
-                },
-                ImmutableArray.Create(OperationKind.VariableDeclaration));
-            }
+            // The SymbolAnalyzerAction does not handle SymbolKind.Parameter because the compiler
+            // does not make CompilationEvents for them. As a workaround, handle them specially by
+            // registering further SymbolActions (for Methods) and utilize the results to construct
+            // the necessary SymbolAnalysisContexts.
 
             if (symbolKinds.Contains(SymbolKind.Parameter))
             {

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -982,7 +982,7 @@ End Class
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InRegularMethods()
+        Public Sub TestParametersAnalyzer_InRegularMethods()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -996,13 +996,13 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                 Diagnostic("Parameter_ID", "a").WithLocation(2, 18),
                                                 Diagnostic("Parameter_ID", "b").WithLocation(2, 32))
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InConstructors()
+        Public Sub TestParametersAnalyzer_InConstructors()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1016,13 +1016,13 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                 Diagnostic("Parameter_ID", "a").WithLocation(2, 20),
                                                 Diagnostic("Parameter_ID", "b").WithLocation(2, 34))
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InIndexers()
+        Public Sub TestParametersAnalyzer_InIndexers()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1041,14 +1041,14 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                     Diagnostic("Parameter_ID", "a").WithLocation(2, 34),
                                                     Diagnostic("Parameter_ID", "b").WithLocation(2, 48),
                                                     Diagnostic("Parameter_ID", "Value").WithLocation(6, 19))
         End Sub
 
         <Fact(Skip:="https://github.com/dotnet/roslyn/issues/14062"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InDelegateTypes()
+        Public Sub TestParametersAnalyzer_InDelegateTypes()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1061,13 +1061,13 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                     Diagnostic("Parameter_ID", "a").WithLocation(2, 34),
                                                     Diagnostic("Parameter_ID", "b").WithLocation(2, 48))
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InOperators()
+        Public Sub TestParametersAnalyzer_InOperators()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1082,13 +1082,13 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                         Diagnostic("Parameter_ID", "h1").WithLocation(2, 36),
                                                         Diagnostic("Parameter_ID", "h2").WithLocation(2, 51))
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InInterfaceImplementations()
+        Public Sub TestParametersAnalyzer_InInterfaceImplementations()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1107,7 +1107,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                             Diagnostic("Parameter_ID", "a").WithLocation(2, 11),
                                                             Diagnostic("Parameter_ID", "b").WithLocation(2, 25),
                                                             Diagnostic("Parameter_ID", "a").WithLocation(7, 18),
@@ -1115,7 +1115,7 @@ End Class
         End Sub
 
         <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
-        Public Sub TestLocalsAndParametersAnalyzer_InParameterizedProperties()
+        Public Sub TestParametersAnalyzer_InParameterizedProperties()
             Dim source = <compilation>
                              <file name="c.vb">
                                  <![CDATA[
@@ -1132,7 +1132,7 @@ End Class
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
             comp.VerifyDiagnostics()
-            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForParameters}, Nothing, Nothing, False,
                                                                 Diagnostic("Parameter_ID", "a").WithLocation(2, 35),
                                                                 Diagnostic("Parameter_ID", "b").WithLocation(2, 49))
         End Sub

--- a/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Diagnostics/DiagnosticAnalyzerTests.vb
@@ -981,6 +981,162 @@ End Class
                                            Diagnostic(OwningSymbolTestAnalyzer.ExpressionDescriptor.Id, "12").WithLocation(12, 36))
         End Sub
 
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InRegularMethods()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Public Sub M(a As Integer, b As String)
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                Diagnostic("Parameter_ID", "a").WithLocation(2, 18),
+                                                Diagnostic("Parameter_ID", "b").WithLocation(2, 32))
+        End Sub
+
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InConstructors()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Public Sub New(a As Integer, b As String)
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                Diagnostic("Parameter_ID", "a").WithLocation(2, 20),
+                                                Diagnostic("Parameter_ID", "b").WithLocation(2, 34))
+        End Sub
+
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InIndexers()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Default Public Property Item(a As Integer, b As Integer) As Integer
+        Get
+            Return 0
+        End Get
+        Set(ByVal Value As Integer)
+        End Set
+    End Property
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                    Diagnostic("Parameter_ID", "a").WithLocation(2, 34),
+                                                    Diagnostic("Parameter_ID", "b").WithLocation(2, 48),
+                                                    Diagnostic("Parameter_ID", "Value").WithLocation(6, 19))
+        End Sub
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/14062"), WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InDelegateTypes()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Delegate Sub DelegateType(a As Integer, b As String)
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                    Diagnostic("Parameter_ID", "a").WithLocation(2, 34),
+                                                    Diagnostic("Parameter_ID", "b").WithLocation(2, 48))
+        End Sub
+
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InOperators()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Public Shared Operator +(ByVal h1 As C, ByVal h2 As C)
+        Return New C()
+    End Operator
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                        Diagnostic("Parameter_ID", "h1").WithLocation(2, 36),
+                                                        Diagnostic("Parameter_ID", "h2").WithLocation(2, 51))
+        End Sub
+
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InInterfaceImplementations()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Interface I
+    Sub M(a As Integer, b As String)
+End Interface
+
+Class C
+    Implements I
+    Public Sub M(a As Integer, b As String) Implements I.M
+    End Sub
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                            Diagnostic("Parameter_ID", "a").WithLocation(2, 11),
+                                                            Diagnostic("Parameter_ID", "b").WithLocation(2, 25),
+                                                            Diagnostic("Parameter_ID", "a").WithLocation(7, 18),
+                                                            Diagnostic("Parameter_ID", "b").WithLocation(7, 32))
+        End Sub
+
+        <Fact, WorkItem(8753, "https://github.com/dotnet/roslyn/issues/8753")>
+        Public Sub TestLocalsAndParametersAnalyzer_InParameterizedProperties()
+            Dim source = <compilation>
+                             <file name="c.vb">
+                                 <![CDATA[
+Class C
+    Public ReadOnly Property Test(a As Integer, b As String) As Integer
+        Get
+            Return 1
+        End Get
+    End Property
+End Class
+]]>
+                             </file>
+                         </compilation>
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(source)
+            comp.VerifyDiagnostics()
+            comp.VerifyAnalyzerDiagnostics({New AnalyzerForLocalsAndParameters}, Nothing, Nothing, False,
+                                                                Diagnostic("Parameter_ID", "a").WithLocation(2, 35),
+                                                                Diagnostic("Parameter_ID", "b").WithLocation(2, 49))
+        End Sub
+
         Private Shared Sub VerifyGeneratedCodeAnalyzerDiagnostics(compilation As Compilation, isGeneratedFileName As Func(Of String, Boolean), generatedCodeAnalysisFlagsOpt As GeneratedCodeAnalysisFlags?)
             Dim expected = GetExpectedGeneratedCodeAnalyzerDiagnostics(compilation, isGeneratedFileName, generatedCodeAnalysisFlagsOpt)
             VerifyGeneratedCodeAnalyzerDiagnostics(compilation, expected, generatedCodeAnalysisFlagsOpt)

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -1069,16 +1069,8 @@ namespace Microsoft.CodeAnalysis
         }
 
         [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
-        public class AnalyzerForLocalsAndParameters : DiagnosticAnalyzer
+        public class AnalyzerForParameters : DiagnosticAnalyzer
         {
-            public static readonly DiagnosticDescriptor LocalDescriptor = new DiagnosticDescriptor(
-                "Local_ID",
-                "Local_Title",
-                "Local_Message",
-                "Local_Category",
-                defaultSeverity: DiagnosticSeverity.Warning,
-                isEnabledByDefault: true);
-
             public static readonly DiagnosticDescriptor ParameterDescriptor = new DiagnosticDescriptor(
                 "Parameter_ID",
                 "Parameter_Title",
@@ -1087,20 +1079,16 @@ namespace Microsoft.CodeAnalysis
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true);
 
-            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(LocalDescriptor, ParameterDescriptor);
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(ParameterDescriptor);
 
             public override void Initialize(AnalysisContext context)
             {
-                context.RegisterSymbolAction(SymbolAction, SymbolKind.Parameter, SymbolKind.Local);
+                context.RegisterSymbolAction(SymbolAction, SymbolKind.Parameter);
             }
 
             private void SymbolAction(SymbolAnalysisContext context)
             {
-                var diagnostic = context.Symbol.Kind == SymbolKind.Parameter
-                    ? Diagnostic.Create(ParameterDescriptor, context.Symbol.Locations[0])
-                    : Diagnostic.Create(LocalDescriptor, context.Symbol.Locations[0]);
-
-                context.ReportDiagnostic(diagnostic);
+                context.ReportDiagnostic(Diagnostic.Create(ParameterDescriptor, context.Symbol.Locations[0]));
             }
         }
     }

--- a/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
+++ b/src/Test/Utilities/Desktop/CommonDiagnosticAnalyzers.cs
@@ -1067,5 +1067,41 @@ namespace Microsoft.CodeAnalysis
                 });
             }
         }
+
+        [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+        public class AnalyzerForLocalsAndParameters : DiagnosticAnalyzer
+        {
+            public static readonly DiagnosticDescriptor LocalDescriptor = new DiagnosticDescriptor(
+                "Local_ID",
+                "Local_Title",
+                "Local_Message",
+                "Local_Category",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public static readonly DiagnosticDescriptor ParameterDescriptor = new DiagnosticDescriptor(
+                "Parameter_ID",
+                "Parameter_Title",
+                "Parameter_Message",
+                "Parameter_Category",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+            public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(LocalDescriptor, ParameterDescriptor);
+
+            public override void Initialize(AnalysisContext context)
+            {
+                context.RegisterSymbolAction(SymbolAction, SymbolKind.Parameter, SymbolKind.Local);
+            }
+
+            private void SymbolAction(SymbolAnalysisContext context)
+            {
+                var diagnostic = context.Symbol.Kind == SymbolKind.Parameter
+                    ? Diagnostic.Create(ParameterDescriptor, context.Symbol.Locations[0])
+                    : Diagnostic.Create(LocalDescriptor, context.Symbol.Locations[0]);
+
+                context.ReportDiagnostic(diagnostic);
+            }
+        }
     }
 }

--- a/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
         {
             var expectedSymbolKinds = new[] 
             {
-                SymbolKind.Event, SymbolKind.Field, SymbolKind.Local, SymbolKind.Method, SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Parameter, SymbolKind.Property
+                SymbolKind.Event, SymbolKind.Field, SymbolKind.Method, SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Parameter, SymbolKind.Property
             };
 
             var actualSymbolKinds = _callLog.Where(a => FilterByAbstractName(a, "Symbol")).Where(e => e.SymbolKind.HasValue).Select(e => e.SymbolKind.Value).Distinct();

--- a/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
+++ b/src/Test/Utilities/Shared/Diagnostics/TrackingDiagnosticAnalyzer.cs
@@ -75,7 +75,11 @@ namespace Microsoft.CodeAnalysis.Test.Utilities
 
         public void VerifyAnalyzeSymbolCalledForAllSymbolKinds()
         {
-            var expectedSymbolKinds = new[] { SymbolKind.Event, SymbolKind.Field, SymbolKind.Method, SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Property };
+            var expectedSymbolKinds = new[] 
+            {
+                SymbolKind.Event, SymbolKind.Field, SymbolKind.Local, SymbolKind.Method, SymbolKind.NamedType, SymbolKind.Namespace, SymbolKind.Parameter, SymbolKind.Property
+            };
+
             var actualSymbolKinds = _callLog.Where(a => FilterByAbstractName(a, "Symbol")).Where(e => e.SymbolKind.HasValue).Select(e => e.SymbolKind.Value).Distinct();
             AssertSequenceEqual(expectedSymbolKinds, actualSymbolKinds);
         }


### PR DESCRIPTION
Fixes #8753

This is just a proposal to get feedback on the approach of registering more operation or symbol actions when a symbol action is registered with SymbolKind.Local or SymbolKind.Parameter. It also includes some hacks to SymbolAnalysisContext and OperationAnalysisContext to make _isSupportedDiagnostic accessible. 

Additionally, we'd need to add tests (somewhere?).