### PR TITLE
Remove code that doesn’t have any observable side-effects.

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -1640,10 +1640,6 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 switch (local.DeclarationKind)
                 {
-                    case LocalDeclarationKind.RegularVariable:
-                        ReportIfUnused(local, assigned: true);
-                        break;
-
                     case LocalDeclarationKind.UsingVariable:
                         NoteRead(local); // At the end of the statement, there's an implied read when the local is disposed
                         break;
@@ -1672,17 +1668,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            var result = base.VisitFixedStatement(node);
-
-            foreach (LocalSymbol local in node.Locals)
-            {
-                if (local.DeclarationKind == LocalDeclarationKind.RegularVariable)
-                {
-                    ReportIfUnused(local, assigned: true);
-                }
-            }
-
-            return result;
+            return base.VisitFixedStatement(node);
         }
 
         public override BoundNode VisitSequence(BoundSequence node)


### PR DESCRIPTION
Fixes #13830.

@dotnet/roslyn-compiler Please review.