### PR TITLE
Mismatching tuple names should not prevent implementing interface

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ExplicitInterfaceHelpers.cs
@@ -263,7 +263,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             if (MemberSignatureComparer.ConsideringTupleNamesCreatesDifference(implementingMember, implementedMember))
             {
                 diagnostics.Add(ErrorCode.ERR_ImplBadTupleNames, memberLocation, implementingMember, implementedMember);
-                return null;
             }
 
             // In constructed types, it is possible that two method signatures could differ by only ref/out

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16752,30 +16752,18 @@ public class C : I0
 
             var comp = CreateCompilationWithMscorlib(source, references: s_valueTupleRefs);
             comp.VerifyDiagnostics(
-                // (12,13): error CS8141: The tuple element names in the signature of method 'C.M2((int notA, int notB))' must match the tuple element names of interface method 'I0.M2((int a, int b))' (including on the return type).
+                // (12,13): error CS8141: The tuple element names in the signature of method 'C.I0.M2((int notA, int notB))' must match the tuple element names of interface method 'I0.M2((int a, int b))' (including on the return type).
                 //     void I0.M2((int notA, int notB) z) { }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M2").WithArguments("C.M2((int notA, int notB))", "I0.M2((int a, int b))").WithLocation(12, 13),
-                // (13,32): error CS8141: The tuple element names in the signature of method 'C.MR1()' must match the tuple element names of interface method 'I0.MR1()' (including on the return type).
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M2").WithArguments("C.I0.M2((int notA, int notB))", "I0.M2((int a, int b))").WithLocation(12, 13),
+                // (13,32): error CS8141: The tuple element names in the signature of method 'C.I0.MR1()' must match the tuple element names of interface method 'I0.MR1()' (including on the return type).
                 //     (int notMissing, int b) I0.MR1() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR1").WithArguments("C.MR1()", "I0.MR1()").WithLocation(13, 32),
-                // (14,29): error CS8141: The tuple element names in the signature of method 'C.MR2()' must match the tuple element names of interface method 'I0.MR2()' (including on the return type).
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR1").WithArguments("C.I0.MR1()", "I0.MR1()").WithLocation(13, 32),
+                // (14,29): error CS8141: The tuple element names in the signature of method 'C.I0.MR2()' must match the tuple element names of interface method 'I0.MR2()' (including on the return type).
                 //     (int notA, int notB) I0.MR2() { return (1, 2); }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR2").WithArguments("C.MR2()", "I0.MR2()").WithLocation(14, 29),
-                // (11,13): error CS8141: The tuple element names in the signature of method 'C.M1((int notMissing, int b))' must match the tuple element names of interface method 'I0.M1((int, int b))' (including on the return type).
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "MR2").WithArguments("C.I0.MR2()", "I0.MR2()").WithLocation(14, 29),
+                // (11,13): error CS8141: The tuple element names in the signature of method 'C.I0.M1((int notMissing, int b))' must match the tuple element names of interface method 'I0.M1((int, int b))' (including on the return type).
                 //     void I0.M1((int notMissing, int b) z) { }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M1").WithArguments("C.M1((int notMissing, int b))", "I0.M1((int, int b))").WithLocation(11, 13),
-                // (9,18): error CS0535: 'C' does not implement interface member 'I0.MR2()'
-                // public class C : I0
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I0").WithArguments("C", "I0.MR2()").WithLocation(9, 18),
-                // (9,18): error CS0535: 'C' does not implement interface member 'I0.M2((int a, int b))'
-                // public class C : I0
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I0").WithArguments("C", "I0.M2((int a, int b))").WithLocation(9, 18),
-                // (9,18): error CS0535: 'C' does not implement interface member 'I0.MR1()'
-                // public class C : I0
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I0").WithArguments("C", "I0.MR1()").WithLocation(9, 18),
-                // (9,18): error CS0535: 'C' does not implement interface member 'I0.M1((int, int b))'
-                // public class C : I0
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I0").WithArguments("C", "I0.M1((int, int b))").WithLocation(9, 18)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M1").WithArguments("C.I0.M1((int notMissing, int b))", "I0.M1((int, int b))").WithLocation(11, 13)
                 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/CustomModifierCopyTests.cs
@@ -876,19 +876,19 @@ class C : I
 ";
             var comp2 = CreateCompilation(source2, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
             comp2.VerifyDiagnostics(
-                // (4,28): error CS8141: The tuple element names in the signature of method 'C.M((object, object))' must match the tuple element names of interface method 'I.M((object c, object d))' (including on the return type).
+                // (4,28): error CS8141: The tuple element names in the signature of method 'C.I.M((object, object))' must match the tuple element names of interface method 'I.M((object c, object d))' (including on the return type).
                 //     (object a, object b) I.M((object, object) x) { return x; }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M((object, object))", "I.M((object c, object d))").WithLocation(4, 28),
-                // (2,11): error CS0535: 'C' does not implement interface member 'I.M((object c, object d))'
-                // class C : I
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.M((object c, object d))").WithLocation(2, 11)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.I.M((object, object))", "I.M((object c, object d))").WithLocation(4, 28)
                 );
 
             var classMethod2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
 
-            Assert.Equal("(System.Object a, System.Object b) C.M((System.Object, System.Object) x)", classMethod2.ToTestDisplayString());
-            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod2.ReturnType.TupleUnderlyingType.ToTestDisplayString());
-            Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
+            Assert.Equal("(System.Object a, System.Object b) C.I.M((System.Object, System.Object) x)", classMethod2.ToTestDisplayString());
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                classMethod2.ReturnType.TupleUnderlyingType.ToTestDisplayString());
+
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
+                classMethod2.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
 
             var source3 = @"
 class C : I
@@ -898,19 +898,16 @@ class C : I
 ";
             var comp3 = CreateCompilation(source3, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
             comp3.VerifyDiagnostics(
-                // (4,24): error CS8141: The tuple element names in the signature of method 'C.M((object c, object d))' must match the tuple element names of interface method 'I.M((object c, object d))' (including on the return type).
+                // (4,24): error CS8141: The tuple element names in the signature of method 'C.I.M((object c, object d))' must match the tuple element names of interface method 'I.M((object c, object d))' (including on the return type).
                 //     (object, object) I.M((object c, object d) x) { return x; }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.M((object c, object d))", "I.M((object c, object d))").WithLocation(4, 24),
-                // (2,11): error CS0535: 'C' does not implement interface member 'I.M((object c, object d))'
-                // class C : I
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.M((object c, object d))").WithLocation(2, 11)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "M").WithArguments("C.I.M((object c, object d))", "I.M((object c, object d))").WithLocation(4, 24)
                 );
 
             var classMethod3 = comp3.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetMethod("I.M");
 
-            Assert.Equal("(System.Object, System.Object) C.M((System.Object c, System.Object d) x)", classMethod3.ToTestDisplayString());
+            Assert.Equal("(System.Object, System.Object) C.I.M((System.Object c, System.Object d) x)", classMethod3.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object, System.Object>", classMethod3.ReturnType.TupleUnderlyingType.ToTestDisplayString());
-            Assert.Equal("System.ValueTuple<System.Object, System.Object>",
+            Assert.Equal("System.ValueTuple<System.Object modopt(System.Runtime.CompilerServices.IsLong), System.Object modopt(System.Runtime.CompilerServices.IsLong)>",
                     classMethod3.ParameterTypes[0].TupleUnderlyingType.ToTestDisplayString());
 
             var source4 = @"
@@ -994,17 +991,14 @@ class C : I
 ";
             var comp2 = CreateCompilation(source2, new[] { MscorlibRef, SystemCoreRef, ilRef, ValueTupleRef, SystemRuntimeFacadeRef, CSharpRef });
             comp2.VerifyDiagnostics(
-                // (4,24): error CS8141: The tuple element names in the signature of method 'C.P' must match the tuple element names of interface method 'I.P' (including on the return type).
+                // (4,24): error CS8141: The tuple element names in the signature of method 'C.I.P' must match the tuple element names of interface method 'I.P' (including on the return type).
                 //     (object, object) I.P { get; set; }
-                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "P").WithArguments("C.P", "I.P").WithLocation(4, 24),
-                // (2,11): error CS0535: 'C' does not implement interface member 'I.P'
-                // class C : I
-                Diagnostic(ErrorCode.ERR_UnimplementedInterfaceMember, "I").WithArguments("C", "I.P").WithLocation(2, 11)
+                Diagnostic(ErrorCode.ERR_ImplBadTupleNames, "P").WithArguments("C.I.P", "I.P").WithLocation(4, 24)
                 );
 
             var classProperty2 = comp2.GlobalNamespace.GetMember<NamedTypeSymbol>("C").GetProperty("I.P");
 
-            Assert.Equal("(System.Object, System.Object) C.P { get; set; }", classProperty2.ToTestDisplayString());
+            Assert.Equal("(System.Object, System.Object) C.I.P { get; set; }", classProperty2.ToTestDisplayString());
             Assert.Equal("System.ValueTuple<System.Object, System.Object>", classProperty2.Type.TupleUnderlyingType.ToTestDisplayString());
 
             var source3 = @"


### PR DESCRIPTION
From implementing tuple names in override/implement scenarios in VB, some questions came up about the C# implementation as well.
Although we do want to report an error for tuple mismatches in implement scenario, it should not prevent recognizing that the interface was implemented.

So the code below should not report an error such as "error CS0535: 'C' does not implement interface member 'I.M((object c, object d))'".
```C#
class C : I
{		  
    (object a, object b) I.M((object mismatchC, object mismatchD) x) { return x; }
}
```

@dotnet/roslyn-compiler for review.
