### PR TITLE
Round trip event parameters for FAR OOP.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -387,7 +387,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// <summary>
         /// Events cannot have parameters in C#.  This is only supported in VB.
         /// </summary>
-        ImmutableArray<IParameterSymbol> IEventSymbol.Parameters => ImmutableArray<IParameterSymbol>.Empty;
+        ImmutableArray<IParameterSymbol> IEventSymbol.Parameters => default(ImmutableArray<IParameterSymbol>);
 
         #endregion
 

--- a/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/EventSymbol.cs
@@ -384,6 +384,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             }
         }
 
+        /// <summary>
+        /// Events cannot have parameters in C#.  This is only supported in VB.
+        /// </summary>
+        ImmutableArray<IParameterSymbol> IEventSymbol.Parameters => ImmutableArray<IParameterSymbol>.Empty;
+
         #endregion
 
         #region ISymbol Members

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -80,6 +80,7 @@ Microsoft.CodeAnalysis.Emit.EmitOptions.WithInstrumentationKinds(System.Collecti
 Microsoft.CodeAnalysis.Emit.InstrumentationKind
 Microsoft.CodeAnalysis.Emit.InstrumentationKind.None = 0 -> Microsoft.CodeAnalysis.Emit.InstrumentationKind
 Microsoft.CodeAnalysis.Emit.InstrumentationKind.TestCoverage = 1 -> Microsoft.CodeAnalysis.Emit.InstrumentationKind
+Microsoft.CodeAnalysis.IEventSymbol.Parameters.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.IParameterSymbol>
 Microsoft.CodeAnalysis.IMethodSymbol.ReturnsByRef.get -> bool
 Microsoft.CodeAnalysis.INamedTypeSymbol.TupleElementNames.get -> System.Collections.Immutable.ImmutableArray<string>
 Microsoft.CodeAnalysis.INamedTypeSymbol.TupleElementTypes.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.ITypeSymbol>

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -58,5 +58,11 @@ namespace Microsoft.CodeAnalysis
         /// Properties imported from metadata can explicitly implement more than one event.
         /// </remarks>
         ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; }
+
+        /// <summary>
+        /// Returns the parameters of this event.  Note: parameters on events are available 
+        /// only in VisualBasic and not in C#
+        /// </summary>
+        ImmutableArray<IParameterSymbol> Parameters { get; }
     }
 }

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis
 {
@@ -61,7 +60,9 @@ namespace Microsoft.CodeAnalysis
 
         /// <summary>
         /// Returns the parameters of this event.  Note: parameters on events are available 
-        /// only in VisualBasic and not in C#
+        /// only in VisualBasic and not in C#.  This property will only return parameters
+        /// if they were directly declared on the Event symbol.  i.e. an event of the form:
+        /// "Public Event E(sender As Object)".
         /// </summary>
         ImmutableArray<IParameterSymbol> Parameters { get; }
     }

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis
         /// Returns the parameters of this event.  Parameters on events are available 
         /// only in VisualBasic and not in C#.  This property will only return parameters
         /// if they were directly declared on the Event symbol.  i.e. an event of the form:
-        /// "Public Event E(sender As Object)".  For any other type of event, an empty array
+        /// "Public Event E(sender As Object)".  For any other type of event, a default array
         /// will be returned.
         /// </summary>
         ImmutableArray<IParameterSymbol> Parameters { get; }

--- a/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IEventSymbol.cs
@@ -59,10 +59,11 @@ namespace Microsoft.CodeAnalysis
         ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; }
 
         /// <summary>
-        /// Returns the parameters of this event.  Note: parameters on events are available 
+        /// Returns the parameters of this event.  Parameters on events are available 
         /// only in VisualBasic and not in C#.  This property will only return parameters
         /// if they were directly declared on the Event symbol.  i.e. an event of the form:
-        /// "Public Event E(sender As Object)".
+        /// "Public Event E(sender As Object)".  For any other type of event, an empty array
+        /// will be returned.
         /// </summary>
         ImmutableArray<IParameterSymbol> Parameters { get; }
     }

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -137,25 +137,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Private ReadOnly Property IEventSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IEventSymbol.Parameters
+        Friend Overridable ReadOnly Property IEventSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IEventSymbol.Parameters
             Get
-                ' Delegate parameters can return either parameters that we directly declared:
-                '
-                ' i.e. Public Event E(x As String)
-                '
-                ' Or it can return parameters from the Invoke method of the Delegate type it has.
-                ' i.e. "Public Event E as EventHandler" will get the parameters of the Invoke method
-                ' of 'EventHandler'.  We only want the parameters that actually belong to us and not
-                ' the Invoke method.
-                Dim parameters = Me.DelegateParameters
-                For Each p In parameters
-                    If Not Me.Equals(p.ContainingSymbol) Then
-                        ' This was a parameter not directly from us.  We don't want to return these.
-                        Return ImmutableArray(Of IParameterSymbol).Empty
-                    End If
-                Next
-
-                Return ImmutableArray(Of IParameterSymbol).CastUp(parameters)
+                Return ImmutableArray(Of IParameterSymbol).Empty
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -137,6 +137,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Private ReadOnly Property IEventSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IEventSymbol.Parameters
+            Get
+                Return ImmutableArray(Of IParameterSymbol).CastUp(Me.DelegateParameters)
+            End Get
+        End Property
+
         ''' <summary>
         ''' Gets the return type of the event (typically System.Void). 
         ''' </summary>

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -139,7 +139,23 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Private ReadOnly Property IEventSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IEventSymbol.Parameters
             Get
-                Return ImmutableArray(Of IParameterSymbol).CastUp(Me.DelegateParameters)
+                ' Delegate parameters can return either parameters that we directly declared:
+                '
+                ' i.e. Public Event E(x As String)
+                '
+                ' Or it can return parameters from the Invoke method of the Delegate type it has.
+                ' i.e. "Public Event E as EventHandler" will get the parameters of the Invoke method
+                ' of 'EventHandler'.  We only want the parameters that actually belong to us and not
+                ' the Invoke method.
+                Dim parameters = Me.DelegateParameters
+                For Each p In parameters
+                    If Not Me.Equals(p.ContainingSymbol) Then
+                        ' This was a parameter not directly from us.  We don't want to return these.
+                        Return ImmutableArray(Of IParameterSymbol).Empty
+                    End If
+                Next
+
+                Return ImmutableArray(Of IParameterSymbol).CastUp(parameters)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/EventSymbol.vb
@@ -139,7 +139,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Friend Overridable ReadOnly Property IEventSymbol_Parameters As ImmutableArray(Of IParameterSymbol) Implements IEventSymbol.Parameters
             Get
-                Return ImmutableArray(Of IParameterSymbol).Empty
+                Return Nothing
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -1,6 +1,5 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-Imports System.Collections.Generic
 Imports System.Collections.Immutable
 Imports System.Globalization
 Imports System.Runtime.InteropServices
@@ -8,7 +7,6 @@ Imports System.Threading
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
-Imports TypeKind = Microsoft.CodeAnalysis.TypeKind
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
     Friend Class SourceEventSymbol

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -327,7 +327,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 ' return the parameters of the underlying Delegate type.
                 Dim syntax = DirectCast(_syntaxRef.GetSyntax(), EventStatementSyntax)
                 If syntax.AsClause IsNot Nothing Then
-                    Return ImmutableArray(Of IParameterSymbol).Empty
+                    Return Nothing
                 Else
                     Debug.Assert(Me.DelegateParameters.All(Function(p) Me.Equals(p.ContainingSymbol)))
                     Return ImmutableArray(Of IParameterSymbol).CastUp(Me.DelegateParameters)

--- a/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
+++ b/src/Features/Core/Portable/MetadataAsSource/AbstractMetadataAsSourceService.WrappedEventSymbol.cs
@@ -17,14 +17,6 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 _symbol = eventSymbol;
             }
 
-            public IMethodSymbol AddMethod
-            {
-                get
-                {
-                    return _symbol.AddMethod;
-                }
-            }
-
             public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations
             {
                 get
@@ -35,53 +27,15 @@ namespace Microsoft.CodeAnalysis.MetadataAsSource
                 }
             }
 
-            public bool IsWindowsRuntimeEvent
-            {
-                get
-                {
-                    return _symbol.IsWindowsRuntimeEvent;
-                }
-            }
+            public new IEventSymbol OriginalDefinition => this;
 
-            public new IEventSymbol OriginalDefinition
-            {
-                get
-                {
-                    return this;
-                }
-            }
-
-            public IEventSymbol OverriddenEvent
-            {
-                get
-                {
-                    return _symbol.OverriddenEvent;
-                }
-            }
-
-            public IMethodSymbol RaiseMethod
-            {
-                get
-                {
-                    return _symbol.RaiseMethod;
-                }
-            }
-
-            public IMethodSymbol RemoveMethod
-            {
-                get
-                {
-                    return _symbol.RemoveMethod;
-                }
-            }
-
-            public ITypeSymbol Type
-            {
-                get
-                {
-                    return _symbol.Type;
-                }
-            }
+            public IMethodSymbol AddMethod => _symbol.AddMethod;
+            public bool IsWindowsRuntimeEvent => _symbol.IsWindowsRuntimeEvent;
+            public IEventSymbol OverriddenEvent => _symbol.OverriddenEvent;
+            public IMethodSymbol RaiseMethod => _symbol.RaiseMethod;
+            public IMethodSymbol RemoveMethod => _symbol.RemoveMethod;
+            public ITypeSymbol Type => _symbol.Type;
+            public ImmutableArray<IParameterSymbol> Parameters => _symbol.Parameters;
         }
     }
 }

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -125,19 +125,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                                                                                         name:=eventHandlerName,
                                                                                         parameters:=delegateSymbol.GetParameters())
 
-                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
-                                                                                    accessibility:=Accessibility.Public, modifiers:=Nothing,
-                                                                                    explicitInterfaceSymbol:=Nothing,
-                                                                                    type:=delegateType, name:=actualEventName,
-                                                                                    parameterList:=TryCast(delegateSymbol, IMethodSymbol).Parameters)
+                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(
+                    attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
+                    accessibility:=Accessibility.Public, modifiers:=Nothing,
+                    explicitInterfaceSymbol:=Nothing,
+                    type:=delegateType, name:=actualEventName,
+                    parameters:=TryCast(delegateSymbol, IMethodSymbol).Parameters)
 
                 Return New GenerateEventCodeAction(document.Project.Solution, targetType, generatedEvent, delegateType, codeGenService, CodeGenerationOptions.Default)
             Else
-                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
-                                                accessibility:=Accessibility.Public, modifiers:=Nothing,
-                                                explicitInterfaceSymbol:=Nothing,
-                                                type:=Nothing, name:=actualEventName,
-                                                parameterList:=delegateSymbol.GetParameters())
+                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(
+                    attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
+                    accessibility:=Accessibility.Public, modifiers:=Nothing,
+                    explicitInterfaceSymbol:=Nothing,
+                    type:=Nothing, name:=actualEventName,
+                    parameters:=delegateSymbol.GetParameters())
 
                 Return New GenerateEventCodeAction(document.Project.Solution, TryCast(targetType, INamedTypeSymbol), generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
             End If
@@ -282,10 +284,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                                                         eventType.TypeParameters,
                                                         parameters)
 
-                        Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(boundEvent.GetAttributes(), boundEvent.DeclaredAccessibility,
-                                                                       modifiers:=Nothing, type:=eventHandlerType, explicitInterfaceSymbol:=Nothing,
-                                                                       name:=actualEventName,
-                                                                       parameterList:=boundEvent.GetParameters())
+                        Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(
+                            boundEvent.GetAttributes(), boundEvent.DeclaredAccessibility,
+                            modifiers:=Nothing, type:=eventHandlerType, explicitInterfaceSymbol:=Nothing,
+                            name:=actualEventName,
+                            parameters:=boundEvent.GetParameters())
                         Return New GenerateEventCodeAction(document.Project.Solution, targetType, generatedEvent, eventHandlerType, codeGenService, New CodeGenerationOptions())
                     End If
                 End If
@@ -382,19 +385,21 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                                                                     name:=actualEventName + "Handler",
                                                                     parameters:=boundMethod.GetParameters())
 
-                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
-                                                            accessibility:=Accessibility.Public, modifiers:=Nothing,
-                                                            explicitInterfaceSymbol:=Nothing,
-                                                            type:=delegateType, name:=actualEventName,
-                                                            parameterList:=TryCast(boundMethod, IMethodSymbol).Parameters)
+                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(
+                    attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
+                    accessibility:=Accessibility.Public, modifiers:=Nothing,
+                    explicitInterfaceSymbol:=Nothing,
+                    type:=delegateType, name:=actualEventName,
+                    parameters:=TryCast(boundMethod, IMethodSymbol).Parameters)
 
                 Return New GenerateEventCodeAction(document.Project.Solution, originalTargetType, generatedEvent, delegateType, codeGenService, New CodeGenerationOptions())
             Else
-                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
-                                                accessibility:=Accessibility.Public, modifiers:=Nothing,
-                                                explicitInterfaceSymbol:=Nothing,
-                                                type:=Nothing, name:=actualEventName,
-                                                parameterList:=boundMethod.GetParameters())
+                Dim generatedEvent = CodeGenerationSymbolFactory.CreateEventSymbol(
+                    attributes:=SpecializedCollections.EmptyList(Of AttributeData)(),
+                    accessibility:=Accessibility.Public, modifiers:=Nothing,
+                    explicitInterfaceSymbol:=Nothing,
+                    type:=Nothing, name:=actualEventName,
+                    parameters:=boundMethod.GetParameters())
 
                 Return New GenerateEventCodeAction(document.Project.Solution, TryCast(originalTargetType, INamedTypeSymbol), generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
             End If

--- a/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
+++ b/src/Features/VisualBasic/Portable/CodeFixes/GenerateEvent/GenerateEventCodeFixProvider.vb
@@ -130,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                     accessibility:=Accessibility.Public, modifiers:=Nothing,
                     explicitInterfaceSymbol:=Nothing,
                     type:=delegateType, name:=actualEventName,
-                    parameters:=TryCast(delegateSymbol, IMethodSymbol).Parameters)
+                    parameters:=delegateSymbol.Parameters)
 
                 Return New GenerateEventCodeAction(document.Project.Solution, targetType, generatedEvent, delegateType, codeGenService, CodeGenerationOptions.Default)
             Else
@@ -141,7 +141,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                     type:=Nothing, name:=actualEventName,
                     parameters:=delegateSymbol.GetParameters())
 
-                Return New GenerateEventCodeAction(document.Project.Solution, TryCast(targetType, INamedTypeSymbol), generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
+                Return New GenerateEventCodeAction(document.Project.Solution, targetType, generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
             End If
         End Function
 
@@ -390,7 +390,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                     accessibility:=Accessibility.Public, modifiers:=Nothing,
                     explicitInterfaceSymbol:=Nothing,
                     type:=delegateType, name:=actualEventName,
-                    parameters:=TryCast(boundMethod, IMethodSymbol).Parameters)
+                    parameters:=boundMethod.Parameters)
 
                 Return New GenerateEventCodeAction(document.Project.Solution, originalTargetType, generatedEvent, delegateType, codeGenService, New CodeGenerationOptions())
             Else
@@ -401,7 +401,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeFixes.GenerateEvent
                     type:=Nothing, name:=actualEventName,
                     parameters:=boundMethod.GetParameters())
 
-                Return New GenerateEventCodeAction(document.Project.Solution, TryCast(originalTargetType, INamedTypeSymbol), generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
+                Return New GenerateEventCodeAction(document.Project.Solution, originalTargetType, generatedEvent, Nothing, codeGenService, CodeGenerationOptions.Default)
             End If
         End Function
     End Class

--- a/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/CodeGenerationSymbolFactory.cs
@@ -26,9 +26,14 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         /// <summary>
         /// Creates an event symbol that can be used to describe an event declaration.
         /// </summary>
-        public static IEventSymbol CreateEventSymbol(IList<AttributeData> attributes, Accessibility accessibility, DeclarationModifiers modifiers, ITypeSymbol type, IEventSymbol explicitInterfaceSymbol, string name, IMethodSymbol addMethod = null, IMethodSymbol removeMethod = null, IMethodSymbol raiseMethod = null, IList<IParameterSymbol> parameterList = null)
+        public static IEventSymbol CreateEventSymbol(
+            IList<AttributeData> attributes, Accessibility accessibility,
+            DeclarationModifiers modifiers, ITypeSymbol type,
+            IEventSymbol explicitInterfaceSymbol, string name,
+            IMethodSymbol addMethod = null, IMethodSymbol removeMethod = null, IMethodSymbol raiseMethod = null,
+            ImmutableArray<IParameterSymbol> parameters = default(ImmutableArray<IParameterSymbol>))
         {
-            var result = new CodeGenerationEventSymbol(null, attributes, accessibility, modifiers, type, explicitInterfaceSymbol, name, addMethod, removeMethod, raiseMethod, parameterList);
+            var result = new CodeGenerationEventSymbol(null, attributes, accessibility, modifiers, type, explicitInterfaceSymbol, name, addMethod, removeMethod, raiseMethod, parameters);
             CodeGenerationEventInfo.Attach(result, modifiers.IsUnsafe);
             return result;
         }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -11,20 +11,12 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
     {
         public ITypeSymbol Type { get; }
 
-        public bool IsWindowsRuntimeEvent
-        {
-            get
-            {
-                return false;
-            }
-        }
-
         public ImmutableArray<IEventSymbol> ExplicitInterfaceImplementations { get; }
 
         public IMethodSymbol AddMethod { get; }
         public IMethodSymbol RemoveMethod { get; }
         public IMethodSymbol RaiseMethod { get; }
-        public IList<IParameterSymbol> ParameterList { get; }
+        public ImmutableArray<IParameterSymbol> Parameters { get; }
 
         public CodeGenerationEventSymbol(
             INamedTypeSymbol containingType,
@@ -37,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             IMethodSymbol addMethod,
             IMethodSymbol removeMethod,
             IMethodSymbol raiseMethod,
-            IList<IParameterSymbol> parameterList)
+            ImmutableArray<IParameterSymbol> parameters)
             : base(containingType, attributes, declaredAccessibility, modifiers, name)
         {
             this.Type = type;
@@ -47,7 +39,9 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             this.AddMethod = addMethod;
             this.RemoveMethod = removeMethod;
             this.RaiseMethod = raiseMethod;
-            this.ParameterList = parameterList;
+            this.Parameters = parameters.IsDefault
+                ? ImmutableArray<IParameterSymbol>.Empty
+                : parameters;
         }
 
         protected override CodeGenerationSymbol Clone()
@@ -55,49 +49,23 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             return new CodeGenerationEventSymbol(
                 this.ContainingType, this.GetAttributes(), this.DeclaredAccessibility,
                 this.Modifiers, this.Type, this.ExplicitInterfaceImplementations.FirstOrDefault(),
-                this.Name, this.AddMethod, this.RemoveMethod, this.RaiseMethod, this.ParameterList);
+                this.Name, this.AddMethod, this.RemoveMethod, this.RaiseMethod, this.Parameters);
         }
 
-        public override SymbolKind Kind
-        {
-            get
-            {
-                return SymbolKind.Event;
-            }
-        }
+        public override SymbolKind Kind => SymbolKind.Event;
 
         public override void Accept(SymbolVisitor visitor)
-        {
-            visitor.VisitEvent(this);
-        }
+            => visitor.VisitEvent(this);
 
         public override TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
-        {
-            return visitor.VisitEvent(this);
-        }
+            => visitor.VisitEvent(this);
 
-        public new IEventSymbol OriginalDefinition
-        {
-            get
-            {
-                return this;
-            }
-        }
+        public new IEventSymbol OriginalDefinition => this;
 
-        public IEventSymbol OverriddenEvent
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public bool IsWindowsRuntimeEvent => false;
 
-        public ImmutableArray<CustomModifier> TypeCustomModifiers
-        {
-            get
-            {
-                return ImmutableArray.Create<CustomModifier>();
-            }
-        }
+        public IEventSymbol OverriddenEvent => null;
+
+        public ImmutableArray<CustomModifier> TypeCustomModifiers => ImmutableArray.Create<CustomModifier>();
     }
 }

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationEventSymbol.cs
@@ -39,9 +39,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
             this.AddMethod = addMethod;
             this.RemoveMethod = removeMethod;
             this.RaiseMethod = raiseMethod;
-            this.Parameters = parameters.IsDefault
-                ? ImmutableArray<IParameterSymbol>.Empty
-                : parameters;
+            this.Parameters = parameters;
         }
 
         protected override CodeGenerationSymbol Clone()

--- a/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
+++ b/src/Workspaces/Core/Portable/SymbolKey/SymbolKey.ParameterSymbolKey.cs
@@ -41,26 +41,8 @@ namespace Microsoft.CodeAnalysis
                 }
                 else if (container is IEventSymbol)
                 {
-                    // Parameters can be owned by events in VB.  i.e. it's legal in VB to have:
-                    //
-                    //      Public Event E(a As Integer, b As Integer);
-                    //
-                    // In this case it's equivalent to:
-                    //
-                    //      Public Delegate UnutterableCompilerName(a As Integer, b As Integer)
-                    //      public Event E As UnutterableCompilerName
-                    //
-                    // So, in this case, to resolve the parameter, we go have to map the event,
-                    // then find the delegate it returns, then find the parameter in the delegate's
-                    // 'Invoke' method.
-                    var eventSymbol = (IEventSymbol)container;
-                    var delegateInvoke = (eventSymbol.Type as INamedTypeSymbol)?.DelegateInvokeMethod;
-
-                    if (delegateInvoke != null)
-                    {
-                        return delegateInvoke.Parameters.Where(
-                            p => SymbolKey.Equals(reader.Compilation, p.MetadataName, metadataName));
-                    }
+                    return ((IEventSymbol)container).Parameters.Where(
+                        p => SymbolKey.Equals(reader.Compilation, p.MetadataName, metadataName));
                 }
 
                 return SpecializedCollections.EmptyEnumerable<IParameterSymbol>();

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -6,8 +6,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Test.Utilities;
@@ -48,8 +46,20 @@ public class C
     public event D E2 { add; remove; }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             TestRoundTrip(GetDeclaredSymbols(compilation), compilation);
+        }
+
+        [Fact]
+        public void TestVBParameterizedEvent()
+        {
+            var source = @"
+Module M
+    Event E(x As Object)
+End Module
+";
+            var compilation = GetCompilation(source, LanguageNames.VisualBasic);
+            TestRoundTrip(GetAllSymbols(compilation.GetSemanticModel(compilation.SyntaxTrees.Single())), compilation);
         }
 
         [Fact]
@@ -62,7 +72,7 @@ namespace A { namespace B.C { } }
 namespace A { namespace B { namespace C { } } }
 namespace A { namespace N { } }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var symbols = GetDeclaredSymbols(compilation);
             Assert.Equal(5, symbols.Count);
             TestRoundTrip(symbols, compilation);
@@ -87,7 +97,7 @@ public class C
     public int** p2;
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             TestRoundTrip(GetDeclaredSymbols(compilation).OfType<IFieldSymbol>().Select(fs => fs.Type), compilation);
         }
 
@@ -105,7 +115,7 @@ public class C
     public T<A> E4;
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             TestRoundTrip(GetDeclaredSymbols(compilation).OfType<IFieldSymbol>().Select(fs => fs.Type), compilation, s => s.ToDisplayString());
         }
 
@@ -126,7 +136,7 @@ public class C
     public void M(ref int p)  { }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             TestRoundTrip(GetDeclaredSymbols(compilation).OfType<IMethodSymbol>().SelectMany(ms => ms.Parameters), compilation);
         }
 
@@ -188,7 +198,7 @@ public class C<S, T>
 }
 ";
 
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             TestRoundTrip(GetDeclaredSymbols(compilation), compilation);
         }
 
@@ -222,7 +232,7 @@ public class C
     }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var symbols = GetDeclaredSymbols(compilation).OfType<IMethodSymbol>().SelectMany(ms => GetInteriorSymbols(ms, compilation).OfType<ILocalSymbol>()).ToList();
             Assert.Equal(7, symbols.Count);
             TestRoundTrip(symbols, compilation);
@@ -244,7 +254,7 @@ public class C
     }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var symbols = GetDeclaredSymbols(compilation).OfType<IMethodSymbol>().SelectMany(ms => GetInteriorSymbols(ms, compilation).OfType<ILabelSymbol>()).ToList();
             Assert.Equal(3, symbols.Count);
             TestRoundTrip(symbols, compilation);
@@ -271,7 +281,7 @@ public class C
     }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var symbols = GetDeclaredSymbols(compilation).OfType<IMethodSymbol>().SelectMany(ms => GetInteriorSymbols(ms, compilation).OfType<IRangeVariableSymbol>()).ToList();
             Assert.Equal(2, symbols.Count);
             TestRoundTrip(symbols, compilation);
@@ -298,10 +308,10 @@ public class C
     }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
-            var symbols = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Select(s => model.GetSymbolInfo(s).Symbol).ToList();
+            var symbols = tree.GetRoot().DescendantNodes().OfType<CSharp.Syntax.InvocationExpressionSyntax>().Select(s => model.GetSymbolInfo(s).Symbol).ToList();
             Assert.True(symbols.Count > 0);
             TestRoundTrip(symbols, compilation);
         }
@@ -334,10 +344,10 @@ public class C
     }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
-            var symbols = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Select(s => model.GetSymbolInfo(s).GetAnySymbol()).ToList();
+            var symbols = tree.GetRoot().DescendantNodes().OfType<CSharp.Syntax.InvocationExpressionSyntax>().Select(s => model.GetSymbolInfo(s).GetAnySymbol()).ToList();
             Assert.True(symbols.Count > 0);
             Assert.True(symbols.All(s => s.IsReducedExtension()));
             TestRoundTrip(symbols, compilation);
@@ -356,11 +366,11 @@ public class C
     public GL F2;
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
-            var symbols = tree.GetRoot().DescendantNodes().OfType<UsingDirectiveSyntax>().Select(s => model.GetDeclaredSymbol(s)).ToList();
+            var symbols = tree.GetRoot().DescendantNodes().OfType<CSharp.Syntax.UsingDirectiveSyntax>().Select(s => model.GetDeclaredSymbol(s)).ToList();
             Assert.Equal(2, symbols.Count);
             Assert.NotNull(symbols[0]);
             Assert.True(symbols[0] is IAliasSymbol);
@@ -381,7 +391,7 @@ public class C
     public dynamic[] F2;
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -399,7 +409,7 @@ public class C
     public void M<S, T>() { }
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -417,7 +427,7 @@ public class C<S, T>
 {
 }
 ";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -437,7 +447,7 @@ public class A<TOuter>
     {
     }
 }";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -460,7 +470,7 @@ public class A<T1>
         void M<T3>(T1 t1, T2, T3 t3, List<int> l1, List<T3> l2) { }
     }
 }";
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -503,7 +513,7 @@ public class A<T1>
         {
             var source = @"class C<T> { }";
 
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
 
@@ -517,7 +527,7 @@ public class A<T1>
         {
             var source = @"class C { void M<T>() { } }";
 
-            var compilation = GetCompilation(source);
+            var compilation = GetCompilation(source, LanguageNames.CSharp);
             var tree = compilation.SyntaxTrees.First();
             var model = compilation.GetSemanticModel(tree);
             var typeParameter = GetDeclaredSymbols(compilation).OfType<INamedTypeSymbol>().Single().GetMembers("M").OfType<IMethodSymbol>().Single().TypeParameters.Single();
@@ -551,7 +561,7 @@ class C
 
             var firstModel = await document.GetSemanticModelAsync();
             var tree1 = await document.GetSyntaxTreeAsync();
-            var basemethod1 = tree1.FindTokenOnLeftOfPosition(position, CancellationToken.None).GetAncestor<BaseMethodDeclarationSyntax>();
+            var basemethod1 = tree1.FindTokenOnLeftOfPosition(position, CancellationToken.None).GetAncestor<CSharp.Syntax.BaseMethodDeclarationSyntax>();
 
             // Modify the document so we can use the old semantic model as a base.
             var updated = sourceText.WithChanges(new TextChange(new TextSpan(position, 0), "insertion"));
@@ -559,9 +569,9 @@ class C
 
             document = workspace.CurrentSolution.GetDocument(document.Id);
             var tree2 = await document.GetSyntaxTreeAsync();
-            var basemethod2 = tree2.FindTokenOnLeftOfPosition(position, CancellationToken.None).GetAncestor<BaseMethodDeclarationSyntax>();
+            var basemethod2 = tree2.FindTokenOnLeftOfPosition(position, CancellationToken.None).GetAncestor<CSharp.Syntax.BaseMethodDeclarationSyntax>();
 
-            var service = new CSharpSemanticFactsService();
+            var service = new CSharp.CSharpSemanticFactsService();
             SemanticModel testModel;
             var m = service.TryGetSpeculativeSemanticModel(firstModel, basemethod1, basemethod2, out testModel);
 
@@ -598,10 +608,50 @@ class C
             }
         }
 
-        private Compilation GetCompilation(string source)
+        private Compilation GetCompilation(string source, string language)
         {
-            var tree = SyntaxFactory.ParseSyntaxTree(source);
-            return CSharpCompilation.Create("Test", syntaxTrees: new[] { tree }, references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+            if (language == LanguageNames.CSharp)
+            {
+                var tree = CSharp.SyntaxFactory.ParseSyntaxTree(source);
+                return CSharp.CSharpCompilation.Create("Test", syntaxTrees: new[] { tree }, references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+            }
+            else if (language == LanguageNames.VisualBasic)
+            {
+                var tree = VisualBasic.SyntaxFactory.ParseSyntaxTree(source);
+                return VisualBasic.VisualBasicCompilation.Create("Test", syntaxTrees: new[] { tree }, references: new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) });
+            }
+
+            throw new NotSupportedException();
+        }
+
+        private List<ISymbol> GetAllSymbols(SemanticModel model)
+        {
+            var list = new List<ISymbol>();
+            GetAllSymbols(model, model.SyntaxTree.GetRoot(), list);
+            return list;
+        }
+
+        private void GetAllSymbols(SemanticModel model, SyntaxNode node, List<ISymbol> list)
+        {
+            var symbol = model.GetDeclaredSymbol(node);
+            if (symbol != null)
+            {
+                list.Add(symbol);
+            }
+
+            symbol = model.GetSymbolInfo(node).GetAnySymbol();
+            if (symbol != null)
+            {
+                list.Add(symbol);
+            }
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (child.IsNode)
+                {
+                    GetAllSymbols(model, child.AsNode(), list);
+                }
+            }
         }
 
         private List<ISymbol> GetDeclaredSymbols(Compilation compilation)

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
@@ -81,7 +81,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 ' have a type that is unmentionable.  So we should not generate it as "Event E() As
                 ' SomeType", but should instead inline the delegate type into the event itself.
                 Return SyntaxFactory.EventStatement(
-                    attributeLists:=AttributeGenerator.GenerateAttributeBlocks([event].GetAttributes(), options),
+                    attributeLists:=GenerateAttributeBlocks([event].GetAttributes(), options),
                     modifiers:=GenerateModifiers([event], destination, options),
                     identifier:=[event].Name.ToIdentifierToken,
                     parameterList:=ParameterGenerator.GenerateParameterList(eventType.DelegateInvokeMethod.Parameters.Select(Function(p) RemoveOptionalOrParamArray(p)).ToList(), options),
@@ -92,7 +92,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 Dim parameters = If([event].Parameters.IsDefault, ImmutableArray(Of IParameterSymbol).Empty, [event].Parameters)
 
                 Return SyntaxFactory.EventStatement(
-                    attributeLists:=AttributeGenerator.GenerateAttributeBlocks([event].GetAttributes(), options),
+                    attributeLists:=GenerateAttributeBlocks([event].GetAttributes(), options),
                     modifiers:=GenerateModifiers([event], destination, options),
                     identifier:=[event].Name.ToIdentifierToken,
                     parameterList:=ParameterGenerator.GenerateParameterList(parameters.Select(AddressOf RemoveOptionalOrParamArray), options),
@@ -100,7 +100,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     implementsClause:=GenerateImplementsClause([event].ExplicitInterfaceImplementations.FirstOrDefault()))
             Else
                 Return SyntaxFactory.EventStatement(
-                    attributeLists:=AttributeGenerator.GenerateAttributeBlocks([event].GetAttributes(), options),
+                    attributeLists:=GenerateAttributeBlocks([event].GetAttributes(), options),
                     modifiers:=GenerateModifiers([event], destination, options),
                     identifier:=[event].Name.ToIdentifierToken,
                     parameterList:=Nothing,

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.CodeGeneration
 Imports Microsoft.CodeAnalysis.CodeGeneration.CodeGenerationHelpers
@@ -86,13 +87,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     parameterList:=ParameterGenerator.GenerateParameterList(eventType.DelegateInvokeMethod.Parameters.Select(Function(p) RemoveOptionalOrParamArray(p)).ToList(), options),
                     asClause:=Nothing,
                     implementsClause:=GenerateImplementsClause([event].ExplicitInterfaceImplementations.FirstOrDefault()))
-            ElseIf [event].Type Is Nothing OrElse [event].Parameters.Length > 0 Then
+            ElseIf [event].Type Is Nothing OrElse Not [event].Parameters.IsDefault Then
                 ' We'll try to generate a parameter list
+                Dim parameters = If([event].Parameters.IsDefault, ImmutableArray(Of IParameterSymbol).Empty, [event].Parameters)
+
                 Return SyntaxFactory.EventStatement(
                     attributeLists:=AttributeGenerator.GenerateAttributeBlocks([event].GetAttributes(), options),
                     modifiers:=GenerateModifiers([event], destination, options),
                     identifier:=[event].Name.ToIdentifierToken,
-                    parameterList:=ParameterGenerator.GenerateParameterList([event].Parameters.Select(AddressOf RemoveOptionalOrParamArray), options),
+                    parameterList:=ParameterGenerator.GenerateParameterList(parameters.Select(AddressOf RemoveOptionalOrParamArray), options),
                     asClause:=Nothing,
                     implementsClause:=GenerateImplementsClause([event].ExplicitInterfaceImplementations.FirstOrDefault()))
             Else

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/EventGenerator.vb
@@ -71,8 +71,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
         End Function
 
         Private Function GenerateEventDeclarationWorker([event] As IEventSymbol,
-                                                       destination As CodeGenerationDestination,
-                                                       options As CodeGenerationOptions) As DeclarationStatementSyntax
+                                                        destination As CodeGenerationDestination,
+                                                        options As CodeGenerationOptions) As DeclarationStatementSyntax
             ' TODO(cyrusn): Handle Add/Remove/Raise events
             Dim eventType = TryCast([event].Type, INamedTypeSymbol)
             If eventType.IsDelegateType() AndAlso eventType.AssociatedSymbol IsNot Nothing Then
@@ -86,13 +86,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                     parameterList:=ParameterGenerator.GenerateParameterList(eventType.DelegateInvokeMethod.Parameters.Select(Function(p) RemoveOptionalOrParamArray(p)).ToList(), options),
                     asClause:=Nothing,
                     implementsClause:=GenerateImplementsClause([event].ExplicitInterfaceImplementations.FirstOrDefault()))
-            ElseIf TypeOf [event] Is CodeGenerationEventSymbol AndAlso TryCast([event], CodeGenerationEventSymbol).ParameterList IsNot Nothing Then
+            ElseIf [event].Type Is Nothing OrElse [event].Parameters.Length > 0 Then
                 ' We'll try to generate a parameter list
                 Return SyntaxFactory.EventStatement(
                     attributeLists:=AttributeGenerator.GenerateAttributeBlocks([event].GetAttributes(), options),
                     modifiers:=GenerateModifiers([event], destination, options),
                     identifier:=[event].Name.ToIdentifierToken,
-                    parameterList:=ParameterGenerator.GenerateParameterList(TryCast([event], CodeGenerationEventSymbol).ParameterList.Select(Function(p) RemoveOptionalOrParamArray(p)).ToArray(), options),
+                    parameterList:=ParameterGenerator.GenerateParameterList([event].Parameters.Select(AddressOf RemoveOptionalOrParamArray), options),
                     asClause:=Nothing,
                     implementsClause:=GenerateImplementsClause([event].ExplicitInterfaceImplementations.FirstOrDefault()))
             Else


### PR DESCRIPTION
tagging @dotnet/roslyn-ide 

Also @dotnet/roslyn-compiler 

As part of this change, i needed to expose a 'Parameters' property on IEventSymbol so that one could resolve back from an event to a parameter that we previously acquired from the compiler for that event.  Prior to this it was possible to get such a parameter, but there was no way in our API to get back to it again.  

This is for events in VB like so:

```
module M
    Event E(x As Object)
end module
```

If you GetDeclaredSymbol on 'x' you'll get an IParameterSymbol whose ContainingSymbol is the event.  However, there is no way from the event symbol to get back to that parameter.  

You can get to the synthesized delegate type, and you can find parameters on it's Invoke method and whatnot.  But those are not the same IParameterSymbols.  Specifically, those parameters have a parent that is the IMethodSymbol of the delegate's Invoke method.

This is important for OOP FAR.  We want to ensure that we can properly marshal pretty much any symbol to/from our local/remote hosts.  Wen we can't, then features can either break, or behave subtly different depending if they're running in our out of proc.

--

Note: i was unable to find any tests for IMethodSymbol.Parameters or IPropertySymbol.Parameters in VB.  If someone can point me to them, i can add commensurate tests for the new IEventSymbol.Parameters property there as well.