### PR TITLE
Small optimisation in CompilerOptionParseUtilities.cs

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/CompilerOptionParseUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CompilerOptionParseUtilities.cs
@@ -20,13 +20,7 @@ namespace Roslyn.Utilities
             }
 
             var all = features.Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            var list = new List<string>(capacity: all.Length);
-            foreach (var feature in all)
-            {
-                list.Add(feature);
-            }
-
-            return list;
+            return all;
         }
 
         public static ImmutableDictionary<string, string> ParseFeatures(List<string> values)

--- a/src/Compilers/Core/Portable/InternalUtilities/CompilerOptionParseUtilities.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/CompilerOptionParseUtilities.cs
@@ -19,8 +19,7 @@ namespace Roslyn.Utilities
                 return SpecializedCollections.EmptyList<string>();
             }
 
-            var all = features.Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
-            return all;
+            return features.Split(new[] { ';', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
         public static ImmutableDictionary<string, string> ParseFeatures(List<string> values)


### PR DESCRIPTION
Just return the array from the `.Split` function as array implements `IList`