### PR TITLE
Correct quote escaping mechanism in cibuild.cmd !@#&^(%$*)$(%_)[]{}.,/\%0A

### DIFF
--- a/build/scripts/escape_pr_title.csx
+++ b/build/scripts/escape_pr_title.csx
@@ -1,3 +1,0 @@
-var prTitle = System.Environment.GetEnvironmentVariable("ghprbPullTitle");
-var escaped = String.Join("", prTitle.Where(c => char.IsLetterOrDigit(c) || c == ' '));
-Console.Write(escaped);

--- a/build/scripts/escape_pr_title.csx
+++ b/build/scripts/escape_pr_title.csx
@@ -1,0 +1,3 @@
+var prTitle = System.Environment.GetEnvironmentVariable("ghprbPullTitle");
+var escaped = String.Join("", prTitle.Where(c => char.IsLetterOrDigit(c) || c == ' '));
+Console.Write(escaped);

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -10,6 +10,11 @@ REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Ot
 REM we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
 set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerparameters:Verbosity=minimal /filelogger /fileloggerparameters:Verbosity=normal
 
+REM Github pull request titles are unescaped, so we need to run another program to
+REM do the escaping and replace it.
+for /f %%i in ('csi .\build\scripts\escape_pr_title.csx') set ghprbPullTitle=%%i
+echo "PULL REQUEST TITLE: %ghprbPullTitle%"
+
 :ParseArguments
 if "%1" == "" goto :DoneParsing
 if /I "%1" == "/?" call :Usage && exit /b 1

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -6,14 +6,9 @@ set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 
 REM Because override the C#/VB toolset to build against our LKG package, it is important
-REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise, 
+REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
 REM we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
 set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerparameters:Verbosity=minimal /filelogger /fileloggerparameters:Verbosity=normal
-
-REM Github pull request titles are unescaped, so we need to run another program to
-REM do the escaping and replace it.
-REM for /f "tokens=*" %%i in ('csi .\build\scripts\escape_pr_title.csx') do set "ghprbPullTitle=%%i"
-REM echo "PULL REQUEST TITLE: %ghprbPullTitle%"
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing
@@ -58,7 +53,7 @@ REM Output the commit that we're building, for reference in Jenkins logs
 echo Building this commit:
 git show --no-patch --pretty=raw HEAD
 
-REM Restore the NuGet packages 
+REM Restore the NuGet packages
 call "%RoslynRoot%\Restore.cmd" || goto :BuildFailed
 
 REM Ensure the binaries directory exists because msbuild can fail when part of the path to LogFile isn't present.

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -12,7 +12,7 @@ set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerp
 
 REM Github pull request titles are unescaped, so we need to run another program to
 REM do the escaping and replace it.
-for /f %%i in ('csi .\build\scripts\escape_pr_title.csx') do set ghprbPullTitle=%%i
+for /f "tokens=*" %%i in ('csi .\build\scripts\escape_pr_title.csx') do set "ghprbPullTitle=%%i"
 echo "PULL REQUEST TITLE: %ghprbPullTitle%"
 
 :ParseArguments

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -6,7 +6,7 @@ set RoslynRoot=%~dp0
 set BuildConfiguration=Debug
 
 REM Because override the C#/VB toolset to build against our LKG package, it is important
-REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise,
+REM that we do not reuse MSBuild nodes from other jobs/builds on the machine. Otherwise, 
 REM we'll run into issues such as https://github.com/dotnet/roslyn/issues/6211.
 set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerparameters:Verbosity=minimal /filelogger /fileloggerparameters:Verbosity=normal
 
@@ -58,7 +58,7 @@ REM Output the commit that we're building, for reference in Jenkins logs
 echo Building this commit:
 git show --no-patch --pretty=raw HEAD
 
-REM Restore the NuGet packages
+REM Restore the NuGet packages 
 call "%RoslynRoot%\Restore.cmd" || goto :BuildFailed
 
 REM Ensure the binaries directory exists because msbuild can fail when part of the path to LogFile isn't present.
@@ -99,8 +99,8 @@ if defined TestPerfRun (
             set "EXTRA_PERF_RUNNER_ARGS=--report-benchview --branch "%GIT_BRANCH%""
 
             REM Check if we are in a PR or this is a rolling submission
-            if defined ghprbPullId (
-                set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-name ^"[%ghprbPullAuthorLogin%] PR %ghprbPullId%^" --benchview-submission-type private"
+            if defined ghprbPullTitle (
+                set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-name ^"[%ghprbPullAuthorLogin%] PR %ghprbPullId%: %ghprbPullTitle%^" --benchview-submission-type private"
             ) else (
                 set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-type rolling"
             )

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -100,7 +100,7 @@ if defined TestPerfRun (
 
             REM Check if we are in a PR or this is a rolling submission
             if defined ghprbPullTitle (
-                set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-name ^"[%ghprbPullAuthorLogin%] PR %ghprbPullId%: %ghprbPullTitle%^" --benchview-submission-type private"
+                set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-name ""[%ghprbPullAuthorLogin%] PR %ghprbPullId%: %ghprbPullTitle%"" --benchview-submission-type private"
             ) else (
                 set "EXTRA_PERF_RUNNER_ARGS=!EXTRA_PERF_RUNNER_ARGS! --benchview-submission-type rolling"
             )

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -12,7 +12,7 @@ set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerp
 
 REM Github pull request titles are unescaped, so we need to run another program to
 REM do the escaping and replace it.
-for /f %%i in ('csi .\build\scripts\escape_pr_title.csx') set ghprbPullTitle=%%i
+for /f %%i in ('csi .\build\scripts\escape_pr_title.csx') do set ghprbPullTitle=%%i
 echo "PULL REQUEST TITLE: %ghprbPullTitle%"
 
 :ParseArguments

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -12,8 +12,8 @@ set MSBuildAdditionalCommandLineArgs=/nologo /m /nodeReuse:false /consoleloggerp
 
 REM Github pull request titles are unescaped, so we need to run another program to
 REM do the escaping and replace it.
-for /f "tokens=*" %%i in ('csi .\build\scripts\escape_pr_title.csx') do set "ghprbPullTitle=%%i"
-echo "PULL REQUEST TITLE: %ghprbPullTitle%"
+REM for /f "tokens=*" %%i in ('csi .\build\scripts\escape_pr_title.csx') do set "ghprbPullTitle=%%i"
+REM echo "PULL REQUEST TITLE: %ghprbPullTitle%"
 
 :ParseArguments
 if "%1" == "" goto :DoneParsing


### PR DESCRIPTION
closes https://github.com/dotnet/roslyn/issues/14480