### PR TITLE
made checksum builder to resilient to missing data such as compilatio…

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/Asset.cs
@@ -18,7 +18,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class Asset : ChecksumObject
     {
-        public static readonly Asset Nil = new NullAsset();
+        public static readonly Asset Null = new NullAsset();
 
         public Asset(Checksum checksum, string kind) : base(checksum, kind)
         {
@@ -32,7 +32,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private sealed class NullAsset : Asset
         {
             public NullAsset() :
-                base(Checksum.Nil, WellKnownChecksumObjects.Nil)
+                base(Checksum.Null, WellKnownChecksumObjects.Null)
             {
             }
 

--- a/src/Workspaces/Core/Portable/Execution/Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/Asset.cs
@@ -18,10 +18,28 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal abstract class Asset : ChecksumObject
     {
+        public static readonly Asset Nil = new NullAsset();
+
         public Asset(Checksum checksum, string kind) : base(checksum, kind)
         {
             // TODO: find out a way to reduce number of asset implementations.
             //       tried once but couldn't figure out
+        }
+
+        /// <summary>
+        /// null asset indicating things that doesn't actually exist
+        /// </summary>
+        private sealed class NullAsset : Asset
+        {
+            public NullAsset() :
+                base(Checksum.Nil, WellKnownChecksumObjects.Nil)
+            {
+            }
+
+            public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+            {
+                return SpecializedTasks.EmptyTask;
+            }
         }
     }
 

--- a/src/Workspaces/Core/Portable/Execution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Execution/Checksum.cs
@@ -14,7 +14,7 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal sealed partial class Checksum : IObjectWritable, IEquatable<Checksum>
     {
-        public static readonly Checksum Nil = new Checksum(ImmutableArray<byte>.Empty);
+        public static readonly Checksum Null = new Checksum(ImmutableArray<byte>.Empty);
 
         private readonly ImmutableArray<byte> _checkSum;
         private int _lazyHash;

--- a/src/Workspaces/Core/Portable/Execution/Checksum.cs
+++ b/src/Workspaces/Core/Portable/Execution/Checksum.cs
@@ -14,6 +14,8 @@ namespace Microsoft.CodeAnalysis.Execution
     /// </summary>
     internal sealed partial class Checksum : IObjectWritable, IEquatable<Checksum>
     {
+        public static readonly Checksum Nil = new Checksum(ImmutableArray<byte>.Empty);
+
         private readonly ImmutableArray<byte> _checkSum;
         private int _lazyHash;
 

--- a/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
@@ -73,6 +73,8 @@ namespace Microsoft.CodeAnalysis.Execution
     // TODO: Kind might not actually needed. see whether we can get rid of this
     internal static class WellKnownChecksumObjects
     {
+        public const string Nil = nameof(Nil);
+
         public const string Projects = nameof(Projects);
         public const string Documents = nameof(Documents);
         public const string TextDocuments = nameof(TextDocuments);

--- a/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumObject.cs
@@ -73,7 +73,7 @@ namespace Microsoft.CodeAnalysis.Execution
     // TODO: Kind might not actually needed. see whether we can get rid of this
     internal static class WellKnownChecksumObjects
     {
-        public const string Nil = nameof(Nil);
+        public const string Null = nameof(Null);
 
         public const string Projects = nameof(Projects);
         public const string Documents = nameof(Documents);

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeBuilder.cs
@@ -90,9 +90,11 @@ namespace Microsoft.CodeAnalysis.Execution
 
             var subAssetBuilder = new AssetBuilder(subTreeNode);
 
-            // set Asset.Nil if this particular project doesn't support compiler options
-            var compilationOptions = projectState.CompilationOptions != null ? subAssetBuilder.Build(projectState, projectState.CompilationOptions, cancellationToken) : Asset.Nil;
-            var parseOptions = projectState.ParseOptions != null ? subAssetBuilder.Build(projectState, projectState.ParseOptions, cancellationToken) : Asset.Nil;
+            // set Asset.Null if this particular project doesn't support compiler options.
+            // this one is really bit wierd since project state has both compilation/parse options but only has support compilation. 
+            // for now, we use support compilation for both options
+            var compilationOptions = projectState.SupportsCompilation ? subAssetBuilder.Build(projectState, projectState.CompilationOptions, cancellationToken) : Asset.Null;
+            var parseOptions = projectState.SupportsCompilation ? subAssetBuilder.Build(projectState, projectState.ParseOptions, cancellationToken) : Asset.Null;
 
             return new ProjectChecksumObject(
                 _serializer, info.Checksum, compilationOptions.Checksum, parseOptions.Checksum,

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeBuilder.cs
@@ -89,8 +89,10 @@ namespace Microsoft.CodeAnalysis.Execution
             var additionalDocuments = await subSnapshotBuilder.BuildAsync(projectState.AdditionalDocumentStates, projectState.AdditionalDocumentIds.Select(id => projectState.AdditionalDocumentStates[id]), WellKnownChecksumObjects.TextDocuments, cancellationToken).ConfigureAwait(false);
 
             var subAssetBuilder = new AssetBuilder(subTreeNode);
-            var compilationOptions = subAssetBuilder.Build(projectState, projectState.CompilationOptions, cancellationToken);
-            var parseOptions = subAssetBuilder.Build(projectState, projectState.ParseOptions, cancellationToken);
+
+            // set Asset.Nil if this particular project doesn't support compiler options
+            var compilationOptions = projectState.CompilationOptions != null ? subAssetBuilder.Build(projectState, projectState.CompilationOptions, cancellationToken) : Asset.Nil;
+            var parseOptions = projectState.ParseOptions != null ? subAssetBuilder.Build(projectState, projectState.ParseOptions, cancellationToken) : Asset.Nil;
 
             return new ProjectChecksumObject(
                 _serializer, info.Checksum, compilationOptions.Checksum, parseOptions.Checksum,

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
@@ -73,6 +73,12 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken)
         {
+            if (checksum == Checksum.Nil)
+            {
+                // check nil case
+                return Asset.Nil;
+            }
+
             // search snapshots we have
             foreach (var kv in _rootTreeNodes)
             {
@@ -105,7 +111,13 @@ namespace Microsoft.CodeAnalysis.Execution
             using (var searchingChecksumsLeft = Creator.CreateChecksumSet(checksums))
             {
                 var numberOfChecksumsToSearch = searchingChecksumsLeft.Object.Count;
-                var result = new Dictionary<Checksum, ChecksumObject>();
+                var result = new Dictionary<Checksum, ChecksumObject>(numberOfChecksumsToSearch);
+
+                // check nil case
+                if (searchingChecksumsLeft.Object.Remove(Checksum.Nil))
+                {
+                    result[Checksum.Nil] = Asset.Nil;
+                }
 
                 // search checksum trees we have
                 foreach (var kv in _rootTreeNodes)

--- a/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
+++ b/src/Workspaces/Core/Portable/Execution/ChecksumTreeCollection.cs
@@ -73,10 +73,10 @@ namespace Microsoft.CodeAnalysis.Execution
 
         public ChecksumObject GetChecksumObject(Checksum checksum, CancellationToken cancellationToken)
         {
-            if (checksum == Checksum.Nil)
+            if (checksum == Checksum.Null)
             {
                 // check nil case
-                return Asset.Nil;
+                return Asset.Null;
             }
 
             // search snapshots we have
@@ -114,9 +114,9 @@ namespace Microsoft.CodeAnalysis.Execution
                 var result = new Dictionary<Checksum, ChecksumObject>(numberOfChecksumsToSearch);
 
                 // check nil case
-                if (searchingChecksumsLeft.Object.Remove(Checksum.Nil))
+                if (searchingChecksumsLeft.Object.Remove(Checksum.Null))
                 {
-                    result[Checksum.Nil] = Asset.Nil;
+                    result[Checksum.Null] = Asset.Null;
                 }
 
                 // search checksum trees we have

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -43,6 +43,9 @@ namespace Microsoft.CodeAnalysis.Execution
 
                 switch (kind)
                 {
+                    case WellKnownChecksumObjects.Nil:
+                        return default(T);
+
                     case SolutionChecksumObject.Name:
                         return (T)(object)DeserializeChecksumObjectWithChildren(reader, cancellationToken);
                     case ProjectChecksumObject.Name:

--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.Execution
 
                 switch (kind)
                 {
-                    case WellKnownChecksumObjects.Nil:
+                    case WellKnownChecksumObjects.Null:
                         return default(T);
 
                     case SolutionChecksumObject.Name:

--- a/src/Workspaces/Remote/Core/Services/SolutionService.cs
+++ b/src/Workspaces/Remote/Core/Services/SolutionService.cs
@@ -79,6 +79,14 @@ namespace Microsoft.CodeAnalysis.Remote
             {
                 var projectSnapshot = await RoslynServices.AssetService.GetAssetAsync<ProjectChecksumObject>(projectChecksum, cancellationToken).ConfigureAwait(false);
 
+                var projectInfo = await RoslynServices.AssetService.GetAssetAsync<ProjectChecksumObjectInfo>(projectSnapshot.Info, cancellationToken).ConfigureAwait(false);
+                if (!workspace.Services.IsSupported(projectInfo.Language))
+                {
+                    // only add project our workspace supports. 
+                    // workspace doesn't allow creating project with unknown languages
+                    continue;
+                }
+
                 var documents = new List<DocumentInfo>();
                 foreach (var documentChecksum in projectSnapshot.Documents)
                 {
@@ -146,7 +154,6 @@ namespace Microsoft.CodeAnalysis.Remote
                             documentInfo.IsGenerated));
                 }
 
-                var projectInfo = await RoslynServices.AssetService.GetAssetAsync<ProjectChecksumObjectInfo>(projectSnapshot.Info, cancellationToken).ConfigureAwait(false);
                 var compilationOptions = await RoslynServices.AssetService.GetAssetAsync<CompilationOptions>(projectSnapshot.CompilationOptions, cancellationToken).ConfigureAwait(false);
                 var parseOptions = await RoslynServices.AssetService.GetAssetAsync<ParseOptions>(projectSnapshot.ParseOptions, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
…n/parse options which some projects such as typescript don't have.

also made creating solution to only include project type workspace knows about to create.

some of these will change once checksum moves into solution state itself, but the concept of having Null data will remain to support projects that don't have all data or filtering out projects that workspace doesn't know how to craete.