### PR TITLE
Guard against reflection failure when retrieving a pipe name for VBCSCompiler

### DIFF
--- a/src/Compilers/Core/MSBuildTask/Utilities.cs
+++ b/src/Compilers/Core/MSBuildTask/Utilities.cs
@@ -20,7 +20,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
         /// </summary>
         internal static bool IsCompilerServerSupported =>
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
-            DesktopBuildClient.GetRuntimeDirectoryOpt() != null;
+            DesktopBuildClient.GetRuntimeDirectoryOpt() != null &&
+            // Test that we can retrieve a valid pipe name
+            DesktopBuildClient.GetPipeNameForPathOpt("") != null;
 
         /// <summary>
         /// Convert a task item metadata to bool. Throw an exception if the string is badly formed and can't

--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -80,7 +80,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         protected override string GetDefaultPipeName()
         {
             var clientDirectory = AppDomain.CurrentDomain.BaseDirectory;
-            return DesktopBuildClient.GetPipeNameForPath(clientDirectory);
+            return DesktopBuildClient.GetPipeNameForPathOpt(clientDirectory);
         }
 
         protected override bool? WasServerRunning(string pipeName)


### PR DESCRIPTION
Fixes #13966

/cc @jaredpar @dotnet/roslyn-compiler 