### PR TITLE
Porting more tuple tests to VB

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -7191,7 +7191,7 @@ class C
             Assert.Equal(Conversion.NoConversion, model.GetConversion(node));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/11289")]
+        [Fact]
         [WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")]
         public void TupleConvertedTypeUDC04()
         {
@@ -7265,7 +7265,7 @@ namespace System
             CompileAndVerify(comp, expectedOutput: "{1, qq}");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/11289")]
+        [Fact]
         [WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")]
         public void TupleConvertedTypeUDC05()
         {
@@ -7348,7 +7348,7 @@ namespace System
 {1, qq}");
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/11289")]
+        [Fact]
         [WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")]
         public void TupleConvertedTypeUDC06()
         {

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1595,6 +1595,9 @@ DoneWithDiagnostics:
 
             If targetType.IsTupleType Then
                 Dim destTupleType = DirectCast(targetType, TupleTypeSymbol)
+
+                TupleTypeSymbol.ReportNamesMismatchesIfAny(targetType, sourceTuple, diagnostics)
+
                 ' do not lose the original element names in the literal if different from names in the target
                 ' Come back to this, what about locations? (https:'github.com/dotnet/roslyn/issues/11013)
                 targetType = destTupleType.WithElementNames(sourceTuple.ArgumentNamesOpt)

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1766,8 +1766,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         WRN_ConstraintsFailedForInferredArgs2 = 41006
         WRN_ConditionalNotValidOnFunction = 41007
         WRN_UseSwitchInsteadOfAttribute = 41008
+        WRN_TupleLiteralNameMismatch = 41009
 
-        '// AVAILABLE                             41009 - 41199
+        '// AVAILABLE                             41010 - 41199
         WRN_ReferencedAssemblyDoesNotHaveStrongName = 41997
         WRN_RecursiveAddHandlerCall = 41998
         WRN_ImplicitConversionCopyBack = 41999

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -14575,6 +14575,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to The tuple element name &apos;{0}&apos; is ignored because a different name is specified by the target type &apos;{1}&apos;..
+        '''</summary>
+        Friend ReadOnly Property WRN_TupleLiteralNameMismatch() As String
+            Get
+                Return ResourceManager.GetString("WRN_TupleLiteralNameMismatch", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to {0} &apos;{1}&apos; and partial {2} &apos;{3}&apos; conflict in {4} &apos;{5}&apos;, but are being merged because one of them is declared partial..
         '''</summary>
         Friend ReadOnly Property WRN_TypeConflictButMerged6() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -14584,6 +14584,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to The tuple element name is ignored because a different name is specified by the assignment target..
+        '''</summary>
+        Friend ReadOnly Property WRN_TupleLiteralNameMismatch_Title() As String
+            Get
+                Return ResourceManager.GetString("WRN_TupleLiteralNameMismatch_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to {0} &apos;{1}&apos; and partial {2} &apos;{3}&apos; conflict in {4} &apos;{5}&apos;, but are being merged because one of them is declared partial..
         '''</summary>
         Friend ReadOnly Property WRN_TypeConflictButMerged6() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5385,6 +5385,9 @@
   <data name="WRN_TupleLiteralNameMismatch" xml:space="preserve">
     <value>The tuple element name '{0}' is ignored because a different name is specified by the target type '{1}'.</value>
   </data>
+  <data name="WRN_TupleLiteralNameMismatch_Title" xml:space="preserve">
+    <value>The tuple element name is ignored because a different name is specified by the assignment target.</value>
+  </data>
   <data name="ERR_TupleReservedElementName" xml:space="preserve">
     <value>Tuple element name '{0}' is only allowed at position {1}.</value>
   </data>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -5382,6 +5382,9 @@
   <data name="ERR_TupleDuplicateElementName" xml:space="preserve">
     <value>Tuple element names must be unique.</value>
   </data>
+  <data name="WRN_TupleLiteralNameMismatch" xml:space="preserve">
+    <value>The tuple element name '{0}' is ignored because a different name is specified by the target type '{1}'.</value>
+  </data>
   <data name="ERR_TupleReservedElementName" xml:space="preserve">
     <value>Tuple element name '{0}' is only allowed at position {1}.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -8978,7 +8978,54 @@ False
             Dim consumer2 = CreateCompilationWithMscorlibAndVBRuntime(source, options:=TestOptions.ReleaseExe, additionalRefs:={[lib].EmitToImageReference()})
             CompileAndVerify(consumer2, expectedOutput:=expectedOutput).VerifyDiagnostics()
         End Sub
+
+        <Fact>
+        Public Sub TupleConversion01()
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb"><![CDATA[
+
+Module C
+    Sub Main()
+        Dim x1 As (a As Integer, b As Integer) = DirectCast((e:=1, f:=2), (c As Long, d As Long))
+        Dim x2 As (a As Short, b As Short) = DirectCast((e:=1, f:=2), (c As Integer, d As Integer))
+        Dim x3 As (a As Integer, b As Integer) = DirectCast((e:=1, f:="qq"), (c As Long, d As Long))
+    End Sub
+End Module
+
+]]></file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            ' REVIEW TODO no conversion error on x2 or x3
+            comp.AssertTheseDiagnostics(
+<errors>
+BC41009: The tuple element name 'e' is ignored because a different name is specified by the target type '(c As Long, d As Long)'.
+        Dim x1 As (a As Integer, b As Integer) = DirectCast((e:=1, f:=2), (c As Long, d As Long))
+                                                             ~~~~
+BC41009: The tuple element name 'f' is ignored because a different name is specified by the target type '(c As Long, d As Long)'.
+        Dim x1 As (a As Integer, b As Integer) = DirectCast((e:=1, f:=2), (c As Long, d As Long))
+                                                                   ~~~~
+BC41009: The tuple element name 'e' is ignored because a different name is specified by the target type '(c As Integer, d As Integer)'.
+        Dim x2 As (a As Short, b As Short) = DirectCast((e:=1, f:=2), (c As Integer, d As Integer))
+                                                         ~~~~
+BC41009: The tuple element name 'f' is ignored because a different name is specified by the target type '(c As Integer, d As Integer)'.
+        Dim x2 As (a As Short, b As Short) = DirectCast((e:=1, f:=2), (c As Integer, d As Integer))
+                                                               ~~~~
+BC41009: The tuple element name 'e' is ignored because a different name is specified by the target type '(c As Long, d As Long)'.
+        Dim x3 As (a As Integer, b As Integer) = DirectCast((e:=1, f:="qq"), (c As Long, d As Long))
+                                                             ~~~~
+BC41009: The tuple element name 'f' is ignored because a different name is specified by the target type '(c As Long, d As Long)'.
+        Dim x3 As (a As Integer, b As Integer) = DirectCast((e:=1, f:="qq"), (c As Long, d As Long))
+                                                                   ~~~~~~~
+</errors>)
+
+        End Sub
+
+
+
     End Class
+
 
 End Namespace
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -10327,48 +10327,6 @@ options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
 
         End Sub
 
-        <Fact>
-        Public Sub TupleConvertedTypeUDC07_StrictOff_Narrowing()
-
-            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
-<compilation name="Tuples">
-    <file name="a.vb">
-Public Class C
-    Shared Sub Main()
-        Dim x As C1 = M1()
-        System.Console.Write(x.ToString())
-    End Sub
-
-    Shared Function M1() As (Integer, String)
-        Return (1, "qq")
-    End Function
-
-    Public Class C1
-        Public Dim val As (Byte, String)
-
-        Public Sub New(ByVal arg As (Byte, String))
-            val = arg
-        End Sub
-
-        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
-            System.Console.Write("C1 ")
-            Return New C1(arg)
-        End Operator
-    End Class
-End Class
-    </file>
-</compilation>,
-options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
-
-            comp.AssertTheseDiagnostics()
-
-            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
-            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
-
-            CompileAndVerify(comp, expectedOutput:="C1 C+C1")
-
-        End Sub
-
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -33,6 +33,25 @@ Namespace System
             me.Item1 = item1
             me.Item2 = item2
         End Sub
+
+        Public Overrides Function ToString() As String
+            Return ""{"" + Item1?.ToString() + "", "" + Item2?.ToString() + ""}""
+        End Function
+    End Structure
+End Namespace
+"
+        ReadOnly s_trivial3uple As String = "
+Namespace System
+    Public Structure ValueTuple(Of T1, T2, T3)
+        Public Dim Item1 As T1
+        Public Dim Item2 As T2
+        Public Dim Item3 As T3
+
+        Public Sub New(item1 As T1, item2 As T2, item3 As T3)
+            me.Item1 = item1
+            me.Item2 = item2
+            me.Item3 = item3
+        End Sub
     End Structure
 End Namespace
 "
@@ -4428,8 +4447,6 @@ Class C
 End Class
     </file>
 </compilation>, additionalRefs:=s_valueTupleRefs, expectedOutput:=<![CDATA[42 Alice]]>)
-
-            verifier.VerifyDiagnostics()
 
         End Sub
 
@@ -9022,10 +9039,1007 @@ BC41009: The tuple element name 'f' is ignored because a different name is speci
 
         End Sub
 
+        <Fact>
+        <WorkItem(11288, "https://github.com/dotnet/roslyn/issues/11288")>
+        Public Sub TupleConversion02()
 
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x4 As (a As Integer, b As Integer) = DirectCast((1, Nothing, 2), (c As Long, d As Long))
+    End Sub
+End Module
+        <%= s_trivial2uple %><%= s_trivial3uple %>
+    </file>
+</compilation>)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30311: Value of type '(Integer, Object, Integer)' cannot be converted to '(c As Long, d As Long)'.
+        Dim x4 As (a As Integer, b As Integer) = DirectCast((1, Nothing, 2), (c As Long, d As Long))
+                                                            ~~~~~~~~~~~~~~~
+</errors>)
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType01()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String)? = (e:=1, f:="hello")
+    End Sub
+End Module
+
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int16, b As System.String))", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int16, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType01insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String)? = DirectCast((e:=1, f:="hello"), (c As Short, d As String)?)
+        Dim y As Short? = DirectCast(11, Short?)
+    End Sub
+End Module
+
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim l11 = nodes.OfType(Of LiteralExpressionSyntax)().ElementAt(2)
+
+            Assert.Equal("11", l11.ToString())
+            Assert.Equal("System.Int32", model.GetTypeInfo(l11).Type.ToTestDisplayString())
+            Assert.Equal("System.Int32", model.GetTypeInfo(l11).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(l11).Kind)
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (c As System.Int16, d As System.String))", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Assert.Equal("System.Nullable(Of (c As System.Int16, d As System.String))", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (c As System.Int16, d As System.String))", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int16, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType01insourceImplicit()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String)? = (1, "hello")
+    End Sub
+End Module
+
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(1, ""hello"")", node.ToString())
+            Dim typeInfo As TypeInfo = model.GetTypeInfo(node)
+            Assert.Equal("(System.Int32, System.String)", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int16, b As System.String))", typeInfo.ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp)
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType02()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String)? = (e:=1, f:="hello")
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Dim typeInfo As TypeInfo = model.GetTypeInfo(node)
+            Assert.Equal("(e As System.Int32, f As System.String)", typeInfo.Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int16, b As System.String))", typeInfo.ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int16, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType02insource00()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String)? = DirectCast((e:=1, f:="hello"), (c As Short, d As String))
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int16, b As System.String))", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int16, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType02insource01()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x = (e:=1, f:="hello")
+        Dim x1 As (a As Object, b As String) = DirectCast((x), (c As Long, d As String))
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of ParenthesizedExpressionSyntax)().Single().Parent
+
+            Assert.Equal("DirectCast((x), (c As Long, d As String))", node.ToString())
+            Assert.Equal("(c As System.Int64, d As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(a As System.Object, b As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of ParenthesizedExpressionSyntax)().Single()
+            Assert.Equal("(x)", x.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(x).Type.ToTestDisplayString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(x).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(x).Kind)
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType02insource02()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x = (e:=1, f:="hello")
+        Dim x1 As (a As Object, b As String)? = DirectCast((x), (c As Long, d As String))
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of ParenthesizedExpressionSyntax)().Single().Parent
+
+            Assert.Equal("DirectCast((x), (c As Long, d As String))", node.ToString())
+            Assert.Equal("(c As System.Int64, d As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Object, b As System.String))", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of ParenthesizedExpressionSyntax)().Single()
+            Assert.Equal("(x)", x.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(x).Type.ToTestDisplayString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(x).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(x).Kind)
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType03()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Integer, b As String)? = (e:=1, f:="hello")
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int32, b As System.String))", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int32, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType03insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Integer, b As String)? = DirectCast((e:=1, f:="hello"), (c As Integer, d As String)?)
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (c As System.Int32, d As System.String))", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Assert.Equal("System.Nullable(Of (c As System.Int32, d As System.String))", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (c As System.Int32, d As System.String))", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node.Parent).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int32, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType04()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Integer, b As String)? = DirectCast((e:=1, f:="hello"), (c As Integer, d As String))
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int32, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node).Kind)
+
+            Assert.Equal("(c As System.Int32, d As System.String)", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("System.Nullable(Of (a As System.Int32, b As System.String))", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningNullable, model.GetConversion(node.Parent).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As System.Nullable(Of (a As System.Int32, b As System.String))", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType05()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Integer, b As String) = (e:=1, f:="hello")
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(a As System.Int32, b As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int32, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType05insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Integer, b As String) = DirectCast((e:=1, f:="hello"), (c As Integer, d As String))
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int32, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int32, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType06()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String) = (e:=1, f:="hello")
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(a As System.Int16, b As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedType06insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String) = DirectCast((e:=1, f:="hello"), (c As Short, d As String))
+        Dim y As Short = DirectCast(11, short)
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim l11 = nodes.OfType(Of LiteralExpressionSyntax)().ElementAt(2)
+
+            Assert.Equal("11", l11.ToString())
+            Assert.Equal("System.Int32", model.GetTypeInfo(l11).Type.ToTestDisplayString())
+            Assert.Equal("System.Int32", model.GetTypeInfo(l11).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(l11).Kind)
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=""hello"")", node.ToString())
+            Assert.Equal("(e As System.Int32, f As System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind)
+
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node.Parent).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeNull01()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String) = (e:=1, f:=Nothing)
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=Nothing)", node.ToString())
+            Assert.Null(model.GetTypeInfo(node).Type)
+            Assert.Equal("(a As System.Int16, b As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeNull01insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Module C
+    Sub Main()
+        Dim x As (a As Short, b As String) = DirectCast((e:=1, f:=Nothing), (c As Short, d As String))
+        Dim y As String = DirectCast(Nothing, String)
+    End Sub
+End Module
+        <%= s_trivial2uple %>
+    </file>
+</compilation>)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim lnothing = nodes.OfType(Of LiteralExpressionSyntax)().ElementAt(2)
+
+            Assert.Equal("Nothing", lnothing.ToString())
+            Assert.Null(model.GetTypeInfo(lnothing).Type)
+            Assert.Equal("System.Object", model.GetTypeInfo(lnothing).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.WideningNothingLiteral, model.GetConversion(lnothing).Kind)
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=Nothing)", node.ToString())
+            Assert.Null(model.GetTypeInfo(node).Type)
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.WideningTuple, model.GetConversion(node).Kind)
+
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node.Parent).Kind)
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeUDC01()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Class C
+    Shared Sub Main()
+        Dim x As (a As Short, b As String) = (e:=1, f:=New C1("qq"))
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Class C1
+        Public Dim s As String
+        Public Sub New(ByVal arg As String)
+            s = arg + "1"
+        End Sub
+        Public Shared Narrowing Operator CType(ByVal arg As C1) As String
+            Return arg.s
+        End Operator
+    End Class
+End Class
+        <%= s_trivial2uple %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=New C1(""qq""))", node.ToString())
+            Assert.Equal("(e As System.Int32, f As C.C1)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(a As System.Int16, b As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.NarrowingTuple, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+            CompileAndVerify(comp, expectedOutput:="{1, qq1}")
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeUDC01insource()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Class C
+    Shared Sub Main()
+        Dim x As (a As Short, b As String) = DirectCast((e:=1, f:=New C1("qq")), (c As Short, d As String))
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Class C1
+        Public Dim s As String
+        Public Sub New(ByVal arg As String)
+            s = arg + "1"
+        End Sub
+        Public Shared Narrowing Operator CType(ByVal arg As C1) As String
+            Return arg.s
+        End Operator
+    End Class
+End Class
+        <%= s_trivial2uple %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(e:=1, f:=New C1(""qq""))", node.ToString())
+            Assert.Equal("(e As System.Int32, f As C.C1)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.NarrowingTuple, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).Type.ToTestDisplayString())
+            Assert.Equal("(c As System.Int16, d As System.String)", model.GetTypeInfo(node.Parent).ConvertedType.ToTestDisplayString()) ' TODO REVIEW
+            Assert.Equal(ConversionKind.Identity, model.GetConversion(node.Parent).Kind) ' TODO REVIEW
+
+            Dim x = nodes.OfType(Of VariableDeclaratorSyntax)().First().Names(0)
+            Assert.Equal("x As (a As System.Int16, b As System.String)", model.GetDeclaredSymbol(x).ToTestDisplayString())
+
+            CompileAndVerify(comp, expectedOutput:="{1, qq1}")
+
+        End Sub
+
+        <Fact>
+        <WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")>
+        Public Sub TupleConvertedTypeUDC02()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Class C
+    Shared Sub Main()
+        Dim x As C1 = (1, "qq")
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Class C1
+        Public Dim val As (Byte, String)
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
+            Return New C1(arg)  ' TODO REVIEW
+        End Operator
+        Public Overrides Function ToString() As String
+            Return val.ToString()
+        End Function
+    End Class
+End Class
+        <%= s_trivial2uple %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(1, ""qq"")", node.ToString())
+            Assert.Equal("(System.Int32, System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("C.C1", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Narrowing Or ConversionKind.UserDefined, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp, expectedOutput:="{1, qq}")
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeUDC03()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Class C
+    Shared Sub Main()
+        Dim x As C1 = ("1", "qq")
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Class C1
+        Public Dim val As (Byte, String)
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
+            Return New C1(arg)
+        End Operator
+        Public Overrides Function ToString() As String
+            Return val.ToString()
+        End Function
+    End Class
+End Class
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe, additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+</errors>) ' TODO REVIEW
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().Single()
+
+            Assert.Equal("(""1"", ""qq"")", node.ToString())
+            Assert.Equal("(System.String, System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("C.C1", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Narrowing Or ConversionKind.UserDefined, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp, expectedOutput:="(1, qq)")
+
+        End Sub
+
+        <Fact>
+        <WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")>
+        Public Sub TupleConvertedTypeUDC04()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim x As C1 = (1, "qq")
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Public Class C1
+        Public Dim val As (Byte, String)
+
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+
+        Public Overrides Function ToString() As String
+            Return val.ToString()
+        End Function
+    End Class
+End Class
+
+Namespace System
+   Public Structure ValueTuple(Of T1, T2)
+        Public Dim Item1 As T1
+        Public Dim Item2 As T2
+
+        Public Sub New(item1 As T1, item2 As T2)
+            me.Item1 = item1
+            me.Item2 = item2
+        End Sub
+
+        Public Overrides Function ToString() As String
+            Return "{" + Item1?.ToString() + ", " + Item2?.ToString() + "}"
+        End Function
+
+        Public Shared Narrowing Operator CType(ByVal arg As (T1, T2)) As C.C1
+            ' TODO REVIEW
+            Return New C.C1((CType(DirectCast(DirectCast(arg.Item1, Object), Integer), Byte),
+                DirectCast(DirectCast(arg.Item2, Object), String)))
+        End Operator
+    End Structure
+End Namespace
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseDiagnostics()
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().First()
+
+            Assert.Equal("(1, ""qq"")", node.ToString())
+            Assert.Equal("(System.Int32, System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("C.C1", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Narrowing Or ConversionKind.UserDefined, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp, expectedOutput:="{1, qq}")
+
+        End Sub
+
+        <Fact>
+        <WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")>
+        Public Sub TupleConvertedTypeUDC05()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim x As C1 = (1, "qq")
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Public Class C1
+        Public Dim val As (Byte, String)
+
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+
+        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
+            System.Console.Write("C1")
+            Return New C1(arg)
+        End Operator
+
+        Public Overrides Function ToString() As String
+            Return val.ToString()
+        End Function
+    End Class
+End Class
+
+Namespace System
+   Public Structure ValueTuple(Of T1, T2)
+        Public Dim Item1 As T1
+        Public Dim Item2 As T2
+
+        Public Sub New(item1 As T1, item2 As T2)
+            me.Item1 = item1
+            me.Item2 = item2
+        End Sub
+
+        Public Overrides Function ToString() As String
+            Return "{" + Item1?.ToString() + ", " + Item2?.ToString() + "}"
+        End Function
+
+        Public Shared Narrowing Operator CType(ByVal arg As (T1, T2)) As C.C1
+            System.Console.Write("VT ")
+            Return New C.C1((CType(DirectCast(DirectCast(arg.Item1, Object), Integer), Byte),
+                DirectCast(DirectCast(arg.Item2, Object), String)))
+        End Operator
+    End Structure
+End Namespace
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseDiagnostics()
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().First()
+
+            Assert.Equal("(1, ""qq"")", node.ToString())
+            Assert.Equal("(System.Int32, System.String)", model.GetTypeInfo(node).Type.ToTestDisplayString())
+            Assert.Equal("C.C1", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Narrowing Or ConversionKind.UserDefined, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp, expectedOutput:="VT {1, qq}")
+
+        End Sub
+
+        <Fact>
+        <WorkItem(11289, "https://github.com/dotnet/roslyn/issues/11289")>
+        Public Sub TupleConvertedTypeUDC06()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim x As C1 = (1, Nothing)
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Public Class C1
+        Public Dim val As (Byte, String)
+
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+
+        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
+            System.Console.Write("C1")
+            Return New C1(arg)
+        End Operator
+
+        Public Overrides Function ToString() As String
+            Return val.ToString()
+        End Function
+    End Class
+End Class
+
+Namespace System
+   Public Structure ValueTuple(Of T1, T2)
+        Public Dim Item1 As T1
+        Public Dim Item2 As T2
+
+        Public Sub New(item1 As T1, item2 As T2)
+            me.Item1 = item1
+            me.Item2 = item2
+        End Sub
+
+        Public Overrides Function ToString() As String
+            Return "{" + Item1?.ToString() + ", " + Item2?.ToString() + "}"
+        End Function
+
+        Public Shared Narrowing Operator CType(ByVal arg As (T1, T2)) As C.C1
+            System.Console.Write("VT ")
+            Return New C.C1((CType(DirectCast(DirectCast(arg.Item1, Object), Integer), Byte),
+                DirectCast(DirectCast(arg.Item2, Object), String)))
+        End Operator
+    End Structure
+End Namespace
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseDiagnostics()
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            Dim node = nodes.OfType(Of TupleExpressionSyntax)().First()
+
+            Assert.Equal("(1, Nothing)", node.ToString())
+            Assert.Null(model.GetTypeInfo(node).Type)
+            Assert.Equal("C.C1", model.GetTypeInfo(node).ConvertedType.ToTestDisplayString())
+            Assert.Equal(ConversionKind.Narrowing Or ConversionKind.UserDefined, model.GetConversion(node).Kind) ' TODO REVIEW
+
+            CompileAndVerify(comp, expectedOutput:="VT {1, }") ' TODO REVIEW
+
+        End Sub
+
+        <Fact>
+        Public Sub TupleConvertedTypeUDC07()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim x As C1 = M1()
+        System.Console.Write(x.ToString())
+    End Sub
+
+    Shared Function M1() As (Integer, String)
+        Return (1, "qq")
+    End Function
+
+    Public Class C1
+        Public Dim val As (Byte, String)
+
+        Public Sub New(ByVal arg As (Byte, String))
+            val = arg
+        End Sub
+
+        Public Shared Narrowing Operator CType(ByVal arg As (Byte, String)) As C1
+            System.Console.Write("C1 ")
+            Return New C1(arg)
+        End Operator
+    End Class
+End Class
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics() ' TODO REVIEW
+
+            Dim model = comp.GetSemanticModel(comp.SyntaxTrees(0))
+            Dim nodes = comp.SyntaxTrees(0).GetCompilationUnitRoot().DescendantNodes()
+
+            CompileAndVerify(comp, expectedOutput:="C1 C+C1") ' TODO REVIEW
+
+        End Sub
 
     End Class
-
 
 End Namespace
 


### PR DESCRIPTION
Here is another batch of tests.

The only functionality that was added is reporting diagnostics for dropping element names.
Note that the TODO tags will be removed before merging. There are here to call attention to questions or differences with C#.

@VSadov @dotnet/roslyn-compiler for review

https://github.com/dotnet/roslyn/issues/13938 tracks this work