### PR TITLE
Only format an open curly if it the first token on a line.

### DIFF
--- a/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
+++ b/src/EditorFeatures/CSharp/Formatting/CSharpEditorFormattingService.cs
@@ -141,11 +141,17 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
         private static async Task<bool> TokenShouldNotFormatOnTypeCharAsync(
             SyntaxToken token, CancellationToken cancellationToken)
         {
+            // If the token is a )  we only want to format if it's the close paren
+            // of a using statement.  That way if we have nested usings, the inner
+            // using will align with the outer one when the user types the close paren.
             if (token.IsKind(SyntaxKind.CloseParenToken) && !token.Parent.IsKind(SyntaxKind.UsingStatement))
             {
                 return true;
             }
 
+            // If the token is a :  we only want to format if it's a labeled statement
+            // or case.  When the colon is typed we'll want ot immediately have those
+            // statements snap to their appropriate indentation level.
             if (token.IsKind(SyntaxKind.ColonToken) && !(token.Parent.IsKind(SyntaxKind.LabeledStatement) || token.Parent is SwitchLabelSyntax))
             {
                 return true;
@@ -185,9 +191,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting
                 return null;
             }
 
-            // Check to see if any of the below. If not, bail.
-            // case 1: The token is ')' and the parent is an using statement.
-            // case 2: The token is ':' and the parent is either labelled statement or case switch or default switch
             var shouldNotFormat = await TokenShouldNotFormatOnTypeCharAsync(token, cancellationToken).ConfigureAwait(false);
             if (shouldNotFormat)
             {

--- a/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
+++ b/src/EditorFeatures/CSharp/Formatting/Indentation/SmartTokenFormatter.cs
@@ -68,7 +68,8 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
                 (endToken.Parent.IsParentKind(SyntaxKind.TryStatement) || endToken.Parent.IsParentKind(SyntaxKind.DoStatement));
         }
 
-        public Task<IList<TextChange>> FormatTokenAsync(Workspace workspace, SyntaxToken token, CancellationToken cancellationToken)
+        public Task<IList<TextChange>> FormatTokenAsync(
+            Workspace workspace, SyntaxToken token, CancellationToken cancellationToken)
         {
             Contract.ThrowIfTrue(token.Kind() == SyntaxKind.None || token.Kind() == SyntaxKind.EndOfFileToken);
 
@@ -100,7 +101,9 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.Formatting.Indentation
             var smartTokenformattingRules = (new SmartTokenFormattingRule()).Concat(_formattingRules);
             var adjustedStartPosition = previousToken.SpanStart;
             var indentStyle = _optionSet.GetOption(FormattingOptions.SmartIndent, LanguageNames.CSharp);
-            if (token.IsKind(SyntaxKind.OpenBraceToken) && token.IsFirstTokenOnLine(token.SyntaxTree.GetText()) && indentStyle != FormattingOptions.IndentStyle.Smart)
+            if (token.IsKind(SyntaxKind.OpenBraceToken) &&
+                token.IsFirstTokenOnLine(token.SyntaxTree.GetText(cancellationToken)) &&
+                indentStyle != FormattingOptions.IndentStyle.Smart)
             {
                 adjustedStartPosition = token.SpanStart;
             }

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Editor.Commands;
 using Microsoft.CodeAnalysis.Editor.Implementation.Formatting;
+using Microsoft.CodeAnalysis.Editor.Options;
 using Microsoft.CodeAnalysis.Editor.Shared.Options;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
@@ -1140,6 +1141,64 @@ class C : Attribute
             };
 
             await AssertFormatAfterTypeCharAsync(code, expected, optionSet);
+        }
+
+        [WpfFact, WorkItem(4435, "https://github.com/dotnet/roslyn/issues/4435")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task OpenCurlyNotFormattedIfNotAtStartOfLine()
+        {
+            var code = 
+@"
+class C
+{
+    public  int     P   {$$
+}
+";
+
+            var expected =
+@"
+class C
+{
+    public  int     P   {
+}
+";
+
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(BraceCompletionOptions.EnableBraceCompletion, LanguageNames.CSharp), false }
+            };
+
+            await AssertFormatAfterTypeCharAsync(code, expected);
+        }
+
+        [WpfFact, WorkItem(4435, "https://github.com/dotnet/roslyn/issues/4435")]
+        [Trait(Traits.Feature, Traits.Features.SmartTokenFormatting)]
+        public async Task OpenCurlyFormattedIfAtStartOfLine()
+        {
+            var code =
+@"
+class C
+{
+    public  int     P
+        {$$
+}
+";
+
+            var expected =
+@"
+class C
+{
+    public  int     P
+    {
+}
+";
+
+            var optionSet = new Dictionary<OptionKey, object>
+            {
+                { new OptionKey(BraceCompletionOptions.EnableBraceCompletion, LanguageNames.CSharp), false }
+            };
+
+            await AssertFormatAfterTypeCharAsync(code, expected);
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]

--- a/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
+++ b/src/EditorFeatures/CSharpTest/Formatting/FormattingEngineTests.cs
@@ -163,7 +163,7 @@ int y;
 
         [WorkItem(977133, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/977133")]
         [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
-        public async Task DoNotFormatRangeButFormatTokenOnOpenBrace()
+        public async Task DoNotFormatRangeOrFormatTokenOnOpenBraceOnSameLine()
         {
             var code = @"class C
 {
@@ -176,7 +176,30 @@ int y;
 {
     public void M()
     {
-        if (true) {
+        if (true)        {
+    }
+}";
+            await AssertFormatAfterTypeCharAsync(code, expected);
+        }
+
+        [WorkItem(14491, "https://github.com/dotnet/roslyn/pull/14491")]
+        [WpfFact, Trait(Traits.Feature, Traits.Features.Formatting)]
+        public async Task DoNotFormatRangeButFormatTokenOnOpenBraceOnNextLine()
+        {
+            var code = @"class C
+{
+    public void M()
+    {
+        if (true)
+            {$$
+    }
+}";
+            var expected = @"class C
+{
+    public void M()
+    {
+        if (true)
+        {
     }
 }";
             await AssertFormatAfterTypeCharAsync(code, expected);


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4435