### PR TITLE
Each kind of compiler should take its /version info from its containing assembly's FileVersion

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -254,6 +254,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             consoleOutput.WriteLine();
         }
 
+        internal override Type Type => typeof(CSharpCompiler);
+
         internal override string GetToolName()
         {
             return ErrorFacts.GetMessage(MessageID.IDS_ToolName, Culture);

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -254,7 +254,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             consoleOutput.WriteLine();
         }
 
-        internal override Type Type => typeof(CSharpCompiler);
+
+        internal override Type Type
+        {
+            get
+            {
+                // We do not use this.GetType() so that we don't break mock subtypes
+                return typeof(CSharpCompiler);
+            }
+        }
 
         internal override string GetToolName()
         {

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis
         /// <param name="consoleOutput"></param>
         public virtual void PrintVersion(TextWriter consoleOutput)
         {
-            consoleOutput.WriteLine(GetAssemblyVersion());
+            consoleOutput.WriteLine(GetAssemblyFileVersion());
         }
 
         internal abstract string GetToolName();
@@ -86,11 +86,17 @@ namespace Microsoft.CodeAnalysis
 
         internal abstract bool SuppressDefaultResponseFile(IEnumerable<string> args);
 
-        internal string GetAssemblyFileVersion()
+        /// <summary>
+        /// The type of the compiler class for version information in /help and /version.
+        /// We don't simply use this.GetType() because that would break mock subclasses.
+        /// </summary>
+        internal abstract Type Type { get; }
+
+        internal virtual string GetAssemblyFileVersion()
         {
             if (_clientDirectory != null)
             {
-                var name = $"{typeof(CommonCompiler).GetTypeInfo().Assembly.GetName().Name}.dll";
+                var name = $"{Type.GetTypeInfo().Assembly.GetName().Name}.dll";
                 var filePath = Path.Combine(_clientDirectory, name);
                 return FileVersionInfo.GetVersionInfo(filePath).FileVersion;
             }
@@ -100,7 +106,7 @@ namespace Microsoft.CodeAnalysis
 
         internal Version GetAssemblyVersion()
         {
-            return typeof(CommonCompiler).GetTypeInfo().Assembly.GetName().Version;
+            return Type.GetTypeInfo().Assembly.GetName().Version;
         }
 
         internal string GetCultureName()

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -55,8 +55,6 @@ namespace Microsoft.CodeAnalysis
             consoleOutput.WriteLine(GetAssemblyFileVersion());
         }
 
-        internal abstract string GetToolName();
-
         protected abstract bool TryGetCompilerDiagnosticCode(string diagnosticId, out uint code);
         protected abstract ImmutableArray<DiagnosticAnalyzer> ResolveAnalyzersFromArguments(
             List<DiagnosticInfo> diagnostics,
@@ -92,6 +90,9 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal abstract Type Type { get; }
 
+        /// <summary>
+        /// The assembly file version of this compiler, used in logo and /version output.
+        /// </summary>
         internal virtual string GetAssemblyFileVersion()
         {
             if (_clientDirectory != null)
@@ -104,6 +105,14 @@ namespace Microsoft.CodeAnalysis
             return "";
         }
 
+        /// <summary>
+        /// Tool name used, along with assembly version, for error logging.
+        /// </summary>
+        internal abstract string GetToolName();
+
+        /// <summary>
+        /// Tool version identifier used for error logging.
+        /// </summary>
         internal Version GetAssemblyVersion()
         {
             return Type.GetTypeInfo().Assembly.GetName().Version;

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -193,6 +193,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Friend Overrides ReadOnly Property Type As Type
             Get
+                ' We do not use Me.GetType() so that we don't break mock subtypes
                 Return GetType(VisualBasicCompiler)
             End Get
         End Property

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -191,6 +191,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return ErrorFactory.IdToString(ERRID.IDS_ToolName, Culture)
         End Function
 
+        Friend Overrides ReadOnly Property Type As Type
+            Get
+                Return GetType(VisualBasicCompiler)
+            End Get
+        End Property
+
         ''' <summary>
         ''' Print Commandline help message (up to 80 English characters per line)
         ''' </summary>

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -18,6 +18,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
         {
         }
 
+        internal override Type Type => typeof(CSharpInteractiveCompiler);
+
+        internal override string GetAssemblyFileVersion()
+        {
+            return Type.GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        }
+
         internal override MetadataReferenceResolver GetCommandLineMetadataReferenceResolver(TouchedFileLogger loggerOpt)
         {
             return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt);
@@ -25,8 +32,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 
         public override void PrintLogo(TextWriter consoleOutput)
         {
-            var version = typeof(CSharpInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
-            consoleOutput.WriteLine(CSharpScriptingResources.LogoLine1, version);
+            consoleOutput.WriteLine(CSharpScriptingResources.LogoLine1, GetAssemblyFileVersion());
             consoleOutput.WriteLine(CSharpScriptingResources.LogoLine2);
             consoleOutput.WriteLine();
         }

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -19,9 +19,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
             Return CommandLineRunner.GetMetadataReferenceResolver(Arguments, loggerOpt)
         End Function
 
+        Friend Overrides ReadOnly Property Type As Type
+            Get
+                Return GetType(VisualBasicInteractiveCompiler)
+            End Get
+        End Property
+
+        Friend Overrides Function GetAssemblyFileVersion() As String
+            Return Type.GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
+        End Function
+
         Public Overrides Sub PrintLogo(consoleOutput As TextWriter)
-            Dim version = GetType(VisualBasicInteractiveCompiler).GetTypeInfo().Assembly.GetCustomAttribute(Of AssemblyFileVersionAttribute)().Version
-            consoleOutput.WriteLine(VBScriptingResources.LogoLine1, version)
+            consoleOutput.WriteLine(VBScriptingResources.LogoLine1, GetAssemblyFileVersion())
             consoleOutput.WriteLine(VBScriptingResources.LogoLine2)
             consoleOutput.WriteLine()
         End Sub


### PR DESCRIPTION
It appears we were lucky things worked before (that is, before I broke things by making the
output use file version and the tests use assembly version), as the implementation and tests
for /help disagreed on which assembly to use to get the version info for the C# and VB
compilers. They were usually the same information by coincidence as a consequence of
how the product is built. We now consistently use the file version of the file containing
the assembly of the compiler main class for /help, /version, and the tests of those flags.
Fixes #14172

@dotnet/roslyn-compiler Please review
@jasonmalinowski FYI
