### PR TITLE
Alter definite assignment for async and iterator local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -32,7 +32,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             _usedLocalFunctions.Add(localFunc);
 
-
             // First process the reads
             ReplayVarUsage(localFunc,
                            syntax,

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.LocalFunctions.cs
@@ -38,10 +38,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                            syntax,
                            isWrite: false);
 
-            // Don't replay writes if the function is
-            // async or an iterator (i.e., is a coroutine)
-            writes &= !localFunc.IsIterator && !localFunc.IsAsync;
-
             // Now the writes
             if (writes)
             {

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -63,8 +63,9 @@ class C
 {
     public static void M2()
     {
-        int x, y, z;
+        int a=0, x, y, z;
         L1();
+        a++;
         x++;
         y++;
         z++;
@@ -78,15 +79,12 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (10,9): error CS0165: Use of unassigned local variable 'x'
-                //         x++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(10, 9),
-                // (11,9): error CS0165: Use of unassigned local variable 'y'
+                // (12,9): error CS0165: Use of unassigned local variable 'y'
                 //         y++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(11, 9),
-                // (12,9): error CS0165: Use of unassigned local variable 'z'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(12, 9),
+                // (13,9): error CS0165: Use of unassigned local variable 'z'
                 //         z++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(12, 9));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(13, 9));
         }
 
         [Fact]
@@ -100,10 +98,11 @@ class C
 {
     public static void M2()
     {
-        int w, x, y, z;
+        int a=0, w, x, y, z;
 
         L1();
 
+        a++;
         w++;
         x++;
         y++;
@@ -120,21 +119,21 @@ class C
     }
 }");
             comp.VerifyDiagnostics(
-                // (23,13): warning CS0162: Unreachable code detected
+                // (24,13): warning CS0162: Unreachable code detected
                 //             y = 0;
-                Diagnostic(ErrorCode.WRN_UnreachableCode, "y").WithLocation(23, 13),
-                // (12,9): error CS0165: Use of unassigned local variable 'w'
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "y").WithLocation(24, 13),
+                // (13,9): error CS0165: Use of unassigned local variable 'w'
                 //         w++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "w").WithArguments("w").WithLocation(12, 9),
-                // (13,9): error CS0165: Use of unassigned local variable 'x'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "w").WithArguments("w").WithLocation(13, 9),
+                // (14,9): error CS0165: Use of unassigned local variable 'x'
                 //         x++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(13, 9),
-                // (14,9): error CS0165: Use of unassigned local variable 'y'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(14, 9),
+                // (15,9): error CS0165: Use of unassigned local variable 'y'
                 //         y++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(14, 9),
-                // (15,9): error CS0165: Use of unassigned local variable 'z'
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(15, 9),
+                // (16,9): error CS0165: Use of unassigned local variable 'z'
                 //         z++;
-                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(15, 9));
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(16, 9));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/LocalFunctions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using Xunit;
 
 namespace Microsoft.CodeAnalysis.CSharp.UnitTests
@@ -6,6 +7,136 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     [CompilerTrait(CompilerFeature.LocalFunctions)]
     public class LocalFunctions : FlowTestBase
     {
+        [Fact]
+        public void InvalidBranchOutOfLocalFunc()
+        {
+            var comp = CreateCompilationWithMscorlib(@"
+class C
+{
+    public static void M()
+    {
+        label1:
+
+        L();
+        L2();
+        L3();
+
+        void L()
+        {
+            goto label1;
+        }
+
+        void L2()
+        {
+            break;
+        }
+
+        void L3()
+        {
+            continue;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (14,13): error CS0159: No such label 'label1' within the scope of the goto statement
+                //             goto label1;
+                Diagnostic(ErrorCode.ERR_LabelNotFound, "goto").WithArguments("label1").WithLocation(14, 13),
+                // (19,13): error CS0139: No enclosing loop out of which to break or continue
+                //             break;
+                Diagnostic(ErrorCode.ERR_NoBreakOrCont, "break;").WithLocation(19, 13),
+                // (24,13): error CS0139: No enclosing loop out of which to break or continue
+                //             continue;
+                Diagnostic(ErrorCode.ERR_NoBreakOrCont, "continue;").WithLocation(24, 13),
+                // (6,9): warning CS0164: This label has not been referenced
+                //         label1:
+                Diagnostic(ErrorCode.WRN_UnreferencedLabel, "label1").WithLocation(6, 9));
+        }
+
+        [Fact]
+        [WorkItem(13762, "https://github.com/dotnet/roslyn/issues/13762")]
+        public void AssignsInAsync()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System.Threading.Tasks;
+
+class C
+{
+    public static void M2()
+    {
+        int x, y, z;
+        L1();
+        x++;
+        y++;
+        z++;
+
+        async void L1()
+        {
+            x = 0;
+            await Task.Delay(0);
+            y = 0;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (10,9): error CS0165: Use of unassigned local variable 'x'
+                //         x++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(10, 9),
+                // (11,9): error CS0165: Use of unassigned local variable 'y'
+                //         y++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(11, 9),
+                // (12,9): error CS0165: Use of unassigned local variable 'z'
+                //         z++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(12, 9));
+        }
+
+        [Fact]
+        [WorkItem(13762, "https://github.com/dotnet/roslyn/issues/13762")]
+        public void AssignsInIterator()
+        {
+            var comp = CreateCompilationWithMscorlib46(@"
+using System.Collections.Generic;
+
+class C
+{
+    public static void M2()
+    {
+        int w, x, y, z;
+
+        L1();
+
+        w++;
+        x++;
+        y++;
+        z++;
+
+        IEnumerable<bool> L1()
+        {
+            w = 0;
+            yield return false;
+            x = 0;
+            yield break;
+            y = 0;
+        }
+    }
+}");
+            comp.VerifyDiagnostics(
+                // (23,13): warning CS0162: Unreachable code detected
+                //             y = 0;
+                Diagnostic(ErrorCode.WRN_UnreachableCode, "y").WithLocation(23, 13),
+                // (12,9): error CS0165: Use of unassigned local variable 'w'
+                //         w++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "w").WithArguments("w").WithLocation(12, 9),
+                // (13,9): error CS0165: Use of unassigned local variable 'x'
+                //         x++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "x").WithArguments("x").WithLocation(13, 9),
+                // (14,9): error CS0165: Use of unassigned local variable 'y'
+                //         y++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "y").WithArguments("y").WithLocation(14, 9),
+                // (15,9): error CS0165: Use of unassigned local variable 'z'
+                //         z++;
+                Diagnostic(ErrorCode.ERR_UseDefViolation, "z").WithArguments("z").WithLocation(15, 9));
+        }
+
         [Fact]
         public void SimpleForwardCall()
         {


### PR DESCRIPTION
This PR both adds the missing branches (yield/await) for async and iterator
local functions and disables allowing async and iterator local functions
definitely assigning captured variables.

Fixes #13762