### PR TITLE
Added 'implement through <memberName>' for events

### DIFF
--- a/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
+++ b/src/EditorFeatures/CSharpTest/ImplementInterface/ImplementInterfaceTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
         internal override (DiagnosticAnalyzer, CodeFixProvider) CreateDiagnosticProviderAndFixer(Workspace workspace)
             => (null, new CSharpImplementInterfaceCodeFixProvider());
 
-        private static readonly Dictionary<OptionKey, object> AllOptionsOff =
+        private static readonly Dictionary<OptionKey, object> s_allOptionsOff =
             new Dictionary<OptionKey, object>
             {
                 {  CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CodeStyleOptions.FalseWithNoneEnforcement },
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
                 {  CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CodeStyleOptions.FalseWithNoneEnforcement }
             };
 
-        private static readonly Dictionary<OptionKey, object> AllOptionsOn =
+        private static readonly Dictionary<OptionKey, object> s_allOptionsOn =
             new Dictionary<OptionKey, object>
             {
                 {  CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CodeStyleOptions.TrueWithNoneEnforcement },
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
                 {  CSharpCodeStyleOptions.PreferExpressionBodiedOperators, CodeStyleOptions.TrueWithNoneEnforcement }
             };
 
-        private static readonly Dictionary<OptionKey, object> AccessorOptionsOn =
+        private static readonly Dictionary<OptionKey, object> s_accessorOptionsOn =
             new Dictionary<OptionKey, object>
             {
                 {  CSharpCodeStyleOptions.PreferExpressionBodiedConstructors, CodeStyleOptions.FalseWithNoneEnforcement },
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
             bool withScriptOption = false)
         {
             await TestAsync(initialMarkup, expectedMarkup, parseOptions, null,
-                index, compareTokens, options: AllOptionsOff, withScriptOption: withScriptOption);
+                index, compareTokens, options: s_allOptionsOff, withScriptOption: withScriptOption);
         }
 
         internal async Task TestWithAllCodeStyleOptionsOnAsync(
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
             bool withScriptOption = false)
         {
             await TestAsync(initialMarkup, expectedMarkup, parseOptions, null,
-                index, compareTokens, options: AllOptionsOn, withScriptOption: withScriptOption);
+                index, compareTokens, options: s_allOptionsOn, withScriptOption: withScriptOption);
         }
 
         internal async Task TestWithAccessorCodeStyleOptionsOnAsync(
@@ -82,7 +82,7 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.ImplementInterface
             bool withScriptOption = false)
         {
             await TestAsync(initialMarkup, expectedMarkup, parseOptions, null,
-                index, compareTokens, options: AccessorOptionsOn, withScriptOption: withScriptOption);
+                index, compareTokens, options: s_accessorOptionsOn, withScriptOption: withScriptOption);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
@@ -2451,6 +2451,63 @@ class B : [|I|]
     }
 }",
 count: 2);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TestImplementEventThroughMember()
+        {
+            await TestAsync(@"
+interface IFoo
+{
+    event System.EventHandler E;
+}
+
+class CanFoo : IFoo
+{
+    public event EventHandler E;
+}
+
+class HasCanFoo : [|IFoo|]
+{
+    CanFoo canFoo;
+}",
+@"
+using System;
+
+interface IFoo
+{ 
+    event System.EventHandler E; 
+}
+
+class CanFoo : IFoo
+{ 
+    public event EventHandler E;
+}
+
+class HasCanFoo : IFoo
+{ 
+    CanFoo canFoo;
+    public event EventHandler E
+    {
+        add
+        {
+            ((IFoo)canFoo).E += value;
+        }
+        remove
+        { 
+            ((IFoo)canFoo).E -= value;
+        }
+    }
+}", index: 1);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]
+        public async Task TestImplementEventThroughExplicitMember()
+        {
+            await TestAsync(
+@"interface IFoo { event System . EventHandler E ; } class CanFoo : IFoo { event IFoo.EventHandler E; } class HasCanFoo : [|IFoo|] { CanFoo canFoo; } ",
+@"using System ; interface IFoo { event System . EventHandler E ; } class CanFoo : IFoo { event IFoo.EventHandler E; } class HasCanFoo : IFoo { CanFoo canFoo; public event EventHandler E { add { ((IFoo)canFoo).E += value; } remove { ((IFoo)canFoo).E -= value; } } } ",
+index: 1);
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)]

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.VisualBasic.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.VisualBasic.cs
@@ -271,8 +271,13 @@ End Namespace";
             [Fact, Trait(Traits.Feature, Traits.Features.CodeGeneration)]
             public async Task AddEvent()
             {
-                var input = "Class [|C|] \n End Class";
-                var expected = "Class C \n Public Event E As Action \n End Class";
+                var input = @"
+Class [|C|]
+End Class";
+                var expected = @"
+Class C
+    Public Event E As Action
+End Class";
                 await TestAddEventAsync(input, expected,
                     codeGenerationOptions: new CodeGenerationOptions(addImports: false));
             }

--- a/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
+++ b/src/EditorFeatures/Test/CodeGeneration/CodeGenerationTests.cs
@@ -333,7 +333,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
             DeclarationModifiers modifiers = default(DeclarationModifiers),
             IList<Func<SemanticModel, IParameterSymbol>> parameters = null,
             Type type = null,
-            IEventSymbol explicitInterfaceSymbol = null,
+            Func<SemanticModel, IEventSymbol> explicitInterfaceSymbol = null,
             IMethodSymbol addMethod = null,
             IMethodSymbol removeMethod = null,
             IMethodSymbol raiseMethod = null,
@@ -351,7 +351,7 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                     accessibility,
                     modifiers,
                     typeSymbol,
-                    explicitInterfaceSymbol,
+                    explicitInterfaceSymbol?.Invoke(context.SemanticModel),
                     name,
                     addMethod,
                     removeMethod,
@@ -664,12 +664,12 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.CodeGeneration
                 null, accessibility, modifiers, GetTypeSymbol(type)(s), name);
         }
 
-        private static Func<SemanticModel, ITypeSymbol> GetTypeSymbol(Type type)
+        private static Func<SemanticModel, INamedTypeSymbol> GetTypeSymbol(Type type)
         {
             return GetTypeSymbol(type.FullName);
         }
 
-        private static Func<SemanticModel, ITypeSymbol> GetTypeSymbol(string typeMetadataName)
+        private static Func<SemanticModel, INamedTypeSymbol> GetTypeSymbol(string typeMetadataName)
         {
             return s => s == null ? null : s.Compilation.GetTypeByMetadataName(typeMetadataName);
         }

--- a/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ImplementInterface/ImplementInterfaceTests.vb
@@ -1594,6 +1594,51 @@ Class C
 End Class")
         End Function
 
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
+        Public Async Function TestImplementThroughMemberEvent() As Task
+            Await TestAsync("
+Imports System.ComponentModel
+
+Class Worker
+	Implements INotifyPropertyChanged
+
+	Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+End Class
+
+Class Boss
+	Implements [|INotifyPropertyChanged|]
+
+	Private worker As Worker
+End Class", "
+Imports System.ComponentModel
+
+Class Worker
+	Implements INotifyPropertyChanged
+
+	Public Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+End Class
+
+Class Boss
+	Implements INotifyPropertyChanged
+
+	Private worker As Worker
+
+	Public Custom Event PropertyChanged As PropertyChangedEventHandler Implements INotifyPropertyChanged.PropertyChanged
+
+		AddHandler(value As PropertyChangedEventHandler)
+			AddHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
+		End AddHandler
+
+		RemoveHandler(value As PropertyChangedEventHandler)
+			RemoveHandler DirectCast(worker, INotifyPropertyChanged).PropertyChanged, value
+		End RemoveHandler
+
+		RaiseEvent(sender As Object, e As PropertyChangedEventArgs)
+		End RaiseEvent
+	End Event
+End Class", index:=1)
+        End Function
+
         <WorkItem(543588, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/543588")>
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsImplementInterface)>
         Public Async Function TestNameSimplifyGenericType() As Task

--- a/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
+++ b/src/Features/Core/Portable/ImplementInterface/AbstractImplementInterfaceService.CodeAction.cs
@@ -389,7 +389,7 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
 
                 var useExplicitInterfaceSymbol = generateInvisibly || !Service.CanImplementImplicitly;
                 var accessibility = member.Name == memberName || generateAbstractly
-                    ? Accessibility.Public 
+                    ? Accessibility.Public
                     : Accessibility.Private;
 
                 if (member.Kind == SymbolKind.Method)
@@ -419,11 +419,32 @@ namespace Microsoft.CodeAnalysis.ImplementInterface
                         modifiers: modifiers,
                         explicitInterfaceSymbol: useExplicitInterfaceSymbol ? @event : null,
                         name: memberName,
-                        addMethod: generateInvisibly ? accessor : null,
-                        removeMethod: generateInvisibly ? accessor : null);
+                        addMethod: GetAddOrRemoveMethod(generateInvisibly, accessor, memberName, factory.AddEventHandler),
+                        removeMethod: GetAddOrRemoveMethod(generateInvisibly, accessor, memberName, factory.RemoveEventHandler));
                 }
 
                 return null;
+            }
+
+            private IMethodSymbol GetAddOrRemoveMethod(bool generateInvisibly,
+                                                       IMethodSymbol accessor,
+                                                       string memberName,
+                                                       Func<SyntaxNode, SyntaxNode, SyntaxNode> createAddOrRemoveHandler)
+            {
+                if (ThroughMember != null)
+                {
+                    var factory = Document.GetLanguageService<SyntaxGenerator>();
+                    var throughExpression = CreateThroughExpression(factory);
+                    var statement = factory.ExpressionStatement(createAddOrRemoveHandler(
+                        factory.MemberAccessExpression(throughExpression, memberName), factory.IdentifierName("value")));
+
+                    return CodeGenerationSymbolFactory.CreateAccessorSymbol(
+                           attributes: null,
+                           accessibility: Accessibility.NotApplicable,
+                           statements: SpecializedCollections.SingletonList(statement));
+                }
+
+                return generateInvisibly ? accessor : null;
             }
 
             private SyntaxNode CreateThroughExpression(SyntaxGenerator factory)

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -2543,7 +2543,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         private class AddMissingTokensRewriter : CSharpSyntaxRewriter
         {
             private readonly bool _recurse;
-            private bool firstVisit = true;
+            private bool _firstVisit = true;
 
             public AddMissingTokensRewriter(bool recurse)
             {
@@ -2552,12 +2552,12 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             public override SyntaxNode Visit(SyntaxNode node)
             {
-                if (!_recurse && !firstVisit)
+                if (!_recurse && !_firstVisit)
                 {
                     return node;
                 }
 
-                firstVisit = false;
+                _firstVisit = false;
                 return base.Visit(node);
             }
 
@@ -3453,6 +3453,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         #endregion
 
         #region Statements and Expressions
+
+        public override SyntaxNode AddEventHandler(SyntaxNode @event, SyntaxNode handler)
+        {
+            return SyntaxFactory.AssignmentExpression(SyntaxKind.AddAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
+        }
+
+        public override SyntaxNode RemoveEventHandler(SyntaxNode @event, SyntaxNode handler)
+        {
+            return SyntaxFactory.AssignmentExpression(SyntaxKind.SubtractAssignmentExpression, (ExpressionSyntax)@event, Parenthesize(handler));
+        }
 
         public override SyntaxNode AwaitExpression(SyntaxNode expression)
         {

--- a/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
+++ b/src/Workspaces/CSharpTest/CodeGeneration/SyntaxGeneratorTests.cs
@@ -435,6 +435,22 @@ public class MyAttribute : Attribute { public int Value {get; set;} }",
         }
 
         [Fact]
+        public void TestAddHandlerExpressions()
+        {
+            VerifySyntax<AssignmentExpressionSyntax>(
+                _g.AddEventHandler(_g.IdentifierName("@event"), _g.IdentifierName("handler")),
+                "@event += (handler)");
+        }
+
+        [Fact]
+        public void TestSubtractHandlerExpressions()
+        {
+            VerifySyntax<AssignmentExpressionSyntax>(
+                _g.RemoveEventHandler(_g.IdentifierName("@event"),
+                _g.IdentifierName("handler")), "@event -= (handler)");
+        }
+
+        [Fact]
         public void TestAwaitExpressions()
         {
             VerifySyntax<AwaitExpressionSyntax>(_g.AwaitExpression(_g.IdentifierName("x")), "await x");

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -310,6 +310,16 @@ namespace Microsoft.CodeAnalysis.Editing
         }
 
         /// <summary>
+        /// Creates a statement that adds the given handler to the given event.
+        /// </summary>
+        public abstract SyntaxNode AddEventHandler(SyntaxNode @event, SyntaxNode handler);
+
+        /// <summary>
+        /// Creates a statement that removes the given handler from the given event.
+        /// </summary>
+        public abstract SyntaxNode RemoveEventHandler(SyntaxNode @event, SyntaxNode handler);
+
+        /// <summary>
         /// Creates an event declaration.
         /// </summary>
         public abstract SyntaxNode EventDeclaration(

--- a/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Workspaces/Core/Portable/PublicAPI.Unshipped.txt
@@ -38,8 +38,10 @@ Microsoft.CodeAnalysis.Workspace.DocumentActiveContextChanged -> System.EventHan
 Microsoft.CodeAnalysis.Workspace.RaiseDocumentActiveContextChangedEventAsync(Microsoft.CodeAnalysis.Text.SourceTextContainer sourceTextContainer, Microsoft.CodeAnalysis.DocumentId oldActiveContextDocumentId, Microsoft.CodeAnalysis.DocumentId newActiveContextDocumentId) -> System.Threading.Tasks.Task
 Microsoft.CodeAnalysis.XmlDocumentationProvider
 Microsoft.CodeAnalysis.XmlDocumentationProvider.XmlDocumentationProvider() -> void
+abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.AddEventHandler(Microsoft.CodeAnalysis.SyntaxNode event, Microsoft.CodeAnalysis.SyntaxNode handler) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.GetSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement) -> System.Collections.Generic.IReadOnlyList<Microsoft.CodeAnalysis.SyntaxNode>
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.InsertSwitchSections(Microsoft.CodeAnalysis.SyntaxNode switchStatement, int index, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxNode> switchSections) -> Microsoft.CodeAnalysis.SyntaxNode
+abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.RemoveEventHandler(Microsoft.CodeAnalysis.SyntaxNode event, Microsoft.CodeAnalysis.SyntaxNode handler) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.Editing.SyntaxGenerator.ThrowExpression(Microsoft.CodeAnalysis.SyntaxNode expression) -> Microsoft.CodeAnalysis.SyntaxNode
 abstract Microsoft.CodeAnalysis.XmlDocumentationProvider.GetSourceStream(System.Threading.CancellationToken cancellationToken) -> System.IO.Stream
 const Microsoft.CodeAnalysis.Tags.WellKnownTags.Assembly = "Assembly" -> string

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
@@ -4,6 +4,7 @@ Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationHelpers
+Imports Microsoft.CodeAnalysis.Editing
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
@@ -74,7 +75,65 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         Private Function GenerateEventDeclarationWorker([event] As IEventSymbol,
                                                         destination As CodeGenerationDestination,
                                                         options As CodeGenerationOptions) As DeclarationStatementSyntax
-            ' TODO(cyrusn): Handle Add/Remove/Raise events
+
+            If options.GenerateMethodBodies AndAlso
+                ([event].AddMethod IsNot Nothing OrElse [event].RemoveMethod IsNot Nothing OrElse [event].RaiseMethod IsNot Nothing) Then
+                Return GenerateCustomEventDeclarationWorker([event], destination, options)
+            Else
+                Return GenerateNotCustomEventDeclarationWorker([event], destination, options)
+            End If
+        End Function
+
+        Private Function GenerateCustomEventDeclarationWorker(
+                [event] As IEventSymbol,
+                destination As CodeGenerationDestination,
+                options As CodeGenerationOptions) As DeclarationStatementSyntax
+            Dim addStatements = If(
+                [event].AddMethod Is Nothing,
+                New SyntaxList(Of StatementSyntax),
+                GenerateStatements([event].AddMethod))
+            Dim removeStatements = If(
+                [event].RemoveMethod Is Nothing,
+                New SyntaxList(Of StatementSyntax),
+                GenerateStatements([event].RemoveMethod))
+            Dim raiseStatements = If(
+                [event].RaiseMethod Is Nothing,
+                New SyntaxList(Of StatementSyntax),
+                GenerateStatements([event].RaiseMethod))
+
+            Dim generator As VisualBasicSyntaxGenerator = New VisualBasicSyntaxGenerator()
+
+            Dim invoke = DirectCast([event].Type, INamedTypeSymbol)?.DelegateInvokeMethod
+            Dim parameters = If(
+                invoke IsNot Nothing,
+                invoke.Parameters.Select(Function(p) generator.ParameterDeclaration(p)),
+                Nothing)
+
+            Dim result = DirectCast(generator.CustomEventDeclarationWithRaise(
+                                        [event].Name,
+                                        generator.TypeExpression([event].Type),
+                                        [event].DeclaredAccessibility,
+                                        DeclarationModifiers.From([event]),
+                                        parameters,
+                                        addStatements,
+                                        removeStatements,
+                                        raiseStatements), EventBlockSyntax)
+            result = DirectCast(
+                result.WithAttributeLists(GenerateAttributeBlocks([event].GetAttributes(), options)),
+                EventBlockSyntax)
+            result = DirectCast(result.WithModifiers(GenerateModifiers([event], destination, options)), EventBlockSyntax)
+            Dim explicitInterface = [event].ExplicitInterfaceImplementations.FirstOrDefault()
+            If (explicitInterface IsNot Nothing)
+                result = result.WithEventStatement(
+                    result.EventStatement.WithImplementsClause(GenerateImplementsClause(explicitInterface)))
+            End If
+            Return result
+        End Function
+
+        Private Function GenerateNotCustomEventDeclarationWorker(
+                [event] As IEventSymbol,
+                destination As CodeGenerationDestination,
+                options As CodeGenerationOptions) As EventStatementSyntax
             Dim eventType = TryCast([event].Type, INamedTypeSymbol)
             If eventType.IsDelegateType() AndAlso eventType.AssociatedSymbol IsNot Nothing Then
                 ' This is a declaration style event like "Event E(x As String)".  This event will

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -22,6 +22,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
 
 #Region "Expressions and Statements"
 
+        Public Overrides Function AddEventHandler([event] As SyntaxNode, handler As SyntaxNode) As SyntaxNode
+            Return SyntaxFactory.AddHandlerStatement(CType([event], ExpressionSyntax), CType(handler, ExpressionSyntax))
+        End Function
+
+        Public Overrides Function RemoveEventHandler([event] As SyntaxNode, handler As SyntaxNode) As SyntaxNode
+            Return SyntaxFactory.RemoveHandlerStatement(CType([event], ExpressionSyntax), CType(handler, ExpressionSyntax))
+        End Function
+
         Public Overrides Function AwaitExpression(expression As SyntaxNode) As SyntaxNode
             Return SyntaxFactory.AwaitExpression(DirectCast(expression, ExpressionSyntax))
         End Function
@@ -3415,16 +3423,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Public Overrides Function CustomEventDeclaration(
-            name As String,
-            type As SyntaxNode,
+            name As String, type As SyntaxNode,
             Optional accessibility As Accessibility = Accessibility.NotApplicable,
             Optional modifiers As DeclarationModifiers = Nothing,
             Optional parameters As IEnumerable(Of SyntaxNode) = Nothing,
             Optional addAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
             Optional removeAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
 
+            Return CustomEventDeclarationWithRaise(name, type, accessibility, modifiers, parameters, addAccessorStatements, removeAccessorStatements)
+        End Function
+
+        Public Function CustomEventDeclarationWithRaise(
+            name As String,
+            type As SyntaxNode,
+            Optional accessibility As Accessibility = Accessibility.NotApplicable,
+            Optional modifiers As DeclarationModifiers = Nothing,
+            Optional parameters As IEnumerable(Of SyntaxNode) = Nothing,
+            Optional addAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
+            Optional removeAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing,
+            Optional raiseAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing) As SyntaxNode
+
             Dim accessors = New List(Of AccessorBlockSyntax)()
-            Dim raiseAccessorStatements As IEnumerable(Of SyntaxNode) = Nothing
 
             If modifiers.IsAbstract Then
                 addAccessorStatements = Nothing


### PR DESCRIPTION
Changes:
- Resolves issue #12023.
- Removes "TODO(cyrusn): Handle Add/Remove/Raise events" in EventGenerator.vb
- Adds unit tests for VB.NET code generation of events
- SyntaxGenerator.CustomEventDeclaration had multiple overloads with optional parameters. Renamed one of these overloads to adhere to coding guidelines defined in: [backwards compatibility](https://github.com/dotnet/roslyn/blob/master/docs/Adding%20Optional%20Parameters%20in%20Public%20API.md)

Points of contention:
- Generates an empty raise accessor block for custom VB.NET event, because no valid implementation can be generated. An alternative would be to generate a throw.
