### PR TITLE
harden jenkins test regex for specifying runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -69,7 +69,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
     if (triggerPhraseExtra) {
       triggerCore = "${triggerCore}|${triggerPhraseExtra}"
     }
-    def triggerPhrase = "(?i).*test\\W+(${triggerCore})\\W+please.*";
+    def triggerPhrase = "(?i)^(@dotnet-bot )?test (${triggerCore})( please)?\\s*$";
     def contextName = jobName
     Utilities.addGithubPRTriggerForBranch(myJob, branchName, contextName, triggerPhrase, triggerPhraseOnly)
   } else {

--- a/netci.groovy
+++ b/netci.groovy
@@ -69,7 +69,7 @@ static void addRoslynJob(def myJob, String jobName, String branchName, Boolean i
     if (triggerPhraseExtra) {
       triggerCore = "${triggerCore}|${triggerPhraseExtra}"
     }
-    def triggerPhrase = "(?i)^(@dotnet-bot )?test (${triggerCore})( please)?\\s*$";
+    def triggerPhrase = "(?i)^\\s*(@?dotnet-bot\\s+)?test\\s+(${triggerCore})(\\s+please)?\\s*$";
     def contextName = jobName
     Utilities.addGithubPRTriggerForBranch(myJob, branchName, contextName, triggerPhrase, triggerPhraseOnly)
   } else {

--- a/perf.groovy
+++ b/perf.groovy
@@ -39,7 +39,7 @@ def generate(boolean isPr) {
         TriggerBuilder prTrigger = TriggerBuilder.triggerOnPullRequest()
         prTrigger.permitOrg('Microsoft')
         prTrigger.permitOrg('dotnet')
-        prTrigger.setCustomTriggerPhrase("(?i).*test\\W+perf.*" )
+        prTrigger.setCustomTriggerPhrase("(?i)^(@dotnet-bot )?test perf( please)?\\s*$" )
         prTrigger.triggerForBranch('master');
         prTrigger.setGithubContext('Performance Test Run')
         prTrigger.emitTrigger(myJob)

--- a/perf.groovy
+++ b/perf.groovy
@@ -39,7 +39,7 @@ def generate(boolean isPr) {
         TriggerBuilder prTrigger = TriggerBuilder.triggerOnPullRequest()
         prTrigger.permitOrg('Microsoft')
         prTrigger.permitOrg('dotnet')
-        prTrigger.setCustomTriggerPhrase("(?i)^(@dotnet-bot )?test perf( please)?\\s*$" )
+        prTrigger.setCustomTriggerPhrase("(?i)^\\s*(@dotnet-bot\\s+)?test\\s+perf(\\s+please)?\\s*$" )
         prTrigger.triggerForBranch('master');
         prTrigger.setGithubContext('Performance Test Run')
         prTrigger.emitTrigger(myJob)


### PR DESCRIPTION
closes https://github.com/dotnet/roslyn/issues/14092

cc: @mmitche, @dotnet/roslyn-infrastructure 

Under this PR, the only lines that will trigger a perf run look like the following:

```
test test_name
@dotnet-bot test test_name
test test_name please
@dotnet-bot test test_name please
```

The trigger text must be the only text on a line, keeping us from accidentally running tests without knowing.

Please stop by and talk to me if you want to talk about the security aspects of this PR.