### PR TITLE
BlockTags should not be reused if they have changed in any way that their consumer might be able to observe.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/Structure/AbstractStructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/AbstractStructureTaggerProvider.cs
@@ -30,8 +30,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
     /// persist them to the SUO file to persist this data across sessions.
     /// </summary>
     internal abstract partial class AbstractStructureTaggerProvider<TRegionTag> : 
-        AsynchronousTaggerProvider<TRegionTag>,
-        IEqualityComparer<TRegionTag>
+        AsynchronousTaggerProvider<TRegionTag>
         where TRegionTag : class, ITag
     {
         private static IComparer<BlockSpan> s_blockSpanComparer =
@@ -53,12 +52,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             EditorOptionsFactoryService = editorOptionsFactoryService;
             ProjectionBufferFactoryService = projectionBufferFactoryService;
         }
-
-        protected sealed override IEqualityComparer<TRegionTag> TagComparer => this;
-
-        public abstract bool Equals(TRegionTag x, TRegionTag y);
-
-        public abstract int GetHashCode(TRegionTag obj);
 
         protected sealed override ITaggerEventSource CreateEventSource(ITextView textViewOpt, ITextBuffer subjectBuffer)
         {

--- a/src/EditorFeatures/Core/Implementation/Structure/RoslynOutliningRegionTag.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/RoslynOutliningRegionTag.cs
@@ -52,6 +52,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
             _hintSpan = snapshot.CreateTrackingSpan(BlockSpan.HintSpan.ToSpan(), SpanTrackingMode.EdgeExclusive);
         }
 
+        public override bool Equals(object obj) 
+            => Equals(obj as RoslynOutliningRegionTag);
+
+        // This is only called if the spans for the tags were the same. In that case, we 
+        // consider ourselves the same unless the CollapsedForm properties are different.
+        public bool Equals(RoslynOutliningRegionTag tag)
+            => tag != null && Equals(this.CollapsedForm, tag.CollapsedForm);
+
+        public override int GetHashCode() 
+            => EqualityComparer<object>.Default.GetHashCode(this.CollapsedForm);
+
         public object CollapsedHintForm =>
             new ViewHostingControl(CreateElisionBufferView, CreateElisionBuffer);
 

--- a/src/EditorFeatures/Core/Implementation/Structure/VisualStudio14StructureTaggerProvider.cs
+++ b/src/EditorFeatures/Core/Implementation/Structure/VisualStudio14StructureTaggerProvider.cs
@@ -40,18 +40,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.Structure
         {
         }
 
-        public override bool Equals(IOutliningRegionTag x, IOutliningRegionTag y)
-        {
-            // This is only called if the spans for the tags were the same. In that case, we consider ourselves the same
-            // unless the CollapsedForm properties are different.
-            return EqualityComparer<object>.Default.Equals(x.CollapsedForm, y.CollapsedForm);
-        }
-
-        public override int GetHashCode(IOutliningRegionTag obj)
-        {
-            return EqualityComparer<object>.Default.GetHashCode(obj.CollapsedForm);
-        }
-
         protected override IOutliningRegionTag CreateTag(
             IOutliningRegionTag parentTag, ITextSnapshot snapshot, BlockSpan region)
         {

--- a/src/EditorFeatures/Next/Structure/VisualStudio15StructureTaggerProvider.cs
+++ b/src/EditorFeatures/Next/Structure/VisualStudio15StructureTaggerProvider.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.Text.Projection;
 using Microsoft.VisualStudio.Text.Tagging;
 using Microsoft.VisualStudio.Utilities;
+using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Editor.Structure
 {
@@ -32,18 +33,6 @@ namespace Microsoft.CodeAnalysis.Editor.Structure
             [ImportMany] IEnumerable<Lazy<IAsynchronousOperationListener, FeatureMetadata>> asyncListeners)
                 : base(notificationService, textEditorFactoryService, editorOptionsFactoryService, projectionBufferFactoryService, asyncListeners)
         {
-        }
-
-        public override bool Equals(IBlockTag x, IBlockTag y)
-        {
-            // This is only called if the spans for the tags were the same. In that case, we consider ourselves the same
-            // unless the CollapsedForm properties are different.
-            return EqualityComparer<object>.Default.Equals(x.CollapsedForm, y.CollapsedForm);
-        }
-
-        public override int GetHashCode(IBlockTag obj)
-        {
-            return EqualityComparer<object>.Default.GetHashCode(obj.CollapsedForm);
         }
 
         protected override IBlockTag CreateTag(
@@ -83,6 +72,36 @@ namespace Microsoft.CodeAnalysis.Editor.Structure
                 Level = parent == null ? 0 : parent.Level + 1;
                 Span = outliningSpan.TextSpan.ToSnapshotSpan(snapshot);
                 StatementSpan = outliningSpan.HintSpan.ToSnapshotSpan(snapshot);
+            }
+
+            public override bool Equals(object obj)
+                => Equals(obj as RoslynBlockTag);
+
+            /// <summary>
+            /// This is only called if the spans for the tags were the same.  However, even if we 
+            /// have the same span as the previous tag (taking into account span mapping) that 
+            /// doesn't mean we can use the old block tag.  Specifically, the editor will look at
+            /// other fields in the tags So we need to make sure that these values have not changed
+            /// if we want to reuse the old block tag.  For example, perhaps the item's type changed
+            /// (i.e. from class to struct).  It will have the same span, but might have a new 
+            /// presentation as the 'Type' will be different.
+            /// </summary>
+            public bool Equals(RoslynBlockTag tag)
+            {
+                return tag != null &&
+                       this.Level == tag.Level &&
+                       this.Type == tag.Type &&
+                       EqualityComparer<object>.Default.Equals(this.CollapsedForm, tag.CollapsedForm) &&
+                       this.StatementSpan == tag.StatementSpan &&
+                       this.Span == tag.Span;
+            }
+
+            public override int GetHashCode()
+            {
+                return Hash.Combine(this.Level,
+                       Hash.Combine(this.Type, 
+                       Hash.Combine(this.CollapsedForm,
+                       Hash.Combine(this.StatementSpan.GetHashCode(), this.Span.GetHashCode()))));
             }
 
             private string ConvertType(string type)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14087
Fixes https://github.com/dotnet/roslyn/issues/14123