### PR TITLE
Use Guid constructor instead of Guid.Parse...

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/SynthesizedPrivateImplementationDetailsStaticConstructor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             //
             //     payloadRoot = new T[MaximumMethodDefIndex + 1][];
             //
-            // where T is the type of the payload at each instrumentation point, and MaximumMethodDefIndex is the 
+            // where T is the type of the payload at each instrumentation point, and MaximumMethodDefIndex is the
             // index portion of the greatest method definition token in the compilation. This guarantees that any
             // method can use the index portion of its own method definition token as an index into the payload array.
 
@@ -52,12 +52,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 }
 
                 // Initialize the module version ID (MVID) field. Dynamic instrumentation requires the MVID of the executing module, and this field makes that accessible.
-                // MVID = Guid.Parse(ModuleVersionIdString);
+                // MVID = new Guid(ModuleVersionIdString);
                 body.Add(
                     factory.Assignment(
                        factory.ModuleVersionId(),
-                       factory.StaticCall(
-                           WellKnownMember.System_Guid__Parse,
+                       factory.New(
+                           factory.WellKnownMethod(WellKnownMember.System_Guid__ctor),
                            factory.ModuleVersionIdString())));
             }
             catch (SyntheticBoundNodeFactory.MissingPredefinedMember missing)

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -461,7 +461,7 @@ True
   IL_0007:  newarr     ""bool[]""
   IL_000c:  stsfld     ""bool[][] <PrivateImplementationDetails>.PayloadRoot0""
   IL_0011:  ldstr      ##MVID##
-  IL_0016:  call       ""System.Guid System.Guid.Parse(string)""
+  IL_0016:  newobj     ""System.Guid..ctor(string)""
   IL_001b:  stsfld     ""System.Guid <PrivateImplementationDetails>.MVID""
   IL_0020:  ret
 }";
@@ -1944,7 +1944,7 @@ public class Program
             foreach (Diagnostic diagnostic in diagnostics)
             {
                 if (diagnostic.Code == (int)ErrorCode.ERR_MissingPredefinedMember &&
-                    diagnostic.Arguments[0].Equals("System.Guid") && diagnostic.Arguments[1].Equals("Parse"))
+                    diagnostic.Arguments[0].Equals("System.Guid") && diagnostic.Arguments[1].Equals(".ctor"))
                 {
                     return;
                 }

--- a/src/Compilers/Core/Portable/WellKnownMember.cs
+++ b/src/Compilers/Core/Portable/WellKnownMember.cs
@@ -48,7 +48,6 @@ namespace Microsoft.CodeAnalysis
         System_CLSCompliantAttribute__ctor,
         System_FlagsAttribute__ctor,
         System_Guid__ctor,
-        System_Guid__Parse,
 
         System_Type__GetTypeFromCLSID,
         System_Type__GetTypeFromHandle,

--- a/src/Compilers/Core/Portable/WellKnownMembers.cs
+++ b/src/Compilers/Core/Portable/WellKnownMembers.cs
@@ -333,14 +333,6 @@ namespace Microsoft.CodeAnalysis
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
 
-                // System_Guid__Parse
-                (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
-                (byte)WellKnownType.System_Guid,                                                                            // DeclaringTypeId
-                0,                                                                                                          // Arity
-                    1,                                                                                                      // Method Signature
-                    (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Guid,
-                    (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_String,
-
                 // System_Type__GetTypeFromCLSID
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.System_Type,                                                                            // DeclaringTypeId
@@ -2361,7 +2353,7 @@ namespace Microsoft.CodeAnalysis
                 0,                                                                                                          // Arity
                     0,                                                                                                      // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)WellKnownType.System_Threading_Tasks_Task,
-                    
+
                 // System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T__Create
                 (byte)(MemberFlags.Method | MemberFlags.Static),                                                            // Flags
                 (byte)WellKnownType.System_Runtime_CompilerServices_AsyncTaskMethodBuilder_T,                               // DeclaringTypeId
@@ -2859,7 +2851,7 @@ namespace Microsoft.CodeAnalysis
                 // System_Runtime_CompilerServices_TupleElementNamesAttribute__ctorTransformNames
                 (byte)MemberFlags.Constructor,                                                                                   // Flags
                 (byte)WellKnownType.ExtSentinel, (byte)(WellKnownType.System_Runtime_CompilerServices_TupleElementNamesAttribute // DeclaringTypeId
-                                                        - WellKnownType.ExtSentinel),                             
+                                                        - WellKnownType.ExtSentinel),
                 0,                                                                                                               // Arity
                     1,                                                                                                           // Method Signature
                     (byte)SignatureTypeCode.TypeHandle, (byte)SpecialType.System_Void,
@@ -2930,7 +2922,6 @@ namespace Microsoft.CodeAnalysis
                 ".ctor",                                    // System_CLSCompliantAttribute__ctor
                 ".ctor",                                    // System_FlagsAttribute__ctor
                 ".ctor",                                    // System_Guid__ctor
-                "Parse",                                    // System_Guid__Parse
                 "GetTypeFromCLSID",                         // System_Type__GetTypeFromCLSID
                 "GetTypeFromHandle",                        // System_Type__GetTypeFromHandle
                 "Missing",                                  // System_Type__Missing

--- a/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/SynthesizedPrivateImplementationDetailsSharedConstructor.vb
@@ -68,7 +68,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             '
             '     payloadRoot = New T(MaximumMethodDefIndex)() {}
             '
-            ' where T Is the type of the payload at each instrumentation point, and MaximumMethodDefIndex is the 
+            ' where T Is the type of the payload at each instrumentation point, and MaximumMethodDefIndex is the
             ' index portion of the greatest method definition token in the compilation. This guarantees that any
             ' method can use the index portion of its own method definition token as an index into the payload array.
 
@@ -84,14 +84,14 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Next
 
             ' Initialize the module version ID (MVID) field. Dynamic instrumentation requires the MVID of the executing module, and this field makes that accessible.
-            ' MVID = Guid.Parse(ModuleVersionIdString)
+            ' MVID = New Guid(ModuleVersionIdString)
 
-            Dim guidParse As MethodSymbol = factory.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Guid__Parse)
-            If guidParse IsNot Nothing Then
+            Dim guidConstructor As MethodSymbol = factory.WellKnownMember(Of MethodSymbol)(WellKnownMember.System_Guid__ctor)
+            If guidConstructor IsNot Nothing Then
                 body.Add(
                     factory.Assignment(
                        factory.ModuleVersionId(isLValue:=True),
-                       factory.Call(Nothing, guidParse, ImmutableArray.Create(factory.ModuleVersionIdString()))))
+                       factory.[New](guidConstructor, factory.ModuleVersionIdString())))
             End If
 
             body.Add(factory.Return())

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -142,6 +142,21 @@ True
   IL_0038:  ret
 }
                 ]]>.Value)
+            verifier.VerifyIL(
+                ".cctor",
+            <![CDATA[
+{
+  // Code size       31 (0x1f)
+  .maxstack  1
+  IL_0000:  ldtoken    Max Method Token Index
+  IL_0005:  newarr     "Boolean()"
+  IL_000a:  stsfld     "Boolean()() <PrivateImplementationDetails>.PayloadRoot0"
+  IL_000f:  ldstr      ##MVID##
+  IL_0014:  newobj     "Sub System.Guid..ctor(String)"
+  IL_0019:  stsfld     "System.Guid <PrivateImplementationDetails>.MVID"
+  IL_001e:  ret
+}
+                ]]>.Value)
             verifier.VerifyDiagnostics()
         End Sub
 

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.vb
@@ -1622,7 +1622,7 @@ End Class
 
             Dim diagnostics As ImmutableArray(Of Diagnostic) = CreateCompilation(source).GetEmitDiagnostics(EmitOptions.Default.WithInstrumentationKinds(ImmutableArray.Create(InstrumentationKind.TestCoverage)))
             For Each Diagnostic As Diagnostic In diagnostics
-                If Diagnostic.Code = ERRID.ERR_MissingRuntimeHelper AndAlso Diagnostic.Arguments(0).Equals("System.Guid.Parse") Then
+                If Diagnostic.Code = ERRID.ERR_MissingRuntimeHelper AndAlso Diagnostic.Arguments(0).Equals("System.Guid..ctor") Then
                     Return
                 End If
             Next


### PR DESCRIPTION
...for dynamic analysis instrumentation.  Guid.Parse is not available when
targeting .NET 2.0/3.5.