### PR TITLE
Filter fields in completion on a tuple

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8876,7 +8876,10 @@ class C
             await VerifyItemExistsAsync(markup, "GetType");
             await VerifyItemExistsAsync(markup, "Item2");
             await VerifyItemExistsAsync(markup, "ITEM3");
-            await VerifyItemExistsAsync(markup, "Item8");
+            for (int i = 4; i <= 8; i++)
+            {
+                await VerifyItemExistsAsync(markup, "Item" + i);
+            }
             await VerifyItemExistsAsync(markup, "ToString");
 
             await VerifyItemIsAbsentAsync(markup, "Item1");

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8854,5 +8854,33 @@ class C
 }";
             await VerifyItemExistsAsync(markup, "i", matchPriority: SymbolMatchPriority.PreferLocalOrParameterOrRangeVariable);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TupleElements()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        var t = (Alice: 1, 2, 3, 4, 5, 6, 7, 8, Bob: 9);
+        t.$$
     }
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+
+            await VerifyItemExistsAsync(markup, "Alice");
+            await VerifyItemExistsAsync(markup, "Bob");
+            await VerifyItemExistsAsync(markup, "CompareTo");
+            await VerifyItemExistsAsync(markup, "Equals");
+            await VerifyItemExistsAsync(markup, "GetHashCode");
+            await VerifyItemExistsAsync(markup, "GetType");
+            await VerifyItemExistsAsync(markup, "Item2");
+            await VerifyItemExistsAsync(markup, "Item8");
+            await VerifyItemExistsAsync(markup, "ToString");
+
+            await VerifyItemIsAbsentAsync(markup, "Item1");
+            await VerifyItemIsAbsentAsync(markup, "Item9");
+            await VerifyItemIsAbsentAsync(markup, "Rest");
+        }
+     }
 }

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8863,7 +8863,7 @@ class C
 {
     void foo()
     {
-        var t = (Alice: 1, 2, 3, 4, 5, 6, 7, 8, Bob: 9);
+        var t = (Alice: 1, Item2: 2, ITEM3: 3, 4, 5, 6, 7, 8, Bob: 9);
         t.$$
     }
 }" + TestResources.NetFX.ValueTuple.tuplelib_cs;
@@ -8875,12 +8875,17 @@ class C
             await VerifyItemExistsAsync(markup, "GetHashCode");
             await VerifyItemExistsAsync(markup, "GetType");
             await VerifyItemExistsAsync(markup, "Item2");
+            await VerifyItemExistsAsync(markup, "ITEM3");
             await VerifyItemExistsAsync(markup, "Item8");
             await VerifyItemExistsAsync(markup, "ToString");
 
             await VerifyItemIsAbsentAsync(markup, "Item1");
             await VerifyItemIsAbsentAsync(markup, "Item9");
             await VerifyItemIsAbsentAsync(markup, "Rest");
+
+            // TODO fix once we have a good public API for tuple elements
+            // See https://github.com/dotnet/roslyn/issues/13229
+            await VerifyItemExistsAsync(markup, "Item3");
         }
-     }
+    }
 }

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7526,5 +7526,40 @@ End Module
             Await VerifyItemExistsAsync(text, "A")
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TupleElements() As Task
+            Dim text =
+<code><![CDATA[
+Module Module1
+    Sub Main()
+        Dim t = (Alice:=1, 2, 3, 4, 5, 6, 7, 8, Bob:=9)
+        t.$$
+    End Sub
+End Module
+Namespace System
+    Public Structure ValueTuple(Of T1, T2)
+        Public Sub New(item1 As T1, item2 As T2)
+        End Sub
+    End Structure
+
+    Public Structure ValueTuple(Of T1, T2, T3, T4, T5, T6, T7, TRest)
+        Public Dim Rest As TRest
+
+        Public Sub New(item1 As T1, item2 As T2, item3 As T3, item4 As T4, item5 As T5, item6 As T6, item7 As T7, rest As TRest)
+        End Sub
+    End Structure
+End Namespace
+]]></code>.Value
+
+            Await VerifyItemExistsAsync(text, "Alice")
+            Await VerifyItemExistsAsync(text, "Item2")
+            Await VerifyItemExistsAsync(text, "Item8")
+            Await VerifyItemExistsAsync(text, "Bob")
+
+            Await VerifyItemIsAbsentAsync(text, "Item1")
+            Await VerifyItemIsAbsentAsync(text, "Item9")
+            Await VerifyItemIsAbsentAsync(text, "Rest")
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7532,7 +7532,7 @@ End Module
 <code><![CDATA[
 Module Module1
     Sub Main()
-        Dim t = (Alice:=1, 2, 3, 4, 5, 6, 7, 8, Bob:=9)
+        Dim t = (Alice:=1, Item2:=2, ITEM3:=3, 4, 5, 6, 7, 8, Bob:=9)
         t.$$
     End Sub
 End Module
@@ -7547,14 +7547,36 @@ Namespace System
 
         Public Sub New(item1 As T1, item2 As T2, item3 As T3, item4 As T4, item5 As T5, item6 As T6, item7 As T7, rest As TRest)
         End Sub
+
+        Public Overrides Function ToString() As String
+            Return ""
+        End Function
+
+        Public Overrides Function GetHashCode As Integer
+            Return 0
+        End Function
+
+        Public Overrides Function CompareTo(value As Object) As Integer
+            Return 0
+        End Function
+
+        Public Overrides Function GetType As Type
+            Return Nothing
+        End Function
     End Structure
 End Namespace
 ]]></code>.Value
 
             Await VerifyItemExistsAsync(text, "Alice")
-            Await VerifyItemExistsAsync(text, "Item2")
-            Await VerifyItemExistsAsync(text, "Item8")
             Await VerifyItemExistsAsync(text, "Bob")
+            Await VerifyItemExistsAsync(text, "CompareTo")
+            Await VerifyItemExistsAsync(text, "Equals")
+            Await VerifyItemExistsAsync(text, "GetHashCode")
+            Await VerifyItemExistsAsync(text, "GetType")
+            Await VerifyItemExistsAsync(text, "Item2")
+            Await VerifyItemExistsAsync(text, "Item3")
+            Await VerifyItemExistsAsync(text, "Item8")
+            Await VerifyItemExistsAsync(text, "ToString")
 
             Await VerifyItemIsAbsentAsync(text, "Item1")
             Await VerifyItemIsAbsentAsync(text, "Item9")

--- a/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Completion/CompletionProviders/SymbolCompletionProviderTests.vb
@@ -7573,9 +7573,9 @@ End Namespace
             Await VerifyItemExistsAsync(text, "Equals")
             Await VerifyItemExistsAsync(text, "GetHashCode")
             Await VerifyItemExistsAsync(text, "GetType")
-            Await VerifyItemExistsAsync(text, "Item2")
-            Await VerifyItemExistsAsync(text, "Item3")
-            Await VerifyItemExistsAsync(text, "Item8")
+            For index = 2 To 8
+                Await VerifyItemExistsAsync(text, "Item" + index.ToString())
+            Next
             Await VerifyItemExistsAsync(text, "ToString")
 
             Await VerifyItemIsAbsentAsync(text, "Item1")

--- a/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
+++ b/src/Workspaces/CSharp/Portable/Recommendations/CSharpRecommendationService.cs
@@ -534,7 +534,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Recommendations
                 ? context.SemanticModel.LookupBaseMembers(position)
                 : excludeInstance
                     ? context.SemanticModel.LookupStaticMembers(position, container)
-                    : context.SemanticModel.LookupSymbols(position, container, includeReducedExtensionMethods: true);
+                    : SuppressDefaultTupleElements(container,
+                        context.SemanticModel.LookupSymbols(position, container, includeReducedExtensionMethods: true));
 
             // If we're showing instance members, don't include nested types
             return excludeStatic

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
@@ -97,10 +97,17 @@ namespace Microsoft.CodeAnalysis.Recommendations
                 return symbols;
             }
 
-            var fieldsToRemove = elementNames.Select((n, i) => elementNames[i] != null ? "Item" + (i + 1) : null)
+            // TODO This should be revised once we have a good public API for tuple fields
+            // See https://github.com/dotnet/roslyn/issues/13229
+            var fieldsToRemove = elementNames.Select((n, i) => IsFriendlyName(i, elementNames[i]) ? "Item" + (i + 1) : null)
                 .Where(n => n != null).Concat("Rest");
 
-            return symbols.Where(s => s.Kind != SymbolKind.Field || !fieldsToRemove.Contains(s.Name));
+            return symbols.Where(s => s.Kind != SymbolKind.Field || elementNames.Contains(s.Name) || !fieldsToRemove.Contains(s.Name));
+        }
+
+        private static bool IsFriendlyName(int i, string elementName)
+        {
+            return elementName != null && string.Compare(elementName, "Item" + (i + 1), StringComparison.OrdinalIgnoreCase) != 0;
         }
 
         private sealed class ShouldIncludeSymbolContext

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
@@ -99,8 +99,8 @@ namespace Microsoft.CodeAnalysis.Recommendations
 
             // TODO This should be revised once we have a good public API for tuple fields
             // See https://github.com/dotnet/roslyn/issues/13229
-            var fieldsToRemove = elementNames.Select((n, i) => IsFriendlyName(i, elementNames[i]) ? "Item" + (i + 1) : null)
-                .Where(n => n != null).Concat("Rest");
+            var fieldsToRemove = elementNames.Select((n, i) => IsFriendlyName(i, n) ? "Item" + (i + 1) : null)
+                .Where(n => n != null).Concat("Rest").ToSet();
 
             return symbols.Where(s => s.Kind != SymbolKind.Field || elementNames.Contains(s.Name) || !fieldsToRemove.Contains(s.Name));
         }

--- a/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Recommendations/VisualBasicRecommendationService.vb
@@ -380,11 +380,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Recommendations
             Return symbolInfo.CandidateSymbols.Any() AndAlso symbolInfo.CandidateSymbols.All(Function(s) s.IsNamespace())
         End Function
 
-        Private Function LookupSymbolsInContainer(container As INamespaceOrTypeSymbol, semanticModel As SemanticModel, position As Integer, excludeInstance As Boolean) As ImmutableArray(Of ISymbol)
-            Return If(
-                    excludeInstance,
-                    semanticModel.LookupStaticMembers(position, container),
-                    semanticModel.LookupSymbols(position, container, includeReducedExtensionMethods:=True))
+        Private Function LookupSymbolsInContainer(container As INamespaceOrTypeSymbol, semanticModel As SemanticModel, position As Integer, excludeInstance As Boolean) As IEnumerable(Of ISymbol)
+            If excludeInstance Then
+                Return semanticModel.LookupStaticMembers(position, container)
+            Else
+                Return SuppressDefaultTupleElements(
+                        container,
+                        semanticModel.LookupSymbols(position, container, includeReducedExtensionMethods:=True))
+            End If
         End Function
 
         ''' <summary>


### PR DESCRIPTION
When dot-completing on a tuple, elements should be listed with their friendly-name if available (otherwise, the default `ItemX` name). Also, `Rest` should be hidden. 

@CyrusNajmabadi for review. Thanks
FYI for @dotnet/roslyn-ide @dotnet/roslyn-compiler 

Fixes https://github.com/dotnet/roslyn/issues/13711