### PR TITLE
Add blanket exception handling in DesktopStrongNameProvider

### DIFF
--- a/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
@@ -43,7 +43,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                 _underlyingProvider.SignAssembly(keys, inputStream, outputStream);
         }
 
-        private class TestDesktopSnProvider : DesktopStrongNameProvider
+        private class TestDesktopStrongNameProvider : DesktopStrongNameProvider
         {
             private readonly Func<string, byte[]> m_readAllBytes;
 
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             private readonly ReadKeysFromContainerDelegate m_readKeysFromContainer;
 
-            public TestDesktopSnProvider(
+            public TestDesktopStrongNameProvider(
                 Func<string, byte[]> readAllBytes = null,
                 ReadKeysFromContainerDelegate readKeysFromContainer = null)
             {
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void ExceptionInReadAllBytes()
         {
             var ex = new Exception("Crazy exception you could never have predicted!");
-            var provider = new TestDesktopSnProvider((_) =>
+            var provider = new TestDesktopStrongNameProvider((_) =>
             {
                 throw ex;
             });
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void ExceptionInReadKeysFromContainer()
         {
             var ex = new Exception("Crazy exception you could never have predicted!");
-            var provider = new TestDesktopSnProvider(readKeysFromContainer:
+            var provider = new TestDesktopStrongNameProvider(readKeysFromContainer:
                 (string _1, out ImmutableArray<byte> _2) =>
             {
                 throw ex;

--- a/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/EmitTestStrongNameProvider.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Roslyn.Test.Utilities;
 using System;
+using System.Collections.Immutable;
 using System.IO;
 using Xunit;
 
@@ -39,6 +41,84 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             internal override void SignAssembly(StrongNameKeys keys, Stream inputStream, Stream outputStream) =>
                 _underlyingProvider.SignAssembly(keys, inputStream, outputStream);
+        }
+
+        private class TestDesktopSnProvider : DesktopStrongNameProvider
+        {
+            private readonly Func<string, byte[]> m_readAllBytes;
+
+            internal delegate void ReadKeysFromContainerDelegate(
+                string keyContainer,
+                out ImmutableArray<byte> publicKey);
+
+            private readonly ReadKeysFromContainerDelegate m_readKeysFromContainer;
+
+            public TestDesktopSnProvider(
+                Func<string, byte[]> readAllBytes = null,
+                ReadKeysFromContainerDelegate readKeysFromContainer = null)
+            {
+                m_readAllBytes = readAllBytes;
+                m_readKeysFromContainer = readKeysFromContainer;
+            }
+
+            internal override byte[] ReadAllBytes(string fullPath) =>
+                m_readAllBytes != null ? m_readAllBytes(fullPath)
+                                       : base.ReadAllBytes(fullPath);
+
+            internal override void ReadKeysFromContainer(string keyContainer, out ImmutableArray<byte> publicKey)
+            {
+                if (m_readKeysFromContainer != null)
+                {
+                    m_readKeysFromContainer(keyContainer, out publicKey);
+                }
+                else
+                {
+                    base.ReadKeysFromContainer(keyContainer, out publicKey);
+                }
+            }
+        }
+
+        [Fact]
+        [WorkItem(209695, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=209694")]
+        public void ExceptionInReadAllBytes()
+        {
+            var ex = new Exception("Crazy exception you could never have predicted!");
+            var provider = new TestDesktopSnProvider((_) =>
+            {
+                throw ex;
+            });
+
+            var src = @"class C {}";
+            var keyFile = Temp.CreateFile().WriteAllBytes(TestResources.General.snKey).Path;
+            var options = TestOptions.DebugDll
+                .WithStrongNameProvider(provider)
+                .WithCryptoKeyFile(keyFile);
+
+            var comp = CreateCompilationWithMscorlib(src, options: options);
+            comp.VerifyEmitDiagnostics(
+                // error CS7027: Error signing output with public key from file '{0}' -- '{1}'
+                Diagnostic(ErrorCode.ERR_PublicKeyFileFailure).WithArguments(keyFile, ex.Message).WithLocation(1, 1));
+        }
+
+        [Fact]
+        public void ExceptionInReadKeysFromContainer()
+        {
+            var ex = new Exception("Crazy exception you could never have predicted!");
+            var provider = new TestDesktopSnProvider(readKeysFromContainer:
+                (string _1, out ImmutableArray<byte> _2) =>
+            {
+                throw ex;
+            });
+
+            var src = @"class C {}";
+            var options = TestOptions.DebugDll
+                .WithStrongNameProvider(provider)
+                .WithCryptoKeyContainer("RoslynTestContainer");
+
+            var comp = CreateCompilationWithMscorlib(src, options: options);
+            comp.VerifyEmitDiagnostics(
+                // error CS7028: Error signing output with public key from container 'RoslynTestContainer' -- Crazy exception you could never have predicted!
+                Diagnostic(ErrorCode.ERR_PublicKeyContainerFailure).WithArguments("RoslynTestContainer", ex.Message).WithLocation(1, 1));
         }
 
         [Fact]

--- a/src/Compilers/Core/Portable/StrongName/DesktopStrongNameProvider.cs
+++ b/src/Compilers/Core/Portable/StrongName/DesktopStrongNameProvider.cs
@@ -213,7 +213,7 @@ namespace Microsoft.CodeAnalysis
                     var fileContent = ImmutableArray.Create(ReadAllBytes(resolvedKeyFile));
                     return StrongNameKeys.CreateHelper(fileContent, keyFilePath);
                 }
-                catch (IOException ex)
+                catch (Exception ex)
                 {
                     return new StrongNameKeys(StrongNameKeys.GetKeyFileError(messageProvider, keyFilePath, ex.Message));
                 }
@@ -232,7 +232,7 @@ namespace Microsoft.CodeAnalysis
                     return new StrongNameKeys(StrongNameKeys.GetContainerError(messageProvider, keyContainerName,
                         new CodeAnalysisResourcesLocalizableErrorArgument(nameof(CodeAnalysisResources.AssemblySigningNotSupported))));
                 }
-                catch (IOException ex)
+                catch (Exception ex)
                 {
                     return new StrongNameKeys(StrongNameKeys.GetContainerError(messageProvider, keyContainerName, ex.Message));
                 }
@@ -241,7 +241,7 @@ namespace Microsoft.CodeAnalysis
             return new StrongNameKeys(keyPair, publicKey, container, keyFilePath);
         }
 
-        private void ReadKeysFromContainer(string keyContainer, out ImmutableArray<byte> publicKey)
+        internal virtual void ReadKeysFromContainer(string keyContainer, out ImmutableArray<byte> publicKey)
         {
             try
             {


### PR DESCRIPTION
/cc @jaredpar @dotnet/roslyn-compiler 