### PR TITLE
Handle TMP correctly in compiler server

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -22,10 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
 
-        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, string clientDirectory, string baseDirectory, string sdkDirectoryOpt, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
-            : base(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectoryOpt, additionalReferenceDirectories, assemblyLoader)
+        protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+            : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader)
         {
-            _diagnosticFormatter = new CommandLineDiagnosticFormatter(baseDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
+            _diagnosticFormatter = new CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
         }
 
         public override DiagnosticFormatter DiagnosticFormatter { get { return _diagnosticFormatter; } }

--- a/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CSharpCompiler.cs
@@ -21,11 +21,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal const string ResponseFileName = "csc.rsp";
 
         private readonly CommandLineDiagnosticFormatter _diagnosticFormatter;
+        private readonly string _tempDirectory;
 
         protected CSharpCompiler(CSharpCommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
             : base(parser, responseFile, args, buildPaths, additionalReferenceDirectories, assemblyLoader)
         {
             _diagnosticFormatter = new CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, Arguments.PrintFullPaths, Arguments.ShouldIncludeErrorEndLocation);
+            _tempDirectory = buildPaths.TempDirectory;
         }
 
         public override DiagnosticFormatter DiagnosticFormatter { get { return _diagnosticFormatter; } }
@@ -135,7 +137,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return null;
             }
 
-            var strongNameProvider = new LoggingStrongNameProvider(Arguments.KeyFileSearchPaths, touchedFilesLogger);
+            var strongNameProvider = new LoggingStrongNameProvider(Arguments.KeyFileSearchPaths, touchedFilesLogger, _tempDirectory);
 
             var compilation = CSharpCompilation.Create(
                 Arguments.CompilationName,

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -217,7 +217,7 @@ public class C { }").Path;
                 var cmd = new CSharpCompilerServer(
                     DesktopCompilerServerHost.SharedAssemblyReferenceProvider,
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
-                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory()),
+                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
                     s_libDirectory,
                     new TestAnalyzerAssemblyLoader());
 

--- a/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/TouchedFileLoggingTests.cs
@@ -217,9 +217,7 @@ public class C { }").Path;
                 var cmd = new CSharpCompilerServer(
                     DesktopCompilerServerHost.SharedAssemblyReferenceProvider,
                     new[] { "/nologo", "/touchedfiles:" + touchedBase, source1 },
-                    null,
-                    _baseDirectory,
-                    RuntimeEnvironment.GetRuntimeDirectory(),
+                    new BuildPaths(null, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory()),
                     s_libDirectory,
                     new TestAnalyzerAssemblyLoader());
 

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Attributes\AttributeTests_Synthesized.cs" />
     <Compile Include="Attributes\AttributeTests_Tuples.cs" />
     <Compile Include="Attributes\AttributeTests_WellKnownAttributes.cs" />
+    <Compile Include="Emit\DesktopStrongNameProviderTests.cs" />
     <Compile Include="Attributes\InternalsVisibleToAndStrongNameTests.cs" />
     <Compile Include="Attributes\WellKnownAttributesTestBase.cs" />
     <Compile Include="BreakingChanges.cs" />

--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -17,18 +17,21 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void RespectCustomTempPath()
         {
             var tempDir = Temp.CreateDirectory();
-            Directory.CreateDirectory(tempDir.Path);
             var provider = new DesktopStrongNameProvider(tempPath: tempDir.Path);
-            var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream();
-            Assert.Equal(tempDir.Path, Path.GetDirectoryName(stream.Path));
+            using (var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream())
+            {
+                Assert.Equal(tempDir.Path, Path.GetDirectoryName(stream.Path));
+            }
         }
 
         [Fact]
         public void RespectDefaultTempPath()
         {
             var provider = new DesktopStrongNameProvider(tempPath: null);
-            var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream();
-            Assert.Equal(Path.GetTempPath(), Path.GetDirectoryName(stream.Path) + @"\");
+            using (var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream())
+            {
+                Assert.Equal(Path.GetTempPath(), Path.GetDirectoryName(stream.Path) + @"\");
+            }
         }
 
         [Fact]
@@ -40,14 +43,13 @@ class C
     public static void Main(string[] args) { }
 }";
             var tempDir = Temp.CreateDirectory();
-            Directory.CreateDirectory(tempDir.Path);
             var provider = new VirtualizedStrongNameProvider(tempPath: tempDir.Path);
             var options = TestOptions
                 .DebugExe
                 .WithStrongNameProvider(provider)
                 .WithCryptoKeyFile(SigningTestHelpers.KeyPairFile);
             var comp = CreateCompilationWithMscorlib(src, options: options);
-            comp.Emit(new MemoryStream()).Diagnostics.Verify();
+            comp.VerifyEmitDiagnostics();
         }
 
         [Fact]
@@ -64,7 +66,7 @@ class C
                 .WithStrongNameProvider(provider)
                 .WithCryptoKeyFile(SigningTestHelpers.KeyPairFile);
             var comp = CreateCompilationWithMscorlib(src, options: options);
-            comp.Emit(new MemoryStream()).Diagnostics.Verify();
+            comp.VerifyEmitDiagnostics();
         }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DesktopStrongNameProviderTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using System;
+using System.IO;
+using Xunit;
+using static Roslyn.Test.Utilities.SigningTestHelpers;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests
+{
+    public partial class DesktopStrongNameProviderTests : CSharpTestBase
+    {
+        [WorkItem(13995, "https://github.com/dotnet/roslyn/issues/13995")]
+        [Fact]
+        public void RespectCustomTempPath()
+        {
+            var tempDir = Temp.CreateDirectory();
+            Directory.CreateDirectory(tempDir.Path);
+            var provider = new DesktopStrongNameProvider(tempPath: tempDir.Path);
+            var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream();
+            Assert.Equal(tempDir.Path, Path.GetDirectoryName(stream.Path));
+        }
+
+        [Fact]
+        public void RespectDefaultTempPath()
+        {
+            var provider = new DesktopStrongNameProvider(tempPath: null);
+            var stream = (DesktopStrongNameProvider.TempFileStream)provider.CreateInputStream();
+            Assert.Equal(Path.GetTempPath(), Path.GetDirectoryName(stream.Path) + @"\");
+        }
+
+        [Fact]
+        public void EmitWithCustomTempPath()
+        {
+            string src = @"
+class C
+{
+    public static void Main(string[] args) { }
+}";
+            var tempDir = Temp.CreateDirectory();
+            Directory.CreateDirectory(tempDir.Path);
+            var provider = new VirtualizedStrongNameProvider(tempPath: tempDir.Path);
+            var options = TestOptions
+                .DebugExe
+                .WithStrongNameProvider(provider)
+                .WithCryptoKeyFile(SigningTestHelpers.KeyPairFile);
+            var comp = CreateCompilationWithMscorlib(src, options: options);
+            comp.Emit(new MemoryStream()).Diagnostics.Verify();
+        }
+
+        [Fact]
+        public void EmitWithDefaultTempPath()
+        {
+            string src = @"
+class C
+{
+    public static void Main(string[] args) { }
+}";
+            var provider = new VirtualizedStrongNameProvider(tempPath: null);
+            var options = TestOptions
+                .DebugExe
+                .WithStrongNameProvider(provider)
+                .WithCryptoKeyFile(SigningTestHelpers.KeyPairFile);
+            var comp = CreateCompilationWithMscorlib(src, options: options);
+            comp.Emit(new MemoryStream()).Diagnostics.Verify();
+        }
+    }
+}

--- a/src/Compilers/CSharp/csc/Program.cs
+++ b/src/Compilers/CSharp/csc/Program.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
         public static int Main(string[] args, string[] extraArgs)
             => DesktopBuildClient.Run(args, extraArgs, RequestLanguage.CSharpCompile, Csc.Run, new DesktopAnalyzerAssemblyLoader());
 
-        public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
-            => Csc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir), textWriter, analyzerLoader);
+        public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
+            => Csc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir), textWriter, analyzerLoader);
     }
 }

--- a/src/Compilers/Core/CommandLine/BuildClient.cs
+++ b/src/Compilers/Core/CommandLine/BuildClient.cs
@@ -16,32 +16,6 @@ namespace Microsoft.CodeAnalysis.CommandLine
 {
     internal delegate int CompileFunc(string[] arguments, BuildPaths buildPaths, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerAssemblyLoader);
 
-    internal struct BuildPaths
-    {
-        /// <summary>
-        /// The path which containts the compiler binaries and response files.
-        /// </summary>
-        internal string ClientDirectory { get; }
-
-        /// <summary>
-        /// The path in which the compilation takes place.
-        /// </summary>
-        internal string WorkingDirectory { get; }
-
-        /// <summary>
-        /// The path which contains mscorlib.  This can be null when specified by the user or running in a 
-        /// CoreClr environment.
-        /// </summary>
-        internal string SdkDirectory { get; }
-
-        internal BuildPaths(string clientDir, string workingDir, string sdkDir)
-        {
-            ClientDirectory = clientDir;
-            WorkingDirectory = workingDir;
-            SdkDirectory = sdkDir;
-        }
-    }
-
     internal struct RunCompilationResult
     {
         internal static readonly RunCompilationResult Succeeded = new RunCompilationResult(CommonCompiler.Succeeded);

--- a/src/Compilers/Core/CommandLine/BuildClient.cs
+++ b/src/Compilers/Core/CommandLine/BuildClient.cs
@@ -207,5 +207,46 @@ namespace Microsoft.CodeAnalysis.CommandLine
             // The first argument will be the executable name hence we skip it. 
             return CommandLineParser.SplitCommandLineIntoArguments(commandLine, removeHashComments: false).Skip(1);
         }
+
+        /// <summary>
+        /// Gets the value of the temporary path for the current environment assuming the working directory
+        /// is <paramref name="workingDir"/>.  This function must emulate <see cref="Path.GetTempPath"/> as 
+        /// closely as possible.
+        /// </summary>
+        public static string GetTempPath(string workingDir)
+        {
+            var tmp = Environment.GetEnvironmentVariable("TMP");
+            if (Path.IsPathRooted(tmp))
+            {
+                return tmp;
+            }
+
+            var temp = Environment.GetEnvironmentVariable("TEMP");
+            if (Path.IsPathRooted(temp))
+            {
+                return temp;
+            }
+
+            if (!string.IsNullOrEmpty(workingDir))
+            {
+                if (!string.IsNullOrEmpty(tmp))
+                {
+                    return Path.Combine(workingDir, tmp);
+                }
+
+                if (!string.IsNullOrEmpty(temp))
+                {
+                    return Path.Combine(workingDir, temp);
+                }
+            }
+
+            var userProfile = Environment.GetEnvironmentVariable("USERPROFILE");
+            if (Path.IsPathRooted(userProfile))
+            {
+                return userProfile;
+            }
+
+            return Environment.GetEnvironmentVariable("SYSTEMROOT");
+        }
     }
 }

--- a/src/Compilers/Core/CommandLine/BuildProtocol.cs
+++ b/src/Compilers/Core/CommandLine/BuildProtocol.cs
@@ -62,24 +62,31 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
         public static BuildRequest Create(RequestLanguage language,
                                           string workingDirectory,
+                                          string tempDirectory,
                                           IList<string> args,
                                           string keepAlive = null,
                                           string libDirectory = null)
         {
             Log("Creating BuildRequest");
             Log($"Working directory: {workingDirectory}");
+            Log($"Temp directory: {tempDirectory}");
             Log($"Lib directory: {libDirectory ?? "null"}");
 
             var requestLength = args.Count + 1 + (libDirectory == null ? 0 : 1);
             var requestArgs = ImmutableArray.CreateBuilder<Argument>(requestLength);
 
             requestArgs.Add(new Argument(ArgumentId.CurrentDirectory, 0, workingDirectory));
+            requestArgs.Add(new Argument(ArgumentId.TempDirectory, 0, tempDirectory));
 
             if (keepAlive != null)
+            {
                 requestArgs.Add(new Argument(ArgumentId.KeepAlive, 0, keepAlive));
+            }
 
             if (libDirectory != null)
+            {
                 requestArgs.Add(new Argument(ArgumentId.LibEnvVariable, 0, libDirectory));
+            }
 
             for (int i = 0; i < args.Count; ++i)
             {
@@ -507,6 +514,9 @@ namespace Microsoft.CodeAnalysis.CommandLine
 
             // Request a server shutdown from the client
             Shutdown,
+
+            // The directory to use for temporary operations.
+            TempDirectory,
         }
 
         /// <summary>

--- a/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
+++ b/src/Compilers/Core/MSBuildTask/ManagedCompiler.cs
@@ -418,11 +418,13 @@ namespace Microsoft.CodeAnalysis.BuildTasks
                     // we'll just print our own message that contains the real client location
                     Log.LogMessage(ErrorString.UsingSharedCompilation, clientDir);
 
+                    var workingDir = CurrentDirectoryToUse();
                     var buildPaths = new BuildPaths(
                         clientDir: clientDir,
                         // MSBuild doesn't need the .NET SDK directory
                         sdkDir: null,
-                        workingDir: CurrentDirectoryToUse());
+                        workingDir: workingDir,
+                        tempDir: BuildClient.GetTempPath(workingDir));
 
                     var responseTask = DesktopBuildClient.RunServerCompilation(
                         Language,
@@ -535,7 +537,9 @@ namespace Microsoft.CodeAnalysis.BuildTasks
             // if ToolTask didn't override. MSBuild uses the process directory.
             string workingDirectory = GetWorkingDirectory();
             if (string.IsNullOrEmpty(workingDirectory))
+            {
                 workingDirectory = Directory.GetCurrentDirectory();
+            }
             return workingDirectory;
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingStrongNameProvider.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.LoggingStrongNameProvider.cs
@@ -10,8 +10,8 @@ namespace Microsoft.CodeAnalysis
         {
             private readonly TouchedFileLogger _loggerOpt;
 
-            public LoggingStrongNameProvider(ImmutableArray<string> keyFileSearchPaths, TouchedFileLogger logger)
-                : base(keyFileSearchPaths)
+            public LoggingStrongNameProvider(ImmutableArray<string> keyFileSearchPaths, TouchedFileLogger logger, string tempPath)
+                : base(keyFileSearchPaths, tempPath)
             {
                 _loggerOpt = logger;
             }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -19,6 +19,32 @@ using System.Security.Cryptography;
 
 namespace Microsoft.CodeAnalysis
 {
+    internal struct BuildPaths
+    {
+        /// <summary>
+        /// The path which containts the compiler binaries and response files.
+        /// </summary>
+        internal string ClientDirectory { get; }
+
+        /// <summary>
+        /// The path in which the compilation takes place.
+        /// </summary>
+        internal string WorkingDirectory { get; }
+
+        /// <summary>
+        /// The path which contains mscorlib.  This can be null when specified by the user or running in a 
+        /// CoreClr environment.
+        /// </summary>
+        internal string SdkDirectory { get; }
+
+        internal BuildPaths(string clientDir, string workingDir, string sdkDir)
+        {
+            ClientDirectory = clientDir;
+            WorkingDirectory = workingDir;
+            SdkDirectory = sdkDir;
+        }
+    }
+
     /// <summary>
     /// Base class for csc.exe, csi.exe, vbc.exe and vbi.exe implementations.
     /// </summary>
@@ -60,10 +86,10 @@ namespace Microsoft.CodeAnalysis
             List<DiagnosticInfo> diagnostics,
             CommonMessageProvider messageProvider);
 
-        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, string clientDirectory, string baseDirectory, string sdkDirectoryOpt, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
+        public CommonCompiler(CommandLineParser parser, string responseFile, string[] args, BuildPaths buildPaths, string additionalReferenceDirectories, IAnalyzerAssemblyLoader assemblyLoader)
         {
             IEnumerable<string> allArgs = args;
-            _clientDirectory = clientDirectory;
+            _clientDirectory = buildPaths.ClientDirectory;
 
             Debug.Assert(null == responseFile || PathUtilities.IsAbsolute(responseFile));
             if (!SuppressDefaultResponseFile(args) && File.Exists(responseFile))
@@ -71,14 +97,14 @@ namespace Microsoft.CodeAnalysis
                 allArgs = new[] { "@" + responseFile }.Concat(allArgs);
             }
 
-            this.Arguments = parser.Parse(allArgs, baseDirectory, sdkDirectoryOpt, additionalReferenceDirectories);
+            this.Arguments = parser.Parse(allArgs, buildPaths.WorkingDirectory, buildPaths.SdkDirectory, additionalReferenceDirectories);
             this.MessageProvider = parser.MessageProvider;
             this.AssemblyLoader = assemblyLoader;
             this.EmbeddedSourcePaths = GetEmbedddedSourcePaths(Arguments);
 
             if (Arguments.ParseOptions.Features.ContainsKey("debug-determinism"))
             {
-                EmitDeterminismKey(Arguments, args, baseDirectory, parser);
+                EmitDeterminismKey(Arguments, args, buildPaths.WorkingDirectory, parser);
             }
         }
 

--- a/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCompiler.cs
@@ -37,11 +37,18 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         internal string SdkDirectory { get; }
 
-        internal BuildPaths(string clientDir, string workingDir, string sdkDir)
+        /// <summary>
+        /// The temporary directory a compilation should use instead of <see cref="Path.GetTempPath"/>.  The latter
+        /// relies on global state individual compilations should ignore.
+        /// </summary>
+        internal string TempDirectory { get; }
+
+        internal BuildPaths(string clientDir, string workingDir, string sdkDir, string tempDir)
         {
             ClientDirectory = clientDir;
             WorkingDirectory = workingDir;
             SdkDirectory = sdkDir;
+            TempDirectory = tempDir;
         }
     }
 

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 *REMOVED*Microsoft.CodeAnalysis.Compilation.Emit(System.IO.Stream peStream, System.IO.Stream pdbStream = null, System.IO.Stream xmlDocumentationStream = null, System.IO.Stream win32Resources = null, System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ResourceDescription> manifestResources = null, Microsoft.CodeAnalysis.Emit.EmitOptions options = null, Microsoft.CodeAnalysis.IMethodSymbol debugEntryPoint = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.Emit.EmitResult
+*REMOVED*Microsoft.CodeAnalysis.DesktopStrongNameProvider.DesktopStrongNameProvider(System.Collections.Immutable.ImmutableArray<string> keyFileSearchPaths = default(System.Collections.Immutable.ImmutableArray<string>)) -> void
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.ChildThatContainsPosition(int position) -> Microsoft.CodeAnalysis.SyntaxNodeOrToken
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.SerializeTo(System.IO.Stream stream, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 *REMOVED*abstract Microsoft.CodeAnalysis.SyntaxNode.ToFullString() -> string
@@ -23,6 +24,8 @@ Microsoft.CodeAnalysis.CompilationOptions.WithMainTypeName(string mainTypeName) 
 Microsoft.CodeAnalysis.CompilationOptions.WithModuleName(string moduleName) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.CompilationOptions.WithOverflowChecks(bool checkOverflow) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.CompilationOptions.WithScriptClassName(string scriptClassName) -> Microsoft.CodeAnalysis.CompilationOptions
+Microsoft.CodeAnalysis.DesktopStrongNameProvider.DesktopStrongNameProvider(System.Collections.Immutable.ImmutableArray<string> keyFileSearchPaths = default(System.Collections.Immutable.ImmutableArray<string>), string tempPath = null) -> void
+Microsoft.CodeAnalysis.DesktopStrongNameProvider.DesktopStrongNameProvider(System.Collections.Immutable.ImmutableArray<string> keyFileSearchPaths) -> void
 Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
 Microsoft.CodeAnalysis.Diagnostics.CompilationStartAnalysisContext.RegisterOperationAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext> action, params Microsoft.CodeAnalysis.OperationKind[] operationKinds) -> void
 Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext

--- a/src/Compilers/Server/ServerShared/BuildProtocolUtil.cs
+++ b/src/Compilers/Server/ServerShared/BuildProtocolUtil.cs
@@ -17,7 +17,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
         {
             string currentDirectory;
             string libDirectory;
-            string[] arguments = GetCommandLineArguments(req, out currentDirectory, out libDirectory);
+            string tempDirectory;
+            string[] arguments = GetCommandLineArguments(req, out currentDirectory, out tempDirectory, out libDirectory);
             string language = "";
             switch (req.Language)
             {
@@ -29,13 +30,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     break;
             }
 
-            return new RunRequest(language, currentDirectory, libDirectory, arguments);
+            return new RunRequest(language, currentDirectory, tempDirectory, libDirectory, arguments);
         }
 
-        internal static string[] GetCommandLineArguments(BuildRequest req, out string currentDirectory, out string libDirectory)
+        internal static string[] GetCommandLineArguments(BuildRequest req, out string currentDirectory, out string tempDirectory, out string libDirectory)
         {
             currentDirectory = null;
             libDirectory = null;
+            tempDirectory = null;
             List<string> commandLineArguments = new List<string>();
 
             foreach (BuildRequest.Argument arg in req.Arguments)
@@ -43,6 +45,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 if (arg.ArgumentId == BuildProtocolConstants.ArgumentId.CurrentDirectory)
                 {
                     currentDirectory = arg.Value;
+                }
+                else if (arg.ArgumentId == BuildProtocolConstants.ArgumentId.TempDirectory)
+                {
+                    tempDirectory = arg.Value;
                 }
                 else if (arg.ArgumentId == BuildProtocolConstants.ArgumentId.LibEnvVariable)
                 {

--- a/src/Compilers/Server/ServerShared/CSharpCompilerServer.cs
+++ b/src/Compilers/Server/ServerShared/CSharpCompilerServer.cs
@@ -14,8 +14,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(CSharpCommandLineParser.Default, clientDirectory != null ? Path.Combine(clientDirectory, ResponseFileName) : null, args, clientDirectory, baseDirectory, sdkDirectory, libDirectory, analyzerLoader)
+        internal CSharpCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+            : base(CSharpCommandLineParser.Default, buildPaths.ClientDirectory != null ? Path.Combine(buildPaths.ClientDirectory, ResponseFileName) : null, args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/ServerShared/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/ServerShared/CompilerRequestHandler.cs
@@ -57,15 +57,14 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         public bool TryCreateCompiler(RunRequest request, out CommonCompiler compiler)
         {
+            var buildPaths = new BuildPaths(ClientDirectory, request.CurrentDirectory, SdkDirectory);
             switch (request.Language)
             {
                 case LanguageNames.CSharp:
                     compiler = new CSharpCompilerServer(
                         AssemblyReferenceProvider,
                         args: request.Arguments,
-                        clientDirectory: ClientDirectory,
-                        baseDirectory: request.CurrentDirectory,
-                        sdkDirectory: SdkDirectory,
+                        buildPaths: buildPaths,
                         libDirectory: request.LibDirectory,
                         analyzerLoader: AnalyzerAssemblyLoader);
                     return true;
@@ -73,9 +72,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                     compiler = new VisualBasicCompilerServer(
                         AssemblyReferenceProvider,
                         args: request.Arguments,
-                        clientDirectory: ClientDirectory,
-                        baseDirectory: request.CurrentDirectory,
-                        sdkDirectory: SdkDirectory,
+                        buildPaths: buildPaths,
                         libDirectory: request.LibDirectory,
                         analyzerLoader: AnalyzerAssemblyLoader);
                     return true;

--- a/src/Compilers/Server/ServerShared/CompilerRequestHandler.cs
+++ b/src/Compilers/Server/ServerShared/CompilerRequestHandler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
                 Log($"Argument[{i}] = '{request.Arguments[i]}'");
             }
 
-            // Compiler server must be provided wiht a valid temporary directory in order to correctly
+            // Compiler server must be provided with a valid temporary directory in order to correctly
             // isolate signing between compilations.
             if (string.IsNullOrEmpty(request.TempDirectory))
             {

--- a/src/Compilers/Server/ServerShared/VisualBasicCompilerServer.cs
+++ b/src/Compilers/Server/ServerShared/VisualBasicCompilerServer.cs
@@ -16,8 +16,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer
     {
         private readonly Func<string, MetadataReferenceProperties, PortableExecutableReference> _metadataProvider;
 
-        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, string clientDirectory, string baseDirectory, string sdkDirectory, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(VisualBasicCommandLineParser.Default, clientDirectory != null ? Path.Combine(clientDirectory, ResponseFileName) : null, args, clientDirectory, baseDirectory, sdkDirectory, libDirectory, analyzerLoader)
+        internal VisualBasicCompilerServer(Func<string, MetadataReferenceProperties, PortableExecutableReference> metadataProvider, string[] args, BuildPaths buildPaths, string libDirectory, IAnalyzerAssemblyLoader analyzerLoader)
+            : base(VisualBasicCommandLineParser.Default, buildPaths.ClientDirectory != null ? Path.Combine(buildPaths.ClientDirectory, ResponseFileName) : null, args, buildPaths, libDirectory, analyzerLoader)
         {
             _metadataProvider = metadataProvider;
         }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerHostTests.cs
@@ -1,0 +1,47 @@
+﻿using Roslyn.Test.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using static Microsoft.CodeAnalysis.CommandLine.BuildResponse;
+
+namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
+{
+    public sealed class CompilerServerHostTests
+    {
+        internal sealed class TestableCompilerServerHost : CompilerServerHost
+        {
+            public override IAnalyzerAssemblyLoader AnalyzerAssemblyLoader { get; }
+
+            public override Func<string, MetadataReferenceProperties, PortableExecutableReference> AssemblyReferenceProvider { get; }
+
+            public TestableCompilerServerHost(
+                IAnalyzerAssemblyLoader loader = null, 
+                Func<string, MetadataReferenceProperties, PortableExecutableReference> assemblyReferenceProvider = null) : 
+                base(ServerUtil.DefaultClientDirectory, ServerUtil.DefaultSdkDirectory)
+            {
+                AnalyzerAssemblyLoader = loader;
+                AssemblyReferenceProvider = assemblyReferenceProvider;
+            }
+
+            public override bool CheckAnalyzers(string baseDirectory, ImmutableArray<CommandLineAnalyzerReference> analyzers)
+            {
+                return true;
+            }
+        }
+
+        [WorkItem(13995, "https://github.com/dotnet/roslyn/issues/13995")]
+        [Fact]
+        public void RejectEmptyTempPath()
+        {
+            var host = new TestableCompilerServerHost();
+            var request = new RunRequest(LanguageNames.CSharp, currentDirectory: @"c:\current", tempDirectory: null, libDirectory: null, arguments: Array.Empty<string>());
+            var response = host.RunCompilation(request, CancellationToken.None);
+            Assert.Equal(ResponseType.Rejected, response.Type);
+        }
+    }
+}

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerHostTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerHostTests.cs
@@ -1,4 +1,5 @@
-﻿using Roslyn.Test.Utilities;
+﻿using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -38,10 +39,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         [Fact]
         public void RejectEmptyTempPath()
         {
-            var host = new TestableCompilerServerHost();
-            var request = new RunRequest(LanguageNames.CSharp, currentDirectory: @"c:\current", tempDirectory: null, libDirectory: null, arguments: Array.Empty<string>());
-            var response = host.RunCompilation(request, CancellationToken.None);
-            Assert.Equal(ResponseType.Rejected, response.Type);
+            using (var temp = new TempRoot())
+            {
+                var host = new TestableCompilerServerHost();
+                var request = new RunRequest(LanguageNames.CSharp, currentDirectory: temp.CreateDirectory().Path, tempDirectory: null, libDirectory: null, arguments: Array.Empty<string>());
+                var response = host.RunCompilation(request, CancellationToken.None);
+                Assert.Equal(ResponseType.Rejected, response.Type);
+            }
         }
     }
 }

--- a/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/CompilerServerTests.cs
@@ -889,7 +889,7 @@ class Hello
             GC.KeepAlive(rootDirectory);
         }
 
-        private async static Task<DisposableFile> RunCompilationAsync(RequestLanguage language, string pipeName, int i, TempDirectory compilationDir)
+        private async static Task<DisposableFile> RunCompilationAsync(RequestLanguage language, string pipeName, int i, TempDirectory compilationDir, TempDirectory tempDir)
         {
             TempFile sourceFile;
             string exeFileName;
@@ -936,7 +936,8 @@ End Module";
             var buildPaths = new BuildPaths(
                 clientDir: CompilerDirectory,
                 workingDir: compilationDir.Path,
-                sdkDir: RuntimeEnvironment.GetRuntimeDirectory());
+                sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
+                tempDir: tempDir.Path);
             var result = await client.RunCompilationAsync(new[] { $"/shared:{pipeName}", "/nologo", Path.GetFileName(sourceFile.Path), $"/out:{exeFileName}" }, buildPaths);
             Assert.Equal(0, result.ExitCode);
             Assert.True(result.RanOnServer);
@@ -964,7 +965,8 @@ End Module";
                 {
                     var language = i % 2 == 0 ? RequestLanguage.CSharpCompile : RequestLanguage.VisualBasicCompile;
                     var compilationDir = Temp.CreateDirectory();
-                    tasks[i] = RunCompilationAsync(language, serverData.PipeName, i, compilationDir);
+                    var tempDir = Temp.CreateDirectory();
+                    tasks[i] = RunCompilationAsync(language, serverData.PipeName, i, compilationDir, tempDir);
                 }
 
                 await Task.WhenAll(tasks);

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -77,7 +77,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             public ServerTests()
             {
-                var wo = Temp.CreateDirectory();
                 _buildPaths = ServerUtil.CreateBuildPaths(
                     workingDir: Temp.CreateDirectory().Path,
                     tempDir: Temp.CreateDirectory().Path);

--- a/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/DesktopBuildClientTests.cs
@@ -70,7 +70,6 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         public sealed class ServerTests : DesktopBuildClientTests
         {
             private readonly string _pipeName = Guid.NewGuid().ToString("N");
-            private readonly TempDirectory _tempDirectory;
             private readonly BuildPaths _buildPaths;
             private readonly List<ServerData> _serverDataList = new List<ServerData>();
             private bool _allowServer = true;
@@ -78,8 +77,10 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
             public ServerTests()
             {
-                _tempDirectory = Temp.CreateDirectory();
-                _buildPaths = ServerUtil.CreateBuildPaths(workingDir: _tempDirectory.Path);
+                var wo = Temp.CreateDirectory();
+                _buildPaths = ServerUtil.CreateBuildPaths(
+                    workingDir: Temp.CreateDirectory().Path,
+                    tempDir: Temp.CreateDirectory().Path);
             }
 
             public override void Dispose()

--- a/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/ServerUtil.cs
@@ -74,12 +74,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         internal static string DefaultClientDirectory { get; } = Path.GetDirectoryName(typeof(DesktopBuildClientTests).Assembly.Location);
         internal static string DefaultSdkDirectory { get; } = RuntimeEnvironment.GetRuntimeDirectory();
 
-        internal static BuildPaths CreateBuildPaths(string workingDir)
+        internal static BuildPaths CreateBuildPaths(string workingDir, string tempDir)
         {
             return new BuildPaths(
                 clientDir: DefaultClientDirectory,
                 workingDir: workingDir,
-                sdkDir: DefaultSdkDirectory);
+                sdkDir: DefaultSdkDirectory,
+                tempDir: tempDir);
         }
 
         internal static ServerData CreateServer(
@@ -199,7 +200,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
 
         internal static CompileFunc GetCompileFunc(RequestLanguage language)
         {
-            Func<string[], string, string, string, TextWriter, IAnalyzerAssemblyLoader, int> func;
+            Func<string[], string, string, string, string, TextWriter, IAnalyzerAssemblyLoader, int> func;
             switch (language)
             {
                 case RequestLanguage.CSharpCompile:
@@ -212,7 +213,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
                     throw new InvalidOperationException();
             }
 
-            return (args, buildPaths, textWriter, loader) => func(args, buildPaths.ClientDirectory, buildPaths.WorkingDirectory, buildPaths.SdkDirectory, textWriter, loader);
+            return (args, buildPaths, textWriter, loader) => func(args, buildPaths.ClientDirectory, buildPaths.WorkingDirectory, buildPaths.SdkDirectory, buildPaths.TempDirectory, textWriter, loader);
         }
 
         private static async Task<int> CreateServerFailsConnectionCore(string pipeName, CancellationToken cancellationToken)

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerTests.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AnalyzerConsistencyCheckerTests.cs" />
     <Compile Include="BuildProtocolTest.cs" />
     <Compile Include="ClientConnectionTests.cs" />
+    <Compile Include="CompilerServerHostTests.cs" />
     <Compile Include="CompilerServerApiTest.cs" />
     <Compile Include="CompilerServerTests.cs" />
     <Compile Include="DesktopBuildClientTests.cs" />

--- a/src/Compilers/Shared/CoreClrBuildClient.cs
+++ b/src/Compilers/Shared/CoreClrBuildClient.cs
@@ -32,7 +32,8 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var client = new CoreClrBuildClient(language, compileFunc);
             var clientDir = AppContext.BaseDirectory;
             var workingDir = Directory.GetCurrentDirectory();
-            var buildPaths = new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: null);
+            var tempDir = GetTempPath(workingDir);
+            var buildPaths = new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: null, tempDir: tempDir);
             return client.RunCompilation(arguments, buildPaths).ExitCode;
         }
 
@@ -52,7 +53,7 @@ namespace Microsoft.CodeAnalysis.CommandLine
             var port = int.Parse(pipeName);
             await client.ConnectAsync("127.0.0.1", port: port).ConfigureAwait(true);
 
-            var request = BuildRequest.Create(_language, buildPaths.WorkingDirectory, arguments, keepAlive, libDirectory);
+            var request = BuildRequest.Create(_language, buildPaths.WorkingDirectory, buildPaths.TempDirectory, arguments, keepAlive, libDirectory);
             await request.WriteAsync(client.GetStream(), cancellationToken).ConfigureAwait(true);
             var ret = await BuildResponse.ReadAsync(client.GetStream(), cancellationToken).ConfigureAwait(true);
             return ret;

--- a/src/Compilers/Shared/Csc.cs
+++ b/src/Compilers/Shared/Csc.cs
@@ -13,7 +13,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine
     internal sealed class Csc : CSharpCompiler
     {
         internal Csc(string responseFile, BuildPaths buildPaths, string[] args, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths.ClientDirectory, buildPaths.WorkingDirectory, buildPaths.SdkDirectory, Environment.GetEnvironmentVariable("LIB"), analyzerLoader)
+            : base(CSharpCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), analyzerLoader)
         {
         }
 

--- a/src/Compilers/Shared/Vbc.cs
+++ b/src/Compilers/Shared/Vbc.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
     internal sealed class Vbc : VisualBasicCompiler
     {
         internal Vbc(string responseFile, BuildPaths buildPaths, string[] args, IAnalyzerAssemblyLoader analyzerLoader)
-            : base(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths.ClientDirectory, buildPaths.WorkingDirectory, buildPaths.SdkDirectory, Environment.GetEnvironmentVariable("LIB"), analyzerLoader)
+            : base(VisualBasicCommandLineParser.Default, responseFile, args, buildPaths, Environment.GetEnvironmentVariable("LIB"), analyzerLoader)
         {
         }
 

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
@@ -30,7 +30,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             return new BuildPaths(
                 clientDir: Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location),
                 workingDir: workingDirectory,
-                sdkDir: RuntimeEnvironment.GetRuntimeDirectory());
+                sdkDir: RuntimeEnvironment.GetRuntimeDirectory(),
+                tempDir: Path.GetTempPath());
         }
 
         protected override ImmutableArray<DiagnosticAnalyzer> ResolveAnalyzersFromArguments(

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
             _analyzers = analyzers;
         }
 
-        public static BuildPaths CreateBuildPaths(string workingDirectory)
+        private static BuildPaths CreateBuildPaths(string workingDirectory)
         {
             return new BuildPaths(
                 clientDir: Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location),

--- a/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
+++ b/src/Compilers/Test/Utilities/CSharp.Desktop/MockCSharpCompiler.cs
@@ -19,10 +19,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Test.Utilities
         {
         }
 
-        public MockCSharpCompiler(string responseFile, string baseDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers)
-            : base(CSharpCommandLineParser.Default, responseFile, args, Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"), new DesktopAnalyzerAssemblyLoader())
+        public MockCSharpCompiler(string responseFile, string workingDirectory, string[] args, ImmutableArray<DiagnosticAnalyzer> analyzers)
+            : base(CSharpCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory), Environment.GetEnvironmentVariable("LIB"), new DesktopAnalyzerAssemblyLoader())
         {
             _analyzers = analyzers;
+        }
+
+        public static BuildPaths CreateBuildPaths(string workingDirectory)
+        {
+            return new BuildPaths(
+                clientDir: Path.GetDirectoryName(typeof(CSharpCompiler).Assembly.Location),
+                workingDir: workingDirectory,
+                sdkDir: RuntimeEnvironment.GetRuntimeDirectory());
         }
 
         protected override ImmutableArray<DiagnosticAnalyzer> ResolveAnalyzersFromArguments(

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -8,7 +8,14 @@ Imports Microsoft.CodeAnalysis.VisualBasic
 Friend Class MockVbi
     Inherits VisualBasicCompiler
 
-    Public Sub New(responseFile As String, baseDirectory As String, args As String())
-        MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Nothing, New DesktopAnalyzerAssemblyLoader())
+    Public Sub New(responseFile As String, workingDirectory As String, args As String())
+        MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, CreateBuildPaths(workingDirectory), Nothing, New DesktopAnalyzerAssemblyLoader())
     End Sub
+
+    Public Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
+        Return New BuildPaths(
+            clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
+            workingDir:=workingDirectory,
+            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory())
+    End Function
 End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -16,6 +16,7 @@ Friend Class MockVbi
         Return New BuildPaths(
             clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
             workingDir:=workingDirectory,
-            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory())
+            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory(),
+            tempDir:=Path.GetTempPath())
     End Function
 End Class

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVbi.vb
@@ -12,7 +12,7 @@ Friend Class MockVbi
         MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, CreateBuildPaths(workingDirectory), Nothing, New DesktopAnalyzerAssemblyLoader())
     End Sub
 
-    Public Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
+    Private Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
         Return New BuildPaths(
             clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
             workingDir:=workingDirectory,

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -11,25 +11,26 @@ Friend Class MockVisualBasicCompiler
     Private ReadOnly _analyzers As ImmutableArray(Of DiagnosticAnalyzer)
     Public Compilation As Compilation
 
-    Public Sub New(baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
-        MyClass.New(Nothing, baseDirectory, args, analyzer)
+    Public Sub New(baseDirectory As String, tempDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
+        MyClass.New(Nothing, baseDirectory, tempDirectory, args, analyzer)
     End Sub
 
-    Public Sub New(responseFile As String, baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
-        MyClass.New(responseFile, baseDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
+    Public Sub New(responseFile As String, baseDirectory As String, tempDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
+        MyClass.New(responseFile, baseDirectory, tempDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
     End Sub
 
-    Public Sub New(responseFile As String, workingDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
+    Public Sub New(responseFile As String, workingDirectory As String, tempDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory, tempDirectory), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
 
         _analyzers = analyzers
     End Sub
 
-    Public Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
+    Public Shared Function CreateBuildPaths(workingDirectory As String, tempDirectory As String) As BuildPaths
         Return New BuildPaths(
             clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
             workingDir:=workingDirectory,
-            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory())
+            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory(),
+            tempDir:=tempDirectory)
     End Function
 
     Protected Overrides Function ResolveAnalyzersFromArguments(

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -19,11 +19,18 @@ Friend Class MockVisualBasicCompiler
         MyClass.New(responseFile, baseDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
     End Sub
 
-    Public Sub New(responseFile As String, baseDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location), baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
+    Public Sub New(responseFile As String, workingDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
 
         _analyzers = analyzers
     End Sub
+
+    Public Shared Function CreateBuildPaths(workingDirectory As String) As BuildPaths
+        Return New BuildPaths(
+            clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
+            workingDir:=workingDirectory,
+            sdkDir:=RuntimeEnvironment.GetRuntimeDirectory())
+    End Function
 
     Protected Overrides Function ResolveAnalyzersFromArguments(
         diagnostics As List(Of DiagnosticInfo),

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -25,7 +25,7 @@ Friend Class MockVisualBasicCompiler
         _analyzers = analyzers
     End Sub
 
-    Public Shared Function CreateBuildPaths(workingDirectory As String, tempDirectory As String) As BuildPaths
+    Private Shared Function CreateBuildPaths(workingDirectory As String, tempDirectory As String) As BuildPaths
         Return New BuildPaths(
             clientDir:=Path.GetDirectoryName(GetType(VisualBasicCompiler).Assembly.Location),
             workingDir:=workingDirectory,

--- a/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
+++ b/src/Compilers/Test/Utilities/VisualBasic/MockVisualBasicCompiler.vb
@@ -11,16 +11,16 @@ Friend Class MockVisualBasicCompiler
     Private ReadOnly _analyzers As ImmutableArray(Of DiagnosticAnalyzer)
     Public Compilation As Compilation
 
-    Public Sub New(baseDirectory As String, tempDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
-        MyClass.New(Nothing, baseDirectory, tempDirectory, args, analyzer)
+    Public Sub New(baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
+        MyClass.New(Nothing, baseDirectory, args, analyzer)
     End Sub
 
-    Public Sub New(responseFile As String, baseDirectory As String, tempDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
-        MyClass.New(responseFile, baseDirectory, tempDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
+    Public Sub New(responseFile As String, baseDirectory As String, args As String(), Optional analyzer As DiagnosticAnalyzer = Nothing)
+        MyClass.New(responseFile, baseDirectory, args, If(analyzer Is Nothing, ImmutableArray(Of DiagnosticAnalyzer).Empty, ImmutableArray.Create(analyzer)))
     End Sub
 
-    Public Sub New(responseFile As String, workingDirectory As String, tempDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
-        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory, tempDirectory), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
+    Public Sub New(responseFile As String, workingDirectory As String, args As String(), analyzers As ImmutableArray(Of DiagnosticAnalyzer))
+        MyBase.New(VisualBasicCommandLineParser.Default, responseFile, args, CreateBuildPaths(workingDirectory, Path.GetTempPath()), Environment.GetEnvironmentVariable("LIB"), New DesktopAnalyzerAssemblyLoader())
 
         _analyzers = analyzers
     End Sub

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -19,10 +19,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private ReadOnly _diagnosticFormatter As CommandLineDiagnosticFormatter
         Private _additionalTextFiles As ImmutableArray(Of AdditionalTextFile)
 
-        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), clientDirectory As String, baseDirectory As String, sdkDirectory As String, additionalReferenceDirectories As String, analyzerLoader As IAnalyzerAssemblyLoader)
-            MyBase.New(parser, responseFile, args, clientDirectory, baseDirectory, sdkDirectory, additionalReferenceDirectories, analyzerLoader)
+        Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), buildPaths As BuildPaths, additionalReferenceDirectories As String, analyzerLoader As IAnalyzerAssemblyLoader)
+            MyBase.New(parser, responseFile, args, buildPaths, additionalReferenceDirectories, analyzerLoader)
 
-            _diagnosticFormatter = New CommandLineDiagnosticFormatter(baseDirectory, AddressOf GetAdditionalTextFiles)
+            _diagnosticFormatter = New CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, AddressOf GetAdditionalTextFiles)
             _additionalTextFiles = Nothing
         End Sub
 

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCompiler.vb
@@ -17,6 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Private Shared s_responseFileName As String
         Private ReadOnly _responseFile As String
         Private ReadOnly _diagnosticFormatter As CommandLineDiagnosticFormatter
+        Private ReadOnly _tempDirectory As String
         Private _additionalTextFiles As ImmutableArray(Of AdditionalTextFile)
 
         Protected Sub New(parser As VisualBasicCommandLineParser, responseFile As String, args As String(), buildPaths As BuildPaths, additionalReferenceDirectories As String, analyzerLoader As IAnalyzerAssemblyLoader)
@@ -24,6 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             _diagnosticFormatter = New CommandLineDiagnosticFormatter(buildPaths.WorkingDirectory, AddressOf GetAdditionalTextFiles)
             _additionalTextFiles = Nothing
+            _tempDirectory = buildPaths.TempDirectory
         End Sub
 
         Private Function GetAdditionalTextFiles() As ImmutableArray(Of AdditionalTextFile)
@@ -128,7 +130,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 PrintReferences(resolvedReferences, consoleOutput)
             End If
 
-            Dim strongNameProvider = New LoggingStrongNameProvider(Arguments.KeyFileSearchPaths, touchedFilesLogger)
+            Dim strongNameProvider = New LoggingStrongNameProvider(Arguments.KeyFileSearchPaths, touchedFilesLogger, _tempDirectory)
             Dim xmlFileResolver = New LoggingXmlFileResolver(Arguments.BaseDirectory, touchedFilesLogger)
 
             ' TODO: support for #load search paths

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -173,9 +173,7 @@ End Class
                     {"/nologo",
                      "/touchedfiles:" + touchedBase,
                      source1},
-                    Nothing,
-                    _baseDirectory,
-                    RuntimeEnvironment.GetRuntimeDirectory(),
+                    New BuildPaths(Nothing, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory()),
                     s_libDirectory,
                     New TestAnalyzerAssemblyLoader())
                 Dim expectedReads As List(Of String) = Nothing

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -173,7 +173,7 @@ End Class
                     {"/nologo",
                      "/touchedfiles:" + touchedBase,
                      source1},
-                    New BuildPaths(Nothing, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory()),
+                    New BuildPaths(Nothing, _baseDirectory, RuntimeEnvironment.GetRuntimeDirectory(), Path.GetTempPath()),
                     s_libDirectory,
                     New TestAnalyzerAssemblyLoader())
                 Dim expectedReads As List(Of String) = Nothing

--- a/src/Compilers/VisualBasic/vbc/Program.cs
+++ b/src/Compilers/VisualBasic/vbc/Program.cs
@@ -15,7 +15,7 @@ namespace Microsoft.CodeAnalysis.VisualBasic.CommandLine
         public static int Main(string[] args, string[] extraArgs)
             => DesktopBuildClient.Run(args, extraArgs, RequestLanguage.VisualBasicCompile, Vbc.Run, new DesktopAnalyzerAssemblyLoader());
 
-        public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
-            => Vbc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir), textWriter, analyzerLoader);
+        public static int Run(string[] args, string clientDir, string workingDir, string sdkDir, string tempDir, TextWriter textWriter, IAnalyzerAssemblyLoader analyzerLoader)
+            => Vbc.Run(args, new BuildPaths(clientDir: clientDir, workingDir: workingDir, sdkDir: sdkDir, tempDir: tempDir), textWriter, analyzerLoader);
     }
 }

--- a/src/Interactive/CsiCore/Csi.cs
+++ b/src/Interactive/CsiCore/Csi.cs
@@ -18,13 +18,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
             try
             {
                 var responseFile = Path.Combine(AppContext.BaseDirectory, InteractiveResponseFileName);
-
+                var buildPaths = new BuildPaths(
+                    clientDir: AppContext.BaseDirectory,
+                    workingDir: Directory.GetCurrentDirectory(),
+                    sdkDir: CorLightup.Desktop.TryGetRuntimeDirectory(),
+                    tempDir: Path.GetTempPath());
                 var compiler = new CSharpInteractiveCompiler(
                     responseFile: responseFile,
-                    baseDirectory: Directory.GetCurrentDirectory(),
-                    sdkDirectoryOpt: CorLightup.Desktop.TryGetRuntimeDirectory(),
+                    buildPaths: buildPaths,
                     args: args,
-                    clientDirectory: AppContext.BaseDirectory,
                     analyzerLoader: new NotImplementedAnalyzerLoader());
 
                 var runner = new CommandLineRunner(

--- a/src/Interactive/VbiCore/Vbi.vb
+++ b/src/Interactive/VbiCore/Vbi.vb
@@ -12,12 +12,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
         Public Shared Function Main(args As String()) As Integer
             Try
                 Dim responseFile = Path.Combine(AppContext.BaseDirectory, InteractiveResponseFileName)
+                Dim buildPaths = New BuildPaths(
+                    clientDir:=AppContext.BaseDirectory,
+                    workingDir:=CorLightup.Desktop.TryGetRuntimeDirectory(),
+                    sdkDir:=AppContext.BaseDirectory,
+                    tempDir:=Path.GetTempPath())
 
                 Dim compiler = New VisualBasicInteractiveCompiler(
                     responseFile,
-                    AppContext.BaseDirectory,
-                    CorLightup.Desktop.TryGetRuntimeDirectory(),
-                    AppContext.BaseDirectory,
+                    buildPaths,
                     args,
                     New NotImplementedAnalyzerLoader())
 

--- a/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
+++ b/src/Scripting/CSharp/Hosting/CommandLine/Csi.cs
@@ -12,9 +12,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.Hosting
 {
     internal sealed class CSharpInteractiveCompiler : CSharpCompiler
     {
-        internal CSharpInteractiveCompiler(string responseFile, string baseDirectory, string sdkDirectoryOpt, string clientDirectory, string[] args, IAnalyzerAssemblyLoader analyzerLoader)
+        internal CSharpInteractiveCompiler(string responseFile, BuildPaths buildPaths, string[] args, IAnalyzerAssemblyLoader analyzerLoader)
             // Unlike C# compiler we do not use LIB environment variable. It's only supported for historical reasons.
-            : base(CSharpCommandLineParser.ScriptRunner, responseFile, args, clientDirectory, baseDirectory, sdkDirectoryOpt, null, analyzerLoader)
+            : base(CSharpCommandLineParser.ScriptRunner, responseFile, args, buildPaths, null, analyzerLoader)
         {
         }
 

--- a/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
+++ b/src/Scripting/CSharpTest/CommandLineRunnerTests.cs
@@ -37,12 +37,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Scripting.UnitTests
             string workingDirectory = null)
         {
             var io = new TestConsoleIO(input);
+            var buildPaths = new BuildPaths(
+                clientDir: AppContext.BaseDirectory,
+                workingDir: workingDirectory ?? AppContext.BaseDirectory,
+                sdkDir: null,
+                tempDir: Path.GetTempPath());
 
             var compiler = new CSharpInteractiveCompiler(
                 responseFile,
-                workingDirectory ?? AppContext.BaseDirectory,
-                null,
-                AppContext.BaseDirectory,
+                buildPaths,
                 args ?? s_defaultArgs,
                 new NotImplementedAnalyzerLoader());
 

--- a/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
+++ b/src/Scripting/VisualBasic/Hosting/CommandLine/Vbi.vb
@@ -11,8 +11,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.Hosting
     Friend NotInheritable Class VisualBasicInteractiveCompiler
         Inherits VisualBasicCompiler
 
-        Friend Sub New(responseFile As String, baseDirectory As String, sdkDirectoryOpt As String, clientDirectory As String, args As String(), analyzerLoader As IAnalyzerAssemblyLoader)
-            MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, clientDirectory, baseDirectory, sdkDirectoryOpt, Nothing, analyzerLoader)
+        Friend Sub New(responseFile As String, buildPaths As BuildPaths, args As String(), analyzerLoader As IAnalyzerAssemblyLoader)
+            MyBase.New(VisualBasicCommandLineParser.ScriptRunner, responseFile, args, buildPaths, Nothing, analyzerLoader)
         End Sub
 
         Friend Overrides Function GetCommandLineMetadataReferenceResolver(loggerOpt As TouchedFileLogger) As MetadataReferenceResolver

--- a/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
+++ b/src/Scripting/VisualBasicTest/CommandLineRunnerTests.vb
@@ -1,6 +1,7 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 Imports System.Reflection
+Imports System.IO
 Imports Microsoft.CodeAnalysis.Scripting
 Imports Microsoft.CodeAnalysis.Scripting.Hosting
 Imports Microsoft.CodeAnalysis.Scripting.Test
@@ -28,11 +29,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Scripting.UnitTests
         ) As CommandLineRunner
             Dim io = New TestConsoleIO(input)
 
+            Dim buildPaths = New BuildPaths(
+                clientDir:=AppContext.BaseDirectory,
+                workingDir:=If(workingDirectory, AppContext.BaseDirectory),
+                sdkDir:=CorLightup.Desktop.TryGetRuntimeDirectory(),
+                tempDir:=Path.GetTempPath())
+
             Dim compiler = New VisualBasicInteractiveCompiler(
                 responseFile,
-                If(workingDirectory, AppContext.BaseDirectory),
-                CorLightup.Desktop.TryGetRuntimeDirectory(),
-                AppContext.BaseDirectory,
+                buildPaths,
                 If(args, s_defaultArgs),
                 New NotImplementedAnalyzerLoader())
 

--- a/src/Test/Utilities/Desktop/SigningTestHelpers.cs
+++ b/src/Test/Utilities/Desktop/SigningTestHelpers.cs
@@ -57,8 +57,8 @@ namespace Roslyn.Test.Utilities
 
         internal sealed class VirtualizedStrongNameProvider : DesktopStrongNameProvider
         {
-            public VirtualizedStrongNameProvider(ImmutableArray<string> searchPaths)
-                : base(searchPaths)
+            public VirtualizedStrongNameProvider(ImmutableArray<string> searchPaths = default(ImmutableArray<string>), string tempPath = null)
+                : base(searchPaths, tempPath)
             {
             }
 


### PR DESCRIPTION
This PRC is broken into two commits to help with reviewing: 

1. Threading `BuildPaths` through the entire code base.  This unified argument passing of build paths and greatly simplified the second change.  This change is mechanical.
2. Implementing the TMP change.  

Here is the full commit message from the second commit which explains the purpose in need. 

The compiler must make use of a temporary path when signing files.  This is a restriction forced on us by the underlying CLR signing APIs.

Historically the compiler used `Path.GetTempPath` (`GetTempPath` in native) as the location to write the temporary files.  This is unsuitable for the compiler server as it makes use of several pieces of process global state that be different between build invocations: TMP, TEMP, USERPROFILE and the current working directory.

In general these variables are the same between invocations but in larger build systems it's not uncommon for TEMP / TMP in particular to be manipulated and set to invalid values.  This can lead to builds where signing fails in the server but passes in the command line.  This occurs because the server gets the initial TEMP value and uses it for all compilations while the command line gets a fresh TEMP value on every invocation.

To work around this the compiler must thread through the temporary path as a build parameter.  This is the general approach we've taken for all state that is typically process global but can differ from invocation to invocation.

Also need a custom implementation of `GetTempPath` in order to pass down the correct working directory.


closes #13995