### PR TITLE
Handle unmapped subject buffer during backspace

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -210,7 +210,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 // matches the text typed so far.
 
                 // Ask the language to determine which of the *matched* items it wants to select.
+                // We have a Document so GetCompletionService should always succeed.
                 var service = this.Controller.GetCompletionService();
+                Contract.ThrowIfNull(service, nameof(service));
 
                 var matchingCompletionItems = filterResults.Where(r => r.MatchedFilterText)
                                                            .Select(t => t.PresentationItem.Item)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -210,9 +210,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 // matches the text typed so far.
 
                 // Ask the language to determine which of the *matched* items it wants to select.
-                // We have a Document so GetCompletionService should always succeed.
                 var service = this.Controller.GetCompletionService();
-                Contract.ThrowIfNull(service, nameof(service));
+                if (service == null)
+                {
+                    return null;
+                }
 
                 var matchingCompletionItems = filterResults.Where(r => r.MatchedFilterText)
                                                            .Select(t => t.PresentationItem.Item)

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.cs
@@ -151,6 +151,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             AssertIsForeground();
             Contract.ThrowIfTrue(sessionOpt != null);
 
+            if (completionService == null)
+            {
+                return false;
+            }
+
             if (this.TextView.Selection.Mode == TextSelectionMode.Box)
             {
                 // No completion with multiple selection

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -114,10 +114,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
         private bool CaretHasLeftDefaultTrackingSpan(int caretPoint, Document document)
         {
+            var completionService = GetCompletionService();
+            if (completionService == null)
+            {
+                // SubjectBuffer no longer even has a workspace mapping
+                return true;
+            }
+
             // We haven't finished computing the model, but we may need to dismiss.
             // Get the context span and see if we're outside it.
             var text = document.GetTextAsync(CancellationToken.None).WaitAndGetResult(CancellationToken.None);
-            var contextSpan = GetCompletionService().GetDefaultCompletionListSpan(text, caretPoint);
+            var contextSpan = completionService.GetDefaultCompletionListSpan(text, caretPoint);
             var newCaretPoint = GetCaretPointInViewBuffer();
             return !contextSpan.IntersectsWith(new TextSpan(newCaretPoint, 0));
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Backspace.cs
@@ -65,8 +65,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 var trigger = CompletionTrigger.CreateDeletionTrigger(deletedChar.GetValueOrDefault());
                 var completionService = this.GetCompletionService();
 
-                this.StartNewModelComputation(
-                    completionService, trigger, filterItems: false, dismissIfEmptyAllowed: true);
+                if (completionService != null)
+                {
+                    this.StartNewModelComputation(
+                        completionService, trigger, filterItems: false, dismissIfEmptyAllowed: true);
+                }
 
                 return;
             }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_Commit.cs
@@ -92,6 +92,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     var triggerSnapshot = model.TriggerSnapshot;
 
                     var completionService = CompletionService.GetService(triggerDocument);
+                    Contract.ThrowIfNull(completionService, nameof(completionService));
+
                     completionChange = completionService.GetChangeAsync(
                         triggerDocument, item.Item, commitChar, CancellationToken.None).WaitAndGetResult(CancellationToken.None);
                     var textChange = completionChange.TextChange;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TabKey.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Editor.Shared.Extensions;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 {
@@ -26,10 +27,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             if (sessionOpt == null)
             {
                 // The user may be trying to invoke snippets through question-tab
-                var completionService = GetCompletionService();
-
-                if (completionService != null &&
-                    TryInvokeSnippetCompletion(args, completionService))
+                if (TryInvokeSnippetCompletion(args))
                 {
                     // We've taken care of the tab. Don't send it to the buffer.
                     return;
@@ -57,7 +55,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
         }
 
-        private bool TryInvokeSnippetCompletion(TabKeyCommandArgs args, CompletionService completionService)
+        private bool TryInvokeSnippetCompletion(TabKeyCommandArgs args)
         {
             var subjectBuffer = args.SubjectBuffer;
             var caretPoint = args.TextView.GetCaretPoint(subjectBuffer).Value.Position;
@@ -99,7 +97,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return false;
             }
 
-            var rules = GetCompletionService().GetRules();
+            // There's was a buffer-Document mapping. We should be able
+            // to get a CompletionService.
+            var completionService = GetCompletionService();
+            Contract.ThrowIfNull(completionService, nameof(completionService));
+
+            var rules = completionService.GetRules();
             if (rules.SnippetsRule != SnippetsRule.IncludeAfterTypingIdentifierQuestionTab)
             {
                 return false;

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller_TypeChar.cs
@@ -317,6 +317,11 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
             }
 
             var completionService = GetCompletionService();
+            if (completionService == null)
+            {
+                return false;
+            }
+
             var textTypedSoFar = GetTextTypedSoFar(model, model.SelectedItem.Item);
             return IsCommitCharacter(
                 completionService.GetRules(), model.SelectedItem.Item, ch, textTypedSoFar);


### PR DESCRIPTION
In Razor/Venus the subject buffer may become unmapped. Update the
backspace handling in completion to deal with cases where the subject
buffer is unapped and no CompletionService is available.