### PR TITLE
Remove unnecessary RemoteHost option.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -54,9 +54,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         return;
                     }
 
-                    // We enable the remote host if either RemoteHostTest or RemoteHost are on.
-                    if (!_workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest) &&
-                        !_workspace.Options.GetOption(RemoteHostOptions.RemoteHost))
+                    if (!_workspace.Options.GetOption(RemoteHostOptions.RemoteHost))
                     {
                         // not turned on
                         return;

--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostOptions.cs
@@ -15,7 +15,5 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
         public static readonly Option<int> SolutionChecksumMonitorBackOffTimeSpanInMS = new Option<int>(nameof(InternalFeatureOnOffOptions), nameof(SolutionChecksumMonitorBackOffTimeSpanInMS), defaultValue: 10000,
             storageLocations: new LocalUserProfileStorageLocation(InternalFeatureOnOffOptions.LocalRegistryPath + nameof(SolutionChecksumMonitorBackOffTimeSpanInMS)));
 
-        [ExportOption]
-        public static readonly Option<bool> RemoteHostTest = new Option<bool>(nameof(InternalFeatureOnOffOptions), nameof(RemoteHostTest), defaultValue: false);
     }
 }

--- a/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
+++ b/src/VisualStudio/Core/Test.Next/Remote/RemoteHostClientServiceFactoryTests.cs
@@ -108,7 +108,6 @@ namespace Roslyn.VisualStudio.Next.UnitTests.Remote
         {
             workspace = workspace ?? new AdhocWorkspace(TestHostServices.CreateHostServices());
             workspace.Options = workspace.Options.WithChangedOption(RemoteHostOptions.RemoteHost, true)
-                                                 .WithChangedOption(RemoteHostOptions.RemoteHostTest, true)
                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.CSharp, true)
                                                  .WithChangedOption(ServiceFeatureOnOffOptions.ClosedFileDiagnostic, LanguageNames.VisualBasic, true);
 


### PR DESCRIPTION
This is a slight tweak of https://github.com/dotnet/roslyn/pull/14178.  Except in this PR we also remove the seemingly redundant RemoteHostTest option.
