### PR TITLE
SemanticModel shouldn’t expose ParameterSymbols parented to an EventSymbol

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -394,7 +394,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub CheckEventTypeCompliance(symbol As EventSymbol)
             Dim type = symbol.Type
-            If type.TypeKind = TypeKind.Delegate AndAlso type.IsImplicitlyDeclared Then
+            If type.TypeKind = TypeKind.Delegate AndAlso type.IsImplicitlyDeclared AndAlso TryCast(type, NamedTypeSymbol)?.AssociatedSymbol Is symbol Then
                 Debug.Assert(symbol.DelegateReturnType.SpecialType = SpecialType.System_Void)
                 CheckParameterCompliance(symbol.DelegateParameters, symbol.ContainingType)
             ElseIf ShouldReportNonCompliantType(type, symbol.ContainingType, symbol) Then

--- a/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/SyntaxTreeSemanticModel.vb
@@ -1063,7 +1063,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             Case SymbolKind.Method
                                 Return GetParameterSymbol(DirectCast(symbol, MethodSymbol).Parameters, parameter)
                             Case SymbolKind.Event
-                                Return GetParameterSymbol(DirectCast(symbol, EventSymbol).DelegateParameters, parameter)
+                                Dim eventSymbol As EventSymbol = DirectCast(symbol, EventSymbol)
+                                Dim type = TryCast(eventSymbol.Type, NamedTypeSymbol)
+
+                                If type?.AssociatedSymbol Is eventSymbol Then
+                                    Return GetParameterSymbol(type.DelegateInvokeMethod.Parameters, parameter)
+                                End If
+
+                                Return Nothing
+
                             Case SymbolKind.Property
                                 Return GetParameterSymbol(DirectCast(symbol, PropertySymbol).Parameters, parameter)
                             Case SymbolKind.NamedType

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Members.vb
@@ -128,10 +128,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim sourceSymbol = TryCast(symbol, SourceEventSymbol)
             If sourceSymbol IsNot Nothing AndAlso sourceSymbol.IsTypeInferred Then
                 If format.MemberOptions.IncludesOption(SymbolDisplayMemberOptions.IncludeParameters) Then
-                    Dim invoke = DirectCast(sourceSymbol.Type, SynthesizedEventDelegateSymbol).DelegateInvokeMethod
-
                     AddPunctuation(SyntaxKind.OpenParenToken)
-                    AddParametersIfRequired(isExtensionMethod:=False, parameters:=StaticCast(Of IParameterSymbol).From(invoke.Parameters))
+                    AddParametersIfRequired(isExtensionMethod:=False, parameters:=StaticCast(Of IParameterSymbol).From(sourceSymbol.DelegateParameters))
                     AddPunctuation(SyntaxKind.CloseParenToken)
                 End If
             End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceEventSymbol.vb
@@ -216,9 +216,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Dim types = _containingType.GetTypeMembers(Me.Name & EVENT_DELEGATE_SUFFIX)
                     Debug.Assert(Not types.IsDefault)
 
-                    If Not types.IsEmpty Then
-                        type = types(0)
-                    Else
+                    type = Nothing
+
+                    For Each candidate In types
+                        If candidate.AssociatedSymbol Is Me Then
+                            type = candidate
+                            Exit For
+                        End If
+                    Next
+
+                    If type Is Nothing Then
                         ' if we still do not know the type, get a temporary one (it is not a member of the containing class)
                         type = New SynthesizedEventDelegateSymbol(Me._syntaxRef, _containingType)
                     End If

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceParameterSymbol.vb
@@ -103,7 +103,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public NotOverridable Overrides ReadOnly Property IsImplicitlyDeclared As Boolean
             Get
-                Return (GetMatchingPropertyParameter() IsNot Nothing) OrElse (Me.ContainingSymbol.IsImplicitlyDeclared)
+                If Me.ContainingSymbol.IsImplicitlyDeclared Then
+
+                    If TryCast(Me.ContainingSymbol, MethodSymbol)?.MethodKind = MethodKind.DelegateInvoke AndAlso
+                       Not Me.ContainingType.AssociatedSymbol?.IsImplicitlyDeclared Then
+                        Return False
+                    End If
+
+                    Return True
+                End If
+
+                Return (GetMatchingPropertyParameter() IsNot Nothing)
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Compilation/SemanticModelGetDeclaredSymbolAPITests.vb
@@ -1324,7 +1324,8 @@ BC30001: Statement is not valid in a namespace.
             Assert.NotNull(paramSymbol1)
             Assert.Equal("Percent", paramSymbol1.Name)
             Assert.Equal("System.Single", paramSymbol1.Type.ToTestDisplayString())
-            Assert.Equal("Event N1.Test.Percent(Percent As System.Single)", paramSymbol1.ContainingSymbol.ToTestDisplayString())
+            Assert.Equal("Event N1.Test.Percent(Percent As System.Single)", paramSymbol1.ContainingType.AssociatedSymbol.ToTestDisplayString())
+            Assert.Equal("Sub N1.Test.PercentEventHandler.Invoke(Percent As System.Single)", paramSymbol1.ContainingSymbol.ToTestDisplayString())
 
         End Sub
 

--- a/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.EventSymbols.vb
+++ b/src/EditorFeatures/Test2/FindReferences/FindReferencesTests.EventSymbols.vb
@@ -183,7 +183,7 @@ End Class
         End Function
 
         <WorkItem(553324, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/553324")>
-        <WpfFact, Trait(Traits.Feature, Traits.Features.FindReferences)>
+        <WpfFact(Skip:="https://github.com/dotnet/roslyn/issues/14428"), Trait(Traits.Feature, Traits.Features.FindReferences)>
         Public Async Function TestEventParameterCascading() As Task
             Dim input =
 <Workspace>

--- a/src/Workspaces/CoreTest/SymbolKeyTests.cs
+++ b/src/Workspaces/CoreTest/SymbolKeyTests.cs
@@ -50,7 +50,8 @@ public class C
             TestRoundTrip(GetDeclaredSymbols(compilation), compilation);
         }
 
-        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14364")]
+        [Fact]
+        [WorkItem(14364, "https://github.com/dotnet/roslyn/issues/14364")]
         public void TestVBParameterizedEvent()
         {
             var source = @"


### PR DESCRIPTION
Parameters of the implicitly declared delegate should be returned instead.

Fixes #14364.

@dotnet/roslyn-compiler Please review.