### PR TITLE
Dominant type for VB tuples

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (type1.Equals(type2, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
-                    return MethodTypeInferrer.MergeTupleNames(type1, type2, MethodTypeInferrer.MergeDynamic(type1, type2, type1, _conversions.CorLibrary), _conversions.CorLibrary);
+                    return MethodTypeInferrer.MergeTupleNames(type1, type2, MethodTypeInferrer.MergeDynamic(type1, type2, type1, _conversions.CorLibrary));
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/BestTypeInferrer.cs
@@ -215,7 +215,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (type1.Equals(type2, TypeCompareKind.IgnoreDynamicAndTupleNames))
                 {
-                    return MethodTypeInferrer.MergeTupleNames(type1, type2, MethodTypeInferrer.MergeDynamic(type1, type2, type1, _conversions.CorLibrary));
+                    return MethodTypeInferrer.MergeTupleNames(MethodTypeInferrer.MergeDynamic(type1, type2, _conversions.CorLibrary), type2);
                 }
 
                 return null;

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2492,7 +2492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(!(best.IsObjectType() && candidate.IsDynamic()));
                         Debug.Assert(!(best.IsDynamic() && candidate.IsObjectType()));
 
-                        best = MergeTupleNames(best, candidate, MergeDynamic(best, candidate, best, _conversions.CorLibrary), _conversions.CorLibrary);
+                        best = MergeTupleNames(best, candidate, MergeDynamic(best, candidate, best, _conversions.CorLibrary));
                     }
 
                     OuterBreak:
@@ -2536,7 +2536,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// Takes the names from the two types, finds the common names, and applies them onto the target.
         /// </summary>
-        internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second, TypeSymbol target, AssemblySymbol corLibrary)
+        internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second, TypeSymbol target)
         {
             if (first.Equals(second, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic) ||
                 !target.ContainsTupleNames())
@@ -2565,7 +2565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return TupleTypeDecoder.DecodeTupleTypesIfApplicable(target, corLibrary, mergedNames);
+            return TupleTypeDecoder.DecodeTupleTypesIfApplicable(target, mergedNames);
         }
 
         private bool ImplicitConversionExists(TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2492,7 +2492,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         Debug.Assert(!(best.IsObjectType() && candidate.IsDynamic()));
                         Debug.Assert(!(best.IsDynamic() && candidate.IsObjectType()));
 
-                        best = MergeTupleNames(best, candidate, MergeDynamic(best, candidate, best, _conversions.CorLibrary));
+                        best = MergeTupleNames(MergeDynamic(best, candidate, _conversions.CorLibrary), candidate);
                     }
 
                     OuterBreak:
@@ -2516,35 +2516,35 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Takes the dynamic flags from both types and applies them onto the target.
+        /// Returns first or a modified version of first with merged dynamic flags from both types.
         /// </summary>
-        internal static TypeSymbol MergeDynamic(TypeSymbol first, TypeSymbol second, TypeSymbol target, AssemblySymbol corLibrary)
+        internal static TypeSymbol MergeDynamic(TypeSymbol first, TypeSymbol second, AssemblySymbol corLibrary)
         {
             // SPEC: 4.7 The Dynamic Type
             //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
             if (first.Equals(second, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreTupleNames))
             {
-                return target;
+                return first;
             }
             ImmutableArray<bool> flags1 = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(first, RefKind.None);
             ImmutableArray<bool> flags2 = CSharpCompilation.DynamicTransformsEncoder.EncodeWithoutCustomModifierFlags(second, RefKind.None);
             ImmutableArray<bool> mergedFlags = flags1.ZipAsArray(flags2, (f1, f2) => f1 | f2);
 
-            return DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(target, corLibrary, RefKind.None, mergedFlags);
+            return DynamicTypeDecoder.TransformTypeWithoutCustomModifierFlags(first, corLibrary, RefKind.None, mergedFlags);
         }
 
         /// <summary>
-        /// Takes the names from the two types, finds the common names, and applies them onto the target.
+        /// Returns first or a modified version of first with common tuple names from both types.
         /// </summary>
-        internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second, TypeSymbol target)
+        internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second)
         {
             if (first.Equals(second, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic) ||
-                !target.ContainsTupleNames())
+                !first.ContainsTupleNames())
             {
-                return target;
+                return first;
             }
 
-            Debug.Assert(target.ContainsTuple());
+            Debug.Assert(first.ContainsTuple());
 
             ImmutableArray<string> names1 = CSharpCompilation.TupleNamesEncoder.Encode(first);
             ImmutableArray<string> names2 = CSharpCompilation.TupleNamesEncoder.Encode(second);
@@ -2565,7 +2565,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            return TupleTypeDecoder.DecodeTupleTypesIfApplicable(target, mergedNames);
+            return TupleTypeDecoder.DecodeTupleTypesIfApplicable(first, mergedNames);
         }
 
         private bool ImplicitConversionExists(TypeSymbol source, TypeSymbol destination, ref HashSet<DiagnosticInfo> useSiteDiagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/MethodTypeInference.cs
@@ -2522,7 +2522,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             // SPEC: 4.7 The Dynamic Type
             //       Type inference (7.5.2) will prefer dynamic over object if both are candidates.
-            if (first.Equals(second, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreTupleNames))
+            if (first.Equals(second, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreDynamic))
             {
                 return first;
             }
@@ -2538,7 +2538,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         internal static TypeSymbol MergeTupleNames(TypeSymbol first, TypeSymbol second)
         {
-            if (first.Equals(second, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds | TypeCompareKind.IgnoreDynamic) ||
+            if (first.Equals(second, TypeCompareKind.AllIgnoreOptions & ~TypeCompareKind.IgnoreTupleNames) ||
                 !first.ContainsTupleNames())
             {
                 return first;

--- a/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ArrayTypeSymbol.cs
@@ -510,9 +510,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 _interfaces = constructedInterfaces;
             }
 
-            internal override ArrayTypeSymbol WithElementType(TypeSymbol elementType)
+            internal override ArrayTypeSymbol WithElementType(TypeSymbol newElementType)
             {
-                return new SZArray(elementType, BaseTypeNoUseSiteDiagnostics, _interfaces, CustomModifiers);
+                ImmutableArray<NamedTypeSymbol> newInterfaces = _interfaces;
+                if (newInterfaces.Length>0)
+                {
+                    newInterfaces = newInterfaces.SelectAsArray(i => i.OriginalDefinition.Construct(newElementType));
+                }
+
+                return new SZArray(newElementType, BaseTypeNoUseSiteDiagnostics, newInterfaces, CustomModifiers);
             }
 
             public override int Rank

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -253,7 +253,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
         private ArrayTypeSymbol DecodeArrayType(ArrayTypeSymbol type)
         {
             var decodedElementType = DecodeType(type.ElementType);
-            return ReferenceEquals(decodedElementType, type)
+            return ReferenceEquals(decodedElementType, type.ElementType)
                 ? type
                 : type.WithElementType(decodedElementType);
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Metadata/PE/TupleTypeDecoder.cs
@@ -59,15 +59,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
     /// </summary>
     internal struct TupleTypeDecoder
     {
-        private readonly AssemblySymbol _containingAssembly;
         private readonly ImmutableArray<string> _elementNames;
         // Keep track of how many names we've "used" during decoding. Starts at
         // the back of the array and moves forward.
         private int _namesIndex;
 
-        private TupleTypeDecoder(ImmutableArray<string> elementNames, AssemblySymbol containingAssembly)
+        private TupleTypeDecoder(ImmutableArray<string> elementNames)
         {
-            _containingAssembly = containingAssembly;
             _elementNames = elementNames;
             _namesIndex = elementNames.IsDefault ? 0 : elementNames.Length;
         }
@@ -89,23 +87,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
                 return new UnsupportedMetadataTypeSymbol();
             }
 
-            return DecodeTupleTypesInternal(metadataType, containingModule.ContainingAssembly, elementNames, hasTupleElementNamesAttribute);
+            return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute);
         }
 
         public static TypeSymbol DecodeTupleTypesIfApplicable(
             TypeSymbol metadataType,
-            AssemblySymbol containingAssembly,
             ImmutableArray<string> elementNames)
         {
-            return DecodeTupleTypesInternal(metadataType, containingAssembly, elementNames, hasTupleElementNamesAttribute: !elementNames.IsDefaultOrEmpty);
+            return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute: !elementNames.IsDefaultOrEmpty);
         }
 
-        private static TypeSymbol DecodeTupleTypesInternal(TypeSymbol metadataType, AssemblySymbol containingAssembly, ImmutableArray<string> elementNames, bool hasTupleElementNamesAttribute)
+        private static TypeSymbol DecodeTupleTypesInternal(TypeSymbol metadataType, ImmutableArray<string> elementNames, bool hasTupleElementNamesAttribute)
         {
             Debug.Assert((object)metadataType != null);
-            Debug.Assert((object)containingAssembly != null);
 
-            var decoder = new TupleTypeDecoder(elementNames, containingAssembly);
+            var decoder = new TupleTypeDecoder(elementNames);
             try
             {
                 var decoded = decoder.DecodeType(metadataType);
@@ -259,16 +255,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE
             var decodedElementType = DecodeType(type.ElementType);
             return ReferenceEquals(decodedElementType, type)
                 ? type
-                : type.IsSZArray
-                    ? ArrayTypeSymbol.CreateSZArray(_containingAssembly,
-                                                    decodedElementType,
-                                                    type.CustomModifiers)
-                    : ArrayTypeSymbol.CreateMDArray(_containingAssembly,
-                                                    decodedElementType,
-                                                    type.Rank,
-                                                    type.Sizes,
-                                                    type.LowerBounds,
-                                                    type.CustomModifiers);
+                : type.WithElementType(decodedElementType);
         }
 
         private ImmutableArray<string> EatElementNamesIfAvailable(int numberOfElements)

--- a/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/CustomModifierUtils.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 // We also preserve tuple names, if present and different
                 ImmutableArray<string> names = CSharpCompilation.TupleNamesEncoder.Encode(destinationType);
-                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeWithDynamic, containingAssembly, names);
+                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(typeWithDynamic, names);
             }
             else
             {

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16299,18 +16299,20 @@ public class C
                 //         System.Console.Write(t.c);
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "c").WithArguments("(int a, int)", "c").WithLocation(9, 32)
                 );
+            // Some missing warnings here. See issue https://github.com/dotnet/roslyn/issues/14485
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
             var nodes = tree.GetCompilationUnitRoot().DescendantNodes();
             var invocation1 = model.GetSymbolInfo(nodes.OfType<InvocationExpressionSyntax>().First());
-            Assert.Equal("(System.Int32 a, System.Int32) C.M2<(System.Int32 a, System.Int32)>((System.Int32 a, System.Int32) x1, (System.Int32 a, System.Int32) x2)", invocation1.Symbol.ToTestDisplayString());
+            Assert.Equal("(System.Int32 a, System.Int32)", ((MethodSymbol)invocation1.Symbol).ReturnType.ToTestDisplayString());
 
             var invocation2 = model.GetSymbolInfo(nodes.OfType<InvocationExpressionSyntax>().Skip(4).First());
-            Assert.Equal("(System.Int32, System.Int32) C.M2<(System.Int32, System.Int32)>((System.Int32, System.Int32) x1, (System.Int32, System.Int32) x2)", invocation2.Symbol.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)", ((MethodSymbol)invocation2.Symbol).ReturnType.ToTestDisplayString());
 
             var invocation3 = model.GetSymbolInfo(nodes.OfType<InvocationExpressionSyntax>().Skip(5).First());
-            Assert.Equal("(System.Int32, System.Int32)[] C.M2<(System.Int32, System.Int32)[]>((System.Int32, System.Int32)[] x1, (System.Int32, System.Int32)[] x2)", invocation3.Symbol.ToTestDisplayString());
+            Assert.Equal("(System.Int32, System.Int32)[]", ((MethodSymbol)invocation3.Symbol).ReturnType.ToTestDisplayString());
+            // TODO REVIEW  Are those expectations wrong?
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16299,7 +16299,6 @@ public class C
                 //         System.Console.Write(t.c);
                 Diagnostic(ErrorCode.ERR_NoSuchMemberOrExtension, "c").WithArguments("(int a, int)", "c").WithLocation(9, 32)
                 );
-            // Some missing warnings here. See issue https://github.com/dotnet/roslyn/issues/14485
 
             var tree = comp.SyntaxTrees.First();
             var model = comp.GetSemanticModel(tree);
@@ -16312,7 +16311,6 @@ public class C
 
             var invocation3 = model.GetSymbolInfo(nodes.OfType<InvocationExpressionSyntax>().Skip(5).First());
             Assert.Equal("(System.Int32, System.Int32)[]", ((MethodSymbol)invocation3.Symbol).ReturnType.ToTestDisplayString());
-            // TODO REVIEW  Are those expectations wrong?
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -16465,6 +16465,11 @@ public class Derived : Base
                 //     public override (dynamic notA, dynamic) M6() { return (1, 2); }
                 Diagnostic(ErrorCode.ERR_CantChangeTupleNamesOnOverride, "M6").WithArguments("Derived.M6()", "Base.M6()").WithLocation(18, 45)
                 );
+
+            var m3 = comp.GetMember<MethodSymbol>("Derived.M3").ReturnType;
+            Assert.Equal("(System.Int32 notA, System.Int32 notB)[]", m3.ToTestDisplayString());
+            Assert.Equal(new []{"System.Collections.Generic.IList<(System.Int32 notA, System.Int32 notB)>"},
+                         m3.Interfaces.SelectAsArray(t => t.ToTestDisplayString()));
         }
 
         [Fact]

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -4503,5 +4503,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend Overrides Function InternalSubstituteTypeParameters(substitution As TypeSubstitution) As TypeWithModifiers
             Throw ExceptionUtilities.Unreachable
         End Function
+
+        Friend Overrides Function WithElementType(elementType As TypeSymbol) As ArrayTypeSymbol
+            Throw ExceptionUtilities.Unreachable
+        End Function
     End Class
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeArgumentInference.vb
@@ -375,6 +375,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                         ' Do not merge array literals with other expressions
                         If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol AndAlso type.IsSameTypeIgnoringAll(competitor.ResultType) Then
+                            competitor.ResultType = TypeInferenceCollection.MergeTupleNames(competitor.ResultType, type)
                             competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
                                                                         competitor.InferenceRestrictions,
                                                                         inferenceRestrictions)

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
@@ -1,10 +1,12 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Diagnostics
 Imports System.Runtime.InteropServices
 Imports Microsoft.CodeAnalysis.Collections
 Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic
@@ -185,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             ' Rule 4. "Otherwise, fail."
             If numberOfUnstrictCandidates = 0 Then
                 Debug.Assert(numberOfStrictCandidates = 0, "code logic error: since every strict candidate is also an unstrict candidate.")
-                inferenceErrorReasons = inferenceErrorReasons Or inferenceErrorReasons.NoBest
+                inferenceErrorReasons = inferenceErrorReasons Or InferenceErrorReasons.NoBest
                 Return
             End If
 
@@ -200,7 +202,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Next
 
                 Debug.Assert(resultList.Count() = numberOfUnstrictCandidates, "code logic error: we should have >1 unstrict candidates, like we calculated earlier")
-                inferenceErrorReasons = inferenceErrorReasons Or inferenceErrorReasons.Ambiguous
+                inferenceErrorReasons = inferenceErrorReasons Or InferenceErrorReasons.Ambiguous
                 Return
             End If
 
@@ -372,7 +374,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' If there were multiple dominant types out of that set, then return them all and say "ambiguous"
             If resultList.Count > 1 Then
-                inferenceErrorReasons = inferenceErrorReasons Or inferenceErrorReasons.Ambiguous
+                inferenceErrorReasons = inferenceErrorReasons Or InferenceErrorReasons.Ambiguous
                 Return
             End If
 
@@ -390,7 +392,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Next
 
             Debug.Assert(resultList.Count > 0, "code logic error: we already said there were multiple strict candidates")
-            inferenceErrorReasons = inferenceErrorReasons Or inferenceErrorReasons.Ambiguous
+            inferenceErrorReasons = inferenceErrorReasons Or InferenceErrorReasons.Ambiguous
         End Sub
 
         Private Shared Sub AppendArrayElements(source As BoundArrayInitialization, elements As ArrayBuilder(Of BoundExpression))
@@ -562,8 +564,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Don't add error types to the dominant type inference collection.
-            If type.IsErrorType then
-                return
+            If type.IsErrorType Then
+                Return
             End If
 
             ' We will add only unique types into this collection. Otherwise, say, if we added two types
@@ -577,15 +579,19 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each competitor As DominantTypeData In Me.GetTypeDataList()
 
                     ' Do not merge array literals with other expressions
-                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol AndAlso type.IsSameTypeIgnoringAll(competitor.ResultType) Then
+                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol Then
+                        If type.IsSameType(competitor.ResultType, TypeCompareKind.AllIgnoreOptionsForVB) Then
 
-                        competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
+                            competitor.ResultType = MergeTupleNames(type, competitor.ResultType)
+
+                            competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
                                                             competitor.InferenceRestrictions,
                                                             conversion)
 
-                        ' TODO: should we simply get out of the loop here? For some reason Dev10 continues, I guess it verifies uniqueness this way.
-                        Debug.Assert(Not foundInList, "List is supposed to be unique: how can we already find two of the same type in this list.")
-                        foundInList = True
+                            ' TODO: should we simply get out of the loop here? For some reason Dev10 continues, I guess it verifies uniqueness this way.
+                            Debug.Assert(Not foundInList, "List is supposed to be unique: how can we already find two of the same type in this list.")
+                            foundInList = True
+                        End If
                     End If
                 Next
             End If
@@ -599,6 +605,33 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
+        Private Function MergeTupleNames(first As TypeSymbol, second As TypeSymbol) As TypeSymbol
+            If first.IsSameType(second, TypeCompareKind.AllIgnoreOptionsForVB And Not TypeCompareKind.IgnoreTupleNames) OrElse
+                Not first.ContainsTupleNames() Then
+
+                Return first
+            End If
+
+            If Not second.ContainsTupleNames() Then
+                Return second
+            End If
+
+            Dim names1 As ImmutableArray(Of String) = VisualBasicCompilation.TupleNamesEncoder.Encode(first)
+            Dim names2 As ImmutableArray(Of String) = VisualBasicCompilation.TupleNamesEncoder.Encode(second)
+
+            Dim mergedNames As ImmutableArray(Of String)
+            If names1.IsDefault OrElse names2.IsDefault Then
+                mergedNames = Nothing
+            Else
+                Debug.Assert(names1.Length = names2.Length)
+                mergedNames = names1.ZipAsArray(names2, Function(n1, n2) If(IdentifierComparison.Equals(n1, n2), n1, Nothing))
+                If mergedNames.All(Function(n) n Is Nothing) Then
+                    mergedNames = Nothing
+                End If
+            End If
+
+            Return TupleTypeDecoder.DecodeTupleTypesIfApplicable(first, mergedNames)
+        End Function
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
@@ -579,19 +579,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each competitor As DominantTypeData In Me.GetTypeDataList()
 
                     ' Do not merge array literals with other expressions
-                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol Then
-                        If type.IsSameType(competitor.ResultType, TypeCompareKind.AllIgnoreOptionsForVB) Then
+                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol AndAlso type.IsSameType(competitor.ResultType, TypeCompareKind.AllIgnoreOptionsForVB) Then
+                        competitor.ResultType = MergeTupleNames(type, competitor.ResultType)
+                        competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
+                                                        competitor.InferenceRestrictions,
+                                                        conversion)
 
-                            competitor.ResultType = MergeTupleNames(type, competitor.ResultType)
-
-                            competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
-                                                            competitor.InferenceRestrictions,
-                                                            conversion)
-
-                            ' TODO: should we simply get out of the loop here? For some reason Dev10 continues, I guess it verifies uniqueness this way.
-                            Debug.Assert(Not foundInList, "List is supposed to be unique: how can we already find two of the same type in this list.")
-                            foundInList = True
-                        End If
+                        ' TODO: should we simply get out of the loop here? For some reason Dev10 continues, I guess it verifies uniqueness this way.
+                        Debug.Assert(Not foundInList, "List is supposed to be unique: how can we already find two of the same type in this list.")
+                        foundInList = True
                     End If
                 Next
             End If
@@ -605,7 +601,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
-        Private Function MergeTupleNames(first As TypeSymbol, second As TypeSymbol) As TypeSymbol
+        Friend Shared Function MergeTupleNames(first As TypeSymbol, second As TypeSymbol) As TypeSymbol
             If first.IsSameType(second, TypeCompareKind.AllIgnoreOptionsForVB And Not TypeCompareKind.IgnoreTupleNames) OrElse
                 Not first.ContainsTupleNames() Then
 

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
@@ -601,6 +601,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
         End Sub
 
+        ''' <summary>
+        ''' Returns first Or a modified version Of first With common tuple names from both types.
+        ''' </summary>
         Friend Shared Function MergeTupleNames(first As TypeSymbol, second As TypeSymbol) As TypeSymbol
             If first.IsSameType(second, TypeCompareKind.AllIgnoreOptionsForVB And Not TypeCompareKind.IgnoreTupleNames) OrElse
                 Not first.ContainsTupleNames() Then

--- a/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/TypeInference/TypeInferenceCollection.vb
@@ -579,7 +579,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 For Each competitor As DominantTypeData In Me.GetTypeDataList()
 
                     ' Do not merge array literals with other expressions
-                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol AndAlso type.IsSameType(competitor.ResultType, TypeCompareKind.AllIgnoreOptionsForVB) Then
+                    If TypeOf competitor.ResultType IsNot ArrayLiteralTypeSymbol AndAlso type.IsSameTypeIgnoringAll(competitor.ResultType) Then
                         competitor.ResultType = MergeTupleNames(type, competitor.ResultType)
                         competitor.InferenceRestrictions = Conversions.CombineConversionRequirements(
                                                         competitor.InferenceRestrictions,

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -579,12 +579,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend Overrides ReadOnly Property HasDefaultSizesAndLowerBounds As Boolean
-                Get
-                    Return True
-                End Get
-            End Property
-
         End Class
 
         Private NotInheritable Class MDArrayNoSizesOrBounds
@@ -597,6 +591,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Friend Overrides Function WithElementType(newElementType As TypeSymbol) As ArrayTypeSymbol
                 Return New MDArrayNoSizesOrBounds(newElementType, CustomModifiers, Rank, BaseTypeNoUseSiteDiagnostics)
             End Function
+
+            Friend Overrides ReadOnly Property HasDefaultSizesAndLowerBounds As Boolean
+                Get
+                    Return True
+                End Get
+            End Property
+
         End Class
 
         Private NotInheritable Class MDArrayWithSizesAndBounds

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -47,7 +47,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             ' Optimize for most common case - no sizes and all dimensions are zero lower bound.
             If sizes.IsDefaultOrEmpty AndAlso lowerBounds.IsDefault Then
-                Return New MDArray(elementType,
+                Return New MDArrayNoSizesOrBounds(elementType,
                                customModifiers,
                                rank,
                                systemArray)
@@ -488,8 +488,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                         newArray = New SZArray(newElementType.Type, newElementType.CustomModifiers, _systemArray, newInterfaces)
 
-                    ElseIf Me.HasDefaultSizesAndLowerBounds
-                        newArray = New MDArray(newElementType.Type, newElementType.CustomModifiers, Me.Rank, _systemArray)
+                    ElseIf Me.HasDefaultSizesAndLowerBounds Then
+                        newArray = New MDArrayNoSizesOrBounds(newElementType.Type, newElementType.CustomModifiers, Me.Rank, _systemArray)
 
                     Else
                         newArray = New MDArrayWithSizesAndBounds(newElementType.Type, newElementType.CustomModifiers, Me.Rank, Me.Sizes, Me.LowerBounds, _systemArray)
@@ -549,7 +549,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' Represents MDARRAY - multi-dimensional array (possibly of rank 1)
         ''' </summary>
-        Private Class MDArray
+        Private MustInherit Class MDArray
             Inherits SZOrMDArray
 
             Private ReadOnly _rank As Integer
@@ -585,8 +585,17 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
+        End Class
+
+        Private NotInheritable Class MDArrayNoSizesOrBounds
+            Inherits MDArray
+
+            Public Sub New(elementType As TypeSymbol, customModifiers As ImmutableArray(Of CustomModifier), rank As Integer, systemArray As NamedTypeSymbol)
+                MyBase.New(elementType, customModifiers, rank, systemArray)
+            End Sub
+
             Friend Overrides Function WithElementType(newElementType As TypeSymbol) As ArrayTypeSymbol
-                Return New MDArray(newElementType, CustomModifiers, Rank, BaseTypeNoUseSiteDiagnostics)
+                Return New MDArrayNoSizesOrBounds(newElementType, CustomModifiers, Rank, BaseTypeNoUseSiteDiagnostics)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -363,6 +363,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             Return Hash.Combine(current, hashCode)
         End Function
 
+        Friend MustOverride Function WithElementType(elementType As TypeSymbol) As ArrayTypeSymbol
+
 #Region "Use-Site Diagnostics"
 
         Friend Overrides Function GetUseSiteErrorInfo() As DiagnosticInfo
@@ -538,6 +540,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return True
                 End Get
             End Property
+
+            Friend Overrides Function WithElementType(elementType As TypeSymbol) As ArrayTypeSymbol
+                Return New SZArray(elementType, CustomModifiers, BaseTypeNoUseSiteDiagnostics, Interfaces)
+            End Function
         End Class
 
         ''' <summary>
@@ -578,6 +584,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return True
                 End Get
             End Property
+
+            Friend Overrides Function WithElementType(newElementType As TypeSymbol) As ArrayTypeSymbol
+                Return New MDArray(newElementType, CustomModifiers, Rank, BaseTypeNoUseSiteDiagnostics)
+            End Function
         End Class
 
         Private NotInheritable Class MDArrayWithSizesAndBounds
@@ -619,6 +629,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     Return False
                 End Get
             End Property
+
+            Friend Overrides Function WithElementType(newElementType As TypeSymbol) As ArrayTypeSymbol
+                Return New MDArrayWithSizesAndBounds(newElementType, CustomModifiers, Rank, Sizes, LowerBounds, BaseTypeNoUseSiteDiagnostics)
+            End Function
         End Class
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ArrayTypeSymbol.vb
@@ -541,8 +541,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                 End Get
             End Property
 
-            Friend Overrides Function WithElementType(elementType As TypeSymbol) As ArrayTypeSymbol
-                Return New SZArray(elementType, CustomModifiers, BaseTypeNoUseSiteDiagnostics, Interfaces)
+            Friend Overrides Function WithElementType(newElementType As TypeSymbol) As ArrayTypeSymbol
+                Dim newInterfaces As ImmutableArray(Of NamedTypeSymbol) = _interfaces
+                If newInterfaces.Length > 0 Then
+                    newInterfaces = newInterfaces.SelectAsArray(Function(i) i.OriginalDefinition.Construct(newElementType))
+                End If
+
+                Return New SZArray(newElementType, CustomModifiers, BaseTypeNoUseSiteDiagnostics, newInterfaces)
             End Function
         End Class
 

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -148,9 +148,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                              DecodeNamedType(DirectCast(type, NamedTypeSymbol)))
 
                 Case SymbolKind.ArrayType
-                    Dim arrayType As ArrayTypeSymbol = DirectCast(type, ArrayTypeSymbol)
-                    Dim decodedElementType = DecodeType(arrayType.ElementType)
-                    Return If(decodedElementType Is type, type, arrayType.WithElementType(decodedElementType))
+                    Return DecodeArrayType(DirectCast(type, ArrayTypeSymbol))
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(type.TypeKind)
@@ -246,6 +244,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             decodedArgs.ReverseContents()
             Return decodedArgs.ToImmutableAndFree()
+        End Function
+
+        Private Function DecodeArrayType(type As ArrayTypeSymbol) As ArrayTypeSymbol
+            Dim decodedElementType = DecodeType(type.ElementType)
+            Return If(decodedElementType Is type, type, type.WithElementType(decodedElementType))
         End Function
 
         Private Function EatElementNamesIfAvailable(numberOfElements As Integer) As ImmutableArray(Of String)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -248,7 +248,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
         Private Function DecodeArrayType(type As ArrayTypeSymbol) As ArrayTypeSymbol
             Dim decodedElementType = DecodeType(type.ElementType)
-            Return If(decodedElementType Is type, type, type.WithElementType(decodedElementType))
+            Return If(decodedElementType Is type.ElementType, type, type.WithElementType(decodedElementType))
         End Function
 
         Private Function EatElementNamesIfAvailable(numberOfElements As Integer) As ImmutableArray(Of String)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/TupleTypeDecoder.vb
@@ -54,14 +54,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
     ''' </example>
     ''' </summary>
     Friend Structure TupleTypeDecoder
-        Private ReadOnly _containingAssembly As AssemblySymbol
         Private ReadOnly _elementNames As ImmutableArray(Of String)
         ' Keep track of how many names we've "used" during decoding. Starts at
         ' the back of the array and moves forward.
         Private _namesIndex As Integer
 
-        Private Sub New(elementNames As ImmutableArray(Of String), containingAssembly As AssemblySymbol)
-            _containingAssembly = containingAssembly
+        Private Sub New(elementNames As ImmutableArray(Of String))
             _elementNames = elementNames
             _namesIndex = If(elementNames.IsDefault, 0, elementNames.Length)
         End Sub
@@ -80,27 +78,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                 Return New UnsupportedMetadataTypeSymbol()
             End If
 
-            Return DecodeTupleTypesInternal(metadataType, containingModule.ContainingAssembly, elementNames, hasTupleElementNamesAttribute)
+            Return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute)
         End Function
 
 
         Public Shared Function DecodeTupleTypesIfApplicable(
              metadataType As TypeSymbol,
-             containingAssembly As AssemblySymbol,
              elementNames As ImmutableArray(Of String)) As TypeSymbol
 
-            Return DecodeTupleTypesInternal(metadataType, containingAssembly, elementNames, hasTupleElementNamesAttribute:=Not elementNames.IsDefaultOrEmpty)
+            Return DecodeTupleTypesInternal(metadataType, elementNames, hasTupleElementNamesAttribute:=Not elementNames.IsDefaultOrEmpty)
         End Function
 
         Private Shared Function DecodeTupleTypesInternal(metadataType As TypeSymbol,
-                                                         containingAssembly As AssemblySymbol,
                                                          elementNames As ImmutableArray(Of String),
                                                          hasTupleElementNamesAttribute As Boolean) As TypeSymbol
 
             Debug.Assert(metadataType IsNot Nothing)
-            Debug.Assert(containingAssembly IsNot Nothing)
 
-            Dim decoder = New TupleTypeDecoder(elementNames, containingAssembly)
+            Dim decoder = New TupleTypeDecoder(elementNames)
 
             Try
                 Dim decoded = decoder.DecodeType(metadataType)
@@ -153,7 +148,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                              DecodeNamedType(DirectCast(type, NamedTypeSymbol)))
 
                 Case SymbolKind.ArrayType
-                    Return DecodeArrayType(DirectCast(type, ArrayTypeSymbol))
+                    Dim arrayType As ArrayTypeSymbol = DirectCast(type, ArrayTypeSymbol)
+                    Dim decodedElementType = DecodeType(arrayType.ElementType)
+                    Return If(decodedElementType Is type, type, arrayType.WithElementType(decodedElementType))
 
                 Case Else
                     Throw ExceptionUtilities.UnexpectedValue(type.TypeKind)
@@ -249,24 +246,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
 
             decodedArgs.ReverseContents()
             Return decodedArgs.ToImmutableAndFree()
-        End Function
-
-        Private Function DecodeArrayType(type As ArrayTypeSymbol) As ArrayTypeSymbol
-            Dim decodedElementType = DecodeType(type.ElementType)
-            Return If(decodedElementType Is type,
-                        type,
-                        If(type.IsSZArray,
-                            ArrayTypeSymbol.CreateSZArray(decodedElementType,
-                                                          type.CustomModifiers,
-                                                          _containingAssembly),
-                            ArrayTypeSymbol.CreateMDArray(decodedElementType,
-                                                          type.CustomModifiers,
-                                                          type.Rank,
-                                                          type.Sizes,
-                                                          type.LowerBounds,
-                                                          _containingAssembly)))
-
-
         End Function
 
         Private Function EatElementNamesIfAvailable(numberOfElements As Integer) As ImmutableArray(Of String)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
@@ -14,7 +14,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                                 sourceMethod As MethodSymbol,
                                 destinationTypeParameters As ImmutableArray(Of TypeSymbol),
                                 <[In], Out> ByRef destinationReturnType As TypeSymbol,
-                                containingAssembly As AssemblySymbol,
                                 <[In], Out> ByRef parameters As ImmutableArray(Of ParameterSymbol))
 
             Debug.Assert(sourceMethod IsNot Nothing)

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
@@ -51,7 +51,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
             If destinationType.ContainsTuple() AndAlso Not sourceType.IsSameType(destinationType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) Then
                 Dim names As ImmutableArray(Of String) = VisualBasicCompilation.TupleNamesEncoder.Encode(destinationType)
-                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(sourceType, containingAssembly, names)
+                resultType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(sourceType, names)
             Else
                 resultType = sourceType
             End If
@@ -110,7 +110,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
                 If thisParamType.ContainsTuple() AndAlso Not overriddenParam.Type.IsSameType(thisParamType, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) Then
                     Dim names As ImmutableArray(Of String) = VisualBasicCompilation.TupleNamesEncoder.Encode(thisParamType)
-                    overriddenParamType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(overriddenParamType, thisParamType.ContainingAssembly, names)
+                    overriddenParamType = TupleTypeDecoder.DecodeTupleTypesIfApplicable(overriddenParamType, names)
                 End If
 
                 thisParam = DirectCast(thisParam, SourceParameterSymbolBase).WithTypeAndCustomModifiers(

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/CustomModifierUtils.vb
@@ -36,7 +36,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             ' we want to retain the original (incorrect) return type to avoid hiding the return type
             ' given in source.
             If destinationReturnType.IsSameType(returnTypeWithCustomModifiers, TypeCompareKind.AllIgnoreOptionsForVB) Then
-                destinationReturnType = CopyTypeCustomModifiers(returnTypeWithCustomModifiers, destinationReturnType, containingAssembly)
+                destinationReturnType = CopyTypeCustomModifiers(returnTypeWithCustomModifiers, destinationReturnType)
             End If
 
         End Sub
@@ -44,7 +44,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' <summary>
         ''' sourceType has the custom modifiers
         ''' </summary>
-        Friend Shared Function CopyTypeCustomModifiers(sourceType As TypeSymbol, destinationType As TypeSymbol, containingAssembly As AssemblySymbol) As TypeSymbol
+        Friend Shared Function CopyTypeCustomModifiers(sourceType As TypeSymbol, destinationType As TypeSymbol) As TypeSymbol
             Dim resultType As TypeSymbol
 
             Debug.Assert(sourceType.IsSameType(destinationType, TypeCompareKind.AllIgnoreOptionsForVB))

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourceMethodSymbol.vb
@@ -2111,7 +2111,7 @@ lReportErrorOnTwoTokens:
                 Dim overridden = overriddenMembers.OverriddenMember
 
                 If overridden IsNot Nothing Then
-                    CustomModifierUtils.CopyMethodCustomModifiers(overridden, Me.TypeArguments, retType, Me.ContainingAssembly, params)
+                    CustomModifierUtils.CopyMethodCustomModifiers(overridden, Me.TypeArguments, retType, params)
                 End If
 
                 ' Unlike MethodSymbol, in SourceMethodSymbol we cache the result of MakeOverriddenOfHiddenMembers, because we use

--- a/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Source/SourcePropertySymbol.vb
@@ -758,7 +758,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
                     ' we want to retain the original (incorrect) return type to avoid hiding the return type
                     ' given in source.
                     If retType.IsSameType(returnTypeWithCustomModifiers, TypeCompareKind.IgnoreCustomModifiersAndArraySizesAndLowerBounds) Then
-                        retType = CustomModifierUtils.CopyTypeCustomModifiers(returnTypeWithCustomModifiers, retType, Me.ContainingAssembly)
+                        retType = CustomModifierUtils.CopyTypeCustomModifiers(returnTypeWithCustomModifiers, retType)
                     End If
 
                     params = CustomModifierUtils.CopyParameterCustomModifiers(overridden.Parameters, params)

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -13850,6 +13850,11 @@ BC40001: 'Public Overrides Function M5() As (c As (notA As Integer, notB As Inte
                               ~~
 </errors>)
 
+            Dim m3 = comp.GetMember(Of MethodSymbol)("Derived.M3").ReturnType
+            Assert.Equal("(notA As System.Int32, notB As System.Int32)()", m3.ToTestDisplayString())
+            Assert.Equal({"System.Collections.Generic.IList(Of (notA As System.Int32, notB As System.Int32))"},
+                         m3.Interfaces.SelectAsArray(Function(t) t.ToTestDisplayString()))
+
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -11818,7 +11818,7 @@ BC36651: Data type(s) of the type parameter(s) in method 'Public Shared Sub Test
 
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/14246")>
+        <Fact>
         Public Sub Inference11()
 
             Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
@@ -11863,9 +11863,6 @@ options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
 
             Assert.Equal("Sub C.Test3(Of (System.Int32, System.Int32))(ByRef x As (System.Int32, System.Int32), ByRef y As (System.Int32, System.Int32))",
                          model.GetSymbolInfo(test3).Symbol.ToTestDisplayString())
-
-            ' Currently, the wrong type is inferred for type arguments and T is inferred to (int a, int b)
-            ' https://github.com/dotnet/roslyn/issues/14246
 
         End Sub
 

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpEESymbolProvider.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/CSharpEESymbolProvider.cs
@@ -110,7 +110,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
             }
             if (!tupleElementNamesOpt.IsDefault)
             {
-                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, _sourceAssembly, tupleElementNamesOpt);
+                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, tupleElementNamesOpt);
             }
             return type;
         }

--- a/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
+++ b/src/ExpressionEvaluator/CSharp/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.cs
@@ -52,7 +52,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ExpressionEvaluator
 
             if (tupleElementNames != null)
             {
-                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, sourceAssembly, tupleElementNames.AsImmutable());
+                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, tupleElementNames.AsImmutable());
             }
 
             var name = alias.FullName;

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
@@ -27,9 +27,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             _containingMethod = containingMethod
             _allowImplicitDeclarations = allowImplicitDeclarations
 
-            Dim compilation = containingBinder.Compilation
-            Dim sourceAssembly = compilation.SourceAssembly
-
             _implicitDeclarations = New Dictionary(Of String, LocalSymbol)(CaseInsensitiveComparison.Comparer)
             For Each [alias] As [Alias] In aliases
                 Dim local = PlaceholderLocalSymbol.Create(

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Binders/PlaceholderLocalBinder.vb
@@ -35,7 +35,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
                 Dim local = PlaceholderLocalSymbol.Create(
                     typeNameDecoder,
                     containingMethod,
-                    sourceAssembly,
                     [alias])
                 _implicitDeclarations.Add(local.Name, local)
             Next

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/CompilationContext.vb
@@ -236,7 +236,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
                                 Dim methodName = GetNextMethodName(methodBuilder)
                                 Dim syntax = SyntaxFactory.IdentifierName(SyntaxFactory.MissingToken(SyntaxKind.IdentifierToken))
-                                Dim local = PlaceholderLocalSymbol.Create(typeNameDecoder, _currentFrame, Compilation.SourceAssembly, [alias])
+                                Dim local = PlaceholderLocalSymbol.Create(typeNameDecoder, _currentFrame, [alias])
                                 Dim aliasMethod = Me.CreateMethod(
                                     container,
                                     methodName,

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/EvaluationContext.vb
@@ -187,7 +187,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
 
             Dim currentFrame = compilation.GetMethod(moduleVersionId, methodHandle)
             Debug.Assert(currentFrame IsNot Nothing)
-            Dim symbolProvider = New VisualBasicEESymbolProvider(compilation.SourceAssembly, DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
+            Dim symbolProvider = New VisualBasicEESymbolProvider(DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
 
             Dim metadataDecoder = New MetadataDecoder(DirectCast(currentFrame.ContainingModule, PEModuleSymbol), currentFrame)
             Dim localInfo = metadataDecoder.GetLocalInfo(localSignatureHandle)

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
@@ -40,7 +40,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
             CustomTypeInfo.Decode([alias].CustomTypeInfoId, [alias].CustomTypeInfo, dynamicFlags, tupleElementNames)
 
             If tupleElementNames IsNot Nothing Then
-                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, sourceAssembly, tupleElementNames.AsImmutable())
+                type = TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, tupleElementNames.AsImmutable())
             End If
 
             Dim name = [alias].FullName

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/Symbols/PlaceholderLocalSymbol.vb
@@ -26,7 +26,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Friend Overloads Shared Function Create(
             typeNameDecoder As TypeNameDecoder(Of PEModuleSymbol, TypeSymbol),
             containingMethod As MethodSymbol,
-            sourceAssembly As AssemblySymbol,
             [alias] As [Alias]) As PlaceholderLocalSymbol
 
             Dim typeName = [alias].Type

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicEESymbolProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicEESymbolProvider.vb
@@ -13,12 +13,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
     Friend NotInheritable Class VisualBasicEESymbolProvider
         Inherits EESymbolProvider(Of TypeSymbol, LocalSymbol)
 
-        Private ReadOnly _sourceAssembly As SourceAssemblySymbol
         Private ReadOnly _metadataDecoder As MetadataDecoder
         Private ReadOnly _method As PEMethodSymbol
 
-        Public Sub New(sourceAssembly As SourceAssemblySymbol, [module] As PEModuleSymbol, method As PEMethodSymbol)
-            _sourceAssembly = sourceAssembly
+        Public Sub New([module] As PEModuleSymbol, method As PEMethodSymbol)
             _metadataDecoder = New MetadataDecoder([module], method)
             _method = method
         End Sub

--- a/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicEESymbolProvider.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Source/ExpressionCompiler/VisualBasicEESymbolProvider.vb
@@ -80,7 +80,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator
         Private Function IncludeTupleElementNamesIfAny(type As TypeSymbol, tupleElementNamesOpt As ImmutableArray(Of String)) As TypeSymbol
             Return If(tupleElementNamesOpt.IsDefault,
                 type,
-                TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, _sourceAssembly, tupleElementNamesOpt))
+                TupleTypeDecoder.DecodeTupleTypesIfApplicable(type, tupleElementNamesOpt))
         End Function
 
     End Class

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/ExpressionCompilerTestBase.vb
@@ -355,7 +355,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.ExpressionEvaluator.UnitTests
             Dim peMethod = peCompilation.GlobalNamespace.GetMember(Of PEMethodSymbol)(qualifiedMethodName)
             Dim peModule = DirectCast(peMethod.ContainingModule, PEModuleSymbol)
             Dim symReader = runtime.Modules.Single(Function(mi) mi.ModuleVersionId = peModule.Module.GetModuleVersionIdOrThrow()).SymReader
-            Dim symbolProvider = New VisualBasicEESymbolProvider(peCompilation.SourceAssembly, peModule, peMethod)
+            Dim symbolProvider = New VisualBasicEESymbolProvider(peModule, peMethod)
             Return MethodDebugInfo(Of TypeSymbol, LocalSymbol).ReadMethodDebugInfo(DirectCast(symReader, ISymUnmanagedReader3), symbolProvider, MetadataTokens.GetToken(peMethod.Handle), methodVersion:=1, ilOffset:=ilOffset, isVisualBasicMethod:=True)
         End Function
 


### PR DESCRIPTION
Drops tuple names as needed in ternary operations and in inference of method types.
Also simplifies `TupleTypeDecoder` to not need a containing assembly parameter and field (fixing https://github.com/dotnet/roslyn/issues/14407).

@dotnet/roslyn-compiler for review. Thanks

Relates to https://github.com/dotnet/roslyn/pull/12834 (C# change)
This is part of a broader list of issues to check in VB: https://github.com/dotnet/roslyn/issues/13938.