### PR TITLE
Propagate InvolvesNarrowingFromNumericConstant flag for tuple conversions.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_Conversions.vb
@@ -1560,7 +1560,7 @@ DoneWithDiagnostics:
 
         Private Function ReclassifyInterpolatedStringExpression(conversionSemantics As SyntaxKind, tree As SyntaxNode, convKind As ConversionKind, isExplicit As Boolean, node As BoundInterpolatedStringExpression, targetType As TypeSymbol, diagnostics As DiagnosticBag) As BoundExpression
 
-            If convKind = ConversionKind.InterpolatedString Then
+            If (convKind And ConversionKind.InterpolatedString) = ConversionKind.InterpolatedString Then
                 Debug.Assert(targetType.Equals(Compilation.GetWellKnownType(WellKnownType.System_IFormattable)) OrElse targetType.Equals(Compilation.GetWellKnownType(WellKnownType.System_FormattableString)))
                 Return New BoundConversion(tree, node, ConversionKind.InterpolatedString, False, isExplicit, targetType)
             End If
@@ -1579,7 +1579,7 @@ DoneWithDiagnostics:
 
             ' We have a successful tuple conversion rather than producing a separate conversion node 
             ' which is a conversion on top of a tuple literal, tuple conversion is an element-wise conversion of arguments.
-            Dim isNullableTupleConversion = (convKind = ConversionKind.WideningNullable) Or (convKind = ConversionKind.NarrowingNullable)
+            Dim isNullableTupleConversion = (convKind And ConversionKind.Nullable) <> 0
             Debug.Assert(Not isNullableTupleConversion OrElse destination.IsNullableType())
 
             Dim targetType = destination

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -105,7 +105,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim convKind As ConversionKind = Conversions.ClassifyPredefinedConversion(parameterType, conversion.Operand.Type, useSiteDiagnostics)
                 Diagnostics.Add(conversion, useSiteDiagnostics)
 
-                If convKind = ConversionKind.NarrowingNullable AndAlso Not toType.IsNullableType Then
+                If (convKind And ConversionKind.NarrowingNullable) = ConversionKind.NarrowingNullable AndAlso Not toType.IsNullableType Then
                     ' Convert to non-nullable type first to mimic Dev11
                     Return Me._factory.Convert(toType, CreateUserDefinedNullableToUnderlyingConversion(parameter, parameterType, isChecked), isChecked)
                 Else
@@ -200,7 +200,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             Dim innerConversionApplied As Boolean = Not Conversions.IsIdentityConversion(innerConversion)
             If innerConversionApplied Then
-                Debug.Assert(innerConversion = ConversionKind.NarrowingNullable)
+                Debug.Assert((innerConversion And ConversionKind.NarrowingNullable) = ConversionKind.NarrowingNullable)
 
                 'If outConv Is Nothing OrElse outConv.ConversionKind = ConversionKind.WideningNullable Then
                 ' NOTE: in simple cases where inner conversion is (T? -> T) and outer conversion is (S -> S?),

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -98,11 +98,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             If node.RelaxationLambdaOpt IsNot Nothing Then
                 returnValue = RewriteLambdaRelaxationConversion(node)
 
-            ElseIf node.ConversionKind = ConversionKind.InterpolatedString Then
+            ElseIf (node.ConversionKind And ConversionKind.InterpolatedString) = ConversionKind.InterpolatedString Then
                 returnValue = RewriteInterpolatedStringConversion(node)
 
-            ElseIf node.ConversionKind = ConversionKind.WideningTuple OrElse
-                node.ConversionKind = ConversionKind.NarrowingTuple Then
+            ElseIf (node.ConversionKind And ConversionKind.Tuple) <> 0 Then
                 returnValue = RewriteTupleConversion(node)
 
             Else

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_InterpolatedString.vb
@@ -50,7 +50,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Function RewriteInterpolatedStringConversion(conversion As BoundConversion) As BoundExpression
 
-            Debug.Assert(conversion.ConversionKind = ConversionKind.InterpolatedString)
+            Debug.Assert((conversion.ConversionKind And ConversionKind.InterpolatedString) = ConversionKind.InterpolatedString)
 
             Dim targetType = conversion.Type
             Dim node = DirectCast(conversion.Operand, BoundInterpolatedStringExpression)

--- a/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/Conversions.vb
@@ -1246,6 +1246,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             ' check arguments against flattened list of target element types 
             Dim result As ConversionKind = wideningConversion
+            Dim involvesNarrowingFromNumericConstant As ConversionKind = Nothing
+            Dim allNarrowingIsFromNumericConstant = ConversionKind.InvolvesNarrowingFromNumericConstant
 
             For i As Integer = 0 To arguments.Length - 1
                 Dim argument = arguments(i)
@@ -1261,12 +1263,16 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Return Nothing 'ConversionKind.NoConversion
                 End If
 
+                involvesNarrowingFromNumericConstant = involvesNarrowingFromNumericConstant Or elementConversion
+
                 If IsNarrowingConversion(elementConversion) Then
+                    allNarrowingIsFromNumericConstant = allNarrowingIsFromNumericConstant And elementConversion
                     result = narrowingConversion
                 End If
             Next
 
-            Return result
+            Return result Or
+                   (involvesNarrowingFromNumericConstant And allNarrowingIsFromNumericConstant And ConversionKind.InvolvesNarrowingFromNumericConstant)
         End Function
 
         Private Shared Function ClassifyArrayInitialization(source As BoundArrayInitialization, targetElementType As TypeSymbol, binder As Binder, <[In], Out> ByRef useSiteDiagnostics As HashSet(Of DiagnosticInfo)) As ConversionKind


### PR DESCRIPTION
Related to #14255.
Fixes #14473.

@dotnet/roslyn-compiler, @VSadov, @jcouv Please review.