### PR TITLE
Properly handle null paths being passed to the RemotePersistenceService.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -5,14 +5,11 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
 using Microsoft.Internal.VisualStudio.Shell.Interop;
-using Microsoft.VisualStudio.ComponentModelHost;
-using Microsoft.VisualStudio.LanguageServices.Remote;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
 
@@ -217,15 +214,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         {
             this.AssertIsForeground();
 
-            lock (_gate)
+            if (_workspaceHosts.Any(hostState => hostState.Host == host))
             {
-                if (_workspaceHosts.Any(hostState => hostState.Host == host))
-                {
-                    throw new ArgumentException("The workspace host is already registered.", nameof(host));
-                }
-
-                _workspaceHosts.Add(new WorkspaceHostState(this, host));
+                throw new ArgumentException("The workspace host is already registered.", nameof(host));
             }
+
+            _workspaceHosts.Add(new WorkspaceHostState(this, host));
         }
 
         public void StartSendingEventsToWorkspaceHost(IVisualStudioWorkspaceHost host)

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker.cs
@@ -209,7 +209,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         public void RegisterWorkspaceHost(IVisualStudioWorkspaceHost host)
         {
-            AssertIsForeground();
+            ExecuteOrScheduleForegroundAffinitizedAction(
+                () => RegisterWorkspaceHostOnForeground(host));
+        }
+
+        private void RegisterWorkspaceHostOnForeground(IVisualStudioWorkspaceHost host)
+        {
+            this.AssertIsForeground();
 
             lock (_gate)
             {

--- a/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
+++ b/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
@@ -33,6 +33,11 @@ namespace Microsoft.CodeAnalysis.Remote.Storage
         {
             lock (_gate)
             {
+                // We can get null when the solution has no corresponding file location
+                // in the host process.  This is not abnormal and can come around for
+                // many reasons.  In that case, we simply do not store a storage location
+                // for this solution, indicating to all remote consumers that persistent
+                // storage is not available for this solution.
                 if (storageLocation == null)
                 {
                     _idToStorageLocation.Remove(id);

--- a/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
+++ b/src/Workspaces/Remote/Core/Storage/RemotePersistentStorageLocationService.cs
@@ -33,8 +33,15 @@ namespace Microsoft.CodeAnalysis.Remote.Storage
         {
             lock (_gate)
             {
-                // Store the esent database in a different location for the out of proc server.
-                _idToStorageLocation[id] = Path.Combine(storageLocation, "Server");
+                if (storageLocation == null)
+                {
+                    _idToStorageLocation.Remove(id);
+                }
+                else
+                {
+                    // Store the esent database in a different location for the out of proc server.
+                    _idToStorageLocation[id] = Path.Combine(storageLocation, "Server");
+                }
             }
         }
     }


### PR DESCRIPTION
It is totally expected that 'null' solution paths will exist in practice.  VS can create lightweight solutions that are never persisted to disk until the user decides to finally save them.  Or there may be Solution objects not backed by .sln files at all.

'null' is expected and flows through the VS side of the persistence layer just fine.  The mistake i made was to try to take the value and use it to produce a new path on the remote side without checking for null first.  We're now resilient to that and handle null properly.
