### PR TITLE
Support tuple element names in locals and expressions in VB EE

### DIFF
--- a/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/CompilationTestUtils.vb
@@ -1206,8 +1206,7 @@ Friend Module CompilationUtils
             Dim context = New ModuleCompilationState()
             DirectCast(symbol, Symbol).AddSynthesizedAttributes(context, attributes)
         Else
-            ' Call AddSynthesizedReturnTypeAttributes() when available: https://github.com/dotnet/roslyn/issues/13948
-            ' DirectCast(symbol, MethodSymbol).AddSynthesizedReturnTypeAttributes(attributes)
+            DirectCast(symbol, MethodSymbol).AddSynthesizedReturnTypeAttributes(attributes)
         End If
         Return If(attributes IsNot Nothing, attributes.ToImmutableAndFree(), ImmutableArray.Create(Of SynthesizedAttributeData)())
     End Function

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitStatement.vb
@@ -1241,7 +1241,10 @@ OtherExpressions:
         End Sub
 
         Private Function DefineLocal(local As LocalSymbol, syntaxNode As SyntaxNode) As LocalDefinition
-            Dim specType = local.Type.SpecialType
+            Dim dynamicTransformFlags = ImmutableArray(Of TypedConstant).Empty
+            Dim tupleElementNames = If(Not local.IsCompilerGenerated AndAlso local.Type.ContainsTupleNames(),
+                VisualBasicCompilation.TupleNamesEncoder.Encode(local.Type, _module.Compilation.GetSpecialType(SpecialType.System_String)),
+                ImmutableArray(Of TypedConstant).Empty)
 
             ' We're treating constants of type Decimal and DateTime as local here to not create a new instance for each time
             ' the value is accessed. This means there will be one local in the scope for this constant.
@@ -1259,8 +1262,8 @@ OtherExpressions:
                     local.Name,
                     If(local.Locations.FirstOrDefault(), Location.None),
                     compileTimeValue,
-                    dynamicTransformFlags:=Nothing,
-                    tupleElementNames:=Nothing)
+                    dynamicTransformFlags:=dynamicTransformFlags,
+                    tupleElementNames:=tupleElementNames)
                 ' Reference in the scope for debugging purpose
                 _builder.AddLocalConstantToScope(localConstantDef)
                 Return Nothing
@@ -1290,8 +1293,8 @@ OtherExpressions:
                 id:=localId,
                 pdbAttributes:=synthesizedKind.PdbAttributes(),
                 constraints:=constraints,
-                dynamicTransformFlags:=Nothing,
-                tupleElementNames:=Nothing,
+                dynamicTransformFlags:=dynamicTransformFlags,
+                tupleElementNames:=tupleElementNames,
                 isSlotReusable:=synthesizedKind.IsSlotReusable(_ilEmitStyle <> ILEmitStyle.Release))
 
             ' If named, add it to the local debug scope.

--- a/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/WellKnownMembers.vb
@@ -698,10 +698,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return names
             End Function
 
-            Private Shared Function TryGetNames(type As TypeSymbol, namesBuilder As ArrayBuilder(Of String)) As Boolean
+            Friend Shared Function TryGetNames(type As TypeSymbol, namesBuilder As ArrayBuilder(Of String)) As Boolean
                 type.VisitType(Function(t As TypeSymbol, builder As ArrayBuilder(Of String)) AddNames(t, builder), namesBuilder)
-                Debug.Assert(namesBuilder.Any())
-
                 Return namesBuilder.Any(Function(name) name IsNot Nothing)
             End Function
 

--- a/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
+++ b/src/Compilers/VisualBasic/Test/Emit/BasicCompilerEmitTest.vbproj
@@ -156,6 +156,7 @@
     <Compile Include="PDB\PDBConstLocalTests.vb" />
     <Compile Include="PDB\PDBExternalSourceDirectiveTests.vb" />
     <Compile Include="PDB\PDBLambdaTests.vb" />
+    <Compile Include="PDB\PDBTupleTests.vb" />
     <Compile Include="PDB\PDBVariableInitializerTests.vb" />
     <Compile Include="PDB\PDBIteratorTests.vb" />
     <Compile Include="PDB\PDBForEachTests.vb" />

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
@@ -1,0 +1,51 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Test.Utilities
+
+Namespace Microsoft.CodeAnalysis.VisualBasic.UnitTests.PDB
+
+    Public Class PDBTupleTests
+        Inherits BasicTestBase
+
+        <Fact>
+        Public Sub Local()
+            Dim source =
+<compilation>
+    <file><![CDATA[
+Class C
+    Shared Sub F()
+        Dim t As (A As Integer, B As Integer, (C As Integer, Integer), Integer, Integer, G As Integer, H As Integer, I As Integer) = (1, 2, (3, 4), 5, 6, 7, 8, 9)
+    End Sub
+End Class
+]]></file>
+</compilation>
+            Dim comp = CreateCompilationWithMscorlib(source, references:={ValueTupleRef}, options:=TestOptions.DebugDll)
+            comp.VerifyPdb("C.F",
+<symbols>
+    <methods>
+        <method containingType="C" name="F">
+            <customDebugInfo>
+                <tupleElementNames>
+                    <local elementNames="|A|B||||G|H|I|C||" slotIndex="0" localName="t" scopeStart="0x0" scopeEnd="0x0"/>
+                </tupleElementNames>
+                <encLocalSlotMap>
+                    <slot kind="0" offset="4"/>
+                </encLocalSlotMap>
+            </customDebugInfo>
+            <sequencePoints>
+                <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="19"/>
+                <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="163"/>
+                <entry offset="0x1b" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+            </sequencePoints>
+            <scope startOffset="0x0" endOffset="0x1c">
+                <currentnamespace name=""/>
+                <local name="t" il_index="0" il_start="0x0" il_end="0x1c" attributes="0"/>
+            </scope>
+        </method>
+    </methods>
+</symbols>)
+        End Sub
+
+    End Class
+
+End Namespace

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/EvaluationContext.cs
@@ -182,8 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             var currentFrame = compilation.GetMethod(moduleVersionId, methodHandle);
             Debug.Assert((object)currentFrame != null);
-            var sourceAssembly = compilation.SourceAssembly;
-            var symbolProvider = new CSharpEESymbolProvider(sourceAssembly, (PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
+            var symbolProvider = new CSharpEESymbolProvider(compilation.SourceAssembly, (PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
 
             var metadataDecoder = new MetadataDecoder((PEModuleSymbol)currentFrame.ContainingModule, currentFrame);
             var localInfo = metadataDecoder.GetLocalInfo(localSignatureHandle);

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/ExpressionCompilerTestBase.cs
@@ -353,7 +353,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator.UnitTests
             var peModule = (PEModuleSymbol)peMethod.ContainingModule;
 
             var symReader = runtime.Modules.Single(mi => mi.ModuleVersionId == peModule.Module.GetModuleVersionIdOrThrow()).SymReader;
-            var symbolProvider = new CSharpEESymbolProvider((SourceAssemblySymbol)peCompilation.Assembly, peModule, peMethod);
+            var symbolProvider = new CSharpEESymbolProvider(peCompilation.SourceAssembly, peModule, peMethod);
 
             return MethodDebugInfo<TypeSymbol, LocalSymbol>.ReadMethodDebugInfo((ISymUnmanagedReader3)symReader, symbolProvider, MetadataTokens.GetToken(peMethod.Handle), methodVersion: 1, ilOffset: ilOffset, isVisualBasicMethod: false);
         }

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
@@ -4,7 +4,6 @@ Imports System.Collections.Immutable
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
-Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Roslyn.Utilities
 
@@ -36,6 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Dim local = PlaceholderLocalSymbol.Create(
                     typeNameDecoder,
                     containingMethod,
+                    sourceAssembly,
                     [alias])
                 _implicitDeclarations.Add(local.Name, local)
             Next

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationExtensions.vb
@@ -1,10 +1,10 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Collections.ObjectModel
 Imports System.Reflection.Metadata
 Imports System.Reflection.Metadata.Ecma335
 Imports System.Runtime.CompilerServices
-Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
@@ -93,6 +93,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 assemblyName:=ExpressionCompilerUtilities.GenerateUniqueName(),
                 references:=references,
                 options:=s_compilationOptions)
+        End Function
+
+        <Extension>
+        Friend Function GetCustomTypeInfoPayload(compilation As VisualBasicCompilation, type As TypeSymbol) As ReadOnlyCollection(Of Byte)
+            Dim builder = ArrayBuilder(Of String).GetInstance()
+            Dim names = If(VisualBasicCompilation.TupleNamesEncoder.TryGetNames(type, builder) AndAlso compilation.HasTupleNamesAttributes,
+                New ReadOnlyCollection(Of String)(builder.ToArray()),
+                Nothing)
+            builder.Free()
+            Return CustomTypeInfo.Encode(Nothing, names)
         End Function
 
         Friend ReadOnly IdentityComparer As AssemblyIdentityComparer = DesktopAssemblyIdentityComparer.Default

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EEAssemblyBuilder.vb
@@ -18,7 +18,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend NotInheritable Class EEAssemblyBuilder
         Inherits PEAssemblyBuilderBase
 
-        Private ReadOnly _methods As ImmutableArray(Of MethodSymbol)
+        Friend ReadOnly Methods As ImmutableArray(Of MethodSymbol)
 
         Friend Sub New(
             sourceAssembly As SourceAssemblySymbol,
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 manifestResources:=SpecializedCollections.EmptyEnumerable(Of ResourceDescription)(),
                 additionalTypes:=additionalTypes)
 
-            _methods = methods
+            Me.Methods = methods
 
             If testData IsNot Nothing Then
                 SetMethodTestData(testData.Methods)
@@ -74,12 +74,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
         Friend Overrides Function TryCreateVariableSlotAllocator(symbol As MethodSymbol, topLevelMethod As MethodSymbol, diagnostics As DiagnosticBag) As VariableSlotAllocator
             Dim method = TryCast(symbol, EEMethodSymbol)
-            If method IsNot Nothing AndAlso _methods.Contains(method) Then
+            If method IsNot Nothing AndAlso Methods.Contains(method) Then
                 Dim defs = GetLocalDefinitions(method.Locals)
                 Return New SlotAllocator(defs)
             End If
 
-            Debug.Assert(Not _methods.Contains(symbol))
+            Debug.Assert(Not Methods.Contains(symbol))
             Return Nothing
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -187,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim currentFrame = compilation.GetMethod(moduleVersionId, methodHandle)
             Debug.Assert(currentFrame IsNot Nothing)
-            Dim symbolProvider = New VisualBasicEESymbolProvider(DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
+            Dim symbolProvider = New VisualBasicEESymbolProvider(compilation.SourceAssembly, DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
 
             Dim metadataDecoder = New MetadataDecoder(DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
             Dim localInfo = metadataDecoder.GetLocalInfo(localSignatureHandle)
@@ -409,8 +409,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 resultProperties = properties
                 Return New VisualBasicCompileResult(
                         stream.ToArray(),
-                        s_typeName,
-                        s_methodName,
+                        GetSynthesizedMethod(moduleBuilder),
                         formatSpecifiers)
             End Using
         End Function
@@ -459,8 +458,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                         properties.ModifierFlags)
                 Return New VisualBasicCompileResult(
                         stream.ToArray(),
-                        s_typeName,
-                        s_methodName,
+                        GetSynthesizedMethod(modulebuilder),
                         formatSpecifiers:=Nothing)
             End Using
         End Function
@@ -647,6 +645,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private Shared Function IsValidMissingAssemblyIdentity(identity As AssemblyIdentity) As Boolean
             Return identity IsNot Nothing AndAlso Not identity.Equals(MissingCorLibrarySymbol.Instance.Identity)
         End Function
+
+        Private Shared Function GetSynthesizedMethod(moduleBuilder As CommonPEModuleBuilder) As MethodSymbol
+            Dim method = DirectCast(moduleBuilder, EEAssemblyBuilder).Methods.Single(Function(m) m.MetadataName = s_methodName)
+            Debug.Assert(method.ContainingType.MetadataName = s_typeName)
+            Return method
+        End Function
+
     End Class
 
 End Namespace

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/SymbolExtensions.vb
@@ -1,12 +1,18 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Collections.ObjectModel
 Imports System.Runtime.CompilerServices
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend Module SymbolExtensions
+        <Extension>
+        Friend Function GetCustomTypeInfoPayload(method As MethodSymbol) As ReadOnlyCollection(Of Byte)
+            Return method.DeclaringCompilation.GetCustomTypeInfoPayload(method.ReturnType)
+        End Function
+
         <Extension>
         Public Function IsContainingSymbolOfAllTypeParameters(containingSymbol As Symbol, type As TypeSymbol) As Boolean
             Return type.VisitType(s_hasInvalidTypeParameterFunc, containingSymbol) Is Nothing

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EEMethodSymbol.vb
@@ -578,6 +578,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             End Select
         End Function
 
+        Friend Overrides Sub AddSynthesizedReturnTypeAttributes(ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
+            MyBase.AddSynthesizedReturnTypeAttributes(attributes)
+
+            Dim returnType = Me.ReturnType
+            If returnType.ContainsTupleNames() AndAlso DeclaringCompilation.HasTupleNamesAttributes() Then
+                AddSynthesizedAttribute(attributes, DeclaringCompilation.SynthesizeTupleNamesAttribute(returnType))
+            End If
+        End Sub
+
         Friend Overrides Function CalculateLocalSyntaxOffset(localPosition As Integer, localTree As SyntaxTree) As Integer
             Return localPosition
         End Function

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
@@ -1,6 +1,7 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Collections.Immutable
+Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
@@ -25,6 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overloads Shared Function Create(
             typeNameDecoder As TypeNameDecoder(Of PEModuleSymbol, TypeSymbol),
             containingMethod As MethodSymbol,
+            sourceAssembly As AssemblySymbol,
             [alias] As [Alias]) As PlaceholderLocalSymbol
 
             Dim typeName = [alias].Type
@@ -32,6 +34,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim type = typeNameDecoder.GetTypeSymbolForSerializedType(typeName)
             Debug.Assert(type IsNot Nothing)
+
+            Dim dynamicFlags As ReadOnlyCollection(Of Byte) = Nothing
+            Dim tupleElementNames As ReadOnlyCollection(Of String) = Nothing
+            CustomTypeInfo.Decode([alias].CustomTypeInfoId, [alias].CustomTypeInfo, dynamicFlags, tupleElementNames)
+
+            If tupleElementNames IsNot Nothing Then
+                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, sourceAssembly, tupleElementNames.AsImmutable())
+            End If
 
             Dim name = [alias].FullName
             Dim displayName = [alias].Name

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicCompileResult.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicCompileResult.vb
@@ -2,23 +2,27 @@
 
 Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
-    Friend NotInheritable Class VisualBasicCompileResult : Inherits CompileResult
+    Friend NotInheritable Class VisualBasicCompileResult
+        Inherits CompileResult
+
+        Private ReadOnly _method As MethodSymbol
 
         Public Sub New(
             assembly As Byte(),
-            typeName As String,
-            methodName As String,
+            method As MethodSymbol,
             formatSpecifiers As ReadOnlyCollection(Of String))
 
-            MyBase.New(assembly, typeName, methodName, formatSpecifiers)
+            MyBase.New(assembly, method.ContainingType.MetadataName, method.MetadataName, formatSpecifiers)
+            _method = method
         End Sub
 
         Public Overrides Function GetCustomTypeInfo(ByRef payload As ReadOnlyCollection(Of Byte)) As Guid
-            payload = Nothing
-            Return Nothing
+            payload = _method.GetCustomTypeInfoPayload()
+            Return If(payload Is Nothing, Nothing, CustomTypeInfo.PayloadTypeId)
         End Function
     End Class
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLocalAndMethod.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicLocalAndMethod.vb
@@ -2,19 +2,23 @@
 
 Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
     Friend NotInheritable Class VisualBasicLocalAndMethod : Inherits LocalAndMethod
 
-        Public Sub New(localName As String, localDisplayName As String, methodName As String, flags As DkmClrCompilationResultFlags)
-            MyBase.New(localName, localDisplayName, methodName, flags)
+        Private ReadOnly _method As MethodSymbol
+
+        Public Sub New(localName As String, localDisplayName As String, method As MethodSymbol, flags As DkmClrCompilationResultFlags)
+            MyBase.New(localName, localDisplayName, method.Name, flags)
+            _method = method
         End Sub
 
         Public Overrides Function GetCustomTypeInfo(ByRef payload As ReadOnlyCollection(Of Byte)) As Guid
-            payload = Nothing
-            Return Nothing
+            payload = _method.GetCustomTypeInfoPayload()
+            Return If(payload Is Nothing, Nothing, CustomTypeInfo.PayloadTypeId)
         End Function
     End Class
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -355,7 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
             Dim peMethod = peCompilation.GlobalNamespace.GetMember(Of PEMethodSymbol)(qualifiedMethodName)
             Dim peModule = DirectCast(peMethod.ContainingModule, PEModuleSymbol)
             Dim symReader = runtime.Modules.Single(Function(mi) mi.ModuleVersionId = peModule.Module.GetModuleVersionIdOrThrow()).SymReader
-            Dim symbolProvider = New VisualBasicEESymbolProvider(peModule, peMethod)
+            Dim symbolProvider = New VisualBasicEESymbolProvider(peCompilation.SourceAssembly, peModule, peMethod)
             Return MethodDebugInfo(Of TypeSymbol, LocalSymbol).ReadMethodDebugInfo(DirectCast(symReader, ISymUnmanagedReader3), symbolProvider, MetadataTokens.GetToken(peMethod.Handle), methodVersion:=1, ilOffset:=ilOffset, isVisualBasicMethod:=True)
         End Function
 

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/TupleTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/TupleTests.vb
@@ -1,10 +1,14 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Collections.ObjectModel
 Imports Microsoft.CodeAnalysis.CodeGen
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator
 Imports Microsoft.CodeAnalysis.ExpressionEvaluator.UnitTests
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.UnitTests
+Imports Microsoft.VisualStudio.Debugger.Clr
+Imports Microsoft.VisualStudio.Debugger.Evaluation
 Imports Microsoft.VisualStudio.Debugger.Evaluation.ClrCompilation
 Imports Roslyn.Test.Utilities
 Imports Xunit
@@ -14,8 +18,104 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
     Public Class TupleTests
         Inherits ExpressionCompilerTestBase
 
+        <Fact>
+        Public Sub Literal()
+            Const source =
+"Class C
+    Shared Sub M()
+        Dim o As (Integer, Integer)
+    End Sub
+End Class"
+            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim errorMessage As String = Nothing
+                    Dim testData = New CompilationTestData()
+                    Dim result = context.CompileExpression(
+                        "(A:=1, B:=2)",
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        errorMessage,
+                        testData)
+                    Assert.Null(errorMessage)
+                    Dim typeInfo As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim typeInfoId = result.GetCustomTypeInfo(typeInfo)
+                    Assert.NotNull(typeInfo)
+                    Dim dynamicFlags As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim tupleElementNames As ReadOnlyCollection(Of String) = Nothing
+                    CustomTypeInfo.Decode(typeInfoId, typeInfo, dynamicFlags, tupleElementNames)
+                    Assert.Equal({"A", "B"}, tupleElementNames)
+                    Dim methodData = testData.GetMethodData("<>x.<>m0")
+                    Dim method = methodData.Method
+                    Assert.True(method.ReturnType.IsTupleType)
+                    Assert.NotNull(GetTupleElementNamesAttributeIfAny(method))
+                    methodData.VerifyIL(
+"{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0) //o
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.2
+  IL_0002:  newobj     ""Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0007:  ret
+}")
+                End Sub)
+        End Sub
+
+        <Fact>
+        Public Sub TupleElementNamesAttribute_NotAvailable()
+            Const source =
+"Namespace System
+    Public Structure ValueTuple(Of T1, T2)
+        Public Item1 As T1
+        Public Item2 As T2
+        Public Sub New(_1 As T1, _2 As T2)
+            Item1 = _1
+            Item2 = _2
+        End Sub
+    End Structure
+End Namespace
+Class C
+    Shared Sub M()
+        Dim o As (Integer, Integer)
+    End Sub
+End Class"
+            Dim comp = CreateCompilationWithMscorlib({source}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim errorMessage As String = Nothing
+                    Dim testData = New CompilationTestData()
+                    Dim result = context.CompileExpression(
+                        "(A:=1, B:=2)",
+                        DkmEvaluationFlags.TreatAsExpression,
+                        NoAliases,
+                        errorMessage,
+                        testData)
+                    Assert.Null(errorMessage)
+                    Dim typeInfo As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim typeInfoId = result.GetCustomTypeInfo(typeInfo)
+                    Assert.Null(typeInfo)
+                    Dim methodData = testData.GetMethodData("<>x.<>m0")
+                    Dim method = methodData.Method
+                    Assert.True(method.ReturnType.IsTupleType)
+                    Assert.Null(GetTupleElementNamesAttributeIfAny(method))
+                    methodData.VerifyIL(
+"{
+  // Code size        8 (0x8)
+  .maxstack  2
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0) //o
+  IL_0000:  ldc.i4.1
+  IL_0001:  ldc.i4.2
+  IL_0002:  newobj     ""Sub System.ValueTuple(Of Integer, Integer)..ctor(Integer, Integer)""
+  IL_0007:  ret
+}")
+                End Sub)
+        End Sub
+
         <WorkItem(13948, "https://github.com/dotnet/roslyn/issues/13948")>
-        <Fact(Skip:="13948")>
+        <Fact>
         Public Sub Local()
             Const source =
 "class C
@@ -47,7 +147,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
 "{
   // Code size        2 (0x2)
   .maxstack  1
-  .locals init ((int A, int B) V_0) //o
+  .locals init ((A As Integer, B As Integer) V_0) //o
   IL_0000:  ldloc.0
   IL_0001:  ret
 }")
@@ -56,7 +156,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
         End Sub
 
         <WorkItem(13948, "https://github.com/dotnet/roslyn/issues/13948")>
-        <Fact(Skip:="13948")>
+        <Fact>
         Public Sub Constant()
             Const source =
 "class A<T>
@@ -99,6 +199,120 @@ class C
   .maxstack  1
   IL_0000:  ldnull
   IL_0001:  ret
+}")
+                    locals.Free()
+                End Sub)
+        End Sub
+
+        ''' <summary>
+        ''' Locals declared in the VB EE do not have an explicit
+        ''' type and are statically typed to Object, so tuple
+        ''' element names on the value are not preserved.
+        ''' </summary>
+        <Fact>
+        Public Sub DeclareLocal()
+            Const source =
+"Class C
+    Shared Sub M()
+        Dim x = (1, 2)
+    End Sub
+End Class"
+            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim errorMessage As String = Nothing
+                    Dim testData = New CompilationTestData()
+                    Dim result = context.CompileExpression(
+                        "y = DirectCast(x, (A As Integer, B As Integer))",
+                        DkmEvaluationFlags.None,
+                        NoAliases,
+                        errorMessage,
+                        testData)
+                    Assert.Null(errorMessage)
+                    Dim typeInfo As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim typeInfoId = result.GetCustomTypeInfo(typeInfo)
+                    Assert.Null(typeInfo)
+                    Dim methodData = testData.GetMethodData("<>x.<>m0")
+                    Dim method = methodData.Method
+                    Assert.Null(GetTupleElementNamesAttributeIfAny(method))
+                    methodData.VerifyIL(
+"{
+  // Code size       43 (0x2b)
+  .maxstack  4
+  .locals init (System.ValueTuple(Of Integer, Integer) V_0, //x
+                System.Guid V_1)
+  IL_0000:  ldtoken    ""Object""
+  IL_0005:  call       ""Function System.Type.GetTypeFromHandle(System.RuntimeTypeHandle) As System.Type""
+  IL_000a:  ldstr      ""y""
+  IL_000f:  ldloca.s   V_1
+  IL_0011:  initobj    ""System.Guid""
+  IL_0017:  ldloc.1
+  IL_0018:  ldnull
+  IL_0019:  call       ""Sub Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.CreateVariable(System.Type, String, System.Guid, Byte())""
+  IL_001e:  ldstr      ""y""
+  IL_0023:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress(Of Object)(String) As Object""
+  IL_0028:  ldloc.0
+  IL_0029:  stind.ref
+  IL_002a:  ret
+}")
+                End Sub)
+        End Sub
+
+        <WorkItem(13589, "https://github.com/dotnet/roslyn/issues/13589")>
+        <Fact>
+        Public Sub [Alias]()
+            Const source =
+"Class C
+    Shared F As (Integer, Integer)
+    Shared Sub M()
+    End Sub
+End Class"
+            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp,
+                Sub(runtime)
+                    Dim context = CreateMethodContext(runtime, "C.M")
+                    Dim locals = ArrayBuilder(Of LocalAndMethod).GetInstance()
+                    Dim typeName As String = Nothing
+                    Dim aliasElementNames = New ReadOnlyCollection(Of String)({"A", "B", Nothing, "D"})
+                    Dim [alias] = New [Alias](
+                        DkmClrAliasKind.Variable,
+                        "t",
+                        "t",
+                        "System.ValueTuple`2[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.ValueTuple`2[[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51]][], System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51",
+                        CustomTypeInfo.PayloadTypeId,
+                        CustomTypeInfo.Encode(Nothing, aliasElementNames))
+                    Dim diagnostics = DiagnosticBag.GetInstance()
+                    Dim testData = New CompilationTestData()
+                    Dim assembly = context.CompileGetLocals(
+                        locals,
+                        argumentsOnly:=False,
+                        aliases:=ImmutableArray.Create([alias]),
+                        diagnostics:=diagnostics,
+                        typeName:=typeName,
+                        testData:=testData)
+                    diagnostics.Verify()
+                    diagnostics.Free()
+                    Assert.Equal(1, locals.Count)
+                    Dim typeInfo As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim typeInfoId = locals(0).GetCustomTypeInfo(typeInfo)
+                    Dim dynamicFlags As ReadOnlyCollection(Of Byte) = Nothing
+                    Dim tupleElementNames As ReadOnlyCollection(Of String) = Nothing
+                    CustomTypeInfo.Decode(typeInfoId, typeInfo, dynamicFlags, tupleElementNames)
+                    Assert.Equal(aliasElementNames, tupleElementNames)
+                    Dim method = testData.Methods.Single().Value.Method
+                    Assert.NotNull(GetTupleElementNamesAttributeIfAny(method))
+                    Dim returnType = DirectCast(method.ReturnType, TypeSymbol)
+                    Assert.False(returnType.IsTupleType)
+                    Assert.True(DirectCast(returnType, ArrayTypeSymbol).ElementType.IsTupleType)
+                    VerifyLocal(testData, typeName, locals(0), "<>m0", "t", expectedILOpt:=
+"{
+  // Code size       16 (0x10)
+  .maxstack  1
+  IL_0000:  ldstr      ""t""
+  IL_0005:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetObjectByAlias(String) As Object""
+  IL_000a:  castclass  ""(A As Integer, B As (Integer, D As Integer))()""
+  IL_000f:  ret
 }")
                     locals.Free()
                 End Sub)


### PR DESCRIPTION
Port #13879 to VB and add missing support for debugger aliases for C# and VB.

@dotnet/roslyn-compiler, @jcouv, @vsadov, @tmat, please review.