### PR TITLE
Ensure that core C# and VB language service works with CPS projects

### DIFF
--- a/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
+++ b/src/VisualStudio/CSharp/Impl/CSharpPackage.cs
@@ -6,7 +6,6 @@ using System.Runtime.InteropServices;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.ErrorReporting;
-using Microsoft.CodeAnalysis.Options;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ObjectBrowser;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim;
 using Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim.Interop;
@@ -64,7 +63,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
     [ProvideAutomationProperties("TextEditor", "CSharp-Specific", packageGuid: Guids.CSharpPackageIdString, profileNodeLabelId: 104, profileNodeDescriptionId: 105)]
     [ProvideService(typeof(CSharpLanguageService), ServiceName = "C# Language Service")]
     [ProvideService(typeof(ICSharpTempPECompilerService), ServiceName = "C# TempPE Compiler Service")]
-    internal class CSharpPackage : AbstractPackage<CSharpPackage, CSharpLanguageService, CSharpProjectShim>, IVsUserSettingsQuery
+    internal class CSharpPackage : AbstractPackage<CSharpPackage, CSharpLanguageService, AbstractProject>, IVsUserSettingsQuery
     {
         private ObjectBrowserLibraryManager _libraryManager;
         private uint _libraryManagerCookie;

--- a/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService.cs
+++ b/src/VisualStudio/CSharp/Impl/LanguageService/CSharpLanguageService.cs
@@ -14,12 +14,13 @@ using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 
 namespace Microsoft.VisualStudio.LanguageServices.CSharp.LanguageService
 {
     [ExcludeFromCodeCoverage]
     [Guid(Guids.CSharpLanguageServiceIdString)]
-    internal partial class CSharpLanguageService : AbstractLanguageService<CSharpPackage, CSharpLanguageService, CSharpProjectShim>
+    internal partial class CSharpLanguageService : AbstractLanguageService<CSharpPackage, CSharpLanguageService, AbstractProject>
     {
         internal CSharpLanguageService(CSharpPackage package)
             : base(package)

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicLanguageService.vb
@@ -3,12 +3,11 @@
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Editor
-Imports Microsoft.CodeAnalysis.Snippets
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.DebuggerIntelliSense
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.LanguageService
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
-Imports Microsoft.VisualStudio.Shell
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports Microsoft.VisualStudio.Text
 Imports Microsoft.VisualStudio.Text.Editor
@@ -17,7 +16,7 @@ Imports Microsoft.VisualStudio.TextManager.Interop
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     <Guid(Guids.VisualBasicLanguageServiceIdString)>
     Partial Friend Class VisualBasicLanguageService
-        Inherits AbstractLanguageService(Of VisualBasicPackage, VisualBasicLanguageService, VisualBasicProject)
+        Inherits AbstractLanguageService(Of VisualBasicPackage, VisualBasicLanguageService, AbstractProject)
 
         Public Sub New(package As VisualBasicPackage)
             MyBase.New(package)
@@ -73,7 +72,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
 
         Protected Overrides Function CreateContainedLanguage(
             bufferCoordinator As IVsTextBufferCoordinator,
-            project As VisualBasicProject,
+            project As AbstractProject,
             hierarchy As IVsHierarchy,
             itemid As UInteger
         ) As IVsContainedLanguage

--- a/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/LanguageService/VisualBasicPackage.vb
@@ -57,7 +57,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic
     <ProvideService(GetType(IVbCompilerService), ServiceName:="Visual Basic Project System Shim")>
     <ProvideService(GetType(IVbTempPECompilerFactory), ServiceName:="Visual Basic TempPE Compiler Factory Service")>
     Friend Class VisualBasicPackage
-        Inherits AbstractPackage(Of VisualBasicPackage, VisualBasicLanguageService, VisualBasicProject)
+        Inherits AbstractPackage(Of VisualBasicPackage, VisualBasicLanguageService, AbstractProject)
         Implements IVbCompilerService
         Implements IVsUserSettingsQuery
 

--- a/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
+++ b/src/VisualStudio/VisualBasic/Impl/Venus/VisualBasicContainedLanguage.vb
@@ -9,8 +9,8 @@ Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.VisualBasic
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 Imports Microsoft.VisualStudio.ComponentModelHost
+Imports Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 Imports Microsoft.VisualStudio.LanguageServices.Implementation.Venus
-Imports Microsoft.VisualStudio.LanguageServices.VisualBasic.ProjectSystemShim
 Imports Microsoft.VisualStudio.Shell.Interop
 Imports IVsTextBufferCoordinator = Microsoft.VisualStudio.TextManager.Interop.IVsTextBufferCoordinator
 Imports VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan
@@ -18,12 +18,12 @@ Imports VsTextSpan = Microsoft.VisualStudio.TextManager.Interop.TextSpan
 Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
 
     Friend Class VisualBasicContainedLanguage
-        Inherits ContainedLanguage(Of VisualBasicPackage, VisualBasicLanguageService, VisualBasicProject)
+        Inherits ContainedLanguage(Of VisualBasicPackage, VisualBasicLanguageService, AbstractProject)
         Implements IVsContainedLanguageStaticEventBinding
 
         Public Sub New(bufferCoordinator As IVsTextBufferCoordinator,
                 componentModel As IComponentModel,
-                project As VisualBasicProject,
+                project As AbstractProject,
                 hierarchy As IVsHierarchy,
                 itemid As UInteger,
                 languageService As VisualBasicLanguageService,
@@ -39,7 +39,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 BasicVSResources.IntelliSense,
                 allowCancel:=False,
                 action:=Sub(c)
-                            Dim visualStudioWorkspace = ComponentModel.GetService(Of visualStudioWorkspace)()
+                            Dim visualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspace)()
                             Dim document = GetThisDocument()
                             ContainedLanguageStaticEventBinding.AddStaticEventBinding(
                                 document, visualStudioWorkspace, pszClassName, pszUniqueMemberID, pszObjectName, pszNameOfEvent, c.CancellationToken)
@@ -115,7 +115,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.VisualBasic.Venus
                 BasicVSResources.IntelliSense,
                 allowCancel:=False,
                 action:=Sub(c)
-                            Dim visualStudioWorkspace = ComponentModel.GetService(Of visualStudioWorkspace)()
+                            Dim visualStudioWorkspace = ComponentModel.GetService(Of VisualStudioWorkspace)()
                             Dim document = GetThisDocument()
                             ContainedLanguageStaticEventBinding.RemoveStaticEventBinding(
                                 document, visualStudioWorkspace, pszClassName, pszUniqueMemberID, pszObjectName, pszNameOfEvent, c.CancellationToken)


### PR DESCRIPTION
This is another change that is needed for ContainedDocuments to work with CPS projects - Razor folks verified that their end to end scenario for razor with CPS projects works fine with the private bits with this change.