### PR TITLE
Deconstruction-declaration in script

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -686,10 +686,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// In embedded statements, returns a BoundLocal when the type was explicit,
-        /// otherwise a DeconstructionLocalPendingInference.
-        /// In global statements, returns a BoundFieldAccess when the type was explicit,
-        /// otherwise a DeconstructionLocalPendingInference.
+        /// In embedded statements, returns a BoundLocal when the type was explicit.
+        /// In global statements, returns a BoundFieldAccess when the type was explicit.
+        /// Otherwise returns a DeconstructionLocalPendingInference when the type is implicit.
         /// </summary>
         private BoundExpression BindDeconstructionDeclarationVariable(
             TypeSyntax typeSyntax,

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -632,7 +632,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Each local or field is either a simple local or field access (when its type is known) or a deconstruction variable pending inference.
         /// The caller is responsible for releasing the nested ArrayBuilders.
         /// </summary>
-        private DeconstructionVariable BindDeconstructionDeclarationVariables(VariableComponentSyntax node, DiagnosticBag diagnostics)
+        private DeconstructionVariable BindDeconstructionDeclarationVariables(
+            VariableComponentSyntax node,
+            DiagnosticBag diagnostics)
         {
             switch (node.Kind())
             {
@@ -656,7 +658,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        private DeconstructionVariable BindDeconstructionDeclarationVariables(TypeSyntax type, VariableDesignationSyntax node, DiagnosticBag diagnostics)
+        private DeconstructionVariable BindDeconstructionDeclarationVariables(
+            TypeSyntax type,
+            VariableDesignationSyntax node,
+            DiagnosticBag diagnostics)
         {
             switch (node.Kind())
             {
@@ -681,12 +686,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// In embedded statements, returns a BoundLocal when the type was explicit, otherwise a DeconstructionLocalPendingInference.
-        /// In global statements, returns a BoundFieldAccess when the type was explicit, otherwise a DeconstructionLocalPendingInference.
+        /// In embedded statements, returns a BoundLocal when the type was explicit,
+        /// otherwise a DeconstructionLocalPendingInference.
+        /// In global statements, returns a BoundFieldAccess when the type was explicit,
+        /// otherwise a DeconstructionLocalPendingInference.
         /// </summary>
-        private BoundExpression BindDeconstructionDeclarationVariable(TypeSyntax typeSyntax, SingleVariableDesignationSyntax designation, DiagnosticBag diagnostics)
+        private BoundExpression BindDeconstructionDeclarationVariable(
+            TypeSyntax typeSyntax,
+            SingleVariableDesignationSyntax designation,
+            DiagnosticBag diagnostics)
         {
-            var localSymbol = LookupLocal(designation.Identifier);
+            SourceLocalSymbol localSymbol = LookupLocal(designation.Identifier);
 
             bool hasErrors = false;
             bool isVar;
@@ -700,7 +710,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     // An explicit type can only be provided next to the variable
                     Error(diagnostics, ErrorCode.ERR_DeconstructionVarFormDisallowsSpecificType, designation);
-                    hasErrors |= true;
+                    hasErrors = true;
                 }
             }
 
@@ -729,13 +739,19 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw ExceptionUtilities.Unreachable;
             }
 
-            BoundThisReference receiver = ThisReference(designation, this.ContainingType, hasErrors: false, wasCompilerGenerated: true);
+            BoundThisReference receiver = ThisReference(designation, this.ContainingType, hasErrors: false,
+                                            wasCompilerGenerated: true);
+
             if (!isVar)
             {
                 TypeSymbol fieldType = field.GetFieldType(this.FieldsBeingBound);
                 return new BoundFieldAccess(designation,
                                             receiver,
-                                            field, null, LookupResultKind.Viable, fieldType, hasErrors);
+                                            field,
+                                            constantValueOpt: null,
+                                            resultKind: LookupResultKind.Viable,
+                                            type: fieldType,
+                                            hasErrors: hasErrors);
             }
 
             return new DeconstructionVariablePendingInference(designation, field, receiver);

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Deconstruct.cs
@@ -688,7 +688,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// In embedded statements, returns a BoundLocal when the type was explicit.
         /// In global statements, returns a BoundFieldAccess when the type was explicit.
-        /// Otherwise returns a DeconstructionLocalPendingInference when the type is implicit.
+        /// Otherwise returns a DeconstructionVariablePendingInference when the type is implicit.
         /// </summary>
         private BoundExpression BindDeconstructionDeclarationVariable(
             TypeSyntax typeSyntax,

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -384,9 +384,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             throw ExceptionUtilities.Unreachable;
         }
+
         protected override Symbol MakeOutVariable(DeclarationExpressionSyntax node, BaseArgumentListSyntax argumentListSyntax, SyntaxNode nodeToBind)
         {
-            return SourceMemberFieldSymbolFromDesignation.Create(_containingType, node.VariableDesignation(), _modifiers, _containingFieldOpt, nodeToBind);
+            var single = node.VariableDesignation();
+
+            return SourceMemberFieldSymbolFromDesignation.Create(_containingType, single, ((TypedVariableComponentSyntax)single.Parent).Type,
+                _modifiers, _containingFieldOpt, nodeToBind);
         }
 
         #region pool

--- a/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExpressionVariableFinder.cs
@@ -387,9 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         protected override Symbol MakeOutVariable(DeclarationExpressionSyntax node, BaseArgumentListSyntax argumentListSyntax, SyntaxNode nodeToBind)
         {
-            var single = node.VariableDesignation();
-
-            return SourceMemberFieldSymbolFromDesignation.Create(_containingType, single, ((TypedVariableComponentSyntax)single.Parent).Type,
+            return SourceMemberFieldSymbolFromDesignation.Create(_containingType, node.VariableDesignation(), node.Type(),
                 _modifiers, _containingFieldOpt, nodeToBind);
         }
 

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundNodes.xml
@@ -1601,10 +1601,13 @@
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
   </Node>
 
-  <!-- The node is transformed into BoundLocal after inference -->
-  <Node Name="DeconstructionLocalPendingInference" Base="BoundExpression">
+  <!-- The node is transformed into BoundLocal or BoundFieldAccess after inference -->
+  <Node Name="DeconstructionVariablePendingInference" Base="BoundExpression">
     <!-- Type is not significant for this node type; always null -->
     <Field Name="Type" Type="TypeSymbol" Override="true" Null="always"/>
-    <Field Name="LocalSymbol" Type="SourceLocalSymbol"/>
+    <!-- A local symbol or a field symbol representing the variable -->
+    <Field Name="VariableSymbol" Type="Symbol"/>
+    <!-- A field receiver when VariableSymbol is a field -->
+    <Field Name="ReceiverOpt" Type="BoundExpression" Null="allow"/>
   </Node>
 </Tree>

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionLocalPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionLocalPendingInference.cs
@@ -6,7 +6,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    // TODO: rename file
+    // TODO: I will rename the file last thing, after code review
     internal partial class DeconstructionVariablePendingInference
     {
         public BoundExpression SetInferredType(TypeSymbol type, bool success)

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionLocalPendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionLocalPendingInference.cs
@@ -1,23 +1,38 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    internal partial class DeconstructionLocalPendingInference
+    // TODO: rename file
+    internal partial class DeconstructionVariablePendingInference
     {
-        public BoundLocal SetInferredType(TypeSymbol type, bool success)
+        public BoundExpression SetInferredType(TypeSymbol type, bool success)
         {
             Debug.Assert((object)type != null);
             Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation);
+            switch (this.VariableSymbol.Kind)
+            {
+                case SymbolKind.Local:
+                    var local = (SourceLocalSymbol)this.VariableSymbol;
+                    local.SetType(type);
+                    return new BoundLocal(this.Syntax, local, constantValueOpt: null, type: type, hasErrors: this.HasErrors || !success);
 
-            this.LocalSymbol.SetType(type);
-            return new BoundLocal(this.Syntax, this.LocalSymbol, constantValueOpt: null, type: type, hasErrors: this.HasErrors || !success);
+                case SymbolKind.Field:
+                    var field = (SourceMemberFieldSymbolFromDesignation)this.VariableSymbol;
+                    var inferenceDiagnostics = DiagnosticBag.GetInstance();
+                    field.SetType(type, inferenceDiagnostics);
+                    inferenceDiagnostics.Free();
+                    return new BoundFieldAccess(this.Syntax, this.ReceiverOpt, field, constantValueOpt: null);
+
+                default:
+                    throw ExceptionUtilities.Unreachable;
+            }
         }
 
-        public BoundLocal FailInference(Binder binder)
+        public BoundExpression FailInference(Binder binder)
         {
             return this.SetInferredType(binder.CreateErrorType("var"), success: false);
         }

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Diagnostics;
 using Roslyn.Utilities;
 
@@ -8,32 +9,56 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class DeconstructionVariablePendingInference
     {
-        public BoundExpression SetInferredType(TypeSymbol type, bool success)
+        public BoundExpression SetInferredType(TypeSymbol type, Binder binderOpt, DiagnosticBag diagnostics)
         {
-            Debug.Assert((object)type != null);
+            Debug.Assert(binderOpt != null || (object)type != null);
             Debug.Assert(this.Syntax.Kind() == SyntaxKind.SingleVariableDesignation);
+
+            bool inferenceFailed = ((object)type == null);
+
+            if (inferenceFailed)
+            {
+                type = binderOpt.CreateErrorType("var");
+            }
+
             switch (this.VariableSymbol.Kind)
             {
                 case SymbolKind.Local:
                     var local = (SourceLocalSymbol)this.VariableSymbol;
+                    if (inferenceFailed)
+                    {
+                        ReportInferenceFailure(diagnostics);
+                    }
                     local.SetType(type);
-                    return new BoundLocal(this.Syntax, local, constantValueOpt: null, type: type, hasErrors: this.HasErrors || !success);
+                    return new BoundLocal(this.Syntax, local, constantValueOpt: null, type: type, hasErrors: this.HasErrors || inferenceFailed);
 
                 case SymbolKind.Field:
                     var field = (SourceMemberFieldSymbolFromDesignation)this.VariableSymbol;
                     var inferenceDiagnostics = DiagnosticBag.GetInstance();
+                    if (inferenceFailed)
+                    {
+                        ReportInferenceFailure(inferenceDiagnostics);
+                    }
                     field.SetType(type, inferenceDiagnostics);
                     inferenceDiagnostics.Free();
-                    return new BoundFieldAccess(this.Syntax, this.ReceiverOpt, field, constantValueOpt: null);
+                    return new BoundFieldAccess(this.Syntax, this.ReceiverOpt, field, constantValueOpt: null, hasErrors: this.HasErrors || inferenceFailed);
 
                 default:
                     throw ExceptionUtilities.Unreachable;
             }
         }
 
-        public BoundExpression FailInference(Binder binder)
+        private void ReportInferenceFailure(DiagnosticBag diagnostics)
         {
-            return this.SetInferredType(binder.CreateErrorType("var"), success: false);
+            var designation = (SingleVariableDesignationSyntax)this.Syntax;
+            Binder.Error(
+                diagnostics, ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, designation.Identifier,
+                designation.Identifier.ValueText);
+        }
+
+        public BoundExpression FailInference(Binder binder, DiagnosticBag diagnosticsOpt)
+        {
+            return this.SetInferredType(null, binder, diagnosticsOpt);
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/DeconstructionVariablePendingInference.cs
@@ -6,7 +6,6 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
-    // TODO: I will rename the file last thing, after code review
     internal partial class DeconstructionVariablePendingInference
     {
         public BoundExpression SetInferredType(TypeSymbol type, bool success)

--- a/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Expression.cs
@@ -3000,7 +3000,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     /// This node represents a deconstruction local.
     /// It is only used temporarily during initial binding.
     /// </summary>
-    internal partial class DeconstructionLocalPendingInference
+    internal partial class DeconstructionVariablePendingInference
     {
         public override void Accept(OperationVisitor visitor)
         {

--- a/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Formatting.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
-    internal partial class DeconstructionLocalPendingInference
+    internal partial class DeconstructionVariablePendingInference
     {
         public override object Display
         {

--- a/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
+++ b/src/Compilers/CSharp/Portable/CSharpCodeAnalysis.csproj
@@ -199,7 +199,7 @@
     <Compile Include="BoundTree\Constructors.cs" />
     <Compile Include="BoundTree\DecisionTree.cs" />
     <Compile Include="BoundTree\Expression.cs" />
-    <Compile Include="BoundTree\DeconstructionLocalPendingInference.cs" />
+    <Compile Include="BoundTree\DeconstructionVariablePendingInference.cs" />
     <Compile Include="BoundTree\OutVariablePendingInference.cs" />
     <Compile Include="BoundTree\OutDeconstructVarPendingInference.cs" />
     <Compile Include="BoundTree\PseudoVariableExpressions.cs" />

--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -3104,15 +3104,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type information on the left-hand-side &apos;{0}&apos; and right-hand-side &apos;{1}&apos; of the deconstruction was insufficient to infer a merged type..
-        /// </summary>
-        internal static string ERR_DeconstructCouldNotInferMergedType {
-            get {
-                return ResourceManager.GetString("ERR_DeconstructCouldNotInferMergedType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Deconstruction &apos;var (...)&apos; form disallows a specific type for &apos;var&apos;..
         /// </summary>
         internal static string ERR_DeconstructionVarFormDisallowsSpecificType {
@@ -8878,6 +8869,15 @@ namespace Microsoft.CodeAnalysis.CSharp {
         internal static string ERR_TypeExpected {
             get {
                 return ResourceManager.GetString("ERR_TypeExpected", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot infer the type of implicitly-typed deconstruction variable &apos;{0}&apos;..
+        /// </summary>
+        internal static string ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable {
+            get {
+                return ResourceManager.GetString("ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable", resourceCulture);
             }
         }
         

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4908,6 +4908,9 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="ERR_TypeInferenceFailedForImplicitlyTypedOutVariable" xml:space="preserve">
     <value>Cannot infer the type of implicitly-typed out variable '{0}'.</value>
   </data>
+  <data name="ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable" xml:space="preserve">
+    <value>Cannot infer the type of implicitly-typed deconstruction variable '{0}'.</value>
+  </data>
   <data name="ERR_DeconstructWrongCardinality" xml:space="preserve">
     <value>Cannot deconstruct a tuple of '{0}' elements into '{1}' variables.</value>
   </data>
@@ -4934,9 +4937,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   </data>
   <data name="ERR_ExplicitTupleElementNames" xml:space="preserve">
     <value>Cannot reference 'System.Runtime.CompilerServices.TupleElementNamesAttribute' explicitly. Use the tuple syntax to define tuple names.</value>
-  </data>
-  <data name="ERR_DeconstructCouldNotInferMergedType" xml:space="preserve">
-    <value>The type information on the left-hand-side '{0}' and right-hand-side '{1}' of the deconstruction was insufficient to infer a merged type.</value>
   </data>
   <data name="ERR_ExpressionTreeContainsOutVariable" xml:space="preserve">
     <value>An expression tree may not contain an out argument variable declaration.</value>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1371,7 +1371,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         ERR_TupleDuplicateMemberName = 8127,
         ERR_PredefinedTypeMemberNotFoundInAssembly = 8128,
         ERR_MissingDeconstruct = 8129,
-        ERR_DeconstructCouldNotInferMergedType = 8130,
+        ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable = 8130,
         ERR_DeconstructRequiresExpression = 8131,
         ERR_DeconstructWrongCardinality = 8132,
         ERR_CannotDeconstructDynamic = 8133,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/PreciseAbstractFlowPass.cs
@@ -2654,7 +2654,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable;
         }
 
-        public sealed override BoundNode VisitDeconstructionLocalPendingInference(DeconstructionLocalPendingInference node)
+        public sealed override BoundNode VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
             throw ExceptionUtilities.Unreachable;
         }

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -287,7 +287,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundNode VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
-            // DeconstructionLocalPendingInference nodes are only used within initial binding, but don't survive past that stage
+            // DeconstructionVariablePendingInference nodes are only used within initial binding, but don't survive past that stage
             throw ExceptionUtilities.Unreachable;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter.cs
@@ -285,7 +285,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             throw ExceptionUtilities.Unreachable;
         }
 
-        public override BoundNode VisitDeconstructionLocalPendingInference(DeconstructionLocalPendingInference node)
+        public override BoundNode VisitDeconstructionVariablePendingInference(DeconstructionVariablePendingInference node)
         {
             // DeconstructionLocalPendingInference nodes are only used within initial binding, but don't survive past that stage
             throw ExceptionUtilities.Unreachable;

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2406,6 +2406,14 @@ tryAgain:
                     }
                 }
 
+                var deconstruction = ParseDeconstructionDeclarationAssignment();
+                if (deconstruction != null)
+                {
+                    var semicolon = this.EatToken(SyntaxKind.SemicolonToken);
+                    // TODO: is that the best way to handle mods?
+                    return _syntaxFactory.GlobalStatement(_syntaxFactory.DeconstructionDeclarationStatement(new SyntaxList<SyntaxToken>(), deconstruction, semicolon));
+                }
+
                 // Everything that's left -- methods, fields, properties, 
                 // indexers, and non-conversion operators -- starts with a type 
                 // (possibly void). Parse that.

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2410,8 +2410,8 @@ tryAgain:
                 if (deconstruction != null)
                 {
                     var semicolon = this.EatToken(SyntaxKind.SemicolonToken);
-                    // TODO: is that the best way to handle mods?
-                    return _syntaxFactory.GlobalStatement(_syntaxFactory.DeconstructionDeclarationStatement(new SyntaxList<SyntaxToken>(), deconstruction, semicolon));
+                    return _syntaxFactory.GlobalStatement(_syntaxFactory.DeconstructionDeclarationStatement(
+                        new SyntaxList<SyntaxToken>(), deconstruction, semicolon));
                 }
 
                 // Everything that's left -- methods, fields, properties, 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2406,12 +2406,15 @@ tryAgain:
                     }
                 }
 
-                var deconstruction = ParseDeconstructionDeclarationAssignment();
-                if (deconstruction != null)
+                if (acceptStatement)
                 {
-                    var semicolon = this.EatToken(SyntaxKind.SemicolonToken);
-                    return _syntaxFactory.GlobalStatement(_syntaxFactory.DeconstructionDeclarationStatement(
-                        new SyntaxList<SyntaxToken>(), deconstruction, semicolon));
+                    var deconstruction = ParseDeconstructionDeclarationAssignment();
+                    if (deconstruction != null)
+                    {
+                        var semicolon = this.EatToken(SyntaxKind.SemicolonToken);
+                        return _syntaxFactory.GlobalStatement(_syntaxFactory.DeconstructionDeclarationStatement(
+                            new SyntaxList<SyntaxToken>(), deconstruction, semicolon));
+                    }
                 }
 
                 // Everything that's left -- methods, fields, properties, 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3246,7 +3246,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 case SyntaxKind.SingleVariableDesignation:
                     var field = SourceMemberFieldSymbolFromDesignation.Create(this, (SingleVariableDesignationSyntax)designation,
-                        type, DeclarationModifiers.Private, null, assignment);
+                                                                        type, DeclarationModifiers.Private, null, assignment);
 
                     builder.Add(field);
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3153,7 +3153,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                                         CollectFieldsFromGlobalDeconstruction(builder.NonTypeNonIndexerMembers,
                                             assignment.VariableComponent,
-                                            this);
+                                            this,
+                                            assignment);
 
                                         ExpressionFieldFinder.FindExpressionVariables(builder.NonTypeNonIndexerMembers,
                                             assignment.Value,
@@ -3214,7 +3215,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableComponentSyntax variableComponent,
-            SourceMemberContainerTypeSymbol containingType)
+            SourceMemberContainerTypeSymbol containingType, VariableComponentAssignmentSyntax assignment)
         {
             switch (variableComponent.Kind())
             {
@@ -3222,13 +3223,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     CollectFieldsFromGlobalDeconstruction(
                         builder,
                         ((TypedVariableComponentSyntax)variableComponent).Designation,
-                        containingType);
+                        containingType,
+                        assignment);
                     break;
 
                 case SyntaxKind.ParenthesizedVariableComponent:
-                    foreach (var variable in ((ParenthesizedVariableComponentSyntax)variableComponent).Variables)
+                    foreach (VariableComponentSyntax variable in ((ParenthesizedVariableComponentSyntax)variableComponent).Variables)
                     {
-                        CollectFieldsFromGlobalDeconstruction(builder, variable, containingType);
+                        CollectFieldsFromGlobalDeconstruction(builder, variable, containingType, assignment);
                     }
                     break;
 
@@ -3238,22 +3240,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableDesignationSyntax designation,
-            SourceMemberContainerTypeSymbol containingType)
+            SourceMemberContainerTypeSymbol containingType, VariableComponentAssignmentSyntax assignment)
         {
             switch (designation.Kind())
             {
                 case SyntaxKind.SingleVariableDesignation:
-                    builder.Add(new SourceMemberFieldSymbolFromDesignation(
-                        containingType,
-                        (SingleVariableDesignationSyntax)designation,
-                        DeclarationModifiers.Private));
+                    var field = SourceMemberFieldSymbolFromDesignation.Create(containingType, (SingleVariableDesignationSyntax)designation,
+                        DeclarationModifiers.Private, null, assignment);
+
+                    builder.Add(field);
 
                     break;
 
                 case SyntaxKind.ParenthesizedVariableDesignation:
-                    foreach (var variable in ((ParenthesizedVariableDesignationSyntax)designation).Variables)
+                    foreach (VariableDesignationSyntax variable in ((ParenthesizedVariableDesignationSyntax)designation).Variables)
                     {
-                       CollectFieldsFromGlobalDeconstruction(builder, variable, containingType);
+                        CollectFieldsFromGlobalDeconstruction(builder, variable, containingType, assignment);
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3214,7 +3214,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableComponentSyntax variableComponent,
-            VariableComponentAssignmentSyntax assignment)
+                        VariableComponentAssignmentSyntax assignment)
         {
             switch (variableComponent.Kind())
             {
@@ -3240,7 +3240,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableDesignationSyntax designation,
-            TypeSyntax type, VariableComponentAssignmentSyntax assignment)
+                        TypeSyntax type, VariableComponentAssignmentSyntax assignment)
         {
             switch (designation.Kind())
             {

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -3153,7 +3153,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                                         CollectFieldsFromGlobalDeconstruction(builder.NonTypeNonIndexerMembers,
                                             assignment.VariableComponent,
-                                            this,
                                             assignment);
 
                                         ExpressionFieldFinder.FindExpressionVariables(builder.NonTypeNonIndexerMembers,
@@ -3215,22 +3214,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableComponentSyntax variableComponent,
-            SourceMemberContainerTypeSymbol containingType, VariableComponentAssignmentSyntax assignment)
+            VariableComponentAssignmentSyntax assignment)
         {
             switch (variableComponent.Kind())
             {
                 case SyntaxKind.TypedVariableComponent:
+                    var typed = (TypedVariableComponentSyntax)variableComponent;
                     CollectFieldsFromGlobalDeconstruction(
                         builder,
-                        ((TypedVariableComponentSyntax)variableComponent).Designation,
-                        containingType,
+                        typed.Designation,
+                        typed.Type,
                         assignment);
                     break;
 
                 case SyntaxKind.ParenthesizedVariableComponent:
                     foreach (VariableComponentSyntax variable in ((ParenthesizedVariableComponentSyntax)variableComponent).Variables)
                     {
-                        CollectFieldsFromGlobalDeconstruction(builder, variable, containingType, assignment);
+                        CollectFieldsFromGlobalDeconstruction(builder, variable, assignment);
                     }
                     break;
 
@@ -3240,13 +3240,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         }
 
         private void CollectFieldsFromGlobalDeconstruction(ArrayBuilder<Symbol> builder, VariableDesignationSyntax designation,
-            SourceMemberContainerTypeSymbol containingType, VariableComponentAssignmentSyntax assignment)
+            TypeSyntax type, VariableComponentAssignmentSyntax assignment)
         {
             switch (designation.Kind())
             {
                 case SyntaxKind.SingleVariableDesignation:
-                    var field = SourceMemberFieldSymbolFromDesignation.Create(containingType, (SingleVariableDesignationSyntax)designation,
-                        DeclarationModifiers.Private, null, assignment);
+                    var field = SourceMemberFieldSymbolFromDesignation.Create(this, (SingleVariableDesignationSyntax)designation,
+                        type, DeclarationModifiers.Private, null, assignment);
 
                     builder.Add(field);
 
@@ -3255,7 +3255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 case SyntaxKind.ParenthesizedVariableDesignation:
                     foreach (VariableDesignationSyntax variable in ((ParenthesizedVariableDesignationSyntax)designation).Variables)
                     {
-                        CollectFieldsFromGlobalDeconstruction(builder, variable, containingType, assignment);
+                        CollectFieldsFromGlobalDeconstruction(builder, variable, type, assignment);
                     }
                     break;
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbolFromDesignation.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbolFromDesignation.cs
@@ -32,7 +32,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 FieldSymbol containingFieldOpt,
                 SyntaxNode nodeToBind)
         {
-            Debug.Assert(nodeToBind.Kind() == SyntaxKind.VariableDeclarator || nodeToBind is ExpressionSyntax);
+            Debug.Assert(nodeToBind.Kind() == SyntaxKind.VariableDeclarator
+                || nodeToBind is ExpressionSyntax
+                || nodeToBind is VariableComponentAssignmentSyntax);
+
             var typeSyntax = ((TypedVariableComponentSyntax)designation.Parent).Type;
             return typeSyntax.IsVar
                 ? new SourceMemberFieldSymbolFromDesignationWithEnclosingContext(containingType, designation, modifiers, containingFieldOpt, nodeToBind)
@@ -54,7 +57,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 return (SingleVariableDesignationSyntax)this.SyntaxNode;
             }
         }
-        
+
         protected override TypeSyntax TypeSyntax
         {
             get
@@ -179,7 +182,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 SyntaxNode nodeToBind)
                 : base(containingType, designation, modifiers)
             {
-                Debug.Assert(nodeToBind.Kind() == SyntaxKind.VariableDeclarator || nodeToBind is ExpressionSyntax);
+                Debug.Assert(nodeToBind.Kind() == SyntaxKind.VariableDeclarator
+                    || nodeToBind is ExpressionSyntax
+                    || nodeToBind is VariableComponentAssignmentSyntax);
+
                 _containingFieldOpt = containingFieldOpt;
                 _nodeToBind = nodeToBind.GetReference();
             }
@@ -205,6 +211,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         // int x, y[out var Z, 1 is int I];
                         // for (int x, y[out var Z, 1 is int I]; ;) {}
                         binder.BindDeclaratorArguments((VariableDeclaratorSyntax)nodeToBind, diagnostics);
+                        break;
+
+                    case SyntaxKind.VariableComponentAssignment:
+                        var deconstruction = (VariableComponentAssignmentSyntax)nodeToBind;
+                        binder.BindDeconstructionDeclaration(deconstruction, deconstruction.VariableComponent, deconstruction.Value, diagnostics);
                         break;
 
                     default:

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbolFromDesignation.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberFieldSymbolFromDesignation.cs
@@ -15,6 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     internal class SourceMemberFieldSymbolFromDesignation : SourceMemberFieldSymbol
     {
         private TypeSymbol _lazyType;
+        private SyntaxReference _typeSyntax;
 
         internal SourceMemberFieldSymbolFromDesignation(
             SourceMemberContainerTypeSymbol containingType,
@@ -24,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             : base(containingType, modifiers, designation.Identifier.ValueText, designation.GetReference(), designation.Identifier.GetLocation())
         {
             Debug.Assert(DeclaredAccessibility == Accessibility.Private);
-            TypeSyntax = typeSyntax;
+            _typeSyntax = typeSyntax.GetReference();
         }
 
         internal static SourceMemberFieldSymbolFromDesignation Create(
@@ -60,10 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
-        protected override TypeSyntax TypeSyntax
-        {
-            get;
-        }
+        protected override TypeSyntax TypeSyntax => (TypeSyntax)_typeSyntax.GetSyntax();
 
         protected override SyntaxTokenList ModifiersTokenList
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3535,7 +3535,22 @@ System.Console.Write($""{x} {y} {z}"");
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43");
         }
-         
+
+        [Fact]
+        public void VarDeconstructionInScript()
+        {
+            var source =
+@"
+(var x, var y) = (""hello"", 42);
+System.Console.Write($""{x} {y}"");
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42");
+            // TODO: verify semantic model
+        }
+
         [Fact]
         public void InScript2()
         {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3592,6 +3592,30 @@ System.Console.Write($""{x} {y}"");
         }
 
         [Fact]
+        public void NoGlobalDeconstructionOutsideScript()
+        {
+            var source =
+@"
+(string x, int y) = (""hello"", 42);
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Regular, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics(
+                // (2,19): error CS1022: Type or namespace definition, or end-of-file expected
+                // (string x, int y) = ("hello", 42);
+                Diagnostic(ErrorCode.ERR_EOFExpected, "=").WithLocation(2, 19),
+                // (2,22): error CS1022: Type or namespace definition, or end-of-file expected
+                // (string x, int y) = ("hello", 42);
+                Diagnostic(ErrorCode.ERR_EOFExpected, @"""hello""").WithLocation(2, 22),
+                // (2,22): error CS1026: ) expected
+                // (string x, int y) = ("hello", 42);
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, @"""hello""").WithLocation(2, 22),
+                // error CS5001: Program does not contain a static 'Main' method suitable for an entry point
+                Diagnostic(ErrorCode.ERR_NoEntryPoint).WithLocation(1, 1)
+                );
+        }
+
+        [Fact]
         public void NestedDeconstructionInScript()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -4102,12 +4102,22 @@ var (x, y) = (1, null);
 ";
 
             var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
-            comp.GetDeclarationDiagnostics().Verify();
+            comp.GetDeclarationDiagnostics().Verify(
+                // (2,6): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x'.
+                // var (x, y) = (1, null);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x").WithArguments("x").WithLocation(2, 6),
+                // (2,9): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'y'.
+                // var (x, y) = (1, null);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "y").WithArguments("y").WithLocation(2, 9)
+                );
 
             comp.VerifyDiagnostics(
-                // (2,1): error CS8130: The type information on the left-hand-side 'y' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                // (2,6): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x'.
                 // var (x, y) = (1, null);
-                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "var (x, y) = (1, null);").WithArguments("y", "null").WithLocation(2, 1)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x").WithArguments("x").WithLocation(2, 6),
+                // (2,9): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'y'.
+                // var (x, y) = (1, null);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "y").WithArguments("y").WithLocation(2, 9)
                 );
 
             var tree = comp.SyntaxTrees.First();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -1968,15 +1968,15 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionLocal(model, x3, x3Ref);
             };
@@ -2006,15 +2006,15 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionLocal(model, x3, x3Ref);
             };
@@ -2173,15 +2173,15 @@ Deconstructing (1, hello)
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionLocal(model, x3, x3Ref);
             };
@@ -2242,7 +2242,7 @@ Deconstructing (1, hello)
             return (decl.Parent as TypedVariableComponentSyntax)?.Type;
         }
 
-        private static SingleVariableDesignationSyntax GetDeconstructionLocal(SyntaxTree tree, string name)
+        private static SingleVariableDesignationSyntax GetDeconstructionVariable(SyntaxTree tree, string name)
         {
             return tree.GetRoot().DescendantNodes().OfType<SingleVariableDesignationSyntax>().Where(d => d.Identifier.ValueText == name).Single();
         }
@@ -2289,11 +2289,11 @@ class var
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
@@ -2334,19 +2334,19 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionLocal(model, x3, x3Ref);
 
-                var x4 = GetDeconstructionLocal(tree, "x4");
+                var x4 = GetDeconstructionVariable(tree, "x4");
                 var x4Ref = GetReference(tree, "x4");
                 VerifyModelForDeconstructionLocal(model, x4, x4Ref);
 
@@ -2391,11 +2391,11 @@ class D
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionLocal(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionLocal(model, x2, x2Ref);
 
@@ -2441,11 +2441,11 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReferences(tree, "x1", 4);
                 VerifyModelForDeconstructionFor(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReferences(tree, "x2", 3);
                 VerifyModelForDeconstructionFor(model, x2, x2Ref);
 
@@ -2486,11 +2486,11 @@ class var
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReferences(tree, "x1", 3);
                 VerifyModelForDeconstructionFor(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionFor(model, x2, x2Ref);
 
@@ -2532,11 +2532,11 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReferences(tree, "x1", 3);
                 VerifyModelForDeconstructionFor(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionFor(model, x2, x2Ref);
 
@@ -2581,11 +2581,11 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
@@ -2668,13 +2668,13 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 var symbol = model.GetDeclaredSymbol(x1);
 
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
@@ -2770,11 +2770,11 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
@@ -2884,11 +2884,11 @@ static class Extension
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
@@ -2967,23 +2967,23 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionForeach(model, x3, x3Ref);
 
-                var x4 = GetDeconstructionLocal(tree, "x4");
+                var x4 = GetDeconstructionVariable(tree, "x4");
                 var x4Ref = GetReference(tree, "x4");
                 VerifyModelForDeconstructionForeach(model, x4, x4Ref);
 
-                var x5 = GetDeconstructionLocal(tree, "x5");
+                var x5 = GetDeconstructionVariable(tree, "x5");
                 var x5Ref = GetReference(tree, "x5");
                 VerifyModelForDeconstructionForeach(model, x5, x5Ref);
 
@@ -3094,15 +3094,15 @@ class C
                 var tree = compilation.SyntaxTrees.First();
                 var model = compilation.GetSemanticModel(tree);
 
-                var x1 = GetDeconstructionLocal(tree, "x1");
+                var x1 = GetDeconstructionVariable(tree, "x1");
                 var x1Ref = GetReference(tree, "x1");
                 VerifyModelForDeconstructionForeach(model, x1, x1Ref);
 
-                var x2 = GetDeconstructionLocal(tree, "x2");
+                var x2 = GetDeconstructionVariable(tree, "x2");
                 var x2Ref = GetReference(tree, "x2");
                 VerifyModelForDeconstructionForeach(model, x2, x2Ref);
 
-                var x3 = GetDeconstructionLocal(tree, "x3");
+                var x3 = GetDeconstructionVariable(tree, "x3");
                 var x3Ref = GetReference(tree, "x3");
                 VerifyModelForDeconstructionForeach(model, x3, x3Ref);
 
@@ -3437,7 +3437,77 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        // TODO: test an embedded statement when a field of the same name exists
+        [Fact]
+        public void FieldAndLocalWithSameName()
+        {
+            string source = @"
+class C
+{
+    public int x = 3;
+    static void Main()
+    {
+        new C().M();
+    }
+    void M()
+    {
+        var (x, y) = (1, 2);
+        System.Console.Write($""{x} {y} {this.x}"");
+    }
+}
+";
+            var comp = CompileAndVerify(source, expectedOutput: "1 2 3", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
+            comp.VerifyDiagnostics();
+        }
+
+        [Fact]
+        public void NoGlobalDeconstructionUnlessScript()
+        {
+            string source = @"
+class C
+{
+    var (x, y) = (1, 2);
+}
+";
+            var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
+            comp.VerifyDiagnostics(
+                // (3,2): error CS1520: Method must have a return type
+                // {
+                Diagnostic(ErrorCode.ERR_MemberNeedsType, "").WithLocation(3, 2),
+                // (4,11): error CS1001: Identifier expected
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ",").WithLocation(4, 11),
+                // (4,14): error CS1001: Identifier expected
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_IdentifierExpected, ")").WithLocation(4, 14),
+                // (4,16): error CS1002: ; expected
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "=").WithLocation(4, 16),
+                // (4,16): error CS1519: Invalid token '=' in class, struct, or interface member declaration
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(4, 16),
+                // (4,18): error CS8124: Tuple must contain at least two elements.
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TupleTooFewElements, "(").WithLocation(4, 18),
+                // (4,19): error CS1031: Type expected
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_TypeExpected, "1").WithLocation(4, 19),
+                // (4,19): error CS1026: ) expected
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "1").WithLocation(4, 19),
+                // (4,19): error CS1519: Invalid token '1' in class, struct, or interface member declaration
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "1").WithArguments("1").WithLocation(4, 19),
+                // (4,10): error CS0246: The type or namespace name 'x' could not be found (are you missing a using directive or an assembly reference?)
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "x").WithArguments("x").WithLocation(4, 10),
+                // (4,13): error CS0246: The type or namespace name 'y' could not be found (are you missing a using directive or an assembly reference?)
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "y").WithArguments("y").WithLocation(4, 13),
+                // (4,5): error CS0501: 'C.var(x, y)' must declare a body because it is not marked abstract, extern, or partial
+                //     var (x, y) = (1, 2);
+                Diagnostic(ErrorCode.ERR_ConcreteMissingBody, "var").WithArguments("C.var(x, y)").WithLocation(4, 5)
+                );
+        }
 
         [Fact]
         public void SimpleDeconstructionInScript()
@@ -3547,7 +3617,6 @@ System.Console.Write($""{x} {y}"");
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42");
-            // TODO: verify semantic model
         }
 
         [Fact]
@@ -3555,34 +3624,62 @@ System.Console.Write($""{x} {y}"");
         {
             var source =
 @"
-var (x, (y, z)) = (""hello"", (42, 43));
-System.Console.Write($""{x} {y} {z}"");
+var (x1, (x2, x3)) = (""hello"", (42, 43));
+System.Console.Write($""{x1} {x2} {x3}"");
+";
+
+            Action<ModuleSymbol> validator = (ModuleSymbol module) =>
+            {
+                var sourceModule = (SourceModuleSymbol)module;
+                var compilation = sourceModule.DeclaringCompilation;
+                var tree = compilation.SyntaxTrees.First();
+                var model = compilation.GetSemanticModel(tree);
+
+                var x1 = GetDeconstructionVariable(tree, "x1");
+                var x1Symbol = model.GetDeclaredSymbol(x1);
+                Assert.Equal("System.String Script.x1", x1Symbol.ToTestDisplayString());
+                Assert.Equal("Field", x1Symbol.Kind.ToString());
+                var x1Field = (FieldSymbol)x1Symbol;
+                Assert.Equal("System.String", x1Field.Type.ToTestDisplayString());
+                Assert.Equal("Private", x1Field.DeclaredAccessibility.ToString());
+
+                var x2 = GetDeconstructionVariable(tree, "x2");
+                var x2Symbol = model.GetDeclaredSymbol(x2);
+                Assert.Equal("System.Int32 Script.x2", x2Symbol.ToTestDisplayString());
+                Assert.Equal("Field", x2Symbol.Kind.ToString());
+                var x2Field = (FieldSymbol)x2Symbol;
+                Assert.Equal("System.Int32", x2Field.Type.ToTestDisplayString());
+                Assert.Equal("Private", x2Field.DeclaredAccessibility.ToString());
+            };
+
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43", sourceSymbolValidator: validator);
+        }
+
+        [Fact]
+        public void EvaluationOrderForDeconstructionInScript()
+        {
+            var source =
+    @"
+(int, int) M(out int x) { x = 1; return (2, 3); }
+var (x2, x3) = M(out var x1);
+System.Console.Write($""{x1} {x2} {x3}"");
 ";
             var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
 
             comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43");
-            // TODO: verify semantic model
-        }
-
-        [Fact]
-        public void InScript2()
-        {
-            var source =
-@"
-var x = 1;
-System.Console.Write($""{x}"");
-";
-            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
-            comp.VerifyDiagnostics();
-            var verifier = CompileAndVerify(comp, expectedOutput: "1");
+            var verifier = CompileAndVerify(comp, expectedOutput: "1 2 3");
             verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      101 (0x65)
-  .maxstack  2
+  // Code size      182 (0xb6)
+  .maxstack  4
   .locals init (int V_0,
                 object V_1,
-                System.Exception V_2)
+                int V_2,
+                int V_3,
+                System.Exception V_4)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <<Initialize>>d__0.<>1__state""
   IL_0006:  stloc.0
@@ -3590,42 +3687,65 @@ System.Console.Write($""{x}"");
   {
     IL_0007:  ldarg.0
     IL_0008:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_000d:  ldc.i4.1
-    IL_000e:  stfld      ""int x""
-    IL_0013:  ldstr      ""{0}""
-    IL_0018:  ldarg.0
-    IL_0019:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
-    IL_001e:  ldfld      ""int x""
-    IL_0023:  box        ""int""
-    IL_0028:  call       ""string string.Format(string, object)""
-    IL_002d:  call       ""void System.Console.Write(string)""
-    IL_0032:  nop
-    IL_0033:  ldnull
-    IL_0034:  stloc.1
-    IL_0035:  leave.s    IL_004f
+    IL_000d:  ldarg.0
+    IL_000e:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0013:  ldflda     ""int x1""
+    IL_0018:  callvirt   ""(int, int) M(out int)""
+    IL_001d:  dup
+    IL_001e:  ldfld      ""int System.ValueTuple<int, int>.Item1""
+    IL_0023:  stloc.2
+    IL_0024:  ldfld      ""int System.ValueTuple<int, int>.Item2""
+    IL_0029:  stloc.3
+    IL_002a:  ldarg.0
+    IL_002b:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0030:  ldloc.2
+    IL_0031:  stfld      ""int x2""
+    IL_0036:  ldarg.0
+    IL_0037:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_003c:  ldloc.3
+    IL_003d:  stfld      ""int x3""
+    IL_0042:  ldstr      ""{0} {1} {2}""
+    IL_0047:  ldarg.0
+    IL_0048:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_004d:  ldfld      ""int x1""
+    IL_0052:  box        ""int""
+    IL_0057:  ldarg.0
+    IL_0058:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_005d:  ldfld      ""int x2""
+    IL_0062:  box        ""int""
+    IL_0067:  ldarg.0
+    IL_0068:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_006d:  ldfld      ""int x3""
+    IL_0072:  box        ""int""
+    IL_0077:  call       ""string string.Format(string, object, object, object)""
+    IL_007c:  call       ""void System.Console.Write(string)""
+    IL_0081:  nop
+    IL_0082:  ldnull
+    IL_0083:  stloc.1
+    IL_0084:  leave.s    IL_00a0
   }
   catch System.Exception
   {
-    IL_0037:  stloc.2
-    IL_0038:  ldarg.0
-    IL_0039:  ldc.i4.s   -2
-    IL_003b:  stfld      ""int <<Initialize>>d__0.<>1__state""
-    IL_0040:  ldarg.0
-    IL_0041:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-    IL_0046:  ldloc.2
-    IL_0047:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_004c:  nop
-    IL_004d:  leave.s    IL_0064
+    IL_0086:  stloc.s    V_4
+    IL_0088:  ldarg.0
+    IL_0089:  ldc.i4.s   -2
+    IL_008b:  stfld      ""int <<Initialize>>d__0.<>1__state""
+    IL_0090:  ldarg.0
+    IL_0091:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+    IL_0096:  ldloc.s    V_4
+    IL_0098:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_009d:  nop
+    IL_009e:  leave.s    IL_00b5
   }
-  IL_004f:  ldarg.0
-  IL_0050:  ldc.i4.s   -2
-  IL_0052:  stfld      ""int <<Initialize>>d__0.<>1__state""
-  IL_0057:  ldarg.0
-  IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
-  IL_005d:  ldloc.1
-  IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_0063:  nop
-  IL_0064:  ret
+  IL_00a0:  ldarg.0
+  IL_00a1:  ldc.i4.s   -2
+  IL_00a3:  stfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_00a8:  ldarg.0
+  IL_00a9:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_00ae:  ldloc.1
+  IL_00af:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_00b4:  nop
+  IL_00b5:  ret
 }
 ");
         }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3436,5 +3436,169 @@ class C
             var comp = CompileAndVerify(source, expectedOutput: "3 4", additionalRefs: new[] { ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef, SystemCoreRef });
             comp.VerifyDiagnostics();
         }
+
+        // TODO: test with var
+        // TODO: test an embedded statement when a field of the same name exists
+
+        [Fact]
+        public void SimpleDeconstructionInScript()
+        {
+            var source =
+@"
+(string x, int y) = (""hello"", 42);
+System.Console.Write($""{x} {y}"");
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42");
+            verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      151 (0x97)
+  .maxstack  3
+  .locals init (int V_0,
+                object V_1,
+                string V_2,
+                int V_3,
+                System.Exception V_4)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldstr      ""hello""
+    IL_000c:  ldc.i4.s   42
+    IL_000e:  newobj     ""System.ValueTuple<string, int>..ctor(string, int)""
+    IL_0013:  dup
+    IL_0014:  ldfld      ""string System.ValueTuple<string, int>.Item1""
+    IL_0019:  stloc.2
+    IL_001a:  ldfld      ""int System.ValueTuple<string, int>.Item2""
+    IL_001f:  stloc.3
+    IL_0020:  ldarg.0
+    IL_0021:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0026:  ldloc.2
+    IL_0027:  stfld      ""string x""
+    IL_002c:  ldarg.0
+    IL_002d:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0032:  ldloc.3
+    IL_0033:  stfld      ""int y""
+    IL_0038:  ldstr      ""{0} {1}""
+    IL_003d:  ldarg.0
+    IL_003e:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_0043:  ldfld      ""string x""
+    IL_0048:  ldarg.0
+    IL_0049:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_004e:  ldfld      ""int y""
+    IL_0053:  box        ""int""
+    IL_0058:  call       ""string string.Format(string, object, object)""
+    IL_005d:  call       ""void System.Console.Write(string)""
+    IL_0062:  nop
+    IL_0063:  ldnull
+    IL_0064:  stloc.1
+    IL_0065:  leave.s    IL_0081
+  }
+  catch System.Exception
+  {
+    IL_0067:  stloc.s    V_4
+    IL_0069:  ldarg.0
+    IL_006a:  ldc.i4.s   -2
+    IL_006c:  stfld      ""int <<Initialize>>d__0.<>1__state""
+    IL_0071:  ldarg.0
+    IL_0072:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+    IL_0077:  ldloc.s    V_4
+    IL_0079:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_007e:  nop
+    IL_007f:  leave.s    IL_0096
+  }
+  IL_0081:  ldarg.0
+  IL_0082:  ldc.i4.s   -2
+  IL_0084:  stfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_0089:  ldarg.0
+  IL_008a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_008f:  ldloc.1
+  IL_0090:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_0095:  nop
+  IL_0096:  ret
+}");
+        }
+
+        [Fact]
+        public void NestedDeconstructionInScript()
+        {
+            var source =
+@"
+(string x, (int y, int z)) = (""hello"", (42, 43));
+System.Console.Write($""{x} {y} {z}"");
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43");
+        }
+         
+        [Fact]
+        public void InScript2()
+        {
+            var source =
+@"
+var x = 1;
+System.Console.Write($""{x}"");
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe);
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "1");
+            verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      101 (0x65)
+  .maxstack  2
+  .locals init (int V_0,
+                object V_1,
+                System.Exception V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_0006:  stloc.0
+  .try
+  {
+    IL_0007:  ldarg.0
+    IL_0008:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_000d:  ldc.i4.1
+    IL_000e:  stfld      ""int x""
+    IL_0013:  ldstr      ""{0}""
+    IL_0018:  ldarg.0
+    IL_0019:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
+    IL_001e:  ldfld      ""int x""
+    IL_0023:  box        ""int""
+    IL_0028:  call       ""string string.Format(string, object)""
+    IL_002d:  call       ""void System.Console.Write(string)""
+    IL_0032:  nop
+    IL_0033:  ldnull
+    IL_0034:  stloc.1
+    IL_0035:  leave.s    IL_004f
+  }
+  catch System.Exception
+  {
+    IL_0037:  stloc.2
+    IL_0038:  ldarg.0
+    IL_0039:  ldc.i4.s   -2
+    IL_003b:  stfld      ""int <<Initialize>>d__0.<>1__state""
+    IL_0040:  ldarg.0
+    IL_0041:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+    IL_0046:  ldloc.2
+    IL_0047:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_004c:  nop
+    IL_004d:  leave.s    IL_0064
+  }
+  IL_004f:  ldarg.0
+  IL_0050:  ldc.i4.s   -2
+  IL_0052:  stfld      ""int <<Initialize>>d__0.<>1__state""
+  IL_0057:  ldarg.0
+  IL_0058:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <<Initialize>>d__0.<>t__builder""
+  IL_005d:  ldloc.1
+  IL_005e:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_0063:  nop
+  IL_0064:  ret
+}
+");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3437,7 +3437,6 @@ class C
             comp.VerifyDiagnostics();
         }
 
-        // TODO: test with var
         // TODO: test an embedded statement when a field of the same name exists
 
         [Fact]
@@ -3548,6 +3547,21 @@ System.Console.Write($""{x} {y}"");
 
             comp.VerifyDiagnostics();
             var verifier = CompileAndVerify(comp, expectedOutput: "hello 42");
+            // TODO: verify semantic model
+        }
+
+        [Fact]
+        public void NestedVarDeconstructionInScript()
+        {
+            var source =
+@"
+var (x, (y, z)) = (""hello"", (42, 43));
+System.Console.Write($""{x} {y} {z}"");
+";
+            var comp = CreateCompilationWithMscorlib45(source, parseOptions: TestOptions.Script, options: TestOptions.DebugExe, references: s_valueTupleRefs);
+
+            comp.VerifyDiagnostics();
+            var verifier = CompileAndVerify(comp, expectedOutput: "hello 42 43");
             // TODO: verify semantic model
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -1325,6 +1325,7 @@ class C
 
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef }, parseOptions: TestOptions.Regular6);
             comp.VerifyDiagnostics(
+                // (6,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         var (x1, x2) = Pair.Create(1, 2);
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "var (x1, x2)").WithArguments("tuples", "7").WithLocation(6, 9),
                 // (7,9): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
@@ -1335,7 +1336,19 @@ class C
                 Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x5, var (x6, x7))").WithArguments("tuples", "7").WithLocation(8, 18),
                 // (9,14): error CS8059: Feature 'tuples' is not available in C# 6.  Please use language version 7 or greater.
                 //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
-                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7").WithLocation(9, 14)
+                Diagnostic(ErrorCode.ERR_FeatureNotAvailableInVersion6, "(int x8, var (x9, x10))").WithArguments("tuples", "7").WithLocation(9, 14),
+                // (8,32): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x6'.
+                //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x6").WithArguments("x6").WithLocation(8, 32),
+                // (8,36): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x7'.
+                //         foreach ((int x5, var (x6, x7)) in new[] { Pair.Create(1, Pair.Create(2, 3)) }) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x7").WithArguments("x7").WithLocation(8, 36),
+                // (9,28): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x9'.
+                //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x9").WithArguments("x9").WithLocation(9, 28),
+                // (9,32): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x10'.
+                //         for ((int x8, var (x9, x10)) = Pair.Create(1, Pair.Create(2, 3)); ; ) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x10").WithArguments("x10").WithLocation(9, 32)
                 );
         }
 
@@ -1535,7 +1548,13 @@ class C
             comp.VerifyDiagnostics(
                 // (6,24): error CS8131: Deconstruct assignment requires an expression with a type on the right-hand-side.
                 //         var (x1, x2) = null;
-                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(6, 24)
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(6, 24),
+                // (6,14): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x1'.
+                //         var (x1, x2) = null;
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x1").WithArguments("x1").WithLocation(6, 14),
+                // (6,18): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
+                //         var (x1, x2) = null;
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 18)
                 );
         }
 
@@ -1553,9 +1572,12 @@ class C
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (6,9): error CS8130: The type information on the left-hand-side 'x2' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                // (6,14): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x1'.
                 //         var (x1, x2) = (1, null);
-                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "var (x1, x2) = (1, null);").WithArguments("x2", "null").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x1").WithArguments("x1").WithLocation(6, 14),
+                // (6,18): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
+                //         var (x1, x2) = (1, null);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 18)
                 );
         }
 
@@ -1573,12 +1595,12 @@ class C
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (6,9): error CS8130: The type information on the left-hand-side 'x3' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                // (6,35): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x3'.
                 //         (string x1, (byte x2, var x3), var x4) = (null, (2, null), null);
-                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "(string x1, (byte x2, var x3), var x4) = (null, (2, null), null);").WithArguments("x3", "null").WithLocation(6, 9),
-                // (6,9): error CS8130: The type information on the left-hand-side 'x4' and right-hand-side 'null' of the deconstruction was insufficient to infer a merged type.
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x3").WithArguments("x3").WithLocation(6, 35),
+                // (6,44): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x4'.
                 //         (string x1, (byte x2, var x3), var x4) = (null, (2, null), null);
-                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "(string x1, (byte x2, var x3), var x4) = (null, (2, null), null);").WithArguments("x4", "null").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x4").WithArguments("x4").WithLocation(6, 44)
                 );
         }
 
@@ -1598,7 +1620,10 @@ class C
             comp.VerifyDiagnostics(
                 // (6,51): error CS8131: Deconstruct assignment requires an expression with a type on the right-hand-side.
                 //         ((string x1, byte x2, var x3), int x4) = (null, 4);
-                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(6, 51)
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(6, 51),
+                // (6,35): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x3'.
+                //         ((string x1, byte x2, var x3), int x4) = (null, 4);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x3").WithArguments("x3").WithLocation(6, 35)
                 );
         }
 
@@ -1616,9 +1641,9 @@ class C
 ";
             var comp = CreateCompilationWithMscorlib(source, references: new[] { ValueTupleRef, SystemRuntimeFacadeRef });
             comp.VerifyDiagnostics(
-                // (6,9): error CS8130: The type information on the left-hand-side 'x2' and right-hand-side '(null, 2)' of the deconstruction was insufficient to infer a merged type.
+                // (6,25): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
                 //         (string x1, var x2) = (null, (null, 2));
-                Diagnostic(ErrorCode.ERR_DeconstructCouldNotInferMergedType, "(string x1, var x2) = (null, (null, 2));").WithArguments("x2", "(null, 2)").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 25)
                 );
         }
 
@@ -1662,7 +1687,10 @@ class C
                 Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, @"(string x1, var y1) = (null, ""hello"", 3);").WithArguments("3", "2").WithLocation(6, 9),
                 // (7,47): error CS8131: Deconstruct assignment requires an expression with a type on the right-hand-side.
                 //         (string x2, var y2) = (null, "hello", null);
-                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(7, 47)
+                Diagnostic(ErrorCode.ERR_DeconstructRequiresExpression, "null").WithLocation(7, 47),
+                // (7,25): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'y2'.
+                //         (string x2, var y2) = (null, "hello", null);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "y2").WithArguments("y2").WithLocation(7, 25)
                 );
         }
 
@@ -1749,7 +1777,13 @@ class C
             comp.VerifyDiagnostics(
                 // (6,9): error CS8132: Cannot deconstruct a tuple of '3' elements into '2' variables.
                 //         (var (x1, x2), var x3) = (1, 2, 3);
-                Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, "(var (x1, x2), var x3) = (1, 2, 3);").WithArguments("3", "2").WithLocation(6, 9)
+                Diagnostic(ErrorCode.ERR_DeconstructWrongCardinality, "(var (x1, x2), var x3) = (1, 2, 3);").WithArguments("3", "2").WithLocation(6, 9),
+                // (6,15): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x1'.
+                //         (var (x1, x2), var x3) = (1, 2, 3);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x1").WithArguments("x1").WithLocation(6, 15),
+                // (6,19): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
+                //         (var (x1, x2), var x3) = (1, 2, 3);
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 19)
                 );
         }
 
@@ -1821,17 +1855,23 @@ class C
             var comp = CreateCompilationWithMscorlib(source);
             comp.VerifyDiagnostics(
                 // (9,13): error CS0128: A local variable named 'x' is already defined in this scope
-                //         var(x, y) = 42;
+                //         var(x, y) = 42; // parsed as deconstruction
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "x").WithArguments("x").WithLocation(9, 13),
                 // (9,16): error CS0128: A local variable named 'y' is already defined in this scope
-                //         var(x, y) = 42;
+                //         var(x, y) = 42; // parsed as deconstruction
                 Diagnostic(ErrorCode.ERR_LocalDuplicate, "y").WithArguments("y").WithLocation(9, 16),
                 // (9,21): error CS1061: 'int' does not contain a definition for 'Deconstruct' and no extension method 'Deconstruct' accepting a first argument of type 'int' could be found (are you missing a using directive or an assembly reference?)
-                //         var(x, y) = 42;
+                //         var(x, y) = 42; // parsed as deconstruction
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "42").WithArguments("int", "Deconstruct").WithLocation(9, 21),
                 // (9,21): error CS8129: No Deconstruct instance or extension method was found for type 'int', with 2 out parameters.
-                //         var(x, y) = 42;
+                //         var(x, y) = 42; // parsed as deconstruction
                 Diagnostic(ErrorCode.ERR_MissingDeconstruct, "42").WithArguments("int", "2").WithLocation(9, 21),
+                // (9,13): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x'.
+                //         var(x, y) = 42; // parsed as deconstruction
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x").WithArguments("x").WithLocation(9, 13),
+                // (9,16): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'y'.
+                //         var(x, y) = 42; // parsed as deconstruction
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "y").WithArguments("y").WithLocation(9, 16),
                 // (8,13): warning CS0219: The variable 'x' is assigned but its value is never used
                 //         int x = 0, y = 0;
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(8, 13),
@@ -2223,7 +2263,13 @@ class C
             comp.VerifyDiagnostics(
                 // (6,34): error CS1579: foreach statement cannot operate on variables of type 'int' because 'int' does not contain a public definition for 'GetEnumerator'
                 //         foreach (var (x1, x2) in 1)
-                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "1").WithArguments("int", "GetEnumerator").WithLocation(6, 34)
+                Diagnostic(ErrorCode.ERR_ForEachMissingMember, "1").WithArguments("int", "GetEnumerator").WithLocation(6, 34),
+                // (6,23): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x1'.
+                //         foreach (var (x1, x2) in 1)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x1").WithArguments("x1").WithLocation(6, 23),
+                // (6,27): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
+                //         foreach (var (x1, x2) in 1)
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 27)
                 );
         }
 
@@ -2277,7 +2323,13 @@ class C
             comp.VerifyDiagnostics(
                 // (6,36): error CS0103: The name 'x1' does not exist in the current context
                 //         foreach (var (x1, x2) in M(x1)) { }
-                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(6, 36)
+                Diagnostic(ErrorCode.ERR_NameNotInContext, "x1").WithArguments("x1").WithLocation(6, 36),
+                // (6,23): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x1'.
+                //         foreach (var (x1, x2) in M(x1)) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x1").WithArguments("x1").WithLocation(6, 23),
+                // (6,27): error CS8130: Cannot infer the type of implicitly-typed deconstruction variable 'x2'.
+                //         foreach (var (x1, x2) in M(x1)) { }
+                Diagnostic(ErrorCode.ERR_TypeInferenceFailedForImplicitlyTypedDeconstructionVariable, "x2").WithArguments("x2").WithLocation(6, 27)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -23103,36 +23103,6 @@ class H
                                                                   options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
                 compilation.VerifyDiagnostics(
-                // (2,17): error CS1519: Invalid token '=' in class, struct, or interface member declaration
-                // (bool a, int b) = (H.TakeOutParam(1, out int x1), 1);
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(2, 17),
-                // (2,17): error CS1525: Invalid expression term '='
-                // (bool a, int b) = (H.TakeOutParam(1, out int x1), 1);
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(2, 17),
-                // (6,17): error CS1519: Invalid token '=' in class, struct, or interface member declaration
-                // (bool c, int d) = (H.TakeOutParam(2, out int x2), 2);
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(6, 17),
-                // (6,17): error CS1525: Invalid expression term '='
-                // (bool c, int d) = (H.TakeOutParam(2, out int x2), 2);
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(6, 17),
-                // (8,17): error CS1519: Invalid token '=' in class, struct, or interface member declaration
-                // (bool e, int f) = (H.TakeOutParam(3, out int x3), 3);
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(8, 17),
-                // (8,17): error CS1525: Invalid expression term '='
-                // (bool e, int f) = (H.TakeOutParam(3, out int x3), 3);
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(8, 17),
-                // (11,18): error CS1519: Invalid token '=' in class, struct, or interface member declaration
-                // (bool g, bool h) = (H.TakeOutParam(41, out int x4),
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(11, 18),
-                // (11,18): error CS1525: Invalid expression term '='
-                // (bool g, bool h) = (H.TakeOutParam(41, out int x4),
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(11, 18),
-                // (14,20): error CS1519: Invalid token '=' in class, struct, or interface member declaration
-                // (bool x5, bool x6) = (H.TakeOutParam(5, out int x5),
-                Diagnostic(ErrorCode.ERR_InvalidMemberDecl, "=").WithArguments("=").WithLocation(14, 20),
-                // (14,20): error CS1525: Invalid expression term '='
-                // (bool x5, bool x6) = (H.TakeOutParam(5, out int x5),
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, "=").WithArguments("=").WithLocation(14, 20),
                 // (6,46): error CS0102: The type 'Script' already contains a definition for 'x2'
                 // (bool c, int d) = (H.TakeOutParam(2, out int x2), 2);
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x2").WithArguments("Script", "x2").WithLocation(6, 46),
@@ -23142,6 +23112,12 @@ class H
                 // (12,48): error CS0102: The type 'Script' already contains a definition for 'x4'
                 //                     H.TakeOutParam(42, out int x4));
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 48),
+                // (14,49): error CS0102: The type 'Script' already contains a definition for 'x5'
+                // (bool x5, bool x6) = (H.TakeOutParam(5, out int x5),
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x5").WithArguments("Script", "x5").WithLocation(14, 49),
+                // (15,49): error CS0102: The type 'Script' already contains a definition for 'x6'
+                //                       H.TakeOutParam(6, out int x6));
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x6").WithArguments("Script", "x6").WithLocation(15, 49),
                 // (19,17): error CS0229: Ambiguity between 'x2' and 'x2'
                 //     H.Dummy(x1, x2, x3, x4, x5, x6);
                 Diagnostic(ErrorCode.ERR_AmbigMember, "x2").WithArguments("x2", "x2").WithLocation(19, 17),
@@ -23150,7 +23126,13 @@ class H
                 Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(19, 21),
                 // (19,25): error CS0229: Ambiguity between 'x4' and 'x4'
                 //     H.Dummy(x1, x2, x3, x4, x5, x6);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25)
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25),
+                // (19,29): error CS0229: Ambiguity between 'x5' and 'x5'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x5").WithArguments("x5", "x5").WithLocation(19, 29),
+                // (19,33): error CS0229: Ambiguity between 'x6' and 'x6'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x6").WithArguments("x6", "x6").WithLocation(19, 33)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -23177,13 +23159,13 @@ class H
 
                 var x5Decl = GetOutVarDeclarations(tree, "x5").Single();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
-                Assert.Equal(2, x5Ref.Length);
-                VerifyModelForOutField(model, x5Decl, x5Ref[1]);
+                Assert.Equal(1, x5Ref.Length);
+                VerifyModelForOutFieldDuplicate(model, x5Decl, x5Ref[0]);
 
                 var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
                 var x6Ref = GetReferences(tree, "x6").ToArray();
-                Assert.Equal(2, x6Ref.Length);
-                VerifyModelForOutField(model, x6Decl, x6Ref[1]);
+                Assert.Equal(1, x6Ref.Length);
+                VerifyModelForOutFieldDuplicate(model, x6Decl, x6Ref[0]);
             }
 
             {
@@ -24016,6 +23998,12 @@ class H
                 // (12,48): error CS0102: The type 'Script' already contains a definition for 'x4'
                 //                     H.TakeOutParam(42, out int x4));
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 48),
+                // (14,49): error CS0102: The type 'Script' already contains a definition for 'x5'
+                // (bool x5, bool x6) = (H.TakeOutParam(5, out int x5),
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x5").WithArguments("Script", "x5").WithLocation(14, 49),
+                // (15,49): error CS0102: The type 'Script' already contains a definition for 'x6'
+                //                       H.TakeOutParam(6, out int x6));
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x6").WithArguments("Script", "x6").WithLocation(15, 49),
                 // (1,1): warning CS0164: This label has not been referenced
                 // l1:
                 Diagnostic(ErrorCode.WRN_UnreferencedLabel, "l1").WithLocation(1, 1),
@@ -24039,7 +24027,13 @@ class H
                 Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(19, 21),
                 // (19,25): error CS0229: Ambiguity between 'x4' and 'x4'
                 //     H.Dummy(x1, x2, x3, x4, x5, x6);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25)
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25),
+                // (19,29): error CS0229: Ambiguity between 'x5' and 'x5'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x5").WithArguments("x5", "x5").WithLocation(19, 29),
+                // (19,33): error CS0229: Ambiguity between 'x6' and 'x6'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x6").WithArguments("x6", "x6").WithLocation(19, 33)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -24067,12 +24061,12 @@ class H
                 var x5Decl = GetOutVarDeclarations(tree, "x5").Single();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(1, x5Ref.Length);
-                VerifyModelForOutField(model, x5Decl, x5Ref);
+                VerifyModelForOutFieldDuplicate(model, x5Decl, x5Ref);
 
                 var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
                 var x6Ref = GetReferences(tree, "x6").ToArray();
                 Assert.Equal(1, x6Ref.Length);
-                VerifyModelForOutField(model, x6Decl, x6Ref);
+                VerifyModelForOutFieldDuplicate(model, x6Decl, x6Ref);
             }
 
             {
@@ -24171,6 +24165,12 @@ class H
                 // (12,48): error CS0102: The type 'Script' already contains a definition for 'x4'
                 //                     H.TakeOutParam(42, out var x4));
                 Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x4").WithArguments("Script", "x4").WithLocation(12, 48),
+                // (14,49): error CS0102: The type 'Script' already contains a definition for 'x5'
+                // (bool x5, bool x6) = (H.TakeOutParam(5, out var x5),
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x5").WithArguments("Script", "x5").WithLocation(14, 49),
+                // (15,49): error CS0102: The type 'Script' already contains a definition for 'x6'
+                //                       H.TakeOutParam(6, out var x6));
+                Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "x6").WithArguments("Script", "x6").WithLocation(15, 49),
                 // (1,1): warning CS0164: This label has not been referenced
                 // l1:
                 Diagnostic(ErrorCode.WRN_UnreferencedLabel, "l1").WithLocation(1, 1),
@@ -24194,7 +24194,13 @@ class H
                 Diagnostic(ErrorCode.ERR_AmbigMember, "x3").WithArguments("x3", "x3").WithLocation(19, 21),
                 // (19,25): error CS0229: Ambiguity between 'x4' and 'x4'
                 //     H.Dummy(x1, x2, x3, x4, x5, x6);
-                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25)
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x4").WithArguments("x4", "x4").WithLocation(19, 25),
+                // (19,29): error CS0229: Ambiguity between 'x5' and 'x5'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x5").WithArguments("x5", "x5").WithLocation(19, 29),
+                // (19,33): error CS0229: Ambiguity between 'x6' and 'x6'
+                //     H.Dummy(x1, x2, x3, x4, x5, x6);
+                Diagnostic(ErrorCode.ERR_AmbigMember, "x6").WithArguments("x6", "x6").WithLocation(19, 33)
                     );
 
                 var tree = compilation.SyntaxTrees.Single();
@@ -24222,12 +24228,12 @@ class H
                 var x5Decl = GetOutVarDeclarations(tree, "x5").Single();
                 var x5Ref = GetReferences(tree, "x5").ToArray();
                 Assert.Equal(1, x5Ref.Length);
-                VerifyModelForOutField(model, x5Decl, x5Ref);
+                VerifyModelForOutFieldDuplicate(model, x5Decl, x5Ref);
 
                 var x6Decl = GetOutVarDeclarations(tree, "x6").Single();
                 var x6Ref = GetReferences(tree, "x6").ToArray();
                 Assert.Equal(1, x6Ref.Length);
-                VerifyModelForOutField(model, x6Decl, x6Ref);
+                VerifyModelForOutFieldDuplicate(model, x6Decl, x6Ref);
             }
 
             {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
@@ -1541,9 +1541,7 @@ class C
         [Fact]
         public void DeconstructionInScript()
         {
-            var tree = UsingTree(@"
-(int x, int y) = (1, 2);
-        ", options: TestOptions.Script);
+            var tree = UsingTree(@" (int x, int y) = (1, 2); ", options: TestOptions.Script);
             N(SyntaxKind.CompilationUnit);
             {
                 N(SyntaxKind.GlobalStatement);
@@ -1602,6 +1600,99 @@ class C
                                 N(SyntaxKind.CloseParenToken);
                             }
                         }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
+        public void DeconstructionForEachInScript()
+        {
+            var tree = UsingTree(@" foreach ((int x, int y) in new[] { (1, 2) }) { }; ", options: TestOptions.Script);
+
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.ForEachComponentStatement);
+                    {
+                        N(SyntaxKind.ForEachKeyword);
+                        N(SyntaxKind.OpenParenToken);
+                        N(SyntaxKind.ParenthesizedVariableComponent);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.TypedVariableComponent);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.SingleVariableDesignation);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "x");
+                                }
+                            }
+                            N(SyntaxKind.CommaToken);
+                            N(SyntaxKind.TypedVariableComponent);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.SingleVariableDesignation);
+                                {
+                                    N(SyntaxKind.IdentifierToken, "y");
+                                }
+                            }
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.InKeyword);
+                        N(SyntaxKind.ImplicitArrayCreationExpression);
+                        {
+                            N(SyntaxKind.NewKeyword);
+                            N(SyntaxKind.OpenBracketToken);
+                            N(SyntaxKind.CloseBracketToken);
+                            N(SyntaxKind.ArrayInitializerExpression);
+                            {
+                                N(SyntaxKind.OpenBraceToken);
+                                N(SyntaxKind.TupleExpression);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    N(SyntaxKind.Argument);
+                                    {
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken);
+                                        }
+                                    }
+                                    N(SyntaxKind.CommaToken);
+                                    N(SyntaxKind.Argument);
+                                    {
+                                        N(SyntaxKind.NumericLiteralExpression);
+                                        {
+                                            N(SyntaxKind.NumericLiteralToken);
+                                        }
+                                    }
+                                    N(SyntaxKind.CloseParenToken);
+                                }
+                                N(SyntaxKind.CloseBraceToken);
+                            }
+                        }
+                        N(SyntaxKind.CloseParenToken);
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.EmptyStatement);
+                    {
                         N(SyntaxKind.SemicolonToken);
                     }
                 }

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeconstructionTests.cs
@@ -1539,6 +1539,78 @@ class C
         }
 
         [Fact]
+        public void DeconstructionInScript()
+        {
+            var tree = UsingTree(@"
+(int x, int y) = (1, 2);
+        ", options: TestOptions.Script);
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.GlobalStatement);
+                {
+                    N(SyntaxKind.DeconstructionDeclarationStatement);
+                    {
+                        N(SyntaxKind.VariableComponentAssignment);
+                        {
+                            N(SyntaxKind.ParenthesizedVariableComponent);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.TypedVariableComponent);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "x");
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.TypedVariableComponent);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.SingleVariableDesignation);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "y");
+                                    }
+                                }
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                            N(SyntaxKind.EqualsToken);
+                            N(SyntaxKind.TupleExpression);
+                            {
+                                N(SyntaxKind.OpenParenToken);
+                                N(SyntaxKind.Argument);
+                                {
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken);
+                                    }
+                                }
+                                N(SyntaxKind.CommaToken);
+                                N(SyntaxKind.Argument);
+                                {
+                                    N(SyntaxKind.NumericLiteralExpression);
+                                    {
+                                        N(SyntaxKind.NumericLiteralToken);
+                                    }
+                                }
+                                N(SyntaxKind.CloseParenToken);
+                            }
+                        }
+                        N(SyntaxKind.SemicolonToken);
+                    }
+                }
+                N(SyntaxKind.EndOfFileToken);
+            }
+            EOF();
+        }
+
+        [Fact]
         public void TupleArray()
         {
             var text = "(T, T)[] id;";


### PR DESCRIPTION
The work on out vars in script (https://github.com/dotnet/roslyn/pull/13818) simplified the task. 

The four changes to support deconstruction declaration statements in script:

1. Parse it as a global statement containing a deconstruction declaration statement
2. Have `SourceMemberContainerSymbol.AddNonTypeMembers` collect fields from the deconstruction statement (when the container class is a script class)
3. The binding of deconstruction declarations now handles two kinds of variables (locals or fields), so returns either a `BoundLocal`, a `BoundFieldAccess`, or a `DeconstructionVariablePendingInference` (for `var` cases).
4. `DeconstructionVariablePendingInference.SetInferredType` can now return a `BoundLocal` or `BoundFieldAccess` once the type is inferred

After that, I will add d-foreach, and add some tests for `for` loops with deconstructions.

@dotnet/roslyn-compiler for review.

Fixes https://github.com/dotnet/roslyn/issues/13716
Fixes https://github.com/dotnet/roslyn/issues/13992

