### PR TITLE
Parsing makes no progress on "()" in lambda parameters

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -11182,7 +11182,8 @@ tryAgain:
                         nodes.Add(parameter);
 
                         // additional parameters
-                        while (true)
+                        int tokenProgress = -1;
+                        while(IsMakingProgress(ref tokenProgress))
                         {
                             if (this.CurrentToken.Kind == SyntaxKind.CloseParenToken)
                             {

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -11258,6 +11258,7 @@ tryAgain:
             var pk = this.PeekToken(1).Kind;
             if (isRefOrOutOrParams
                 || (pk != SyntaxKind.CommaToken && pk != SyntaxKind.CloseParenToken && (hasTypes || isFirst))
+                || (this.CurrentToken.Kind == SyntaxKind.OpenParenToken && pk == SyntaxKind.CloseParenToken && (hasTypes || isFirst))
                 || IsPredefinedType(this.CurrentToken.Kind))
             {
                 if (isRefOrOutOrParams)

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -1071,7 +1071,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return this.Options.IsFeatureEnabled(feature);
         }
 
-        // TODO REVIEW
+        /// <summary>
+        /// Whenever parsing in a `while (true)` loop and a bug could prevent the loop from making progress,
+        /// this method can prevent the parsing from hanging.
+        /// Use as:
+        ///     int tokenProgress = -1;
+        ///     while (IsMakingProgress(ref tokenProgress))
+        /// It should be used as a guardrail, not as a crutch, so it asserts if no progress was made.
+        /// </summary>
         protected bool IsMakingProgress(ref int lastTokenOffset)
         {
             if (_tokenOffset > lastTokenOffset)
@@ -1079,6 +1086,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 lastTokenOffset = _tokenOffset;
                 return true;
             }
+
+            Debug.Assert(false);
             return false;
         }
     }

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -1070,5 +1070,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
             return this.Options.IsFeatureEnabled(feature);
         }
+
+        // TODO REVIEW
+        protected bool IsMakingProgress(ref int lastTokenOffset)
+        {
+            if (_tokenOffset > lastTokenOffset)
+            {
+                lastTokenOffset = _tokenOffset;
+                return true;
+            }
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Issue https://github.com/dotnet/roslyn/issues/14167 reported an IDE hang which is due to parsing forever in [ParseLambdaParameterList](http://source.roslyn.io/#Microsoft.CodeAnalysis.CSharp/Parser/LanguageParser.cs,0df2a44ff3e16dc5).

When it encounters the open paren, it will attempt to parse a lambda parameter (this could be the open paren of a tuple type). But when it sees the following close paren, it doesn't try to parse a type.
So it doesn't eat the open paren and is stuck in a loop.

For discussion, I've included a un-used method in the PR, `IsMakingProgress`.
It would allow writing:
```C#
int tokenProgress = -1;
while (IsMakingProgress(ref tokenProgress)
{
```
instead of `while (true)`.

Vlad thought the cost may not be worthwhile (some runtime cost and also it may hide bugs). I'd like to hear what you think. 

@dotnet/roslyn-compiler for review for RC.