### PR TITLE
Don't let target type preselection override an exact case-sensitive match

### DIFF
--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -2121,6 +2121,25 @@ class Program
             End Using
         End Function
 
+        <WorkItem(14085, "https://github.com/dotnet/roslyn/issues/14085")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TargetTypePreselectionExactMatching() As Task
+            Using state = TestState.CreateCSharpTestState(
+                           <Document><![CDATA[
+using System.IO.
+class Program
+{
+    void Main()
+    {
+        string path = Path$$
+    }
+}]]></Document>, extraExportedTypes:={GetType(CSharpEditorFormattingService)}.ToList())
+                state.SendInvokeCompletionList()
+                Await state.WaitForAsynchronousOperationsAsync().ConfigureAwait(True)
+                Await state.AssertSelectedCompletionItem("Path", isHardSelected:=True).ConfigureAwait(True)
+            End Using
+        End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
         <WorkItem(12530, "https://github.com/dotnet/roslyn/issues/12530")>
         Public Async Function TestAnonymousTypeDescription() As Task

--- a/src/Features/Core/Portable/Completion/CompletionHelper.cs
+++ b/src/Features/Core/Portable/Completion/CompletionHelper.cs
@@ -234,8 +234,15 @@ namespace Microsoft.CodeAnalysis.Completion
             // and 'False' (with the latter being 'Preselected').  Both will be a prefix match.
             // And because we are ignoring case, neither will be seen as better.  Now, because
             // 'False' is preselected we pick it even though 'foo' matches 'f' case sensitively.
+
+            // At this point, we've only done case insesitive comparisons. Consider:
+            // using System.IO; ...
+            // string path = Path$$ 
+            // System.IO.Path is a better case-sensitive match but has a worse
+            // preselection score from target typing
+            
             diff = item2.Rules.MatchPriority - item1.Rules.MatchPriority;
-            if (diff != 0)
+            if (!IsExactAndCaseSensitive(match1) && !IsExactAndCaseSensitive(match2) && diff != 0)
             {
                 return diff;
             }
@@ -266,6 +273,11 @@ namespace Microsoft.CodeAnalysis.Completion
             }
 
             return 0;
+        }
+
+        private bool IsExactAndCaseSensitive(PatternMatch match)
+        {
+            return match.IsCaseSensitive && match.Kind == PatternMatchKind.Exact;
         }
     }
 }


### PR DESCRIPTION
tag @dotnet/roslyn-ide for review
