### PR TITLE
Enable speculating on expressions with expression variables

### DIFF
--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -214,8 +214,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binder = new TypeofBinder(expression, binder);
             }
 
-            // May be binding an expression in a context that doesn't have a LocalScopeBinder in the chain.
-            return new ExpressionVariableBinder(expression, binder);
+            return new ExecutableCodeBinder(expression, binder.ContainingMemberOrLambda, binder).GetBinder(expression);
         }
 
         private Binder GetSpeculativeBinderForAttribute(int position, AttributeSyntax attribute)
@@ -228,8 +227,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            // May be binding an expression in a context that doesn't have a LocalScopeBinder in the chain.
-            return new ExpressionVariableBinder(attribute, binder);
+            return new ExecutableCodeBinder(attribute, binder.ContainingMemberOrLambda, binder).GetBinder(attribute);
         }
 
         private static BoundExpression GetSpeculativelyBoundExpressionHelper(Binder binder, ExpressionSyntax expression, SpeculativeBindingOption bindingOption, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpSemanticModel.cs
@@ -215,10 +215,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // May be binding an expression in a context that doesn't have a LocalScopeBinder in the chain.
-            return new LocalScopeBinder(binder);
+            return new ExpressionVariableBinder(expression, binder);
         }
 
-        private Binder GetSpeculativeBinderForAttribute(int position)
+        private Binder GetSpeculativeBinderForAttribute(int position, AttributeSyntax attribute)
         {
             position = CheckAndAdjustPositionForSpeculativeAttribute(position);
 
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // May be binding an expression in a context that doesn't have a LocalScopeBinder in the chain.
-            return new LocalScopeBinder(binder);
+            return new ExpressionVariableBinder(attribute, binder);
         }
 
         private static BoundExpression GetSpeculativelyBoundExpressionHelper(Binder binder, ExpressionSyntax expression, SpeculativeBindingOption bindingOption, DiagnosticBag diagnostics)
@@ -396,7 +396,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 throw new ArgumentNullException(nameof(attribute));
             }
 
-            binder = this.GetSpeculativeBinderForAttribute(position);
+            binder = this.GetSpeculativeBinderForAttribute(position, attribute);
             if (binder == null)
             {
                 return null;
@@ -2393,7 +2393,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             CheckModelAndSyntaxNodeToSpeculate(attribute);
 
-            var binder = GetSpeculativeBinderForAttribute(position);
+            var binder = GetSpeculativeBinderForAttribute(position, attribute);
             if (binder == null)
             {
                 speculativeModel = null;

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -1550,7 +1550,7 @@ class C
             Assert.Equal(SymbolKind.Local, info2.Symbol.Kind);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8778")]
+        [Fact]
         public void TestGetSpeculativeSemanticModelForStatement_DeclaredLocal()
         {
             var compilation = CreateCompilationWithMscorlib(@"
@@ -1558,7 +1558,7 @@ class C
 {
   void M(int x)
   {
-    int y = 1000;     
+    int y = 1000;
   }
 }
 ");
@@ -1980,7 +1980,7 @@ class C
             Assert.Throws<InvalidOperationException>(() => speculativeModel.TryGetSpeculativeSemanticModel(speculatedStatement.SpanStart, newSpeculatedStatement, out newModel));
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/8778")]
+        [Fact]
         public void TestGetSpeculativeSemanticModelInsideUnsafeCode()
         {
             var compilation = CreateCompilationWithMscorlib(@"
@@ -3052,7 +3052,7 @@ class C
         }
 
         [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
         public void SpeculateWithExpressionVariables_out3()
         {
             var source = @"
@@ -3080,6 +3080,48 @@ class C
             var position = source.IndexOf("TakesOut", StringComparison.Ordinal);
             var statementSyntax = SyntaxFactory.ParseExpression("TakesOut(out int x)");
             var info2 = model.GetSpeculativeSymbolInfo(position, statementSyntax, SpeculativeBindingOption.BindAsExpression);
+            Assert.NotNull(info2.Symbol);
+
+            Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
+        [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
+        public void SpeculateWithExpressionVariables_out4()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        int y;
+        TakesOut(out y);
+    }
+    void TakesOut(out int y) { y = 0; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var method1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info1 = model.GetSymbolInfo(method1);
+            Assert.NotNull(info1.Symbol);
+
+            var position = source.IndexOf("TakesOut", StringComparison.Ordinal);
+            var statementSyntax = SyntaxFactory.ParseStatement("{ TakesOut(out int x); }");
+            statementSyntax = ((BlockSyntax)statementSyntax).Statements[0];
+
+            SemanticModel speculativeModel;
+            var success = model.TryGetSpeculativeSemanticModel(position, statementSyntax, out speculativeModel);
+            Assert.True(success);
+            Assert.NotNull(speculativeModel);
+
+            var method2 = statementSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info2 = speculativeModel.GetSymbolInfo(method2);
             Assert.NotNull(info2.Symbol);
 
             Assert.Equal(info1.Symbol, info2.Symbol);
@@ -3168,7 +3210,7 @@ class C
         }
 
         [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
         public void SpeculateWithExpressionVariables_pattern3()
         {
             var source = @"
@@ -3199,6 +3241,55 @@ class C
             Assert.NotNull(info2.Symbol);
 
             Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
+        [Fact]
+        public void BindSpeculativeAttributeWithExpressionVariable_1()
+        {
+            new ObsoleteAttribute("foo");
+
+            var source =
+@"using System;
+class C { }";
+            var compilation = CreateCompilationWithMscorlib(source);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var position = tree.GetText().ToString().IndexOf("class C {", StringComparison.Ordinal);
+            var attr2 = ParseAttributeSyntax("[ObsoleteAttribute(string.Empty is string s ? s : string.Empty)]");
+
+            var symbolInfo = model.GetSpeculativeSymbolInfo(position, attr2);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+            Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
+        [Fact]
+        public void BindSpeculativeAttributeWithExpressionVariable_2()
+        {
+            new ObsoleteAttribute("foo");
+
+            var source =
+@"using System;
+class C { }";
+            var compilation = CreateCompilationWithMscorlib(source);
+
+            var tree = compilation.SyntaxTrees.Single();
+            var model = compilation.GetSemanticModel(tree);
+
+            var position = tree.GetText().ToString().IndexOf("class C {", StringComparison.Ordinal);
+            var attr2 = ParseAttributeSyntax("[ObsoleteAttribute(string.Empty is string s ? s : string.Empty)]");
+            SemanticModel model2;
+            model.TryGetSpeculativeSemanticModel(position, attr2, out model2);
+
+            var symbolInfo = model2.GetSymbolInfo(attr2);
+            Assert.Equal(CandidateReason.None, symbolInfo.CandidateReason);
+            Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
+        }
+
+        private AttributeSyntax ParseAttributeSyntax(string source)
+        {
+            return SyntaxFactory.ParseCompilationUnit(source + " class X {}").Members.First().AsTypeDeclarationSyntax().AttributeLists.First().Attributes.First();
         }
 
         [WorkItem(784255, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/784255")]

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelAPITests.cs
@@ -2969,6 +2969,170 @@ class C
             Assert.Equal(0, info.CandidateSymbols.Length);
         }
 
+        [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
+        public void SpeculateWithExpressionVariables_out()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        int x;
+        TakesOut(out x);
+    }
+    void TakesOut(out int x) { x = 0; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var method1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info1 = model.GetSymbolInfo(method1);
+            Assert.NotNull(info1.Symbol);
+
+            var position = source.IndexOf("TakesOut", StringComparison.Ordinal);
+            var statementSyntax = SyntaxFactory.ParseStatement("TakesOut(out int x);");
+
+            SemanticModel speculativeModel;
+            var success = model.TryGetSpeculativeSemanticModel(position, statementSyntax, out speculativeModel);
+            Assert.True(success);
+            Assert.NotNull(speculativeModel);
+
+            var method2 = statementSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info2 = speculativeModel.GetSymbolInfo(method2);
+            Assert.NotNull(info2.Symbol);
+
+            Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
+        [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
+        public void SpeculateWithExpressionVariables_out2()
+        {
+            var source = @"
+class C
+{
+    void M()
+    {
+        int y;
+        TakesOut(out y);
+    }
+    void TakesOut(out int y) { y = 0; }
+}
+";
+
+            var comp = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var method1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info1 = model.GetSymbolInfo(method1);
+            Assert.NotNull(info1.Symbol);
+
+            var position = source.IndexOf("TakesOut", StringComparison.Ordinal);
+            var statementSyntax = SyntaxFactory.ParseStatement("TakesOut(out int x);");
+
+            SemanticModel speculativeModel;
+            var success = model.TryGetSpeculativeSemanticModel(position, statementSyntax, out speculativeModel);
+            Assert.True(success);
+            Assert.NotNull(speculativeModel);
+
+            var method2 = statementSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info2 = speculativeModel.GetSymbolInfo(method2);
+            Assert.NotNull(info2.Symbol);
+
+            Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
+        [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
+        public void SpeculateWithExpressionVariables_pattern()
+        {
+            var source = @"
+class C
+{
+    void M(object o)
+    {
+        Method(o is string);
+        string s = o as string;
+    }
+    bool Method(bool b) => b;
+}
+";
+
+            var comp = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var method1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info1 = model.GetSymbolInfo(method1);
+            Assert.NotNull(info1.Symbol);
+
+            var position = source.IndexOf("Method", StringComparison.Ordinal);
+            var statementSyntax = SyntaxFactory.ParseStatement("Method(o is string s);");
+
+            SemanticModel speculativeModel;
+            var success = model.TryGetSpeculativeSemanticModel(position, statementSyntax, out speculativeModel);
+            Assert.True(success);
+            Assert.NotNull(speculativeModel);
+
+            var method2 = statementSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info2 = speculativeModel.GetSymbolInfo(method2);
+            Assert.NotNull(info2.Symbol);
+
+            Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
+        [WorkItem(14384, "https://github.com/dotnet/roslyn/issues/14384")]
+        [Fact]
+        public void SpeculateWithExpressionVariables_pattern2()
+        {
+            var source = @"
+class C
+{
+    void M(object o)
+    {
+        Method(o is string);
+        string s2 = o as string;
+    }
+    bool Method(bool b) => b;
+}
+";
+
+            var comp = CreateCompilationWithMscorlibAndDocumentationComments(source);
+            comp.VerifyDiagnostics();
+
+            var tree = comp.SyntaxTrees.Single();
+            var model = comp.GetSemanticModel(tree);
+
+            var method1 = tree.GetRoot().DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info1 = model.GetSymbolInfo(method1);
+            Assert.NotNull(info1.Symbol);
+
+            var position = source.IndexOf("Method", StringComparison.Ordinal);
+            var statementSyntax = SyntaxFactory.ParseStatement("Method(o is string s);");
+
+            SemanticModel speculativeModel;
+            var success = model.TryGetSpeculativeSemanticModel(position, statementSyntax, out speculativeModel);
+            Assert.True(success);
+            Assert.NotNull(speculativeModel);
+
+            var method2 = statementSyntax.DescendantNodes().OfType<InvocationExpressionSyntax>().Single().Expression;
+            var info2 = speculativeModel.GetSymbolInfo(method2);
+            Assert.NotNull(info2.Symbol);
+
+            Assert.Equal(info1.Symbol, info2.Symbol);
+        }
+
         [WorkItem(784255, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/784255")]
         [Fact]
         public void Repro784255()

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetDeclaredSymbolAPITests.cs
@@ -4045,8 +4045,8 @@ class M {
             Assert.Equal("B=System.Console", semanticInfoExpression.Alias.ToTestDisplayString());
         }
 
-        // Bind an attribute. No such API, so use a bit of a workaround.
-        private AttributeSyntax BindAttributeSyntax(string source)
+        // Parse an attribute. No such API, so use a bit of a workaround.
+        private AttributeSyntax ParseAttributeSyntax(string source)
         {
             return SyntaxFactory.ParseCompilationUnit(source + " class X {}").Members.First().AsTypeDeclarationSyntax().AttributeLists.First().Attributes.First();
         }
@@ -4112,7 +4112,7 @@ class C {
             var model = compilation.GetSemanticModel(tree);
 
             var position = tree.GetText().ToString().IndexOf("class C {", StringComparison.Ordinal);
-            var attr1 = BindAttributeSyntax("[Obsolete]");
+            var attr1 = ParseAttributeSyntax("[Obsolete]");
 
             var symbolInfo = model.GetSpeculativeSymbolInfo(position, attr1);
             Assert.NotNull(symbolInfo.Symbol);
@@ -4120,7 +4120,7 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr2 = BindAttributeSyntax("[ObsoleteAttribute(4)]");
+            var attr2 = ParseAttributeSyntax("[ObsoleteAttribute(4)]");
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr2);
             Assert.Null(symbolInfo.Symbol);
@@ -4130,7 +4130,7 @@ class C {
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.CandidateSymbols[1].ToTestDisplayString());
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message, System.Boolean error)", symbolInfo.CandidateSymbols[2].ToTestDisplayString());
 
-            var attr3 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr3 = ParseAttributeSyntax(@"[O(""hello"")]");
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr3);
             Assert.NotNull(symbolInfo.Symbol);
@@ -4138,14 +4138,14 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr4 = BindAttributeSyntax("[P]");
+            var attr4 = ParseAttributeSyntax("[P]");
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr4);
             Assert.Null(symbolInfo.Symbol);
             Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
 
-            var attr5 = BindAttributeSyntax("[D]");
+            var attr5 = ParseAttributeSyntax("[D]");
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position, attr5);
             Assert.NotNull(symbolInfo.Symbol);
@@ -4153,7 +4153,7 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("C.DAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr6 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr6 = ParseAttributeSyntax(@"[O(""hello"")]");
             var position2 = tree.GetText().ToString().IndexOf("C foo<O>", StringComparison.Ordinal);
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position2, attr6);
@@ -4162,7 +4162,7 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor(System.String message)", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr7 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr7 = ParseAttributeSyntax(@"[O(""hello"")]");
             var position3 = tree.GetText().ToString().IndexOf("Serializable", StringComparison.Ordinal);
 
             symbolInfo = model.GetSpeculativeSymbolInfo(position3, attr7);
@@ -4191,7 +4191,7 @@ class C {
 
             var position = tree.GetText().ToString().IndexOf("class C {", StringComparison.Ordinal);
 
-            var attr1 = BindAttributeSyntax("[Obsolete]");
+            var attr1 = ParseAttributeSyntax("[Obsolete]");
 
             SemanticModel speculativeModel;
             var success = parentModel.TryGetSpeculativeSemanticModel(position, attr1, out speculativeModel);
@@ -4204,7 +4204,7 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("System.ObsoleteAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr2 = BindAttributeSyntax("[ObsoleteAttribute(4)]");
+            var attr2 = ParseAttributeSyntax("[ObsoleteAttribute(4)]");
             success = parentModel.TryGetSpeculativeSemanticModel(position, attr2, out speculativeModel);
             Assert.True(success);
             Assert.NotNull(speculativeModel);
@@ -4221,7 +4221,7 @@ class C {
             Assert.True(constantInfo.HasValue, "must be constant");
             Assert.Equal(4, constantInfo.Value);
 
-            var attr3 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr3 = ParseAttributeSyntax(@"[O(""hello"")]");
 
             success = parentModel.TryGetSpeculativeSemanticModel(position, attr3, out speculativeModel);
             Assert.True(success);
@@ -4242,7 +4242,7 @@ class C {
             Assert.NotNull(aliasSymbol.Target);
             Assert.Equal("ObsoleteAttribute", aliasSymbol.Target.Name);
 
-            var attr4 = BindAttributeSyntax("[P]");
+            var attr4 = ParseAttributeSyntax("[P]");
 
             success = parentModel.TryGetSpeculativeSemanticModel(position, attr4, out speculativeModel);
             Assert.True(success);
@@ -4253,7 +4253,7 @@ class C {
             Assert.Equal(symbolInfo.CandidateReason, CandidateReason.None);
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
 
-            var attr5 = BindAttributeSyntax("[D]");
+            var attr5 = ParseAttributeSyntax("[D]");
 
             success = parentModel.TryGetSpeculativeSemanticModel(position, attr5, out speculativeModel);
             Assert.True(success);
@@ -4265,7 +4265,7 @@ class C {
             Assert.Equal(0, symbolInfo.CandidateSymbols.Length);
             Assert.Equal("C.DAttribute..ctor()", symbolInfo.Symbol.ToTestDisplayString());
 
-            var attr6 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr6 = ParseAttributeSyntax(@"[O(""hello"")]");
             var position2 = tree.GetText().ToString().IndexOf("C foo<O>", StringComparison.Ordinal);
 
             success = parentModel.TryGetSpeculativeSemanticModel(position, attr6, out speculativeModel);
@@ -4288,7 +4288,7 @@ class C {
             Assert.NotNull(aliasSymbol.Target);
             Assert.Equal("ObsoleteAttribute", aliasSymbol.Target.Name);
 
-            var attr7 = BindAttributeSyntax(@"[O(""hello"")]");
+            var attr7 = ParseAttributeSyntax(@"[O(""hello"")]");
             var position3 = tree.GetText().ToString().IndexOf("Serializable", StringComparison.Ordinal);
 
             success = parentModel.TryGetSpeculativeSemanticModel(position3, attr7, out speculativeModel);

--- a/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Compilation/SemanticModelGetSemanticInfoTests.cs
@@ -3837,7 +3837,7 @@ class D {
 
             Assert.Null(semanticInfo.Symbol);
 
-            // Should bind to "field" with a candidateReason (not a typeornamespace>)Skip:
+            // Should bind to "field" with a candidateReason (not a typeornamespace>)
             Assert.NotEqual(CandidateReason.None, semanticInfo.CandidateReason);
             Assert.NotEqual(0, semanticInfo.CandidateSymbols.Length);
 


### PR DESCRIPTION
Fixes #14384 

@dotnet/roslyn-compiler Please review.