### PR TITLE
A ref type's subtype is a context in which only a type is expected.

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFacts.cs
@@ -138,6 +138,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                     case RefValueExpression:
                         return ((RefValueExpressionSyntax)parent).Type == node;
 
+                    case RefType:
+                        return ((RefTypeSyntax)parent).Type == node;
+
                     case Parameter:
                         return ((ParameterSyntax)parent).Type == node;
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/RefLocalsAndReturnsTests.cs
@@ -960,5 +960,43 @@ class C
                 Diagnostic(ErrorCode.ERR_BadArgExtraRef, "i").WithArguments("1", "ref").WithLocation(12, 20)
                 );
         }
+
+        [Fact, WorkItem(14174, "https://github.com/dotnet/roslyn/issues/14174")]
+        public void RefDynamicBinding()
+        {
+            var text = @"
+class C
+{
+    static object[] arr = new object[] { ""f"" };
+    static void Main(string[] args)
+    {
+        System.Console.Write(arr[0].ToString());
+
+        RefParam(ref arr[0]);
+        System.Console.Write(arr[0].ToString());
+
+        ref dynamic x = ref arr[0];
+        x = ""o"";
+        System.Console.Write(arr[0].ToString());
+
+        RefReturn() = ""g"";
+        System.Console.Write(arr[0].ToString());
+    }
+
+    static void RefParam(ref dynamic p)
+    {
+        p = ""r"";
+    }
+
+    static ref dynamic RefReturn()
+    {
+        return ref arr[0];
+    }
+}
+";
+            CompileAndVerify(text,
+                expectedOutput: "frog",
+                additionalRefs: new[] { SystemCoreRef, CSharpRef }).VerifyDiagnostics();
+        }
     }
 }


### PR DESCRIPTION
Fixes #14174 

@VSadov @dotnet/roslyn-compiler Please review this tiny bug fix.