### PR TITLE
add an awaiter for the snippet info service

### DIFF
--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -84,6 +84,7 @@
     <InternalsVisibleToTypeScript Include="Roslyn.Services.Editor.TypeScript.UnitTests" />
     <InternalsVisibleToFSharp Include="FSharp.Editor" />
     <InternalsVisibleToMoq Include="DynamicProxyGenAssembly2" />
+    <InternalsVisibleToVisualStudio Include="Microsoft.Test.Apex.VisualStudio" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.Alm.Shared.CodeAnalysisClient" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.ReferencesProvider" />
     <InternalsVisibleToVisualStudio Include="Microsoft.VisualStudio.CodeSense.TestsProvider" />

--- a/src/Test/Diagnostics/Diagnostics.csproj
+++ b/src/Test/Diagnostics/Diagnostics.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Waiters\ReferenceHighlightingWaiter.cs" />
     <Compile Include="Waiters\RenameWaiter.cs" />
     <Compile Include="Waiters\SignatureHelpWaiter.cs" />
+    <Compile Include="Waiters\SnippetWaiter.cs" />
     <Compile Include="Waiters\SolutionCrawlerWaiter.cs" />
     <Compile Include="Waiters\TodoCommentListWaiter.cs" />
     <Compile Include="Waiters\WorkspaceWaiter.cs" />

--- a/src/Test/Diagnostics/Waiters/SnippetWaiter.cs
+++ b/src/Test/Diagnostics/Waiters/SnippetWaiter.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Composition;
+using Microsoft.CodeAnalysis.Shared.TestHooks;
+
+namespace Roslyn.Hosting.Diagnostics.Waiters
+{
+    [Shared]
+    [Export(typeof(IAsynchronousOperationListener))]
+    [Export(typeof(IAsynchronousOperationWaiter))]
+    [Feature(FeatureAttribute.Snippets)]
+    internal class SnippetWaiter : AsynchronousOperationListener { }
+}


### PR DESCRIPTION
This is to make some internal tests more stable where the completion list is expected to have the snippets loaded, but since they're loaded asynchronously (see [here](http://source.roslyn.io/#Microsoft.VisualStudio.LanguageServices/Implementation/Snippets/AbstractSnippetInfoService.cs,870c415f19add6e3)), we need to add an awaiter.

Future work: Consume this awaiter in non-Roslyn code (i.e., in the internal VS test sources.)