### PR TITLE
If no IDocumentDifferenceService is exported, consider the whole document changed

### DIFF
--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -543,7 +543,14 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
             private async Task EnqueueWorkItemAsync(Document oldDocument, Document newDocument)
             {
                 var differenceService = newDocument.GetLanguageService<IDocumentDifferenceService>();
-                if (differenceService != null)
+
+                if (differenceService == null)
+                {
+                    /// For languages that don't use a Roslyn syntax tree, they don't export a <see cref="IDocumentDifferenceService"/>
+                    /// So we should consider the whole document changed.
+                    await EnqueueWorkItemAsync(newDocument, InvocationReasons.DocumentChanged).ConfigureAwait(false);
+                }
+                else
                 {
                     var differenceResult = await differenceService.GetDifferenceAsync(oldDocument, newDocument, _shutdownToken).ConfigureAwait(false);
 

--- a/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
+++ b/src/Features/Core/Portable/SolutionCrawler/WorkCoordinator.cs
@@ -546,8 +546,8 @@ namespace Microsoft.CodeAnalysis.SolutionCrawler
 
                 if (differenceService == null)
                 {
-                    /// For languages that don't use a Roslyn syntax tree, they don't export a <see cref="IDocumentDifferenceService"/>
-                    /// So we should consider the whole document changed.
+                    // For languages that don't use a Roslyn syntax tree, they don't export a document difference service.
+                    // The whole document should be considered as changed in that case.
                     await EnqueueWorkItemAsync(newDocument, InvocationReasons.DocumentChanged).ConfigureAwait(false);
                 }
                 else


### PR DESCRIPTION
Fixes #14316
@dotnet/roslyn-ide @CyrusNajmabadi 