### PR TITLE
Make Workspaces IVT FSharp.Editor

### DIFF
--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -284,6 +284,7 @@
     <InternalsVisibleToTest Include="Roslyn.VisualStudio.Services.UnitTests" />
     <InternalsVisibleToTest Include="RoslynETAHost" />
     <InternalsVisibleToTest Include="RoslynTaoActions" />
+    <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToTypeScript Include="Microsoft.CodeAnalysis.TypeScript.EditorFeatures" />
     <InternalsVisibleToTypeScript Include="Microsoft.VisualStudio.LanguageServices.TypeScript" />
     <InternalsVisibleToTypeScript Include="Roslyn.Services.Editor.TypeScript.UnitTests" />


### PR DESCRIPTION
Type InvocationReasons is needed in F# to implement IDocumentDifferenceService.
This is needed for F# Roslyn integration.
@dotnet/roslyn-ide @CyrusNajmabadi @jaredpar 