### PR TITLE
Memoize calls to ProjectAlreadyReferencesProject where possible to ac…

### DIFF
--- a/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
+++ b/src/Workspaces/Core/Desktop/Workspace/MSBuild/MSBuildProjectLoader.cs
@@ -263,7 +263,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
             /// Used to memoize results of <see cref="ProjectAlreadyReferencesProject"/> calls.
             /// Reset any time internal state is changed.
             /// </summary>
-            private Dictionary<ProjectId, Dictionary<ProjectId, bool>> ProjectAlreadyReferencesProjectMemo
+            private Dictionary<ProjectId, Dictionary<ProjectId, bool>> _projectAlreadyReferencesProjectResultCache
                 = new Dictionary<ProjectId, Dictionary<ProjectId, bool>>();
 
             private readonly Dictionary<string, ProjectId> _projectPathToProjectIdMap
@@ -282,12 +282,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 _projectIdToProjectInfoMap.Add(info.Id, info);
                 //Memoized results of ProjectAlreadyReferencesProject may no longer be correct;
                 //reset the cache.
-                ProjectAlreadyReferencesProjectMemo = new Dictionary<ProjectId, Dictionary<ProjectId, bool>>();
-            }
-
-            private bool TryGetValue(ProjectId id, out ProjectInfo info)
-            {
-                return _projectIdToProjectInfoMap.TryGetValue(id, out info);
+                _projectAlreadyReferencesProjectResultCache.Clear();
             }
 
             /// <summary>
@@ -298,10 +293,10 @@ namespace Microsoft.CodeAnalysis.MSBuild
             {
                 Dictionary<ProjectId, bool> fromProjectMemo;
 
-                if ( !ProjectAlreadyReferencesProjectMemo.TryGetValue(fromProject, out fromProjectMemo))
+                if ( !_projectAlreadyReferencesProjectResultCache.TryGetValue(fromProject, out fromProjectMemo))
                 {
                     fromProjectMemo = new Dictionary<ProjectId, bool>();
-                    ProjectAlreadyReferencesProjectMemo.Add(fromProject, fromProjectMemo);
+                    _projectAlreadyReferencesProjectResultCache.Add(fromProject, fromProjectMemo);
                 }
 
                 bool answer;
@@ -310,7 +305,7 @@ namespace Microsoft.CodeAnalysis.MSBuild
                 {
                     ProjectInfo info;
                     answer =
-                        TryGetValue(fromProject, out info) &&
+                        _projectIdToProjectInfoMap.TryGetValue(fromProject, out info) &&
                         info.ProjectReferences.Any(pr =>
                             pr.ProjectId == targetProject ||
                             ProjectAlreadyReferencesProject(pr.ProjectId, targetProject)


### PR DESCRIPTION
Backstory:
Attempting to use SourceBrowser (https://github.com/KirillOsenkov/SourceBrowser) on our codebase was giving strange results -- by default, cross-assembly type references wouldn't be properly linked, but if I changed all references to project references the indexer would never complete.

I eventually solved this by using assembly references, doing a build first, and turning on LoadMetadataForReferencedProjects on the MSBuildWorkspace instance in SourceBrowser. I also, however, went back to diagnose why project references made the indexer never complete and quickly discovered that in this configuration MSBuildWorkspace::OpenProjectAsync was taking hours on every individual project.

Actual change explanation:
Digging into this I found a lot of time was being spent in deep nestings of MSBuildProjectLoader::ProjectAlreadyReferencesProject. I did some minor refactoring to memoize this call and found that loading an exemplar projects which used to take over an hour (I killed the process before it came back) now took 96 seconds. I don't believe actual behavior is changed, and the additional memory usage should be under a megabyte in all but the most extreme cases. Therefore, I've left this as the only codepath (rather than providing a flag to revert to the old behavior).