### PR TITLE
Ensure a use-site error is reported for an alias that cannot be resolved

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BackstopBinder.vb
@@ -80,13 +80,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Public Overrides Function GetErrorSymbol(name As String,
-                                                 errorInfo As DiagnosticInfo,
-                                                 candidateSymbols As ImmutableArray(Of Symbol),
-                                                 resultKind As LookupResultKind) As ErrorTypeSymbol
-            Throw ExceptionUtilities.Unreachable
-        End Function
-
         Public Overrides Function GetSyntaxReference(node As VisualBasicSyntaxNode) As SyntaxReference
             Throw ExceptionUtilities.Unreachable
         End Function

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder.vb
@@ -623,15 +623,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' <summary>
         ''' Get an error symbol.
         ''' </summary>
-        Public Overridable Function GetErrorSymbol(name As String,
-                                                   errorInfo As DiagnosticInfo,
-                                                   candidateSymbols As ImmutableArray(Of Symbol),
-                                                   resultKind As LookupResultKind) As ErrorTypeSymbol
-            Return m_containingBinder.GetErrorSymbol(name, errorInfo, candidateSymbols, resultKind)
+        Public Shared Function GetErrorSymbol(
+            name As String,
+            errorInfo As DiagnosticInfo,
+            candidateSymbols As ImmutableArray(Of Symbol),
+            resultKind As LookupResultKind,
+            Optional reportErrorWhenReferenced As Boolean = False
+        ) As ErrorTypeSymbol
+            Return New ExtendedErrorTypeSymbol(errorInfo, name, 0, candidateSymbols, resultKind, reportErrorWhenReferenced)
         End Function
 
-        Public Function GetErrorSymbol(name As String, errorInfo As DiagnosticInfo) As ErrorTypeSymbol
-            Return GetErrorSymbol(name, errorInfo, ImmutableArray(Of Symbol).Empty, LookupResultKind.Empty)
+        Public Shared Function GetErrorSymbol(name As String, errorInfo As DiagnosticInfo, Optional reportErrorWhenReferenced As Boolean = False) As ErrorTypeSymbol
+            Return GetErrorSymbol(name, errorInfo, ImmutableArray(Of Symbol).Empty, LookupResultKind.Empty, reportErrorWhenReferenced)
         End Function
 
         ''' <summary>

--- a/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/SourceModuleBinder.vb
@@ -36,13 +36,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 AccessCheck.CheckSymbolAccessibility(sym, _sourceModule.ContainingSourceAssembly, useSiteDiagnostics, basesBeingResolved))  ' accessThroughType doesn't matter at assembly level.
         End Function
 
-        Public Overrides Function GetErrorSymbol(name As String,
-                                                 errorInfo As DiagnosticInfo,
-                                                 candidateSymbols As ImmutableArray(Of Symbol),
-                                                 resultKind As LookupResultKind) As ErrorTypeSymbol
-            Return New ExtendedErrorTypeSymbol(errorInfo, name, 0, candidateSymbols, resultKind)
-        End Function
-
         Public Overrides ReadOnly Property OptionStrict As OptionStrict
             Get
                 Return _sourceModule.Options.OptionStrict

--- a/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ExtendedErrorTypeSymbol.vb
@@ -48,6 +48,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        resultKind As LookupResultKind,
                        Optional reportErrorWhenReferenced As Boolean = False)
             MyBase.New(arity)
+            Debug.Assert(errorInfo Is Nothing OrElse errorInfo.Severity = DiagnosticSeverity.Error)
+
             _name = name
             _diagnosticInfo = errorInfo
             _reportErrorWhenReferenced = reportErrorWhenReferenced
@@ -74,6 +76,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                        Optional reportErrorWhenReferenced As Boolean = False,
                        Optional nonErrorGuessType As NamedTypeSymbol = Nothing)
             MyBase.New(arity)
+            Debug.Assert(errorInfo Is Nothing OrElse errorInfo.Severity = DiagnosticSeverity.Error)
+
             _name = name
             _diagnosticInfo = errorInfo
             _reportErrorWhenReferenced = reportErrorWhenReferenced

--- a/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Symbol/SymbolsTests/SymbolErrorTests.vb
@@ -7854,6 +7854,41 @@ Imports bb = ns1.Intfc2.intfc2foo    'BC40056
         End Sub
 
         <Fact>
+        <WorkItem(13926, "https://github.com/dotnet/roslyn/issues/13926")>
+        Public Sub BadAliasTarget()
+            Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib(
+    <compilation>
+        <file name="a.vb"><![CDATA[
+Imports BadAlias = unknown
+
+Public Class Class1
+    Public Shared Sub Main()
+    End Sub
+
+    Function Test() As BadAlias 
+        Return Nothing
+    End Function
+End Class
+        ]]></file>
+    </compilation>)
+            Dim expectedErrors1 = <errors><![CDATA[
+BC40056: Namespace or type specified in the Imports 'unknown' doesn't contain any public member or cannot be found. Make sure the namespace or the type is defined and contains at least one public member. Make sure the imported element name doesn't use any aliases.
+Imports BadAlias = unknown
+                   ~~~~~~~
+BC31208: Type or namespace 'unknown' is not defined.
+    Function Test() As BadAlias 
+                       ~~~~~~~~
+                 ]]></errors>
+
+            CompilationUtils.AssertTheseDiagnostics(compilation1, expectedErrors1)
+
+            Dim test = compilation1.GetTypeByMetadataName("Class1").GetMember(Of MethodSymbol)("Test")
+
+            Assert.True(test.ReturnType.IsErrorType())
+            Assert.Equal(DiagnosticSeverity.Error, DirectCast(test.ReturnType, ErrorTypeSymbol).ErrorInfo.Severity)
+        End Sub
+
+        <Fact>
         Public Sub BC30828ERR_ObsoleteAsAny()
             Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib(
     <compilation name="ObsoleteAsAny">


### PR DESCRIPTION
Fixes #13926.

@dotnet/roslyn-compiler Please review Update 5 fix.