### PR TITLE
Move to the new roslyn NuGet feed

### DIFF
--- a/build/Targets/VSL.Versions.targets
+++ b/build/Targets/VSL.Versions.targets
@@ -9,8 +9,12 @@
     <RoslynAssemblyVersionBase Condition="'$(RoslynAssemblyVersion)' == ''">2.0.0</RoslynAssemblyVersionBase>
     <!-- This is the file version of Roslyn, as placed in the PE header. It should be revved during point releases, and is also what provides the basis for our NuGet package versioning. -->
     <RoslynFileVersionBase Condition="'$(RoslynFileVersionBase)' == ''">2.0.0</RoslynFileVersionBase>
+    <!-- The release moniker for our packages.  Developers should use "dev" and official builds pick the branch
+         moniker listed below -->
+    <RoslynNuGetMoniker Condition="'$(RoslynNuGetMoniker)' == ''">dev</RoslynNuGetMoniker>
+    <RoslynNuGetMoniker Condition="'$(OfficialBuild)' == 'true'">rc</RoslynNuGetMoniker>
     <!-- This is the base of the NuGet versioning for prerelease packages -->
-    <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-beta6</NuGetPreReleaseVersion>
+    <NuGetPreReleaseVersion>$(RoslynFileVersionBase)-$(RoslynNuGetMoniker)</NuGetPreReleaseVersion>
     <!-- Currently we version IW the same as Roslyn. -->
     <MicrosoftVisualStudioInteractiveWindowVersion>$(RoslynAssemblyVersionBase)</MicrosoftVisualStudioInteractiveWindowVersion>
   </PropertyGroup>

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -6,7 +6,8 @@
     <ProjectDir>$(MSBuildThisFileDirectory)..\..\..\</ProjectDir>
     <BranchName Condition="'$(BranchName)' == ''">$(BUILD_SOURCEBRANCH)</BranchName>
     <BinariesPath>$(ProjectDir)Binaries\$(Configuration)</BinariesPath>
-    <RoslynMyGetApiKey Condition="'$(RoslynMyGetApiKey)' == ''">"no key"</RoslynMyGetApiKey>
+    <RoslynNuGetApiKey Condition="'$(RoslynNuGetApiKey)' == ''">"no key"</RoslynNuGetApiKey>
+    <PublishAssetsArgs Condition="'$(SkipPublish)' == 'true'">-test</PublishAssetsArgs>
   </PropertyGroup>
 
   <!-- Non-official builds / local testing have different defaults -->
@@ -38,7 +39,7 @@
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)stop-compiler-server.ps1" />
 
-    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)publish-assets.ps1 -binariesPath &quot;$(BinariesPath)&quot; -branchName $(BranchName) -apiKey $(RoslynMyGetApiKey) $(PublishAssetsArgs)" />
+    <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)publish-assets.ps1 -binariesPath &quot;$(BinariesPath)&quot; -branchName $(BranchName) -apiKey $(RoslynNuGetApiKey) $(PublishAssetsArgs)" />
 
     <Exec Command="powershell -noprofile -executionPolicy ByPass -file $(MSBuildThisFileDirectory)copy-insertion-items.ps1 -binariesPath &quot;$(BinariesPath)&quot; $(CopyInsertionFileArgs)" />
   </Target>


### PR DESCRIPTION
This changes dotnet/roslyn to use a single NuGet feed.  Packages will now differentiate based on release monikers in the package name.