### PR TITLE
Pass through any failing exit codes from cibuild.cmd

### DIFF
--- a/build/scripts/run_perf.ps1
+++ b/build/scripts/run_perf.ps1
@@ -20,3 +20,7 @@ Invoke-WebRequest -Uri http://dotnetci.blob.core.windows.net/roslyn-perf/cpc.zip
 [Environment]::SetEnvironmentVariable("VS150COMNTOOLS", "C:\\Program Files (x86)\\Microsoft Visual Studio\\VS15Preview\\Common7\\Tools", "Process")
 
 ./cibuild.cmd /testPerfRun /release
+if ($LASTEXITCODE -ne 0)
+{
+    exit $LASTEXITCODE
+}


### PR DESCRIPTION
Performance runs don't fail if cibuild.cmd returns a failing exit code. Need to pass it through explicitly in the powershell script.

@TyOverby 