### PR TITLE
removed allocation caused by concurrent dictionary

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.TreeNodes.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.TreeNodes.cs
@@ -140,10 +140,11 @@ namespace Microsoft.CodeAnalysis.Execution
             public virtual ChecksumObject TryGetChecksumObject(Checksum checksum, CancellationToken cancellationToken)
             {
                 ChecksumObject checksumObject;
-                foreach (var entry in _cache.Values)
+                foreach (var kv in _cache)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    var entry = kv.Value;
                     if (entry.TryGetValue(checksum, out checksumObject))
                     {
                         // this cache has information for the checksum
@@ -177,8 +178,9 @@ namespace Microsoft.CodeAnalysis.Execution
                     return;
                 }
 
-                foreach (var entry in _cache.Values)
+                foreach (var kv in _cache)
                 {
+                    var entry = kv.Value;
                     AppendChecksumObjects(map, searchingChecksumsLeft, entry, cancellationToken);
                     if (searchingChecksumsLeft.Count == 0)
                     {
@@ -215,8 +217,9 @@ namespace Microsoft.CodeAnalysis.Execution
                     return self;
                 }
 
-                foreach (var entry in _cache.Values)
+                foreach (var kv in _cache)
                 {
+                    var entry = kv.Value;
                     var tree = entry.TryGetSubTreeNode();
                     if (tree == null)
                     {

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
@@ -74,8 +74,9 @@ namespace Microsoft.CodeAnalysis.Execution
         public ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken)
         {
             // search snapshots we have
-            foreach (var cache in _rootTreeNodes.Values)
+            foreach (var kv in _rootTreeNodes)
             {
+                var cache = kv.Value;
                 var checksumObject = cache.TryGetChecksumObject(checksum, cancellationToken);
                 if (checksumObject != null)
                 {
@@ -84,10 +85,11 @@ namespace Microsoft.CodeAnalysis.Execution
             }
 
             // search global assets
-            foreach (var asset in _globalAssets.Values)
+            foreach (var kv in _globalAssets)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
+                var asset = kv.Value;
                 if (asset.Checksum == checksum)
                 {
                     return asset;
@@ -106,8 +108,9 @@ namespace Microsoft.CodeAnalysis.Execution
                 var result = new Dictionary<Checksum, ChecksumObject>();
 
                 // search checksum trees we have
-                foreach (var cache in _rootTreeNodes.Values)
+                foreach (var kv in _rootTreeNodes)
                 {
+                    var cache = kv.Value;
                     cache.AppendChecksumObjects(result, searchingChecksumsLeft.Object, cancellationToken);
                     if (result.Count == numberOfChecksumsToSearch)
                     {
@@ -118,10 +121,11 @@ namespace Microsoft.CodeAnalysis.Execution
                 }
 
                 // search global assets
-                foreach (var asset in _globalAssets.Values)
+                foreach (var kv in _globalAssets)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    var asset = kv.Value;
                     if (searchingChecksumsLeft.Object.Remove(asset.Checksum))
                     {
                         result[asset.Checksum] = asset;
@@ -142,8 +146,9 @@ namespace Microsoft.CodeAnalysis.Execution
 
         private ChecksumObjectCache TryGetChecksumObjectEntry(object key, string kind, CancellationToken cancellationToken)
         {
-            foreach (var cache in _rootTreeNodes.Values)
+            foreach (var kv in _rootTreeNodes)
             {
+                var cache = kv.Value;
                 var entry = cache.TryGetChecksumObjectEntry(key, kind, cancellationToken);
                 if (entry != null)
                 {


### PR DESCRIPTION
removed usage of Values from concurrent dictionary which will copy over every entries to new list.

main enumerator of concurrent dictionary will not create new list to create snapshot, rather it will return plain enumerator that is thread-safe. difference is, it is not snapshot of the dictionary but one that can observe change that happened in between enumerating.

but in this context, map once created won't mutate. so it should be fine.