### PR TITLE
Miscellaneous fixes to CPSProjectFactory/CPSProject

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -130,6 +130,9 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             CommandLineParserService = commandLineParserServiceOpt;
             HostDiagnosticUpdateSource = hostDiagnosticUpdateSourceOpt;
 
+            // Set the default value for last design time build result to be true, until the project system lets us know that it failed.
+            LastDesignTimeBuildSucceeded = true;
+
             UpdateProjectDisplayNameAndFilePath(projectSystemName, projectFilePath);
 
             if (ProjectFilePath != null)
@@ -260,8 +263,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// Flag indicating if the latest design time build has succeeded for current project state.
         /// </summary>
-        /// <remarks>Defaults to true if the project system never sets the design time build result with <see cref="SetIntellisenseBuildResultAndNotifyWorkspaceHosts(bool)"/>.</remarks>
-        protected bool LastDesignTimeBuildSucceeded { get; }
+        /// <remarks>Default value is true.</remarks>
+        protected bool LastDesignTimeBuildSucceeded { get; private set; }
 
         internal VsENCRebuildableProjectImpl EditAndContinueImplOpt { get; private set; }
 
@@ -295,14 +298,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                     analyzerReferences: _analyzers.Values.Select(a => a.GetReference()),
                     additionalDocuments: _additionalDocuments.Values.Select(d => d.GetInitialState()));
 
-                return info.WithHasAllInformation(hasAllInformation: _lastDesignTimeBuildSucceeded);
+                return info.WithHasAllInformation(hasAllInformation: LastDesignTimeBuildSucceeded);
             }
         }
 
         protected void SetIntellisenseBuildResultAndNotifyWorkspaceHosts(bool succeeded)
         {
             // set intellisense related info
-            _lastDesignTimeBuildSucceeded = succeeded;
+            LastDesignTimeBuildSucceeded = succeeded;
 
             if (PushingChangesToWorkspaceHosts)
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IIntellisenseBuildTarget.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/Legacy/AbstractLegacyProject_IIntellisenseBuildTarget.cs
@@ -14,29 +14,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.L
     {
         private static readonly object s_diagnosticKey = new object();
 
-        // set default to true so that we maintain old behavior when project system doesn't
-        // implement IIntellisenseBuildTarget
-        private bool _intellisenseBuildSucceeded = true;
-        private string _intellisenseBuildFailureReason = null;
-
-        protected override bool LastDesignTimeBuildSucceeded => _intellisenseBuildSucceeded;
-
-        public void SetIntellisenseBuildResult(bool succeeded, string reason)
+        void IIntellisenseBuildTarget.SetIntellisenseBuildResult(bool succeeded, string reason)
         {
-            // set intellisense related info
-            _intellisenseBuildSucceeded = succeeded;
-            _intellisenseBuildFailureReason = string.IsNullOrWhiteSpace(reason) ? null : reason.Trim();
+            SetIntellisenseBuildResultAndNotifyWorkspaceHosts(succeeded);
 
-            UpdateHostDiagnostics(succeeded, reason);
-
-            if (PushingChangesToWorkspaceHosts)
-            {
-                // set workspace reference info
-                ProjectTracker.NotifyWorkspaceHosts(host => (host as IVisualStudioWorkspaceHost2)?.OnHasAllInformation(Id, succeeded));
-            }
+            UpdateIntellisenseBuildFailureDiagnostic(succeeded, reason);
         }
 
-        private void UpdateHostDiagnostics(bool succeeded, string reason)
+        private void UpdateIntellisenseBuildFailureDiagnostic(bool succeeded, string reason)
         {
             if (!succeeded)
             {

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
@@ -11,8 +11,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 {
     internal sealed partial class CPSProject : AbstractProject
     {
-        private bool _lastDesignTimeBuildSucceeded;
-
         public CPSProject(
             VisualStudioProjectTracker projectTracker,
             Func<ProjectId, IVsReportExternalErrors> reportExternalErrorCreatorOpt,
@@ -34,11 +32,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
             // Now hook up the project to the project tracker.
             projectTracker.AddProject(this);
-
-            _lastDesignTimeBuildSucceeded = true;
         }
-
-        protected sealed override bool LastDesignTimeBuildSucceeded => _lastDesignTimeBuildSucceeded;
 
         // We might we invoked from a background thread, so schedule the disconnect on foreground task scheduler.
         public sealed override void Disconnect()

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly VisualStudioWorkspaceImpl _visualStudioWorkspace;
         private readonly HostDiagnosticUpdateSource _hostDiagnosticUpdateSource;
 
-        private readonly Dictionary<string, IVsReportExternalErrors> _externalErrorReporterMap;
+        private readonly Dictionary<ProjectId, IVsReportExternalErrors> _externalErrorReporterMap;
         private readonly ImmutableDictionary<string, string> _projectLangaugeToErrorCodePrefixMap =
             ImmutableDictionary.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
             {
@@ -39,7 +39,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             _serviceProvider = serviceProvider;
             _visualStudioWorkspace = visualStudioWorkspace;
             _hostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
-            _externalErrorReporterMap = new Dictionary<string, IVsReportExternalErrors>(StringComparer.OrdinalIgnoreCase);
+            _externalErrorReporterMap = new Dictionary<ProjectId, IVsReportExternalErrors>();
         }
 
         // internal for testing purposes only.
@@ -92,7 +92,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             lock (_externalErrorReporterMap)
             {
                 IVsReportExternalErrors errorReporter;
-                if (!_externalErrorReporterMap.TryGetValue(languageName, out errorReporter))
+                if (!_externalErrorReporterMap.TryGetValue(projectId, out errorReporter))
                 {
                     string errorCodePrefix;
                     if (!_projectLangaugeToErrorCodePrefixMap.TryGetValue(languageName, out errorCodePrefix))
@@ -101,7 +101,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                     }
 
                     errorReporter = new ProjectExternalErrorReporter(projectId, errorCodePrefix, _serviceProvider);
-                    _externalErrorReporterMap.Add(languageName, errorReporter);
+                    _externalErrorReporterMap.Add(projectId, errorReporter);
                 }
 
                 return errorReporter;

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProjectFactory.cs
@@ -22,7 +22,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         private readonly VisualStudioWorkspaceImpl _visualStudioWorkspace;
         private readonly HostDiagnosticUpdateSource _hostDiagnosticUpdateSource;
 
-        private readonly Dictionary<ProjectId, IVsReportExternalErrors> _externalErrorReporterMap;
         private readonly ImmutableDictionary<string, string> _projectLangaugeToErrorCodePrefixMap =
             ImmutableDictionary.CreateRange(StringComparer.OrdinalIgnoreCase, new[]
             {
@@ -39,7 +38,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             _serviceProvider = serviceProvider;
             _visualStudioWorkspace = visualStudioWorkspace;
             _hostDiagnosticUpdateSource = hostDiagnosticUpdateSource;
-            _externalErrorReporterMap = new Dictionary<ProjectId, IVsReportExternalErrors>();
         }
 
         // internal for testing purposes only.
@@ -89,23 +87,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
 
         private IVsReportExternalErrors GetExternalErrorReporter(ProjectId projectId, string languageName)
         {
-            lock (_externalErrorReporterMap)
+            string errorCodePrefix;
+            if (!_projectLangaugeToErrorCodePrefixMap.TryGetValue(languageName, out errorCodePrefix))
             {
-                IVsReportExternalErrors errorReporter;
-                if (!_externalErrorReporterMap.TryGetValue(projectId, out errorReporter))
-                {
-                    string errorCodePrefix;
-                    if (!_projectLangaugeToErrorCodePrefixMap.TryGetValue(languageName, out errorCodePrefix))
-                    {
-                        throw new NotSupportedException(nameof(languageName));
-                    }
-
-                    errorReporter = new ProjectExternalErrorReporter(projectId, errorCodePrefix, _serviceProvider);
-                    _externalErrorReporterMap.Add(projectId, errorReporter);
-                }
-
-                return errorReporter;
+                throw new NotSupportedException(nameof(languageName));
             }
+
+            return new ProjectExternalErrorReporter(projectId, errorCodePrefix, _serviceProvider);
         }
     }
 }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -53,11 +53,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
         {
             get
             {
-                return _lastDesignTimeBuildSucceeded;
+                return LastDesignTimeBuildSucceeded;
             }
             set
             {
-                _lastDesignTimeBuildSucceeded = value;
+                SetIntellisenseBuildResultAndNotifyWorkspaceHosts(value);
             }
         }
 

--- a/src/VisualStudio/Core/Test/ProjectSystemShim/Framework/TestEnvironment.vb
+++ b/src/VisualStudio/Core/Test/ProjectSystemShim/Framework/TestEnvironment.vb
@@ -250,7 +250,7 @@ Namespace Microsoft.VisualStudio.LanguageServices.UnitTests.ProjectSystemShim.Fr
             End Sub
 
             Public Sub OnHasAllInformation(projectId As ProjectId, hasAllInformation As Boolean) Implements IVisualStudioWorkspaceHost2.OnHasAllInformation
-                Throw New NotImplementedException()
+                _workspace.OnHasAllInformationChanged(projectId, hasAllInformation)
             End Sub
 
             Public Sub OnMetadataReferenceAdded(projectId As ProjectId, metadataReference As PortableExecutableReference) Implements IVisualStudioWorkspaceHost.OnMetadataReferenceAdded


### PR DESCRIPTION
1. Make sure that we notify the workspace hosts when IWorkspaceProjectContext.LastDesignTimeBuildSucceeded is updated.
Fixes #14306

2. Ensure that we create an external error reporter per-project ID in the CPSProjectFactory.
Fixes #14329