### PR TITLE
Fix XamlProject constructor exceptions

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProject.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProject.cs
@@ -2,8 +2,6 @@
 
 using System;
 using System.Diagnostics;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;
@@ -25,9 +23,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
                 visualStudioWorkspaceOpt: visualStudioWorkspace,
                 hostDiagnosticUpdateSourceOpt: null)
         {
-            // Use default options
-            SetOptions(new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions());
-
             projectTracker.AddProject(this);
         }
 

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlProject.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlProject.cs
@@ -2,6 +2,8 @@
 
 using System;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Xaml;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.Legacy;
@@ -12,20 +14,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
     internal class XamlProject : AbstractLegacyProject
     {
-        public XamlProject(IVsHierarchy hierarchy, IServiceProvider serviceProvider, VisualStudioWorkspaceImpl visualStudioWorkspace) :
+        public XamlProject(VisualStudioProjectTracker projectTracker, IVsHierarchy hierarchy, IServiceProvider serviceProvider, VisualStudioWorkspaceImpl visualStudioWorkspace) :
             base(
-                visualStudioWorkspace.ProjectTracker,
+                projectTracker,
                 reportExternalErrorCreatorOpt: null,
-                projectSystemName: $"{XamlProject.GetProjectName(hierarchy)}|{nameof(XamlProject)}",
+                projectSystemName: $"{XamlProject.GetProjectName(hierarchy)}-{nameof(XamlProject)}",
                 hierarchy: hierarchy,
                 language: StringConstants.XamlLanguageName,
                 serviceProvider: serviceProvider,
                 visualStudioWorkspaceOpt: visualStudioWorkspace,
                 hostDiagnosticUpdateSourceOpt: null)
         {
-            // We initialized ProjectSystemName to include nameof(XamlProject).
-            // Update DisplayName to just the project name.
-            UpdateProjectDisplayName(XamlProject.GetProjectName(hierarchy));
+            // Use default options
+            SetOptions(new CSharpCompilationOptions(OutputKind.ConsoleApplication), new CSharpParseOptions());
+
+            projectTracker.AddProject(this);
         }
 
         private static string GetProjectName(IVsHierarchy hierarchy)
@@ -36,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
 
         private string GetDebuggerDisplay()
         {
-            return $"{this.DisplayName}|{nameof(XamlProject)}";
+            return $"{this.DisplayName}";
         }
     }
 }

--- a/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
+++ b/src/VisualStudio/Xaml/Impl/Implementation/XamlTextViewCreationListener.cs
@@ -105,8 +105,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Xaml
             AbstractProject project = GetXamlProject(hierarchy);
             if (project == null)
             {
-                project = new XamlProject(hierarchy, _serviceProvider, _vsWorkspace);
-                _vsWorkspace.ProjectTracker.AddProject(project);
+                project = new XamlProject(_vsWorkspace.ProjectTracker, hierarchy, _serviceProvider, _vsWorkspace);
             }
 
             IVisualStudioHostDocument vsDocument = project.GetCurrentDocumentFromPath(filePath);

--- a/src/VisualStudio/Xaml/Impl/XamlVisualStudio.csproj
+++ b/src/VisualStudio/Xaml/Impl/XamlVisualStudio.csproj
@@ -27,6 +27,10 @@
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\CSharpCodeAnalysis.csproj">
+      <Project>{b501a547-c911-4a05-ac6e-274a50dff30e}</Project>
+      <Name>CSharpCodeAnalysis</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\EditorFeatures\Core\EditorFeatures.csproj">
       <Project>{3CDEEAB7-2256-418A-BEB2-620B5CB16302}</Project>
       <Name>EditorFeatures</Name>

--- a/src/VisualStudio/Xaml/Impl/XamlVisualStudio.csproj
+++ b/src/VisualStudio/Xaml/Impl/XamlVisualStudio.csproj
@@ -27,10 +27,6 @@
       <Project>{1EE8CAD3-55F9-4D91-96B2-084641DA9A6C}</Project>
       <Name>CodeAnalysis</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\Compilers\CSharp\Portable\CSharpCodeAnalysis.csproj">
-      <Project>{b501a547-c911-4a05-ac6e-274a50dff30e}</Project>
-      <Name>CSharpCodeAnalysis</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\..\EditorFeatures\Core\EditorFeatures.csproj">
       <Project>{3CDEEAB7-2256-418A-BEB2-620B5CB16302}</Project>
       <Name>EditorFeatures</Name>


### PR DESCRIPTION
Fixes issue #14079 by initializing XamlProjects with C# default options and avoiding illegal path characters in the project name.

Also passing VisualStudioProjectTracker into constructor separately to enable future tests. Due to 14.0/15.0 assembly mismatch issues I was unable to add any tests at this point.