### PR TITLE
Updating the VisualStudioInstanceFactory to require support for package enumeration.

### DIFF
--- a/src/NuGet/Roslyn.VisualStudio.Test.Utilities.nuspec
+++ b/src/NuGet/Roslyn.VisualStudio.Test.Utilities.nuspec
@@ -18,5 +18,6 @@
   </metadata>
   <files>
     <file src="Roslyn.VisualStudio.Test.Utilities.dll" target="lib\net46" />
+    <file src="Microsoft.VisualStudio.Setup.Configuration.Interop.dll" target="lib\net46" />
   </files>
 </package>

--- a/src/VisualStudio/TestUtilities/VisualStudioInstanceFactory.cs
+++ b/src/VisualStudio/TestUtilities/VisualStudioInstanceFactory.cs
@@ -92,15 +92,7 @@ namespace Roslyn.VisualStudio.Test.Utilities
         {
             var instance = LocateVisualStudioInstance(requiredPackageIds) as ISetupInstance2;
 
-            try
-            {
-                _supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetUniqueId()));
-            }
-            catch (NotImplementedException)
-            {
-                // Just ignore the error while the method is NYI.
-            }
-
+            _supportedPackageIds = ImmutableHashSet.CreateRange(instance.GetPackages().Select((supportedPackage) => supportedPackage.GetId()));
             _installationPath = instance.GetInstallationPath();
 
             var process = StartNewVisualStudioProcess(_installationPath);
@@ -162,20 +154,12 @@ namespace Roslyn.VisualStudio.Test.Utilities
 
             foreach (ISetupInstance2 instance in instances)
             {
-                try
-                {
-                    var packages = instance.GetPackages()
-                                           .Where((package) => requiredPackageIds.Contains(package.GetUniqueId()));
+                var packages = instance.GetPackages()
+                                        .Where((package) => requiredPackageIds.Contains(package.GetId()));
 
-                    if (packages.Count() != requiredPackageIds.Count())
-                    {
-                        continue;
-                    }
-                }
-                catch (NotImplementedException)
+                if (packages.Count() != requiredPackageIds.Count())
                 {
-                    Debug.WriteLine($"{nameof(ISetupInstance2)}.{nameof(ISetupInstance2.GetPackages)} is NYI.");
-                    Debug.WriteLine("We will return the first instance that has the minimum required state.");
+                    continue;
                 }
 
                 const InstanceState minimumRequiredState = InstanceState.Local | InstanceState.Registered;


### PR DESCRIPTION
FYI. @jasonmalinowski, @jaredpar, @dotnet/roslyn-infrastructure 

This forces the requirement for package enumeration and additionally ensures that we are only checking against the package id (rather than the unique id).