### PR TITLE
Disable the IDE oop features by default.

### DIFF
--- a/src/Features/Core/Portable/NavigateTo/NavigateToOptions.cs
+++ b/src/Features/Core/Portable/NavigateTo/NavigateToOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.NavigateTo
         private const string LocalRegistryPath = @"Roslyn\Features\NavigateTo\";
 
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(NavigateToOptions), nameof(OutOfProcessAllowed), defaultValue: true,
+            nameof(NavigateToOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
     }
 }

--- a/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SymbolFinderOptions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.CodeAnalysis.FindSymbols
         private const string LocalRegistryPath = @"Roslyn\Features\SymbolFinder\";
 
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(SymbolFinderOptions), nameof(OutOfProcessAllowed), defaultValue: true,
+            nameof(SymbolFinderOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
     }
 }

--- a/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
+++ b/src/Workspaces/Core/Portable/SymbolSearch/SymbolSearchOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.SymbolSearch
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(Enabled)));
 
         public static readonly Option<bool> OutOfProcessAllowed = new Option<bool>(
-            nameof(SymbolSearchOptions), nameof(OutOfProcessAllowed), defaultValue: true,
+            nameof(SymbolSearchOptions), nameof(OutOfProcessAllowed), defaultValue: false,
             storageLocations: new LocalUserProfileStorageLocation(LocalRegistryPath + nameof(OutOfProcessAllowed)));
 
         public static PerLanguageOption<bool> SuggestForTypesInReferenceAssemblies =


### PR DESCRIPTION
We're going to do some quality/perf testing (and possibly full on dogfooding) first to get
more confidence about this before having them be on by default.