### PR TITLE
Properly calculate OverridenProperty for synthesized WithEvents overrides.

### DIFF
--- a/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/OutVarTests.cs
@@ -26584,7 +26584,7 @@ class H
 ";
             var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.ReleaseExe.WithScriptClassName("Script"), parseOptions: TestOptions.Script);
 
-            compilation.VerifyDiagnostics(
+            compilation.GetDeclarationDiagnostics().Verify(
                 // (3,24): error CS7019: Type of 'x1' cannot be inferred since its initializer directly or indirectly refers to the definition.
                 // H.TakeOutParam(out var x1, x1);
                 Diagnostic(ErrorCode.ERR_RecursivelyTypedVariable, "x1").WithArguments("x1").WithLocation(3, 24)

--- a/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockSymbols.vb
@@ -365,6 +365,10 @@ Friend Class MockNamedTypeSymbol
     Friend Overrides Sub GenerateDeclarationErrors(cancellationToken As CancellationToken)
         Throw New InvalidOperationException()
     End Sub
+
+    Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+        Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+    End Function
 End Class
 
 Friend Class MockMethodSymbol

--- a/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/StateMachineRewriter/SynthesizedContainer.vb
@@ -295,7 +295,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Overrides Sub AddSynthesizedAttributes(compilationState as ModuleCompilationState, ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
+        Friend Overrides Sub AddSynthesizedAttributes(compilationState As ModuleCompilationState, ByRef attributes As ArrayBuilder(Of SynthesizedAttributeData))
             MyBase.AddSynthesizedAttributes(compilationState, attributes)
 
             Dim compilation = Me.DeclaringCompilation
@@ -308,5 +308,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         WellKnownMember.System_Runtime_CompilerServices_CompilerGeneratedAttribute__ctor))
         End Sub
 
+        Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/PublicSymbols/AnonymousTypeOrDelegatePublicSymbol.vb
@@ -300,6 +300,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Throw ExceptionUtilities.Unreachable
             End Function
 
+            Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+                Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+            End Function
         End Class
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/AnonymousTypes/SynthesizedSymbols/AnonymousTypeOrDelegateTemplateSymbol.vb
@@ -355,6 +355,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Throw ExceptionUtilities.Unreachable
             End Sub
 
+            Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+                Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+            End Function
         End Class
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ErrorTypeSymbol.vb
@@ -396,6 +396,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Throw ExceptionUtilities.Unreachable
         End Sub
 
+        Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
+
 #Region "IErrorTypeSymbol members"
 
         Public ReadOnly Property IErrorTypeSymbol_CandidateSymbols As ImmutableArray(Of ISymbol) Implements IErrorTypeSymbol.CandidateSymbols

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/PENamedTypeSymbol.vb
@@ -1475,6 +1475,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
             Next
         End Function
 
+        Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/NamedTypeSymbol.vb
@@ -1080,6 +1080,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <returns>True if this Is an interface type.</returns>
         Friend MustOverride ReadOnly Property IsInterface As Boolean
 
+        ''' <summary>
+        ''' Get synthesized WithEvents overrides that aren't returned by <see cref="GetMembers"/>
+        ''' </summary>
+        Friend MustOverride Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+
 #Region "INamedTypeSymbol"
 
         Private ReadOnly Property INamedTypeSymbol_Arity As Integer Implements INamedTypeSymbol.Arity

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingNamedTypeSymbol.vb
@@ -522,5 +522,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
         Public Overrides Function GetDocumentationCommentXml(Optional preferredCulture As CultureInfo = Nothing, Optional expandIncludes As Boolean = False, Optional cancellationToken As CancellationToken = Nothing) As String
             Return _underlyingType.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken)
         End Function
+
+        Friend Overrides Iterator Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            For Each underlying As PropertySymbol In _underlyingType.GetSynthesizedWithEventsOverrides()
+                Yield RetargetingTranslator.Retarget(underlying)
+            Next
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/ImplicitNamedTypeSymbol.vb
@@ -191,5 +191,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
         End Sub
 
+        Friend Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            ' All infrastructure for proper WithEvents handling is in SourceNamedTypeSymbol, 
+            ' but this type derives directly from SourceMemberContainerTypeSymbol, which is a base class of 
+            ' SourceNamedTypeSymbol.
+            ' Tracked by https://github.com/dotnet/roslyn/issues/14073.
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
+
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/OverrideHidingHelper.vb
@@ -697,54 +697,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Dim overriddenInThisType As ArrayBuilder(Of TSymbol) = ArrayBuilder(Of TSymbol).GetInstance()
 
             For Each sym In currType.GetMembers(overridingSym.Name)
-                ' Use original definition for accessibility check, because substitutions can cause
-                ' reductions in accessibility that aren't appropriate (see bug #12038 for example).
-                Dim accessible = AccessCheck.IsSymbolAccessible(sym.OriginalDefinition, overridingContainingType.OriginalDefinition, Nothing, useSiteDiagnostics:=Nothing)
-
-                If sym.Kind = overridingSym.Kind AndAlso
-                    CanOverrideOrHide(sym) Then
-
-                    Dim member As TSymbol = DirectCast(sym, TSymbol)
-                    Dim exactMatch As Boolean = True ' considered to be True for all runtime signature comparisons
-                    Dim exactMatchIgnoringCustomModifiers As Boolean = True ' considered to be True for all runtime signature comparisons
-
-                    If If(overridingIsFromSomeCompilation,
-                        sym.IsWithEventsProperty = overridingSym.IsWithEventsProperty AndAlso
-                            SignaturesMatch(overridingSym, member, exactMatch, exactMatchIgnoringCustomModifiers),
-                        s_runtimeSignatureComparer.Equals(overridingSym, member)) Then
-
-                        If accessible Then
-                            If exactMatchIgnoringCustomModifiers Then
-                                If exactMatch Then
-                                    If Not haveExactMatch Then
-                                        haveExactMatch = True
-                                        stopLookup = True
-                                        overriddenInThisType.Clear()
-                                    End If
-
-                                    overriddenInThisType.Add(member)
-                                ElseIf Not haveExactMatch Then
-                                    overriddenInThisType.Add(member)
-                                End If
-                            Else
-                                ' Add only if not hidden by signature
-                                AddMemberToABuilder(member, inexactOverriddenMembers)
-                            End If
-                        Else
-                            If exactMatchIgnoringCustomModifiers Then
-                                ' only exact matched methods are to be added 
-                                inaccessibleBuilder.Add(member)
-                            End If
-                        End If
-                    ElseIf Not member.IsOverloads() AndAlso accessible Then
-                        ' hiding symbol by name
-                        stopLookup = True
-                    End If
-                ElseIf accessible Then
-                    ' Any accessible symbol of different kind stops further lookup
-                    stopLookup = True
-                End If
+                ProcessMemberWithMatchingName(sym, overridingSym, overridingIsFromSomeCompilation, overridingContainingType, inexactOverriddenMembers,
+                                              inaccessibleBuilder, overriddenInThisType, stopLookup, haveExactMatch)
             Next
+
+            If overridingSym.Kind = SymbolKind.Property Then
+                Dim prop = DirectCast(DirectCast(overridingSym, Object), PropertySymbol)
+
+                If prop.IsImplicitlyDeclared AndAlso prop.IsWithEvents Then
+                    For Each sym In currType.GetSynthesizedWithEventsOverrides()
+                        If sym.Name.Equals(prop.Name) Then
+                            ProcessMemberWithMatchingName(sym, overridingSym, overridingIsFromSomeCompilation, overridingContainingType, inexactOverriddenMembers,
+                                              inaccessibleBuilder, overriddenInThisType, stopLookup, haveExactMatch)
+                        End If
+                    Next
+                End If
+            End If
 
             If overriddenInThisType.Count > 1 Then
                 RemoveMembersWithConflictingAccessibility(overriddenInThisType)
@@ -764,6 +732,66 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             overriddenInThisType.Free()
             Return stopLookup
         End Function
+
+        Private Shared Sub ProcessMemberWithMatchingName(
+            sym As Symbol,
+            overridingSym As TSymbol,
+            overridingIsFromSomeCompilation As Boolean,
+            overridingContainingType As NamedTypeSymbol,
+            inexactOverriddenMembers As ArrayBuilder(Of TSymbol),
+            inaccessibleBuilder As ArrayBuilder(Of TSymbol),
+            overriddenInThisType As ArrayBuilder(Of TSymbol),
+            ByRef stopLookup As Boolean,
+            ByRef haveExactMatch As Boolean
+        )
+            ' Use original definition for accessibility check, because substitutions can cause
+            ' reductions in accessibility that aren't appropriate (see bug #12038 for example).
+            Dim accessible = AccessCheck.IsSymbolAccessible(sym.OriginalDefinition, overridingContainingType.OriginalDefinition, Nothing, useSiteDiagnostics:=Nothing)
+
+            If sym.Kind = overridingSym.Kind AndAlso
+                CanOverrideOrHide(sym) Then
+
+                Dim member As TSymbol = DirectCast(sym, TSymbol)
+                Dim exactMatch As Boolean = True ' considered to be True for all runtime signature comparisons
+                Dim exactMatchIgnoringCustomModifiers As Boolean = True ' considered to be True for all runtime signature comparisons
+
+                If If(overridingIsFromSomeCompilation,
+                    sym.IsWithEventsProperty = overridingSym.IsWithEventsProperty AndAlso
+                        SignaturesMatch(overridingSym, member, exactMatch, exactMatchIgnoringCustomModifiers),
+                    s_runtimeSignatureComparer.Equals(overridingSym, member)) Then
+
+                    If accessible Then
+                        If exactMatchIgnoringCustomModifiers Then
+                            If exactMatch Then
+                                If Not haveExactMatch Then
+                                    haveExactMatch = True
+                                    stopLookup = True
+                                    overriddenInThisType.Clear()
+                                End If
+
+                                overriddenInThisType.Add(member)
+                            ElseIf Not haveExactMatch Then
+                                overriddenInThisType.Add(member)
+                            End If
+                        Else
+                            ' Add only if not hidden by signature
+                            AddMemberToABuilder(member, inexactOverriddenMembers)
+                        End If
+                    Else
+                        If exactMatchIgnoringCustomModifiers Then
+                            ' only exact matched methods are to be added 
+                            inaccessibleBuilder.Add(member)
+                        End If
+                    End If
+                ElseIf Not member.IsOverloads() AndAlso accessible Then
+                    ' hiding symbol by name
+                    stopLookup = True
+                End If
+            ElseIf accessible Then
+                ' Any accessible symbol of different kind stops further lookup
+                stopLookup = True
+            End If
+        End Sub
 
         Private Shared Sub AddMemberToABuilder(member As TSymbol,
                                                builder As ArrayBuilder(Of TSymbol))

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol.vb
@@ -35,6 +35,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' Overriding properties are created when a methods "Handles" is bound and can happen concurrently.
         ' We need this table to ensure that we create each override just once.
         Private _lazyWithEventsOverrides As ConcurrentDictionary(Of PropertySymbol, SynthesizedOverridingWithEventsProperty)
+        Private _withEventsOverridesAreFrozen As Boolean
 
         ' method flags for the synthesized delegate methods
         Friend Const DelegateConstructorMethodFlags As SourceMemberFlags = SourceMemberFlags.MethodKindConstructor
@@ -99,7 +100,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
 #Region "Completion"
         Protected Overrides Sub GenerateAllDeclarationErrorsImpl(cancellationToken As CancellationToken)
+#If DEBUG Then
+            EnsureAllHandlesAreBound()
+#End If
+
             MyBase.GenerateAllDeclarationErrorsImpl(cancellationToken)
+            _withEventsOverridesAreFrozen = True
 
             cancellationToken.ThrowIfCancellationRequested()
             PerformComClassAnalysis()
@@ -144,7 +150,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ' for cases where constraint checking may result in a recursive binding attempt.
         Private Function CreateLocationSpecificBinderForType(tree As SyntaxTree, location As BindingLocation) As Binder
             Debug.Assert(location <> BindingLocation.None)
-            Dim binder As binder = BinderBuilder.CreateBinderForType(ContainingSourceModule, tree, Me)
+            Dim binder As Binder = BinderBuilder.CreateBinderForType(ContainingSourceModule, tree, Me)
             Return New LocationSpecificBinder(location, binder)
         End Function
 #End Region
@@ -164,7 +170,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Dim node = syntaxRef.GetVisualBasicSyntax()
 
                 ' Set up a binder for this part of the type.
-                Dim binder As binder = BinderBuilder.CreateBinderForType(ContainingSourceModule, syntaxRef.SyntaxTree, Me)
+                Dim binder As Binder = BinderBuilder.CreateBinderForType(ContainingSourceModule, syntaxRef.SyntaxTree, Me)
 
                 ' Script and implicit classes are syntactically represented by CompilationUnitSyntax or NamespaceBlockSyntax nodes.
                 Dim staticInitializers As ArrayBuilder(Of FieldOrPropertyInitializer) = Nothing
@@ -2472,9 +2478,35 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Else
                 ' we need to create a lambda here since we need to close over baseProperty
                 ' we will however create a lambda only on a cache miss, hopefully not very often.
-                Return overridesDict.GetOrAdd(baseProperty, Function() New SynthesizedOverridingWithEventsProperty(baseProperty, Me))
+                Return overridesDict.GetOrAdd(baseProperty, Function()
+                                                                Debug.Assert(Not _withEventsOverridesAreFrozen)
+                                                                Return New SynthesizedOverridingWithEventsProperty(baseProperty, Me)
+                                                            End Function)
             End If
         End Function
+
+        Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            EnsureAllHandlesAreBound()
+
+            Dim overridesDict = Me._lazyWithEventsOverrides
+            If overridesDict IsNot Nothing Then
+                Return overridesDict.Values
+            End If
+
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
+
+        Private Sub EnsureAllHandlesAreBound()
+            If Not _withEventsOverridesAreFrozen Then
+                For Each member In Me.GetMembersUnordered()
+                    If member.Kind = SymbolKind.Method Then
+                        Dim notUsed = DirectCast(member, MethodSymbol).HandledEvents
+                    End If
+                Next
+
+                _withEventsOverridesAreFrozen = True
+            End If
+        End Sub
 
         Protected Overrides Sub AddEntryPointIfNeeded(membersBuilder As MembersAndInitializersBuilder)
             If Me.TypeKind = TypeKind.Class AndAlso Not Me.IsGenericType Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceNamedTypeSymbol_ComClass.vb
@@ -1009,6 +1009,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Friend Overrides Function GetUnificationUseSiteDiagnosticRecursive(owner As Symbol, ByRef checkedTypes As HashSet(Of TypeSymbol)) As DiagnosticInfo
                     Return Nothing
                 End Function
+
+                Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+                    Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+                End Function
             End Class
 
             Private Class SynthesizedComMethod

--- a/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SubstitutedNamedType.vb
@@ -536,6 +536,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return OriginalDefinition.GetDocumentationCommentXml(preferredCulture, expandIncludes, cancellationToken)
         End Function
 
+        Friend NotOverridable Overrides Iterator Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            For Each definition In OriginalDefinition.GetSynthesizedWithEventsOverrides()
+                Yield SubstituteTypeParametersForMemberProperty(definition)
+            Next
+        End Function
+
         ''' <summary>
         ''' Base class for symbols representing non-generic or open generic types contained within constructed generic type.
         ''' For example: A(Of Integer).B, A(Of Integer).B.C or A(Of Integer).B.C(Of ).

--- a/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SynthesizedSymbols/SynthesizedEventDelegateSymbol.vb
@@ -431,6 +431,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 Return Nothing
             End Get
         End Property
+
+        Friend Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
     End Class
 End Namespace
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -999,5 +999,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         Friend Overrides Sub GenerateDeclarationErrors(cancellationToken As CancellationToken)
             Me._underlyingType.GenerateDeclarationErrors(cancellationToken)
         End Sub
+
+        Friend Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            ' We might need to have a real implementation here, depending on the resolution
+            ' of https://github.com/dotnet/roslyn/issues/14104
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/UnboundGenericType.vb
@@ -317,6 +317,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Throw ExceptionUtilities.Unreachable
         End Function
 
+        Friend NotOverridable Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
+
         Private NotInheritable Class ConstructedSymbol
             Inherits UnboundGenericType
 

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/EENamedTypeSymbol.vb
@@ -356,6 +356,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             Next
         End Sub
 
+        Friend Overrides Function GetSynthesizedWithEventsOverrides() As IEnumerable(Of PropertySymbol)
+            Return SpecializedCollections.EmptyEnumerable(Of PropertySymbol)()
+        End Function
     End Class
 
 End Namespace


### PR DESCRIPTION
Fixes #7659.

@dotnet/roslyn-compiler, @VSadov Please review.