### PR TITLE
Remove race condition in squiggles that could leave old squiggles around

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -6,11 +6,9 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Common;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
@@ -28,6 +26,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             private int _refCount;
             private bool _disposed;
+
+            /// <summary>
+            /// The current Document that our <see cref="_subjectBuffer"/> is associated with.
+            /// If our buffer becomes associated with another document, we will clear out any
+            /// cached diagnostic information we've collected so far as it's no longer valid.
+            /// </summary>
             private DocumentId _currentDocumentId;
 
             private readonly Dictionary<object, ValueTuple<TaggerProvider, IAccurateTagger<TTag>>> _idToProviderAndTagger = new Dictionary<object, ValueTuple<TaggerProvider, IAccurateTagger<TTag>>>();

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -40,6 +40,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
             public event EventHandler<SnapshotSpanEventArgs> TagsChanged;
 
+            // Use a chain of tasks to make sure that we process each diagnostic event serially.
+            // This also ensures that the first diagnostic event we hear about will be processed
+            // after the initial background work to get the first group of diagnostics.
             private readonly object _taskGate = new object();
             private Task _taskChain;
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -207,6 +207,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 RegisterNotification(() => OnDiagnosticsUpdatedOnForeground(e));
             }
 
+            /// <summary>
+            /// We do all mutation work on the UI thread.  That ensures that all mutation
+            /// is processed serially *and* it means we can safely examine things like
+            /// subject buffers and open documents without any threat of race conditions.
+            /// Note that we do not do any expensive work here.  We just store (or remove)
+            /// the data we were given in appropriate buckets.
+            /// 
+            /// For example, we create a TaggerProvider per unique DiagnosticUpdatedArgs.Id
+            /// we get.  So if we see a new id we simply create a tagger for it and pass it
+            /// these args to store.  Otherwise we pass these args to the existing tagger.
+            /// </summary>
             private void OnDiagnosticsUpdatedOnForeground(DiagnosticsUpdatedArgs e)
             {
                 this.AssertIsForeground();

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -10,12 +10,12 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Common;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Editor.Shared.Utilities;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Text.Shared.Extensions;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Tagging;
 using Roslyn.Utilities;
-using Microsoft.CodeAnalysis.Shared.TestHooks;
 
 namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -79,24 +79,22 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 this.AssertIsBackground();
                 cancellationToken.ThrowIfCancellationRequested();
 
-                if (document == null)
+                if (document != null)
                 {
-                    return;
-                }
-
-                var project = document.Project;
-                var workspace = project.Solution.Workspace;
-                foreach (var updateArgs in _owner._diagnosticService.GetDiagnosticsUpdatedEventArgs(workspace, project.Id, document.Id, cancellationToken))
-                {
-                    var diagnostics = AdjustInitialDiagnostics(project.Solution, updateArgs, cancellationToken);
-                    if (diagnostics.Length == 0)
+                    var project = document.Project;
+                    var workspace = project.Solution.Workspace;
+                    foreach (var updateArgs in _owner._diagnosticService.GetDiagnosticsUpdatedEventArgs(workspace, project.Id, document.Id, cancellationToken))
                     {
-                        continue;
-                    }
+                        var diagnostics = AdjustInitialDiagnostics(project.Solution, updateArgs, cancellationToken);
+                        if (diagnostics.Length == 0)
+                        {
+                            continue;
+                        }
 
-                    OnDiagnosticsUpdatedOnBackground(
-                        DiagnosticsUpdatedArgs.DiagnosticsCreated(
-                            updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics));
+                        OnDiagnosticsUpdatedOnBackground(
+                            DiagnosticsUpdatedArgs.DiagnosticsCreated(
+                                updateArgs.Id, updateArgs.Workspace, project.Solution, updateArgs.ProjectId, updateArgs.DocumentId, diagnostics));
+                    }
                 }
             }
 

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -325,6 +325,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             private void ProcessRemovedDiagnostics(DiagnosticsUpdatedArgs e)
             {
                 this.AssertIsForeground();
+                Debug.Assert(!_disposed);
 
                 if (e.Kind != DiagnosticsUpdatedKind.DiagnosticsRemoved)
                 {
@@ -362,6 +363,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 DiagnosticsUpdatedArgs e, SourceText sourceText, ITextSnapshot editorSnapshot)
             {
                 this.AssertIsForeground();
+                Debug.Assert(!_disposed);
 
                 // Find the appropriate async tagger for this diagnostics id, and let it know that
                 // there were new diagnostics produced for it.

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -77,6 +77,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 Document document, CancellationToken cancellationToken)
             {
                 this.AssertIsBackground();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (document == null)
                 {

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -163,6 +163,18 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 }
             }
 
+            private void DisconnectFromTagger(IAccurateTagger<TTag> tagger)
+            {
+                this.AssertIsForeground();
+
+                tagger.TagsChanged -= OnUnderlyingTaggerTagsChanged;
+                var disposable = tagger as IDisposable;
+                if (disposable != null)
+                {
+                    disposable.Dispose();
+                }
+            }
+
             private void DisconnectFromAllTaggers()
             {
                 this.AssertIsForeground();
@@ -175,18 +187,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 }
 
                 _idToProviderAndTagger.Clear();
-            }
-
-            private void DisconnectFromTagger(IAccurateTagger<TTag> tagger)
-            {
-                this.AssertIsForeground();
-
-                tagger.TagsChanged -= OnUnderlyingTaggerTagsChanged;
-                var disposable = tagger as IDisposable;
-                if (disposable != null)
-                {
-                    disposable.Dispose();
-                }
             }
 
             private void RegisterNotification(Action action)

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -336,14 +336,15 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 // was removed.  If so, clear out any diagnostics we have associated with this
                 // diagnostic source ID and notify any listeners that 
 
+                var id = e.Id;
                 ValueTuple<TaggerProvider, IAccurateTagger<TTag>> providerAndTagger;
-                if (!_idToProviderAndTagger.TryGetValue(e.Id, out providerAndTagger))
+                if (!_idToProviderAndTagger.TryGetValue(id, out providerAndTagger))
                 {
                     // Wasn't a diagnostic source we care about.
                     return;
                 }
 
-                _idToProviderAndTagger.Remove(e.Id);
+                _idToProviderAndTagger.Remove(id);
                 DisconnectFromTagger(providerAndTagger.Item2);
 
                 OnUnderlyingTaggerTagsChanged(this, new SnapshotSpanEventArgs(_subjectBuffer.CurrentSnapshot.GetFullSpan()));

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -203,7 +203,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                     // that we don't process events while still getting our initial set
                     // of diagnostics.
                     var asyncToken = _owner._listener.BeginAsyncOperation(GetType() + ".OnDiagnosticsUpdated");
-                    _taskChain = _taskChain.ContinueWith(
+                    _taskChain = _taskChain.SafeContinueWith(
                         _ => OnDiagnosticsUpdatedOnBackground(e), TaskScheduler.Default);
                     _taskChain.CompletesAsyncOperation(asyncToken);
                 }

--- a/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
+++ b/src/EditorFeatures/Core/Implementation/Diagnostics/AbstractDiagnosticsTaggerProvider.AggregatingTagger.cs
@@ -217,6 +217,9 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
             /// For example, we create a TaggerProvider per unique DiagnosticUpdatedArgs.Id
             /// we get.  So if we see a new id we simply create a tagger for it and pass it
             /// these args to store.  Otherwise we pass these args to the existing tagger.
+            /// 
+            /// Similarly, clearing out data is just a matter of us clearing our reference
+            /// to the data.  
             /// </summary>
             private void OnDiagnosticsUpdatedOnForeground(DiagnosticsUpdatedArgs e)
             {
@@ -328,6 +331,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 }
 
                 RemoveCachedDiagnostics(e.Id);
+                OnUnderlyingTaggerTagsChanged(this, new SnapshotSpanEventArgs(_subjectBuffer.CurrentSnapshot.GetFullSpan()));
             }
 
             private void RemoveAllCachedDiagnostics()
@@ -341,6 +345,8 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
                 {
                     RemoveCachedDiagnostics(id);
                 }
+
+                OnUnderlyingTaggerTagsChanged(this, new SnapshotSpanEventArgs(_subjectBuffer.CurrentSnapshot.GetFullSpan()));
             }
 
             private void RemoveCachedDiagnostics(object id)
@@ -356,8 +362,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Diagnostics
 
                 _idToProviderAndTagger.Remove(id);
                 DisconnectFromTagger(providerAndTagger.Item2);
-
-                OnUnderlyingTaggerTagsChanged(this, new SnapshotSpanEventArgs(_subjectBuffer.CurrentSnapshot.GetFullSpan()));
             }
 
             private void OnDiagnosticsUpdatedOnForeground(

--- a/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
+++ b/src/Features/Core/Portable/Diagnostics/DiagnosticService.cs
@@ -253,7 +253,8 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
-        public IEnumerable<UpdatedEventArgs> GetDiagnosticsUpdatedEventArgs(Workspace workspace, ProjectId projectId, DocumentId documentId, CancellationToken cancellationToken)
+        public IEnumerable<UpdatedEventArgs> GetDiagnosticsUpdatedEventArgs(
+            Workspace workspace, ProjectId projectId, DocumentId documentId, CancellationToken cancellationToken)
         {
             foreach (var source in _updateSources)
             {


### PR DESCRIPTION
Squiggles had two race conditions around how it consumed the DiagnosticService.  THe first was that it would kick off work into the background to collect hte initial batch of squiggles.  However, it also registered to hear about events from the diagnostic service.  There was nothing to ensure that these would be ordered properly, and getting the initial diagnostics might then override some diagnostics event.

The second was that we would hear about diagnostics, but compare them to a text buffer that we were accessing from a BG thread.  ON that thread we would then try to see if those diagnostics were relevant to that text buffer, not considering that the text buffer might have changed from one document to another.

--

We now order and process all events in order.  At the start of processing each event we check if our current state is valid, and if not, we clear out any data that is no longer valid.  This ensures that stale data is not kept around, and it means that we get proper ordering of all diagnostic events. 

--

Fixes https://github.com/dotnet/roslyn/issues/13917