### PR TITLE
Expose a special CodeActionOperation so users can navigate to document positions as part of a code action.

### DIFF
--- a/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.AbstractGlobalSuppressMessageCodeAction.cs
+++ b/src/Features/Core/Portable/CodeFixes/Suppression/AbstractSuppressionCodeFixProvider.AbstractGlobalSuppressMessageCodeAction.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CodeFixes.Suppression
                 {
                     new ApplyChangesOperation(changedSuppressionDocument.Project.Solution),
                     new OpenDocumentOperation(changedSuppressionDocument.Id, activateIfAlreadyOpen: true),
-                    new NavigationOperation(changedSuppressionDocument.Id, position: 0)
+                    new DocumentNavigationOperation(changedSuppressionDocument.Id, position: 0)
                 };
             }
 

--- a/src/Features/Core/Portable/Common/NavigationOperation.cs
+++ b/src/Features/Core/Portable/Common/NavigationOperation.cs
@@ -1,17 +1,31 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using Microsoft.CodeAnalysis.Navigation;
 
 namespace Microsoft.CodeAnalysis.CodeActions
 {
-    internal class NavigationOperation : CodeActionOperation
+    /// <summary>
+    /// A <see cref="CodeActionOperation"/> for navigating to a specific position in a document.
+    /// When <see cref="CodeAction.GetOperationsAsync(CancellationToken)"/> is called an implementation
+    /// of <see cref="CodeAction"/> can return an instance of this operation along with the other 
+    /// operations they want to apply.  For example, an implementation could generate a new <see cref="Document"/>
+    /// in one <see cref="CodeActionOperation"/> and then have the host editor navigate to that
+    /// <see cref="Document"/> using this operation.
+    /// </summary>
+    public class DocumentNavigationOperation : CodeActionOperation
     {
         private readonly DocumentId _documentId;
         private readonly int _position;
 
-        public NavigationOperation(DocumentId documentId, int position)
+        public DocumentNavigationOperation(DocumentId documentId, int position = 0)
         {
+            if (documentId == null)
+            {
+                throw new ArgumentNullException(nameof(documentId));
+            }
+
             _documentId = documentId;
             _position = position;
         }

--- a/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
+++ b/src/Features/Core/Portable/ExtractInterface/ExtractInterfaceCodeAction.cs
@@ -48,7 +48,7 @@ namespace Microsoft.CodeAnalysis.ExtractInterface
                     operations = new CodeActionOperation[]
                         {
                         new ApplyChangesOperation(extractInterfaceResult.UpdatedSolution),
-                        new NavigationOperation(extractInterfaceResult.NavigationDocumentId, position: 0)
+                        new DocumentNavigationOperation(extractInterfaceResult.NavigationDocumentId, position: 0)
                         };
                 }
             }

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 *REMOVED*static Microsoft.CodeAnalysis.Completion.CompletionItem.Create(string displayText, string filterText = null, string sortText = null, Microsoft.CodeAnalysis.Text.TextSpan span = default(Microsoft.CodeAnalysis.Text.TextSpan), System.Collections.Immutable.ImmutableDictionary<string, string> properties = null, System.Collections.Immutable.ImmutableArray<string> tags = default(System.Collections.Immutable.ImmutableArray<string>), Microsoft.CodeAnalysis.Completion.CompletionItemRules rules = null) -> Microsoft.CodeAnalysis.Completion.CompletionItem
+Microsoft.CodeAnalysis.CodeActions.DocumentNavigationOperation
+Microsoft.CodeAnalysis.CodeActions.DocumentNavigationOperation.DocumentNavigationOperation(Microsoft.CodeAnalysis.DocumentId documentId, int position = 0) -> void
 Microsoft.CodeAnalysis.Completion.CompletionChange.TextChange.get -> Microsoft.CodeAnalysis.Text.TextChange
 Microsoft.CodeAnalysis.Completion.CompletionChange.WithTextChange(Microsoft.CodeAnalysis.Text.TextChange textChange) -> Microsoft.CodeAnalysis.Completion.CompletionChange
 Microsoft.CodeAnalysis.Completion.CompletionContext.CompletionListSpan.get -> Microsoft.CodeAnalysis.Text.TextSpan
@@ -18,6 +20,7 @@ Microsoft.CodeAnalysis.Completion.SnippetsRule.AlwaysInclude = 2 -> Microsoft.Co
 Microsoft.CodeAnalysis.Completion.SnippetsRule.Default = 0 -> Microsoft.CodeAnalysis.Completion.SnippetsRule
 Microsoft.CodeAnalysis.Completion.SnippetsRule.IncludeAfterTypingIdentifierQuestionTab = 3 -> Microsoft.CodeAnalysis.Completion.SnippetsRule
 Microsoft.CodeAnalysis.Completion.SnippetsRule.NeverInclude = 1 -> Microsoft.CodeAnalysis.Completion.SnippetsRule
+override Microsoft.CodeAnalysis.CodeActions.DocumentNavigationOperation.Apply(Microsoft.CodeAnalysis.Workspace workspace, System.Threading.CancellationToken cancellationToken) -> void
 static Microsoft.CodeAnalysis.Completion.CompletionChange.Create(Microsoft.CodeAnalysis.Text.TextChange textChange, int? newPosition = null, bool includesCommitCharacter = false) -> Microsoft.CodeAnalysis.Completion.CompletionChange
 static Microsoft.CodeAnalysis.Completion.CompletionItem.Create(string displayText, string filterText = null, string sortText = null, System.Collections.Immutable.ImmutableDictionary<string, string> properties = null, System.Collections.Immutable.ImmutableArray<string> tags = default(System.Collections.Immutable.ImmutableArray<string>), Microsoft.CodeAnalysis.Completion.CompletionItemRules rules = null) -> Microsoft.CodeAnalysis.Completion.CompletionItem
 static Microsoft.CodeAnalysis.Completion.CompletionItem.Create(string displayText, string filterText, string sortText, Microsoft.CodeAnalysis.Text.TextSpan span, System.Collections.Immutable.ImmutableDictionary<string, string> properties, System.Collections.Immutable.ImmutableArray<string> tags, Microsoft.CodeAnalysis.Completion.CompletionItemRules rules) -> Microsoft.CodeAnalysis.Completion.CompletionItem


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/8532

Note: we already had this capability.  It was just never exposed publicly. 