### PR TITLE
REmove attributes from the new partial types we're generating when we move a type.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -308,6 +308,48 @@ class Class2 { }";
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        [WorkItem(14004, "https://github.com/dotnet/roslyn/issues/14004")]
+        public async Task MoveNestedTypeToNewFile_Attributes1()
+        {
+            var code =
+@"namespace N1
+{
+    [Outer]
+    class Class1 
+    {
+        [Inner]
+        [||]class Class2 { }
+    }
+    
+}";
+
+            var codeAfterMove =
+@"namespace N1
+{
+    [Outer]
+    partial class Class1
+    {
+
+    }
+}";
+
+            var expectedDocumentName = "Class2.cs";
+
+            var destinationDocumentText =
+@"namespace N1
+{
+    partial class Class1 
+    {
+        [Inner]
+        class Class2
+        {
+        }
+    }
+}";
+            await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public async Task MoveNestedTypeToNewFile_Simple_DottedName()
         {
             var code =

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -174,7 +174,6 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             /// <summary>
             /// if a nested type is being moved, this ensures its containing type is partial.
             /// </summary>
-            /// <param name="documentEditor">document editor for the new document being created</param>
             private void AddPartialModifiersToTypeChain(
                 DocumentEditor documentEditor, bool removeAttributes)
             {

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -78,7 +78,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 var projectToBeUpdated = SemanticDocument.Document.Project;
                 var documentEditor = await DocumentEditor.CreateAsync(SemanticDocument.Document, CancellationToken).ConfigureAwait(false);
 
-                AddPartialModifiersToTypeChain(documentEditor);
+                // Make the type chain above this new type partial.  Also, remove any 
+                // attributes from the containing partial types.  We don't want to create
+                // duplicate attributes on things.
+                AddPartialModifiersToTypeChain(documentEditor, removeAttributes: true);
 
                 // remove things that are not being moved, from the forked document.
                 var membersToRemove = GetMembersToRemove(root);
@@ -112,7 +115,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             {
                 var documentEditor = await DocumentEditor.CreateAsync(sourceDocument, CancellationToken).ConfigureAwait(false);
 
-                AddPartialModifiersToTypeChain(documentEditor);
+                // Make the type chain above the type we're moving 'partial'.  
+                // However, keep all the attributes on these types as theses are the 
+                // original attributes and we don't want to mess with them. 
+                AddPartialModifiersToTypeChain(documentEditor, removeAttributes: false);
                 documentEditor.RemoveNode(State.TypeNode, SyntaxRemoveOptions.KeepNoTrivia);
 
                 var updatedDocument = documentEditor.GetChangedDocument();
@@ -169,7 +175,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             /// if a nested type is being moved, this ensures its containing type is partial.
             /// </summary>
             /// <param name="documentEditor">document editor for the new document being created</param>
-            private void AddPartialModifiersToTypeChain(DocumentEditor documentEditor)
+            private void AddPartialModifiersToTypeChain(
+                DocumentEditor documentEditor, bool removeAttributes)
             {
                 var semanticFacts = State.SemanticDocument.Document.GetLanguageService<ISemanticFactsService>();
                 var typeChain = State.TypeNode.Ancestors().OfType<TTypeDeclarationSyntax>();
@@ -180,6 +187,11 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                     if (!semanticFacts.IsPartial(symbol, CancellationToken))
                     {
                         documentEditor.SetModifiers(node, DeclarationModifiers.Partial);
+                    }
+
+                    if (removeAttributes)
+                    {
+                        documentEditor.RemoveAllAttributes(node);
                     }
                 }
             }

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
@@ -16,6 +16,11 @@ namespace Microsoft.CodeAnalysis.Editing
             editor.ReplaceNode(declaration, (d, g) => g.WithModifiers(d, modifiers));
         }
 
+        internal static void RemoveAllAttributes(this SyntaxEditor editor, SyntaxNode declaration)
+        {
+            editor.ReplaceNode(declaration, (d, g) => g.RemoveAllAttributes(d));
+        }
+
         public static void SetName(this SyntaxEditor editor, SyntaxNode declaration, string name)
         {
             editor.ReplaceNode(declaration, (d, g) => g.WithName(d, name));


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14004