### PR TITLE
Adjust parsing to fix local function typing in IDE

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -8897,8 +8897,13 @@ tryAgain:
             // "did you mean to make this method be an async method?" (it's invalid either way, so the spec doesn't care)
             var resetPoint = this.GetResetPoint();
 
-            // if forceAccept is true, then the parse is okay to return a local function statement even if a body doesn't follow the declaration.
-            var forceAccept = false;
+            // Indicates this must be parsed as a local function, even if there's no body
+            bool forceLocalFunc = true;
+            if (type.Kind == SyntaxKind.IdentifierName)
+            {
+                var id = ((IdentifierNameSyntax)type).Identifier;
+                forceLocalFunc = id.ContextualKind != SyntaxKind.AwaitKeyword;
+            }
 
             bool parentScopeIsInAsync = IsInAsync;
             IsInAsync = false;
@@ -8909,10 +8914,10 @@ tryAgain:
                 {
                     case SyntaxKind.AsyncKeyword:
                         IsInAsync = true;
-                        forceAccept = true;
+                        forceLocalFunc = true;
                         break;
                     case SyntaxKind.UnsafeKeyword:
-                        forceAccept = true;
+                        forceLocalFunc = true;
                         break;
                     case SyntaxKind.StaticKeyword:
                     case SyntaxKind.ReadOnlyKeyword:
@@ -8938,14 +8943,14 @@ tryAgain:
             // "await f<T>()" still makes sense, so don't force accept a local function if there's a type parameter list.
             ParameterListSyntax paramList = this.ParseParenthesizedParameterList(allowThisKeyword: true, allowDefaults: true, allowAttributes: true);
             // "await x()" is ambiguous (see note at start of this method), but we assume "await x(await y)" is meant to be a function if it's in a non-async context.
-            if (!forceAccept)
+            if (!forceLocalFunc)
             {
                 var paramListSyntax = paramList.Parameters;
                 for (int i = 0; i < paramListSyntax.Count; i++)
                 {
                     // "await x(y)" still parses as a parameter list, so check to see if it's a valid parameter (like "x(t y)")
-                    forceAccept |= !paramListSyntax[i].ContainsDiagnostics;
-                    if (forceAccept)
+                    forceLocalFunc |= !paramListSyntax[i].ContainsDiagnostics;
+                    if (forceLocalFunc)
                         break;
                 }
             }
@@ -8955,7 +8960,7 @@ tryAgain:
             {
                 constraints = _pool.Allocate<TypeParameterConstraintClauseSyntax>();
                 this.ParseTypeParameterConstraintClauses(typeParameterListOpt != null, constraints);
-                forceAccept = true;
+                forceLocalFunc = true;
             }
 
             BlockSyntax blockBody;
@@ -8965,7 +8970,7 @@ tryAgain:
 
             IsInAsync = parentScopeIsInAsync;
 
-            if (!forceAccept && blockBody == null && expressionBody == null)
+            if (!forceLocalFunc && blockBody == null && expressionBody == null)
             {
                 this.Reset(ref resetPoint);
                 this.Release(ref resetPoint);

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
         public void IncompleteLocalFunc()
         {
-            var file = ParseFile(@"
+            UsingTree(@"
 class C
 {
     void M1()
@@ -44,58 +44,264 @@ class C
         int? L(
     }
 }");
-            Assert.NotNull(file);
-
-            var m1 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M1")
-                .Single();
-            var m1Stmts = m1.Body.Statements;
-            Assert.Equal(2, m1Stmts.Count);
-            Assert.Equal(SyntaxKind.LocalDeclarationStatement, m1Stmts[0].Kind());
-            Assert.Equal("await L", m1Stmts[0].ToFullString().Trim());
-            Assert.Equal(SyntaxKind.ExpressionStatement, m1Stmts[1].Kind());
-            Assert.Equal("<", m1Stmts[1].ToFullString().Trim());
-
-            var m2 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M2")
-                .Single();
-            var m2s1 = m2.Body.Statements.Single();
-            Assert.Equal(SyntaxKind.LocalFunctionStatement, m2s1.Kind());
-            Assert.Equal("int L<", m2s1.ToFullString().Trim());
-
-            var m3 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M3")
-                .Single();
-            var m3s1 = m3.Body.Statements.Single();
-            Assert.Equal(SyntaxKind.LocalFunctionStatement, m3s1.Kind());
-            Assert.Equal("int? L<", m3s1.ToFullString().Trim());
-
-            var m4 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M4")
-                .Single();
-            var m4s1 = m4.Body.Statements.Single();
-            Assert.Equal(SyntaxKind.LocalDeclarationStatement, m4s1.Kind());
-            Assert.Equal("await L(", m4s1.ToFullString().Trim());
-
-            var m5 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M5")
-                .Single();
-            var m5s1 = m5.Body.Statements.Single();
-            Assert.Equal(SyntaxKind.LocalFunctionStatement, m5s1.Kind());
-            Assert.Equal("int L(", m5s1.ToFullString().Trim());
-
-            var m6 = file.DescendantNodes()
-                .OfType<MethodDeclarationSyntax>()
-                .Where(m => (string)m.Identifier.Value == "M6")
-                .Single();
-            var m6s1 = m6.Body.Statements.Single();
-            Assert.Equal(SyntaxKind.LocalFunctionStatement, m6s1.Kind());
-            Assert.Equal("int? L(", m6s1.ToFullString().Trim());
+            N(SyntaxKind.CompilationUnit);
+            {
+                N(SyntaxKind.ClassDeclaration);
+                {
+                    N(SyntaxKind.ClassKeyword);
+                    N(SyntaxKind.IdentifierToken);
+                    N(SyntaxKind.OpenBraceToken);
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M1");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "await");
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "L");
+                                    }
+                                    M(SyntaxKind.SemicolonToken);
+                                }
+                            }
+                            N(SyntaxKind.ExpressionStatement);
+                            {
+                                N(SyntaxKind.LessThanExpression);
+                                {
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    N(SyntaxKind.LessThanToken);
+                                    M(SyntaxKind.IdentifierName);
+                                    {
+                                        M(SyntaxKind.IdentifierToken);
+                                    }
+                                    M(SyntaxKind.SemicolonToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M2");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                }
+                                N(SyntaxKind.IdentifierToken, "L");
+                                N(SyntaxKind.TypeParameterList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    M(SyntaxKind.TypeParameter);
+                                    M(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.GreaterThanToken);
+                                }
+                                M(SyntaxKind.ParameterList);
+                                {
+                                    M(SyntaxKind.OpenParenToken);
+                                    M(SyntaxKind.CloseParenToken);
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M3");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.NullableType);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.QuestionToken);
+                                }
+                                N(SyntaxKind.IdentifierToken, "L");
+                                N(SyntaxKind.TypeParameterList);
+                                {
+                                    N(SyntaxKind.LessThanToken);
+                                    M(SyntaxKind.TypeParameter);
+                                    M(SyntaxKind.IdentifierToken);
+                                    M(SyntaxKind.GreaterThanToken);
+                                }
+                                M(SyntaxKind.ParameterList);
+                                {
+                                    M(SyntaxKind.OpenParenToken);
+                                    M(SyntaxKind.CloseParenToken);
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M4");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalDeclarationStatement);
+                            {
+                                N(SyntaxKind.VariableDeclaration);
+                                {
+                                    N(SyntaxKind.IdentifierName);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "await");
+                                    }
+                                    N(SyntaxKind.VariableDeclarator);
+                                    {
+                                        N(SyntaxKind.IdentifierToken, "L");
+                                    }
+                                    N(SyntaxKind.BracketedArgumentList);
+                                    {
+                                        M(SyntaxKind.OpenBracketToken);
+                                        N(SyntaxKind.Argument);
+                                        {
+                                            N(SyntaxKind.ParenthesizedExpression);
+                                            {
+                                                N(SyntaxKind.OpenParenToken);
+                                                M(SyntaxKind.IdentifierName);
+                                                {
+                                                    M(SyntaxKind.IdentifierToken);
+                                                }
+                                                M(SyntaxKind.CloseParenToken);
+                                            }
+                                        }
+                                        M(SyntaxKind.CloseBracketToken);
+                                    }
+                                    M(SyntaxKind.SemicolonToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M5");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.PredefinedType);
+                                {
+                                    N(SyntaxKind.IntKeyword);
+                                    N(SyntaxKind.IdentifierToken, "L");
+                                    N(SyntaxKind.ParameterList);
+                                    {
+                                        N(SyntaxKind.OpenParenToken);
+                                        M(SyntaxKind.CloseParenToken);
+                                    }
+                                    M(SyntaxKind.SemicolonToken);
+                                }
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                    N(SyntaxKind.MethodDeclaration);
+                    {
+                        N(SyntaxKind.PredefinedType);
+                        {
+                            N(SyntaxKind.VoidKeyword);
+                        }
+                        N(SyntaxKind.IdentifierToken, "M6");
+                        N(SyntaxKind.ParameterList);
+                        {
+                            N(SyntaxKind.OpenParenToken);
+                            N(SyntaxKind.CloseParenToken);
+                        }
+                        N(SyntaxKind.Block);
+                        {
+                            N(SyntaxKind.OpenBraceToken);
+                            N(SyntaxKind.LocalFunctionStatement);
+                            {
+                                N(SyntaxKind.NullableType);
+                                {
+                                    N(SyntaxKind.PredefinedType);
+                                    {
+                                        N(SyntaxKind.IntKeyword);
+                                    }
+                                    N(SyntaxKind.QuestionToken);
+                                }
+                                N(SyntaxKind.IdentifierToken, "L");
+                                N(SyntaxKind.ParameterList);
+                                {
+                                    N(SyntaxKind.OpenParenToken);
+                                    M(SyntaxKind.CloseParenToken);
+                                }
+                                M(SyntaxKind.SemicolonToken);
+                            }
+                            N(SyntaxKind.CloseBraceToken);
+                        }
+                    }
+                }
+            }
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/LocalFunctionParsingTests.cs
@@ -13,6 +13,92 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class LocalFunctionParsingTests : ParsingTests
     {
         [Fact]
+        [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
+        public void IncompleteLocalFunc()
+        {
+            var file = ParseFile(@"
+class C
+{
+    void M1()
+    {
+        await L<
+    }
+    void M2()
+    {
+        int L<
+    }
+    void M3()
+    {
+        int? L<
+    }
+    void M4()
+    {
+        await L(
+    }
+    void M5()
+    {
+        int L(
+    }
+    void M6()
+    {
+        int? L(
+    }
+}");
+            Assert.NotNull(file);
+
+            var m1 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M1")
+                .Single();
+            var m1Stmts = m1.Body.Statements;
+            Assert.Equal(2, m1Stmts.Count);
+            Assert.Equal(SyntaxKind.LocalDeclarationStatement, m1Stmts[0].Kind());
+            Assert.Equal("await L", m1Stmts[0].ToFullString().Trim());
+            Assert.Equal(SyntaxKind.ExpressionStatement, m1Stmts[1].Kind());
+            Assert.Equal("<", m1Stmts[1].ToFullString().Trim());
+
+            var m2 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M2")
+                .Single();
+            var m2s1 = m2.Body.Statements.Single();
+            Assert.Equal(SyntaxKind.LocalFunctionStatement, m2s1.Kind());
+            Assert.Equal("int L<", m2s1.ToFullString().Trim());
+
+            var m3 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M3")
+                .Single();
+            var m3s1 = m3.Body.Statements.Single();
+            Assert.Equal(SyntaxKind.LocalFunctionStatement, m3s1.Kind());
+            Assert.Equal("int? L<", m3s1.ToFullString().Trim());
+
+            var m4 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M4")
+                .Single();
+            var m4s1 = m4.Body.Statements.Single();
+            Assert.Equal(SyntaxKind.LocalDeclarationStatement, m4s1.Kind());
+            Assert.Equal("await L(", m4s1.ToFullString().Trim());
+
+            var m5 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M5")
+                .Single();
+            var m5s1 = m5.Body.Statements.Single();
+            Assert.Equal(SyntaxKind.LocalFunctionStatement, m5s1.Kind());
+            Assert.Equal("int L(", m5s1.ToFullString().Trim());
+
+            var m6 = file.DescendantNodes()
+                .OfType<MethodDeclarationSyntax>()
+                .Where(m => (string)m.Identifier.Value == "M6")
+                .Single();
+            var m6s1 = m6.Body.Statements.Single();
+            Assert.Equal(SyntaxKind.LocalFunctionStatement, m6s1.Kind());
+            Assert.Equal("int? L(", m6s1.ToFullString().Trim());
+        }
+
+        [Fact]
         [WorkItem(12280, "https://github.com/dotnet/roslyn/issues/12280")]
         public void LocalFuncWithWhitespace()
         {

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/ParserErrorMessageTests.cs
@@ -3356,15 +3356,18 @@ public class mine {
 ";
             // Extra errors
             ParseAndValidate(test,
-    // (12,17): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
-    //         try {B b(3);
-    Diagnostic(ErrorCode.ERR_BadVarDecl, "(3)"),
-    // (12,17): error CS1003: Syntax error, '[' expected
-    //         try {B b(3);
-    Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "("),
-    // (12,20): error CS1003: Syntax error, ']' expected
-    //         try {B b(3);
-    Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments("]", ";"));
+                // (12,18): error CS1026: ) expected
+                //         try {B b(3);
+                Diagnostic(ErrorCode.ERR_CloseParenExpected, "3").WithLocation(12, 18),
+                // (12,18): error CS1002: ; expected
+                //         try {B b(3);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, "3").WithLocation(12, 18),
+                // (12,19): error CS1002: ; expected
+                //         try {B b(3);
+                Diagnostic(ErrorCode.ERR_SemicolonExpected, ")").WithLocation(12, 19),
+                // (12,19): error CS1513: } expected
+                //         try {B b(3);
+                Diagnostic(ErrorCode.ERR_RbraceExpected, ")").WithLocation(12, 19));
         }
 
         [Fact]
@@ -5127,30 +5130,19 @@ class Program
 
             SyntaxFactory.ParseSyntaxTree(source).GetDiagnostics().Verify(
                 // (7,14): error CS1514: { expected
+                //     delegate int F1(); 
                 Diagnostic(ErrorCode.ERR_LbraceExpected, "int").WithLocation(7, 14),
                 // (7,14): error CS1002: ; expected
+                //     delegate int F1(); 
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(7, 14),
-                // (7,20): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
-                Diagnostic(ErrorCode.ERR_BadVarDecl, "()").WithLocation(7, 20),
-                // (7,20): error CS1003: Syntax error, '[' expected
-                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "(").WithLocation(7, 20),
-                // (7,21): error CS1525: Invalid expression term ')'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(7, 21),
-                // (7,22): error CS1003: Syntax error, ']' expected
-                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments("]", ";").WithLocation(7, 22),
                 // (8,14): error CS1514: { expected
+                //     delegate int F2();
                 Diagnostic(ErrorCode.ERR_LbraceExpected, "int").WithLocation(8, 14),
                 // (8,14): error CS1002: ; expected
+                //     delegate int F2();
                 Diagnostic(ErrorCode.ERR_SemicolonExpected, "int").WithLocation(8, 14),
-                // (8,20): error CS1528: Expected ; or = (cannot specify constructor arguments in declaration)
-                Diagnostic(ErrorCode.ERR_BadVarDecl, "()").WithLocation(8, 20),
-                // (8,20): error CS1003: Syntax error, '[' expected
-                Diagnostic(ErrorCode.ERR_SyntaxError, "(").WithArguments("[", "(").WithLocation(8, 20),
-                // (8,21): error CS1525: Invalid expression term ')'
-                Diagnostic(ErrorCode.ERR_InvalidExprTerm, ")").WithArguments(")").WithLocation(8, 21),
-                // (8,22): error CS1003: Syntax error, ']' expected
-                Diagnostic(ErrorCode.ERR_SyntaxError, ";").WithArguments("]", ";").WithLocation(8, 22),
                 // (9,2): error CS1513: } expected
+                // }
                 Diagnostic(ErrorCode.ERR_RbraceExpected, "").WithLocation(9, 2));
         }
 

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8905,8 +8905,15 @@ class C
         int Local<$$";
 
             await VerifyNoItemsExistAsync(markup);
+        }
 
-            markup = @"
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Completion)]
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]
+        [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
+        public async Task CompletionForAwaitWithoutAsync()
+        {
+            var markup = @"
 class C
 {
     void M()

--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8890,5 +8890,30 @@ class C
             // See https://github.com/dotnet/roslyn/issues/13229
             await VerifyItemExistsAsync(markup, "Item3");
         }
+
+        [Fact]
+        [Trait(Traits.Feature, Traits.Features.Completion)]
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]
+        [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
+        public async Task NoCompletionInLocalFuncGenericParamList()
+        {
+            var markup = @"
+class C
+{
+    void M()
+    {
+        int Local<$$";
+
+            await VerifyNoItemsExistAsync(markup);
+
+            markup = @"
+class C
+{
+    void M()
+    {
+        await Local<$$";
+
+            await VerifyAnyItemExistsAsync(markup);
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/Indentation/SmartIndenterTests.cs
@@ -2587,7 +2587,7 @@ class Program
             await AssertSmartIndentAsync(
                 code,
                 indentationLine: 6,
-                expectedIndentation: 12);
+                expectedIndentation: 8);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.SmartIndent)]


### PR DESCRIPTION
Previously, when parsing a local function we held off on creating the
node until we actually saw a body because the local function could be
ambiguous with an await statement until then. However, we never verified
that the parsed return type was "await", meaning we were overly
conservative in classifying incomplete local functions. This created a
very bad typing experience where completion could not tell that you were
declaring a local function until the body, which created many incorrect
results in the completion list, including in the generic parameter list.

This change verifies that the return type we've parsed is actually the
literal text "await" before considering the parse ambiguous.

Fixes #13480.