### PR TITLE
Load IOptionPersisters in RoslynPackage

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/LanguageService/HACK_AbstractCreateServicesOnUiThread.cs
+++ b/src/VisualStudio/Core/Def/Implementation/LanguageService/HACK_AbstractCreateServicesOnUiThread.cs
@@ -62,12 +62,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
                     break;
                 }
             }
-
-            var serializers = componentModel.DefaultExportProvider.GetExports<IOptionPersister>();
-            foreach (var serializer in serializers)
-            {
-                var unused = serializer.Value;
-            }
         }
     }
 }

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -29,6 +29,7 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Shell.Interop;
 using static Microsoft.CodeAnalysis.Utilities.ForegroundThreadDataKind;
 using Task = System.Threading.Tasks.Task;
+using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.VisualStudio.LanguageServices.Setup
 {
@@ -66,6 +67,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
 
             var componentModel = (IComponentModel)this.GetService(typeof(SComponentModel));
             _workspace = componentModel.GetService<VisualStudioWorkspace>();
+
+            // Ensure the options persisters are loaded since we have to fetch options from the shell
+            componentModel.GetExtensions<IOptionPersister>();
 
             var telemetrySetupExtensions = componentModel.GetExtensions<IRoslynTelemetrySetup>();
             foreach (var telemetrySetup in telemetrySetupExtensions)


### PR DESCRIPTION
This is probably where it should have been originally, but there's been
a lot of refactoring on this over the years. Putting it here means
that it's loaded when our tests load RoslynPackage directly.

This is a proposal to fix an issue for @panopticoncentral.