### PR TITLE
Typing delay: CSharpEditorFormatingService constructor

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -29,23 +29,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
     internal partial class CSharpEditorFormattingService : IEditorFormattingService
     {
         private readonly ImmutableHashSet<char> _supportedChars;
-        private readonly ImmutableHashSet<char> _autoFormattingTriggerChars;
-        private readonly ImmutableDictionary<char, ImmutableHashSet<SyntaxKind>> _multiWordsMap;
 
         public CSharpEditorFormattingService()
         {
-            _autoFormattingTriggerChars = ImmutableHashSet.CreateRange<char>(";}");
-
             // add all auto formatting trigger to supported char
-            _supportedChars = _autoFormattingTriggerChars.Union("{}#nte:)");
-
-            // set up multi words map
-            _multiWordsMap = ImmutableDictionary.CreateRange(new[]
-            {
-                KeyValuePair.Create('n', ImmutableHashSet.Create(SyntaxKind.RegionKeyword, SyntaxKind.EndRegionKeyword)),
-                KeyValuePair.Create('t', ImmutableHashSet.Create(SyntaxKind.SelectKeyword)),
-                KeyValuePair.Create('e', ImmutableHashSet.Create(SyntaxKind.WhereKeyword)),
-            });
+            _supportedChars = ImmutableHashSet.CreateRange<char>(";{}#nte:)");
         }
 
         public bool SupportsFormatDocument { get { return true; } }
@@ -271,14 +259,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         private bool ValidSingleOrMultiCharactersTokenKind(char typedChar, SyntaxKind kind)
         {
-            ImmutableHashSet<SyntaxKind> set;
-            if (!_multiWordsMap.TryGetValue(typedChar, out set))
+            switch (typedChar)
             {
-                // all single char token is valid
-                return true;
+                case ('n'):
+                    return kind == SyntaxKind.RegionKeyword || kind == SyntaxKind.EndRegionKeyword;
+                case ('t'):
+                    return kind == SyntaxKind.SelectKeyword;
+                case ('e'):
+                    return kind == SyntaxKind.WhereKeyword;
+                default:
+                    return true;
             }
-
-            return set.Contains(kind);
         }
 
         private bool IsInvalidToken(char typedChar, SyntaxToken token)

--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -28,12 +28,11 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
     [ExportLanguageService(typeof(IEditorFormattingService), LanguageNames.CSharp), Shared]
     internal partial class CSharpEditorFormattingService : IEditorFormattingService
     {
-        private readonly ImmutableHashSet<char> _supportedChars;
+        // All the characters that might potentially trigger formatting when typed
+        private readonly char[] _supportedChars = ";{}#nte:)".ToCharArray();
 
         public CSharpEditorFormattingService()
         {
-            // add all auto formatting trigger to supported char
-            _supportedChars = ImmutableHashSet.CreateRange<char>(";{}#nte:)");
         }
 
         public bool SupportsFormatDocument { get { return true; } }
@@ -259,6 +258,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
 
         private bool ValidSingleOrMultiCharactersTokenKind(char typedChar, SyntaxKind kind)
         {
+            // We'll autoformat on n, t, e, only if they are the last character of the below
+            // keywords.  
             switch (typedChar)
             {
                 case ('n'):


### PR DESCRIPTION
CSharpEditorFormattingService creates an ImmutableDictionary and multiple ImmutableHashSets in its constructor. This shows up in the editor's typing delay telemetry because all of these sets are created when the C#EFS is statisfied by MEF on the UI thread. To ameliorate this:
* Replace _multiWordsMap with a switch statement
* Remove the unused _autoFormattingTriggerChars set
* Construct the _supportedChars set with one call to CreateRange