### PR TITLE
Use a different file and assembly version for non-official builds

### DIFF
--- a/build/Targets/VSL.Imports.targets
+++ b/build/Targets/VSL.Imports.targets
@@ -190,10 +190,6 @@
 
   <Target Name="VerifyBuildFlags">
     <Error 
-        Condition="'$(OfficialBuild)' == 'true' AND '$(BuildVersion)' == '42.42.42.42'"
-        Text="Must specify a build version in order to real sign a build." />
-
-    <Error 
         Condition="'$(CheckForOverflowUnderflow)' != '' OR '$(RemoveIntegerChecks)' != ''"
         Text="The following properties cannot be set by individual projects: CheckForOverflowUnderflow and RemoveIntegerChecks" />
     

--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -52,13 +52,14 @@
 
     <Otherwise>
       <!-- No build version was supplied.  We'll use a special version, higher than anything
-          installed, so that the assembly identity is different.  This will allows us to
-          have a build with an actual number installed, but then build and F5 a build with
-          this number.  -->
+           installed, so that the assembly identity is different.  This will allows us to
+           have a build with an actual number installed, but then build and F5 a build with
+           this number. We will make AssemblyVersion and BuildVersion different, to catch
+           any bugs where people might assume they are the same. -->
       <PropertyGroup>
         <AssemblyVersion>42.42.42.42</AssemblyVersion>
-        <BuildVersion>42.42.42.42</BuildVersion>
-        <VsixVersion>42.42.42.42</VsixVersion>
+        <BuildVersion>42.42.42.42424</BuildVersion>
+        <VsixVersion>42.42.42.42424</VsixVersion>
       </PropertyGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
In official builds, these are different, so we should make them
different for non-official builds. Otherwise code that assumes they
are the same can sneak through and break stuff.

This is inspired by bug #14172 where exactly that thing happened.

*Review:* @dotnet/roslyn-infrastructure