### PR TITLE
removed /bugreport from csc /help output (closes #14171)

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4479,7 +4479,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
 
                         - ADVANCED -
  /baseaddress:&lt;address&gt;        Base address for the library to be built
- /bugreport:&lt;file&gt;             Create a 'Bug Report' file
  /checksumalgorithm:&lt;alg&gt;      Specify algorithm for calculating source file 
                                checksum stored in PDB. Supported values are:
                                SHA1 (default) or SHA256.


### PR DESCRIPTION
As suggested by #14171, removed the /bugreport output from csc /help. This does _not_ remove parsing of the /bugreport flag from the compiler. Should it? 
