### PR TITLE
Signature help improvements for C# tuples (renamed to work around jenkins issues)

### DIFF
--- a/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
+++ b/src/EditorFeatures/CSharpTest/CSharpEditorServicesTest.csproj
@@ -317,6 +317,7 @@
     <Compile Include="UseExpressionBody\UseExpressionBodyForAccessorsTests.cs" />
     <Compile Include="UseExpressionBody\UseExpressionBodyForOperatorsTests.cs" />
     <Compile Include="UseExpressionBody\UseExpressionBodyForMethodsTests.cs" />
+    <Compile Include="SignatureHelp\TupleConstructionSignatureHelpProviderTests.cs" />
     <Compile Include="UseThrowExpression\UseThrowExpressionTests_FixAllTests.cs" />
     <Compile Include="UseThrowExpression\UseThrowExpressionTests.cs" />
     <Compile Include="Structure\AbstractCSharpSyntaxNodeStructureTests.cs" />

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -514,5 +514,73 @@ class Derived : BaseClass
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
             await TestAsync(markup, expectedOrderedItems);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss1()
+        {
+            var markup = @"
+class D { public D(object o) {} }
+class C : D
+{
+    public C() [|: base(($$)
+    |]{}
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("D(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss2()
+        {
+            var markup = @"
+class D { public D(object o) {} }
+class C : D
+{
+    public C() [|: base((1, $$)
+    |]{}
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("D(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss3()
+        {
+            var markup = @"
+class D { public D(object o) {} }
+class C : D
+{
+    public C() [|: base((1, ($$)
+    |]{}
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("D(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss4()
+        {
+            var markup = @"
+class D { public D(object o) {} }
+class C : D
+{
+    public C() : [|base((1, (2, $$)
+    |]{}
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("D(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ConstructorInitializerSignatureHelpProviderTests.cs
@@ -539,8 +539,7 @@ class C : D
 class D { public D(object o) {} }
 class C : D
 {
-    public C() [|: base((1, $$)
-    |]{}
+    public C() [|: base((1,$$) |]{}
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
@@ -573,8 +572,7 @@ class C : D
 class D { public D(object o) {} }
 class C : D
 {
-    public C() : [|base((1, (2, $$)
-    |]{}
+    public C() [|: base((1, (2,$$) |]{}
 }";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2022,5 +2022,77 @@ class B : A
 
             await TestAsync(markup, new[] { new SignatureHelpTestItem("void List<int>.Add(int item)") });
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss1()
+        {
+            var markup = @"
+class C
+{
+    int Foo(object x)
+    {
+        [|Foo(($$)|];
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("int C.Foo(object x)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss2()
+        {
+            var markup = @"
+class C
+{
+    int Foo(object x)
+    {
+        [|Foo((1, $$|]);
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("int C.Foo(object x)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss3()
+        {
+            var markup = @"
+class C
+{
+    int Foo(object x)
+    {
+        [|Foo((1, ($$)|];
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("int C.Foo(object x)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss4()
+        {
+            var markup = @"
+class C
+{
+    int Foo(object x)
+    {
+        [|Foo((1, (2, $$|]);
+    }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("int C.Foo(object x)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/InvocationExpressionSignatureHelpProviderTests.cs
@@ -2049,7 +2049,7 @@ class C
 {
     int Foo(object x)
     {
-        [|Foo((1, $$|]);
+        [|Foo((1,$$)|];
     }
 }";
 
@@ -2085,7 +2085,7 @@ class C
 {
     int Foo(object x)
     {
-        [|Foo((1, (2, $$|]);
+        [|Foo((1, (2,$$)|];
     }
 }";
 

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -568,5 +568,85 @@ class C
 
             await TestAsync(markup);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss1()
+        {
+            var markup = @"
+class C
+{
+    public C(object o) { }
+    public C M()
+    {
+        return [|new C(($$)
+    |]}
+
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("C(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss2()
+        {
+            var markup = @"
+class C
+{
+    public C(object o) { }
+    public C M()
+    {
+        return [|new C((1, $$)
+    |]}
+
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("C(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss3()
+        {
+            var markup = @"
+class C
+{
+    public C(object o) { }
+    public C M()
+    {
+        return [|new C((1, ($$)
+    |]}
+
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("C(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task TypingTupleDoesNotDismiss4()
+        {
+            var markup = @"
+class C
+{
+    public C(object o) { }
+    public C M()
+    {
+        return [|new C((1, (2, $$)
+    |]}
+
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("C(object o)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/ObjectCreationExpressionSignatureHelpProviderTests.cs
@@ -598,7 +598,7 @@ class C
     public C(object o) { }
     public C M()
     {
-        return [|new C((1, $$)
+        return [|new C((1,$$)
     |]}
 
 }";
@@ -638,7 +638,7 @@ class C
     public C(object o) { }
     public C M()
     {
-        return [|new C((1, (2, $$)
+        return [|new C((1, (2,$$)
     |]}
 
 }";

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
+using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.CodeAnalysis.CSharp.SignatureHelp;
+using Xunit;
+using Microsoft.CodeAnalysis.Editor.UnitTests.SignatureHelp;
+using Roslyn.Test.Utilities;
+
+namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.SignatureHelp
+{
+    public class TupleConstructionSignatureHelpProviderTests : AbstractCSharpSignatureHelpProviderTests
+    {
+        public TupleConstructionSignatureHelpProviderTests(CSharpTestWorkspaceFixture workspaceFixture) : base(workspaceFixture)
+        {
+        }
+
+        internal override ISignatureHelpProvider CreateSignatureHelpProvider()
+        {
+            return new TupleConstructionSignatureHelpProvider();
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task InvocationAfterOpenParen()
+        {
+            var markup = @"
+class C
+{
+    (int, int) y = [|($$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task InvocationAfterOpenParen2()
+        {
+            var markup = @"
+class C
+{
+    (int, int) y = [|($$)
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task InvocationAfterComma1()
+        {
+            var markup = @"
+class C
+{
+    (int, int) y = [|(1, $$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task InvocationAfterComma2()
+        {
+            var markup = @"
+class C
+{
+    (int, int) y = [|(1, $$)
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task ParameterIndexWithNameTyped()
+        {
+            var markup = @"
+class C
+{
+    (int a, int b) y = [|(b: $$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+
+            // currentParameterIndex only considers the position in the argument list 
+            // and not names, hence passing 0 even though the controller will highlight
+            // "int b" in the actual display
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int a, int b)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems);
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14277"), Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedTuple()
+        {
+            var markup = @"
+class C
+{
+    (int a, (int b, int c)) y = [|(1, ($$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int b, int c)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedTupleWhenNotInferred()
+        {
+            var markup = @"
+class C
+{
+    (int, object) y = [|(1, ($$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, object)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedTupleWhenNotInferred2()
+        {
+            var markup = @"
+class C
+{
+    (int, object) y = [|(1, (2, $$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, object)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task MultipleOverloads()
+        {
+            var markup = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        Do1([|($$)|])
+    }
+
+    static void Do1((int, int) i) { }
+    static void Do1((string, string) s) { }
+}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 0));
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(string, string)", currentParameterIndex: 0));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+    }
+}

--- a/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/SignatureHelp/TupleConstructionSignatureHelpProviderTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -44,8 +46,8 @@ class C
             var markup = @"
 class C
 {
-    (int, int) y = [|($$)
-|]}";
+    (int, int) y = [|($$)|]
+}";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
             expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 0));
@@ -59,7 +61,7 @@ class C
             var markup = @"
 class C
 {
-    (int, int) y = [|(1, $$
+    (int, int) y = [|(1,$$
 |]}";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
@@ -74,8 +76,8 @@ class C
             var markup = @"
 class C
 {
-    (int, int) y = [|(1, $$)
-|]}";
+    (int, int) y = [|(1,$$)|]
+}";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
             expectedOrderedItems.Add(new SignatureHelpTestItem("(int, int)", currentParameterIndex: 1));
@@ -138,11 +140,41 @@ class C
             var markup = @"
 class C
 {
-    (int, object) y = [|(1, (2, $$
+    (int, object) y = [|(1, (2,$$
 |]}";
 
             var expectedOrderedItems = new List<SignatureHelpTestItem>();
             expectedOrderedItems.Add(new SignatureHelpTestItem("(int, object)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedTupleWhenNotInferred3()
+        {
+            var markup = @"
+class C
+{
+    (int, object) y = [|(1, ($$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(int, object)", currentParameterIndex: 1));
+
+            await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.SignatureHelp)]
+        public async Task NestedTupleWhenNotInferred4()
+        {
+            var markup = @"
+class C
+{
+    (object, object) y = [|(($$
+|]}";
+
+            var expectedOrderedItems = new List<SignatureHelpTestItem>();
+            expectedOrderedItems.Add(new SignatureHelpTestItem("(object, object)", currentParameterIndex: 0));
 
             await TestAsync(markup, expectedOrderedItems, usePreviousCharAsTrigger: true);
         }

--- a/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/SignatureHelp/Controller.Session_UpdateModel.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.SignatureHel
 
                 private static int GetSelectedParameter(SignatureHelpItem bestItem, int parameterIndex, string parameterName, bool isCaseSensitive)
                 {
-                    if (parameterName != null)
+                    if (!string.IsNullOrEmpty(parameterName))
                     {
                         var comparer = isCaseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
                         var index = bestItem.Parameters.IndexOf(p => comparer.Equals(p.Name, parameterName));

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
@@ -477,5 +477,42 @@ class C
                 Await state.AssertSignatureHelpSession()
             End Using
         End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Async Function MixedTupleNaming() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Foo()
+    {
+        (int, int x) t = (5$$
+    }
+}
+                              </Document>)
+
+                state.SendTypeChars(",")
+                Await state.AssertSelectedSignatureHelpItem(displayText:="(int, int x)", selectedParameter:="int x")
+            End Using
+        End Function
+
+        <WpfFact, Trait(Traits.Feature, Traits.Features.SignatureHelp)>
+        Public Async Function ParameterSelectionWhileParsedAsParenthesizedExpression() As Task
+            Using state = TestState.CreateCSharpTestState(
+                              <Document>
+class C
+{
+    void Foo()
+    {
+        (int a, string b) x = (b$$
+    }
+}
+                              </Document>)
+
+                state.SendInvokeSignatureHelp()
+                Await state.AssertSelectedSignatureHelpItem(displayText:="(int a, string b)", selectedParameter:="string b")
+            End Using
+        End Function
+
     End Class
 End Namespace

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpSignatureHelpCommandHandlerTests.vb
@@ -510,7 +510,7 @@ class C
                               </Document>)
 
                 state.SendInvokeSignatureHelp()
-                Await state.AssertSelectedSignatureHelpItem(displayText:="(int a, string b)", selectedParameter:="string b")
+                Await state.AssertSelectedSignatureHelpItem(displayText:="(int a, string b)", selectedParameter:="int a")
             End Using
         End Function
 

--- a/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
+++ b/src/EditorFeatures/TestUtilities/MinimalTestExportProvider.cs
@@ -45,10 +45,10 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests
                 typeof(TestExtensionErrorHandler)
             };
 
-            return types.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(InternalSolutionCrawlerOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
-                        .Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(EditorComponentOnOffOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
-                        .Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(ServiceComponentOnOffOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
-                        .Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(Microsoft.CodeAnalysis.Formatting.FormattingOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
+            return types//.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(InternalSolutionCrawlerOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
+                        //.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(EditorComponentOnOffOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
+                        //.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(ServiceComponentOnOffOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
+                        //.Concat(TestHelpers.GetAllTypesWithStaticFieldsImplementingType(typeof(Microsoft.CodeAnalysis.Formatting.FormattingOptions).Assembly, typeof(Microsoft.CodeAnalysis.Options.IOption)))
                         .Distinct()
                         .ToArray();
         }

--- a/src/Features/CSharp/Portable/CSharpFeatures.csproj
+++ b/src/Features/CSharp/Portable/CSharpFeatures.csproj
@@ -380,6 +380,7 @@
     <Compile Include="UseExpressionBody\AbstractUseExpressionBodyCodeFixProvider.cs" />
     <Compile Include="UseExpressionBody\AbstractUseExpressionBodyDiagnosticAnalyzer.cs" />
     <Compile Include="UseObjectInitializer\CSharpUseObjectInitializerCodeFixProvider.cs" />
+    <Compile Include="SignatureHelp\TupleConstructionSignatureHelpProvider.cs" />
     <Compile Include="UseThrowExpression\CSharpUseThrowExpressionDiagnosticAnalyzer.cs" />
     <Compile Include="Structure\CSharpBlockStructureProvider.cs" />
     <Compile Include="Structure\CSharpStructureHelpers.cs" />

--- a/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ConstructorInitializerSignatureHelpProvider.cs
@@ -43,11 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 
         private bool IsTriggerToken(SyntaxToken token)
         {
-            return !token.IsKind(SyntaxKind.None) &&
-                token.ValueText.Length == 1 &&
-                IsTriggerCharacter(token.ValueText[0]) &&
-                token.Parent is ArgumentListSyntax &&
-                token.Parent.Parent is ConstructorInitializerSyntax;
+            return SignatureHelpUtilities.IsTriggerParenOrComma<ConstructorInitializerSyntax>(token, IsTriggerCharacter);
         }
 
         private static bool IsArgumentListToken(ConstructorInitializerSyntax expression, SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/InvocationExpressionSignatureHelpProvider.cs
@@ -42,11 +42,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 
         private bool IsTriggerToken(SyntaxToken token)
         {
-            return !token.IsKind(SyntaxKind.None) &&
-                token.ValueText.Length == 1 &&
-                IsTriggerCharacter(token.ValueText[0]) &&
-                token.Parent is ArgumentListSyntax &&
-                token.Parent.Parent is InvocationExpressionSyntax;
+            return SignatureHelpUtilities.IsTriggerParenOrComma<InvocationExpressionSyntax>(token, IsTriggerCharacter);
         }
 
         private static bool IsArgumentListToken(InvocationExpressionSyntax expression, SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/ObjectCreationExpressionSignatureHelpProvider.cs
@@ -10,6 +10,7 @@ using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 {
@@ -38,11 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 
         private bool IsTriggerToken(SyntaxToken token)
         {
-            return !token.IsKind(SyntaxKind.None) &&
-                token.ValueText.Length == 1 &&
-                IsTriggerCharacter(token.ValueText[0]) &&
-                token.Parent is ArgumentListSyntax &&
-                token.Parent.Parent is ObjectCreationExpressionSyntax;
+            return SignatureHelpUtilities.IsTriggerParenOrComma<ObjectCreationExpressionSyntax>(token, IsTriggerCharacter);
         }
 
         private static bool IsArgumentListToken(ObjectCreationExpressionSyntax expression, SyntaxToken token)

--- a/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.SignatureHelp;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
 {
@@ -82,6 +83,31 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
         internal static TextSpan GetSignatureHelpSpan(AttributeArgumentListSyntax argumentList)
         {
             return CommonSignatureHelpUtilities.GetSignatureHelpSpan(argumentList, s_getAttributeArgumentListCloseToken);
+        }
+
+        internal static bool IsTriggerParenOrComma<TSyntaxNode>(SyntaxToken token, Func<char, bool> isTriggerCharacter) where TSyntaxNode : SyntaxNode
+        {
+            // Don't dismiss if the user types ( to start a parenthesized expression or tuple
+            // Note that the tuple initially parses as a parenthesized expression 
+            if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
+            {
+                var parenthesizedExpr = ((ParenthesizedExpressionSyntax)token.Parent).WalkUpParentheses();
+                return parenthesizedExpr.Parent is ArgumentSyntax &&
+                       ((parenthesizedExpr.Parent.Parent is ArgumentListSyntax && parenthesizedExpr.Parent.Parent.Parent is TSyntaxNode) ||
+                        (parenthesizedExpr.Parent.Parent is TupleExpressionSyntax && parenthesizedExpr.GetAncestor<TSyntaxNode>() != null));
+            }
+
+            // Don't dismiss if the user types ',' to add a member to a tuple
+            if (token.IsKind(SyntaxKind.CommaToken) && token.Parent is TupleExpressionSyntax && token.GetAncestor<TSyntaxNode>() != null)
+            {
+                return true;
+            }
+
+            return !token.IsKind(SyntaxKind.None) &&
+                token.ValueText.Length == 1 &&
+                isTriggerCharacter(token.ValueText[0]) &&
+                token.Parent is ArgumentListSyntax &&
+                token.Parent.Parent is ConstructorInitializerSyntax;
         }
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
@@ -107,7 +107,7 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
                 token.ValueText.Length == 1 &&
                 isTriggerCharacter(token.ValueText[0]) &&
                 token.Parent is ArgumentListSyntax &&
-                token.Parent.Parent is ConstructorInitializerSyntax;
+                token.Parent.Parent is TSyntaxNode;
         }
     }
 }

--- a/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/SignatureHelpUtilities.cs
@@ -92,9 +92,26 @@ namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
             if (token.IsKind(SyntaxKind.OpenParenToken) && token.Parent.IsKind(SyntaxKind.ParenthesizedExpression))
             {
                 var parenthesizedExpr = ((ParenthesizedExpressionSyntax)token.Parent).WalkUpParentheses();
-                return parenthesizedExpr.Parent is ArgumentSyntax &&
-                       ((parenthesizedExpr.Parent.Parent is ArgumentListSyntax && parenthesizedExpr.Parent.Parent.Parent is TSyntaxNode) ||
-                        (parenthesizedExpr.Parent.Parent is TupleExpressionSyntax && parenthesizedExpr.GetAncestor<TSyntaxNode>() != null));
+                if (parenthesizedExpr.Parent is ArgumentSyntax)
+                {
+                    var parent = parenthesizedExpr.Parent;
+                    var grandParent = parent.Parent;
+                    if (grandParent is ArgumentListSyntax && grandParent.Parent is TSyntaxNode)
+                    {
+                        // Argument to TSyntaxNode's argument list
+                        return true;
+                    }
+                    else
+                    {
+                        // Argument to a tuple in TSyntaxNode's argument list
+                        return grandParent is TupleExpressionSyntax && parenthesizedExpr.GetAncestor<TSyntaxNode>() != null;
+                    }
+                }
+                else
+                {
+                    // Not an argument
+                    return false;
+                }
             }
 
             // Don't dismiss if the user types ',' to add a member to a tuple

--- a/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
+++ b/src/Features/CSharp/Portable/SignatureHelp/TupleConstructionSignatureHelpProvider.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.LanguageServices;
+using Microsoft.CodeAnalysis.SignatureHelp;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Roslyn.Utilities;
+using System.Collections.Immutable;
+
+namespace Microsoft.CodeAnalysis.CSharp.SignatureHelp
+{
+    [ExportSignatureHelpProvider("TupleSignatureHelpProvider", LanguageNames.CSharp), Shared]
+    internal class TupleConstructionSignatureHelpProvider : AbstractCSharpSignatureHelpProvider
+    {
+        private static readonly Func<TupleExpressionSyntax, SyntaxToken> s_getOpenToken = e => e.OpenParenToken;
+        private static readonly Func<TupleExpressionSyntax, SyntaxToken> s_getCloseToken = e => e.CloseParenToken;
+        private static readonly Func<TupleExpressionSyntax, IEnumerable<SyntaxNodeOrToken>> s_getArgumentsWithSeparators = e => e.Arguments.GetWithSeparators();
+        private static readonly Func<TupleExpressionSyntax, IEnumerable<string>> s_getArgumentNames = e => e.Arguments.Select(a => a.NameColon?.Name.Identifier.ValueText ?? string.Empty);
+
+        public override SignatureHelpState GetCurrentArgumentState(SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, TextSpan currentSpan, CancellationToken cancellationToken)
+        {
+            TupleExpressionSyntax expression;
+            if (TryGetTupleExpression(SignatureHelpTriggerReason.InvokeSignatureHelpCommand,
+                root, position, syntaxFacts, cancellationToken, out expression) &&
+                 currentSpan.Start == expression.SpanStart)
+            {
+                return CommonSignatureHelpUtilities.GetSignatureHelpState(expression, position,
+                    getOpenToken: s_getOpenToken,
+                    getCloseToken: s_getCloseToken,
+                    getArgumentsWithSeparators: s_getArgumentsWithSeparators,
+                    getArgumentNames: s_getArgumentNames);
+            }
+
+            ParenthesizedExpressionSyntax parenthesizedExpression;
+            if (TryGetParenthesizedExpression(SignatureHelpTriggerReason.InvokeSignatureHelpCommand, 
+                root, position, syntaxFacts, cancellationToken, out parenthesizedExpression))
+            {
+                // This could only have parsed as a parenthesized expression in these two cases:
+                // ($$)
+                // (name$$)
+                string name = 0.ToString(); // This causes the controller to match against the 0th tuple member
+                if (parenthesizedExpression.Expression is IdentifierNameSyntax)
+                {
+                    name = ((IdentifierNameSyntax)parenthesizedExpression.Expression).Identifier.ValueText;
+                }
+
+                return new SignatureHelpState(
+                    argumentIndex: 0,
+                    argumentCount: 0,
+                    argumentName: name,
+                    argumentNames: null);
+            }
+
+            return null;
+        }
+
+        public override Boolean IsRetriggerCharacter(Char ch)
+        {
+            return ch == ')';
+        }
+
+        public override Boolean IsTriggerCharacter(Char ch)
+        {
+            return ch == '(' || ch == ',';
+        }
+
+        protected override async Task<SignatureHelpItems> GetItemsWorkerAsync(Document document, int position, SignatureHelpTriggerInfo triggerInfo, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var syntaxFacts = document.Project.LanguageServices.GetService<ISyntaxFactsService>();
+            TupleExpressionSyntax tupleExpression;
+            ParenthesizedExpressionSyntax parenthesizedExpression = null;
+            if (!TryGetTupleExpression(triggerInfo.TriggerReason, root, position, syntaxFacts, cancellationToken, out tupleExpression) &&
+                !TryGetParenthesizedExpression(triggerInfo.TriggerReason, root, position, syntaxFacts, cancellationToken, out parenthesizedExpression))
+            {
+                return null;
+            }
+
+            var targetExpression = (SyntaxNode)tupleExpression ?? parenthesizedExpression;
+
+            var typeInferrer = document.Project.LanguageServices.GetService<ITypeInferenceService>();
+
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+            var inferredTypes = typeInferrer.InferTypes(semanticModel, targetExpression.SpanStart, cancellationToken);
+
+            var tupleTypes = inferredTypes.Where(t => t.IsTupleType).OfType<INamedTypeSymbol>();
+            return CreateItems(position, root, syntaxFacts, targetExpression, semanticModel, tupleTypes, cancellationToken);
+        }
+
+        private SignatureHelpItems CreateItems(int position, SyntaxNode root, ISyntaxFactsService syntaxFacts, SyntaxNode targetExpression, SemanticModel semanticModel, IEnumerable<INamedTypeSymbol> tupleTypes, CancellationToken cancellationToken)
+        {
+            var prefixParts = SpecializedCollections.SingletonEnumerable(new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, "("));
+            var suffixParts = SpecializedCollections.SingletonEnumerable(new SymbolDisplayPart(SymbolDisplayPartKind.Punctuation, null, ")"));
+            var separatorParts = GetSeparatorParts();
+
+            var items = tupleTypes.Select(t =>
+                new SignatureHelpItem(isVariadic: false,
+                    documentationFactory: c => null,
+                    prefixParts: prefixParts,
+                    separatorParts: separatorParts,
+                    suffixParts: suffixParts,
+                    parameters: ConvertTupleMembers(t, semanticModel, position),
+                    descriptionParts: null)).ToList();
+
+            var state = GetCurrentArgumentState(root, position, syntaxFacts, targetExpression.FullSpan, cancellationToken);
+            return CreateSignatureHelpItems(items, targetExpression.FullSpan, state);
+        }
+
+        private IEnumerable<SignatureHelpParameter> ConvertTupleMembers(INamedTypeSymbol tupleType, SemanticModel semanticModel, int position)
+        {
+            var spacePart = Space();
+            var result = new List<SignatureHelpParameter>();
+            for (int i = 0; i < tupleType.TupleElementTypes.Length; i++)
+            {
+                var type = tupleType.TupleElementTypes[i];
+                var parameterItemName = GetParameterName(tupleType.TupleElementNames, i); 
+                var elementName = GetElementName(tupleType.TupleElementNames, i);
+
+                var typeParts = type.ToMinimalDisplayParts(semanticModel, position).ToList();
+                if (!string.IsNullOrEmpty(elementName))
+                {
+                    typeParts.Add(spacePart);
+                    typeParts.Add(new SymbolDisplayPart(SymbolDisplayPartKind.PropertyName, null, elementName));
+                }
+
+                result.Add(new SignatureHelpParameter(parameterItemName, false, c => null, typeParts));
+            }
+
+            return result;
+        }
+
+        // The name used by the controller when selecting parameters
+        // Each element needs a unique name to make selection work property
+        private string GetParameterName(ImmutableArray<string> tupleElementNames, int i)
+        {
+            if (tupleElementNames == default(ImmutableArray<string>))
+            {
+                return i.ToString();
+            }
+
+            return tupleElementNames[i] ?? i.ToString();
+        }
+
+        // The display name for each parameter. Empty strings are allowed for
+        // parameters without names.
+        private string GetElementName(ImmutableArray<string> tupleElementNames, int i)
+        {
+            if (tupleElementNames == default(ImmutableArray<string>))
+            {
+                return string.Empty;
+            }
+
+            return tupleElementNames[i] ?? string.Empty;
+        }
+
+        private bool TryGetTupleExpression(SignatureHelpTriggerReason triggerReason, SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken, out TupleExpressionSyntax tupleExpression)
+        {
+            return CommonSignatureHelpUtilities.TryGetSyntax(root, position, syntaxFacts, triggerReason, IsTupleExpressionTriggerToken, IsTupleArgumentListToken, cancellationToken, out tupleExpression);
+        }
+
+        private bool IsTupleExpressionTriggerToken(SyntaxToken token)
+        {
+            return SignatureHelpUtilities.IsTriggerParenOrComma<TupleExpressionSyntax>(token, IsTriggerCharacter);
+        }
+
+        private static bool IsTupleArgumentListToken(TupleExpressionSyntax tupleExpression, SyntaxToken token)
+        {
+            return tupleExpression.Arguments.FullSpan.Contains(token.SpanStart) &&
+                token != tupleExpression.CloseParenToken;
+        }
+
+        private bool TryGetParenthesizedExpression(SignatureHelpTriggerReason triggerReason, SyntaxNode root, int position, ISyntaxFactsService syntaxFacts, CancellationToken cancellationToken, out ParenthesizedExpressionSyntax parenthesizedExpression)
+        {
+            return CommonSignatureHelpUtilities.TryGetSyntax(root, position, syntaxFacts, triggerReason, IsParenthesizedExpressionTriggerToken, IsParenthesizedExpressionToken, cancellationToken, out parenthesizedExpression);
+        }
+
+        private bool IsParenthesizedExpressionTriggerToken(SyntaxToken token)
+        {
+            return token.IsKind(SyntaxKind.OpenParenToken) && token.Parent is ParenthesizedExpressionSyntax;
+        }
+
+        private static bool IsParenthesizedExpressionToken(ParenthesizedExpressionSyntax expr, SyntaxToken token)
+        {
+            return expr.FullSpan.Contains(token.SpanStart) &&
+                token != expr.CloseParenToken;
+        }
+    }
+}

--- a/src/Features/Core/Portable/SignatureHelp/SignatureHelpItem.cs
+++ b/src/Features/Core/Portable/SignatureHelp/SignatureHelpItem.cs
@@ -69,7 +69,9 @@ namespace Microsoft.CodeAnalysis.SignatureHelp
             IEnumerable<SignatureHelpParameter> parameters,
             IEnumerable<SymbolDisplayPart> descriptionParts)
             : this(isVariadic,
-                  c => documentationFactory(c).ToTaggedText(), 
+                  documentationFactory != null 
+                    ? c => documentationFactory(c).ToTaggedText()
+                    : s_emptyDocumentationFactory, 
                   prefixParts.ToTaggedText(),
                   separatorParts.ToTaggedText(),
                   suffixParts.ToTaggedText(),


### PR DESCRIPTION
* The invocation/initializer/objectcreation sighelp providers no longer dismiss sighelp if the user starts typing a tuple
* When the user starts typing a tuple, show signature help for the tuple member types/names if the type of the tuple can be inferred