### PR TITLE
make sure checksum doesn't collide with different kind of asset.

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
+++ b/src/Workspaces/Core/Portable/Execution/AbstractReferenceSerializationService.cs
@@ -167,6 +167,11 @@ namespace Microsoft.CodeAnalysis.Execution
             writer.WriteString(nameof(PortableExecutableReference));
             writer.WriteInt32((int)kind);
 
+            WritePortableExecutableReferencePropertiesTo(reference, writer, cancellationToken);
+        }
+
+        private void WritePortableExecutableReferencePropertiesTo(PortableExecutableReference reference, ObjectWriter writer, CancellationToken cancellationToken)
+        {
             WriteTo(reference.Properties, writer, cancellationToken);
             writer.WriteString(reference.FilePath);
         }
@@ -176,6 +181,7 @@ namespace Microsoft.CodeAnalysis.Execution
             using (var stream = SerializableBytes.CreateWritableStream())
             using (var writer = new ObjectWriter(stream, cancellationToken: cancellationToken))
             {
+                WritePortableExecutableReferencePropertiesTo(reference, writer, cancellationToken);
                 WriteMvidsTo(TryGetMetadata(reference), writer, cancellationToken);
 
                 stream.Position = 0;

--- a/src/Workspaces/Core/Portable/Execution/Asset.cs
+++ b/src/Workspaces/Core/Portable/Execution/Asset.cs
@@ -100,7 +100,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private readonly MetadataReference _reference;
 
         public MetadataReferenceAsset(Serializer serializer, MetadataReference reference, Checksum checksum, string kind) :
-            base(checksum, WellKnownChecksumObjects.MetadataReference)
+            base(Checksum.Create(kind, checksum), WellKnownChecksumObjects.MetadataReference)
         {
             Contract.Requires(kind == WellKnownChecksumObjects.MetadataReference);
 
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private readonly AnalyzerReference _reference;
 
         public AnalyzerReferenceAsset(Serializer serializer, AnalyzerReference reference, Checksum checksum, string kind) :
-            base(checksum, WellKnownChecksumObjects.AnalyzerReference)
+            base(Checksum.Create(kind, checksum), WellKnownChecksumObjects.AnalyzerReference)
         {
             Contract.Requires(kind == WellKnownChecksumObjects.AnalyzerReference);
 
@@ -147,7 +147,7 @@ namespace Microsoft.CodeAnalysis.Execution
         private readonly TextDocumentState _state;
 
         public SourceTextAsset(Serializer serializer, TextDocumentState state, Checksum checksum, string kind) :
-            base(checksum, WellKnownChecksumObjects.SourceText)
+            base(Checksum.Create(kind, checksum), WellKnownChecksumObjects.SourceText)
         {
             Contract.Requires(kind == WellKnownChecksumObjects.SourceText);
 

--- a/src/Workspaces/Core/Portable/Execution/Checksum_Factory.cs
+++ b/src/Workspaces/Core/Portable/Execution/Checksum_Factory.cs
@@ -24,6 +24,18 @@ namespace Microsoft.CodeAnalysis.Execution
             }
         }
 
+        public static Checksum Create(string kind, Checksum checksum)
+        {
+            using (var stream = SerializableBytes.CreateWritableStream())
+            using (var writer = new ObjectWriter(stream))
+            {
+                writer.WriteString(kind);
+                checksum.WriteTo(writer);
+
+                return Create(stream);
+            }
+        }
+
         public static Checksum Create<TChecksums>(string kind, TChecksums checksums)
             where TChecksums : IEnumerable<Checksum>
         {

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -512,6 +512,21 @@ namespace Microsoft.CodeAnalysis.UnitTests
             }
         }
 
+        [Fact]
+        public void EmptyAssetChecksumTest()
+        {
+            var document = new AdhocWorkspace().CurrentSolution.AddProject("empty", "empty", LanguageNames.CSharp).AddDocument("empty", SourceText.From(""));
+            var assetBuilder = new AssetBuilder(document.Project.Solution);
+
+            var source = assetBuilder.Build(document.State, document.GetTextAsync().Result, CancellationToken.None);
+            var metadata = assetBuilder.Build(new MissingMetadataReference(), CancellationToken.None);
+            var analyzer = assetBuilder.Build(new AnalyzerFileReference("missing", new MissingAnalyzerLoader()), CancellationToken.None);
+
+            Assert.NotEqual(source.Checksum, metadata.Checksum);
+            Assert.NotEqual(source.Checksum, analyzer.Checksum);
+            Assert.NotEqual(metadata.Checksum, analyzer.Checksum);
+        }
+
         private static async Task VerifyOptionSetsAsync(Workspace workspace, string language)
         {
             var assetBuilder = new AssetBuilder(workspace.CurrentSolution);


### PR DESCRIPTION
the common issue is when content where checksum get created is empty.

asset probably will change when I move checksum tree into solution state but until then, this should fix the collision between different asset kind on empty content.