### PR TITLE
Avoid calling ReportErrors concurrently from multiple threads

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
             else
             {
-                Debug.Assert(!diagnosticBag.HasAnyErrors());
+                Debug.Assert(diagnosticBag.IsEmptyWithoutResolution);
                 diagnosticBag.Free();
             }
 

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var sourceFiles = Arguments.SourceFiles;
             var trees = new SyntaxTree[sourceFiles.Length];
-            var normalizedFilePaths = new String[sourceFiles.Length];
+            var normalizedFilePaths = new string[sourceFiles.Length];
             var diagnosticBag = DiagnosticBag.GetInstance();
 
             if (Arguments.CompilationOptions.ConcurrentBuild)
@@ -66,11 +66,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // If errors had been reported in ParseFile, while trying to read files, then we should simply exit.
             if (hadErrors)
             {
+                Debug.Assert(diagnosticBag.HasAnyErrors());
                 ReportErrors(diagnosticBag.ToReadOnlyAndFree(), consoleOutput, errorLogger);
                 return null;
             }
             else
             {
+                Debug.Assert(!diagnosticBag.HasAnyErrors());
                 diagnosticBag.Free();
             }
 
@@ -152,7 +154,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         private SyntaxTree ParseFile(
             CSharpParseOptions parseOptions,
             CSharpParseOptions scriptParseOptions,
-            ref bool hadErrors,
+            ref bool addedDiagnostics,
             CommandLineSourceFile file,
             DiagnosticBag diagnostics,
             out string normalizedFilePath)
@@ -167,11 +169,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                     diagnostics.Add(MessageProvider.CreateDiagnostic(info));
                 }
                 fileDiagnostics.Clear();
-                hadErrors = true;
+                addedDiagnostics = true;
                 return null;
             }
             else
             {
+                Debug.Assert(fileDiagnostics.Count == 0);
                 return ParseFile(parseOptions, scriptParseOptions, content, file);
             }
         }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineTests.cs
@@ -7258,8 +7258,7 @@ public class C { }
             // Multiple duplicates
             commandLineArgs = new[] { "a.cs", "a.cs", "a.cs" };
             // warning CS2002: Source file 'a.cs' specified multiple times
-            // warning CS2002: Source file 'a.cs' specified multiple times
-            var warnings = new[] { aWrnString, aWrnString };
+            var warnings = new[] { aWrnString };
             TestCS2002(commandLineArgs, tempDir.Path, 0, warnings);
 
             // Case-insensitive

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -162,11 +162,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             consoleOutput.WriteLine()
         End Sub
 
-        Protected Overrides Sub PrintError(Diagnostic As DiagnosticInfo, consoleOutput As TextWriter)
-            consoleOutput.Write(VisualBasicCompiler.VbcCommandLinePrefix)
-            consoleOutput.WriteLine(Diagnostic.ToString(Culture))
-        End Sub
-
         Friend Overrides Function SuppressDefaultResponseFile(args As IEnumerable(Of String)) As Boolean
             For Each arg In args
                 Select Case arg.ToLowerInvariant


### PR DESCRIPTION
ReportErrors is not safe to call from multiple threads.

Fixes #12550.