### PR TITLE
Move type should move the type into the same folder as the original file.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/CSharpMoveTypeTestsBase.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/CSharpMoveTypeTestsBase.cs
@@ -17,7 +17,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.CodeActions.MoveType
 
         protected override Task<TestWorkspace> CreateWorkspaceFromFileAsync(string definition, ParseOptions parseOptions, CompilationOptions compilationOptions)
         {
-            return TestWorkspace.CreateCSharpAsync(definition, parseOptions, compilationOptions);
+            return TestWorkspace.IsWorkspaceElement(definition)
+                ? TestWorkspace.CreateAsync(definition)
+                : TestWorkspace.CreateCSharpAsync(definition, parseOptions, compilationOptions);
         }
 
         protected override string GetLanguage()

--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -53,6 +53,30 @@ class Class2 { }";
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        [WorkItem(14008, "https://github.com/dotnet/roslyn/issues/14008")]
+        public async Task TestFolders()
+        {
+            var code =
+@"
+<Workspace>
+    <Project Language=""C#"" AssemblyName=""Assembly1"" CommonReferences=""true"">
+        <Document Folders=""A\B""> 
+[|class|] Class1 { }
+class Class2 { }
+        </Document>
+    </Project>
+</Workspace>";
+            var codeAfterMove = @"class Class2 { }";
+
+            var expectedDocumentName = "Class1.cs";
+            var destinationDocumentText = @"class Class1 { }";
+
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, 
+                destinationDocumentText, destinationDocumentContainers: new [] {"A", "B"});
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public async Task TestForSpans2()
         {
             var code =

--- a/src/EditorFeatures/Test/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
+++ b/src/EditorFeatures/Test/CodeActions/AbstractCodeActionOrUserDiagnosticTest.cs
@@ -379,7 +379,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeActions
 
         private static bool IsWorkspaceElement(string text)
         {
-            return text.TrimStart('\r', '\n', ' ').StartsWith("<Workspace>", StringComparison.Ordinal);
+            return TestWorkspace.IsWorkspaceElement(text);
         }
 
         protected async Task<Tuple<Solution, Solution>> TestOperationsAsync(

--- a/src/EditorFeatures/Test/Workspaces/TestWorkspace_XmlConsumption.cs
+++ b/src/EditorFeatures/Test/Workspaces/TestWorkspace_XmlConsumption.cs
@@ -822,5 +822,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 
             return references;
         }
+
+        public static bool IsWorkspaceElement(string text)
+        {
+            return text.TrimStart('\r', '\n', ' ').StartsWith("<Workspace>", StringComparison.Ordinal);
+        }
     }
 }

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -71,12 +71,13 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             private async Task<Solution> AddNewDocumentWithSingleTypeDeclarationAndImportsAsync(
                 DocumentId newDocumentId)
             {
-                Debug.Assert(SemanticDocument.Document.Name != FileName,
+                var document = SemanticDocument.Document;
+                Debug.Assert(document.Name != FileName,
                              $"New document name is same as old document name:{FileName}");
 
                 var root = SemanticDocument.Root;
-                var projectToBeUpdated = SemanticDocument.Document.Project;
-                var documentEditor = await DocumentEditor.CreateAsync(SemanticDocument.Document, CancellationToken).ConfigureAwait(false);
+                var projectToBeUpdated = document.Project;
+                var documentEditor = await DocumentEditor.CreateAsync(document, CancellationToken).ConfigureAwait(false);
 
                 AddPartialModifiersToTypeChain(documentEditor);
 
@@ -90,7 +91,8 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 var modifiedRoot = documentEditor.GetChangedRoot();
 
                 // add an empty document to solution, so that we'll have options from the right context.
-                var solutionWithNewDocument = projectToBeUpdated.Solution.AddDocument(newDocumentId, FileName, text: string.Empty);
+                var solutionWithNewDocument = projectToBeUpdated.Solution.AddDocument(
+                    newDocumentId, FileName, text: string.Empty, folders: document.Folders);
 
                 // update the text for the new document
                 solutionWithNewDocument = solutionWithNewDocument.WithDocumentSyntaxRoot(newDocumentId, modifiedRoot, PreservationMode.PreserveIdentity);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14008