### PR TITLE
add regression test for oom

### DIFF
--- a/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/IncrementalParsing/IncrementalParsingTests.cs
@@ -2612,6 +2612,70 @@ class D { }
             Assert.Equal(0, newTree.GetCompilationUnitRoot().Errors().Length);
         }
 
+        [Fact]
+        public void Foo()
+        {
+            var oldText = SourceText.From(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+
+    }
+
+    protected abstract int Stuff { get; }
+}
+
+class G: Program
+{
+    protected override int Stuff
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+    }
+}");
+            var newText = SourceText.From(@"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+class Program
+{
+    static void Main(string[] args)
+    {
+
+    }
+
+    protected abstract int Stuff { get; }
+}
+
+class G: Program
+{
+    protected override int Stuff =>
+    {
+        get
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+");
+            var oldTree = SyntaxFactory.ParseSyntaxTree(oldText);
+            var newTree = oldTree.WithChangedText(newText);
+            WalkTreeAndVerify(newTree.GetCompilationUnitRoot(), SyntaxFactory.ParseSyntaxTree(newText).GetCompilationUnitRoot());
+        }
+
+        #endregion
+
+        #region Helper functions
         private void WalkTreeAndVerify(SyntaxNodeOrToken incNode, SyntaxNodeOrToken fullNode)
         {
             var incChildren = incNode.ChildNodesAndTokens();
@@ -2627,9 +2691,6 @@ class D { }
             }
         }
 
-        #endregion
-
-        #region Helper functions
         private static void CommentOutText(SourceText oldText, int locationOfChange, int widthOfChange, out SyntaxTree incrementalTree, out SyntaxTree parsedTree)
         {
             var newText = oldText.WithChanges(


### PR DESCRIPTION
this test *should* trigger the bug described in https://github.com/dotnet/roslyn/issues/11833, but since I can't repro that bug, I'm adding this as a regression test.