### PR TITLE
Simplify our delay-loaded services.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/AbstractPackage`2.cs
@@ -126,9 +126,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
 
         protected override void Dispose(bool disposing)
         {
-            _packageInstallerService?.Disconnect(this.RoslynLanguageName);
-            _symbolSearchService?.Disconnect(this.RoslynLanguageName);
-
             if (_miscellaneousFilesWorkspace != null)
             {
                 _miscellaneousFilesWorkspace.StopSolutionCrawler();

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory.cs
@@ -101,20 +101,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
             _packageServices.SourcesChanged += OnSourceProviderSourcesChanged;
         }
 
-        protected override void StopWorking()
-        {
-            this.AssertIsForeground();
-
-            if (!IsEnabled)
-            {
-                return;
-            }
-
-            // Stop listening to workspace changes.
-            _workspace.WorkspaceChanged -= OnWorkspaceChanged;
-            _packageServices.SourcesChanged -= OnSourceProviderSourcesChanged;
-        }
-
         protected override void StartWorking()
         {
             this.AssertIsForeground();

--- a/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/AbstractDelayStartedService.cs
@@ -43,7 +43,6 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         protected abstract void EnableService();
 
         protected abstract void StartWorking();
-        protected abstract void StopWorking();
 
         internal void Connect(string languageName)
         {
@@ -94,31 +93,6 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
         {
             var options = Workspace.Options;
             return _perLanguageOptions.Any(o => options.GetOption(o, language));
-        }
-
-        internal void Disconnect(string languageName)
-        {
-            this.AssertIsForeground();
-
-            var options = Workspace.Options;
-            if (!options.GetOption(_serviceOnOffOption))
-            {
-                // Feature is totally disabled.  Do nothing.
-                return;
-            }
-
-            _registeredLanguageNames.Remove(languageName);
-            if (_registeredLanguageNames.Count == 0)
-            {
-                if (_enabled)
-                {
-                    _enabled = false;
-                    StopWorking();
-                }
-
-                var optionsService = Workspace.Services.GetService<IOptionService>();
-                optionsService.OptionChanged -= OnOptionChanged;
-            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/SymbolSearch/SymbolSearchService.cs
+++ b/src/VisualStudio/Core/Def/SymbolSearch/SymbolSearchService.cs
@@ -140,12 +140,6 @@ namespace Microsoft.VisualStudio.LanguageServices.SymbolSearch
             }
         }
 
-        protected override void StopWorking()
-        {
-            _installerService.PackageSourcesChanged -= OnPackageSourcesChanged;
-            _cancellationTokenSource.Cancel();
-        }
-
         public IEnumerable<PackageWithTypeResult> FindPackagesWithType(
             string source, string name, int arity, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
The important part is that we don't create these services until they are needed.
We don't need complicated logic about later on disabling them.  The current logic
attempts to disable them when the same packages that loaded them, get unloaded.
But packages only get unloaded when VS is shutting down. And we don't need to
do complex work in that case as our entire environment is going away.

--

In other words, we had complexity around returning teh service to an 'unstarted'
state just so it could be started up later.  But it will never be the case that
we'll ever start the service up again as the only reason we moved it to 'unstarted'
was because VS was shutting down.