### PR TITLE
Fix option race causing crashes

### DIFF
--- a/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
+++ b/src/Workspaces/Core/Portable/Options/GlobalOptionService.cs
@@ -143,6 +143,17 @@ namespace Microsoft.CodeAnalysis.Options
         {
             lock (_gate)
             {
+                object oldValue;
+
+                if (_currentValues.TryGetValue(optionKey, out oldValue))
+                {
+                    if (object.Equals(oldValue, newValue))
+                    {
+                        // Value is still the same, no reason to raise events
+                        return;
+                    }
+                }
+
                 _currentValues = _currentValues.SetItem(optionKey, newValue);
             }
 


### PR DESCRIPTION
Fix race where we are raising option changed events after a user has unsubscribed. This bug existed for awhile, but was made worse when we started raising a bunch of events when events didn't actually change. This fixes both issues.

*Review:* @dotnet/roslyn-ide