### PR TITLE
Optimize documentation comment querying

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
+++ b/src/Workspaces/Core/Portable/Utilities/Documentation/XmlDocumentationProvider.cs
@@ -53,7 +53,11 @@ So we suppress this error until the reporting for CA3053 has been updated to acc
                         {
                             if (e.Attribute("name") != null)
                             {
-                                _docComments[e.Attribute("name").Value] = string.Concat(e.Nodes());
+                                using (var reader = e.CreateReader())
+                                {
+                                    reader.MoveToContent();
+                                    _docComments[e.Attribute("name").Value] = reader.ReadInnerXml();
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Based on a stress test that uses ~similar code to get documentation comments from the xml docs generated by Microsoft.CodeAnalysis.CSharp, I came up with the following results purely from getting the inner xml content:

`string.Concat` - 142MB of allocations
`XmlReader` - 9.4MB of allocations.

The allocation gap widens the more tags the xml member contains.

On a benchmark which uses the same algorithm as in GetDocumentationForSymbol, we have the following results:

```
          Method |     Median |    StdDev |
---------------- |----------- |---------- |
 XmlStringConcat | 28.4576 ms | 0.4254 ms |
    XmlXmlReader | 18.9115 ms | 0.2044 ms |
```