### PR TITLE
Enable finding the breakpoint location for a pattern switch case

### DIFF
--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -3986,5 +3986,148 @@ $$        int
     public int Id { get { return 42; } set { [|}|] $$}
 }");
         }
+
+        [Fact]
+        public void WhenClause_1()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+$$      case string s [|when b|]:
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void WhenClause_2()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s [|whe$$n b|]:
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void WhenClause_3()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s [|when b|]:$$
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_1()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+$$      case string s:
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_2()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      $$case string s:
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_3()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s:$$
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void DeconstructionDeclarationStatement_1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+$$    [|var (x, y) = (1, 2);|]
+  }
+}");
+        }
+
+        [Fact]
+        public void DeconstructionDeclarationStatement_2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|var (x, y) = $$(1, 2);|]
+  }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -193,6 +193,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.DefaultSwitchLabel:
                     return TryCreateSpanForSwitchLabel((SwitchLabelSyntax)node, position);
 
+                case SyntaxKind.CasePatternSwitchLabel:
+                    var caseClause = (CasePatternSwitchLabelSyntax)node;
+                    return caseClause.WhenClause == null
+                        ? TryCreateSpanForSwitchLabel((SwitchLabelSyntax)node, position)
+                        : CreateSpan(caseClause.WhenClause);
+
+                case SyntaxKind.WhenClause:
+                    return CreateSpan(node);
+
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                     var body = ((AccessorDeclarationSyntax)node).Body;
@@ -535,6 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ThrowStatement:
                 case SyntaxKind.ExpressionStatement:
                 case SyntaxKind.EmptyStatement:
+                case SyntaxKind.DeconstructionDeclarationStatement:
                 default:
                     // Fallback case.  If it was none of the above types of statements, then we make a span
                     // over the entire statement.  Note: this is not a very desirable thing to do (as


### PR DESCRIPTION
Fixes #12378 
@dotnet/roslyn-ide Please review
/cc @dotnet/roslyn-compiler FYI
