### PR TITLE
Porting two recent tuple-related fixes to VB

### DIFF
--- a/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
+++ b/src/Compilers/CSharp/Portable/Emitter/Model/PEModuleBuilder.cs
@@ -898,7 +898,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Emit
             // but if it does happen we should make it a failure.
             // NOTE: declaredBase could be null for interfaces
             var declaredBase = namedTypeSymbol.BaseTypeNoUseSiteDiagnostics;
-            if (declaredBase?.SpecialType != SpecialType.System_ValueType && declaredBase?.IsErrorType() != true)
+            if (declaredBase == null ||
+                (declaredBase.SpecialType != SpecialType.System_ValueType && !declaredBase.IsErrorType()))
             {
                 // Try to decrease noise by not complaining about the same type over and over again.
                 if (_reportedErrorTypesMap.Add(namedTypeSymbol))

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -315,8 +315,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     resultKind = LookupResultKind.NotCreatable
                     errorReported = True
 
-
-
                 Case TypeKind.Array
                     ' the diagnostic that AsNew cannot be used to init arrays has already been reported
                     ' so there is nothing to do here.

--- a/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/Binder_ObjectInitializer.vb
@@ -315,6 +315,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     resultKind = LookupResultKind.NotCreatable
                     errorReported = True
 
+
+
                 Case TypeKind.Array
                     ' the diagnostic that AsNew cannot be used to init arrays has already been reported
                     ' so there is nothing to do here.

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1706,8 +1706,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_TupleElementNamesAttributeMissing = 37268
         ERR_ExplicitTupleElementNamesAttribute = 37269
         ERR_TupleLiteralDisallowsTypeChar = 37270
-        ERR_NewWithTupleTypeSyntax = 37271
-        ERR_PredefinedValueTupleTypeMustBeStruct = 37272
 
         ' Available 37270
         ERR_DuplicateProcDefWithDifferentTupleNames2 = 37271
@@ -1720,6 +1718,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_InterfaceInheritedTwiceWithDifferentTupleNames3 = 37277
         ERR_InterfaceInheritedTwiceWithDifferentTupleNamesReverse3 = 37278
         ERR_InterfaceInheritedTwiceWithDifferentTupleNames4 = 37279
+
+        ERR_NewWithTupleTypeSyntax = 37280
+        ERR_PredefinedValueTupleTypeMustBeStruct = 37281
 
         '// WARNINGS BEGIN HERE
         WRN_UseOfObsoleteSymbol2 = 40000

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1706,6 +1706,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_TupleElementNamesAttributeMissing = 37268
         ERR_ExplicitTupleElementNamesAttribute = 37269
         ERR_TupleLiteralDisallowsTypeChar = 37270
+        ERR_NewWithTupleTypeSyntax = 37271
 
         ' Available 37270
         ERR_DuplicateProcDefWithDifferentTupleNames2 = 37271

--- a/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
+++ b/src/Compilers/VisualBasic/Portable/Errors/Errors.vb
@@ -1707,6 +1707,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ERR_ExplicitTupleElementNamesAttribute = 37269
         ERR_TupleLiteralDisallowsTypeChar = 37270
         ERR_NewWithTupleTypeSyntax = 37271
+        ERR_PredefinedValueTupleTypeMustBeStruct = 37272
 
         ' Available 37270
         ERR_DuplicateProcDefWithDifferentTupleNames2 = 37271

--- a/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/ParseExpression.vb
@@ -864,6 +864,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
 
             ' Here we are after parsing " New Blah(a1,a2)"
 
+            If Type.Kind = SyntaxKind.TupleType Then
+                Type = ReportSyntaxError(Type, ERRID.ERR_NewWithTupleTypeSyntax)
+            End If
+
             Dim FromToken As KeywordSyntax = Nothing
             If TryTokenAsContextualKeyword(CurrentToken, SyntaxKind.FromKeyword, FromToken) Then
 

--- a/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
+++ b/src/Compilers/VisualBasic/Portable/Parser/Parser.vb
@@ -2252,6 +2252,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Syntax.InternalSyntax
                     Else
                         typeName = ParseTypeName()
 
+                        If typeName.Kind = SyntaxKind.TupleType Then
+                            typeName = ReportSyntaxError(typeName, ERRID.ERR_NewWithTupleTypeSyntax)
+                        End If
+
                         If CurrentToken.Kind = SyntaxKind.OpenParenToken Then
                             ' New <Type> ( <Arguments> )
                             newArguments = ParseParenthesizedArguments()

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -68,18 +68,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
-        Public Overrides ReadOnly Property IsReferenceType As Boolean
-            Get
-                Return Not Me._underlyingType.IsErrorType() AndAlso Me._underlyingType.IsReferenceType
-            End Get
-        End Property
-
-        Public Overrides ReadOnly Property IsValueType As Boolean
-            Get
-                Return Me._underlyingType.IsErrorType() OrElse Me._underlyingType.IsValueType
-            End Get
-        End Property
-
         Public Overrides ReadOnly Property IsImplicitlyDeclared As Boolean
             Get
                 Return False
@@ -122,7 +110,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
 
         Public Overrides ReadOnly Property TypeKind As TypeKind
             Get
-                Return If(Me._underlyingType.TypeKind = TypeKind.Class, TypeKind.Class, TypeKind.Struct)
+                ' From the language perspective tuple is a value type
+                ' composed of its underlying elements
+                Return TypeKind.Struct
             End Get
         End Property
 

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -9118,6 +9118,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to Predefined type &apos;{0}&apos; must be a structure..
+        '''</summary>
+        Friend ReadOnly Property ERR_PredefinedValueTupleTypeMustBeStruct() As String
+            Get
+                Return ResourceManager.GetString("ERR_PredefinedValueTupleTypeMustBeStruct", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to SecurityAction value &apos;{0}&apos; is invalid for PrincipalPermission attribute..
         '''</summary>
         Friend ReadOnly Property ERR_PrincipalPermissionInvalidAction() As String

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -7801,6 +7801,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;New&apos; cannot be used with tuple type. Use a tuple literal expression instead..
+        '''</summary>
+        Friend ReadOnly Property ERR_NewWithTupleTypeSyntax() As String
+            Get
+                Return ResourceManager.GetString("ERR_NewWithTupleTypeSyntax", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Next control variable does not match For loop control variable &apos;{0}&apos;..
         '''</summary>
         Friend ReadOnly Property ERR_NextForMismatch1() As String
@@ -10389,11 +10398,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Tuple member names must be unique..
+        '''  Looks up a localized string similar to Tuple element names must be unique..
         '''</summary>
-        Friend ReadOnly Property ERR_TupleDuplicateMemberName() As String
+        Friend ReadOnly Property ERR_TupleDuplicateElementName() As String
             Get
-                Return ResourceManager.GetString("ERR_TupleDuplicateMemberName", resourceCulture)
+                Return ResourceManager.GetString("ERR_TupleDuplicateElementName", resourceCulture)
             End Get
         End Property
         
@@ -10407,20 +10416,29 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Tuple member name &apos;{0}&apos; is only allowed at position {1}..
+        '''  Looks up a localized string similar to Type characters cannot be used in tuple literals..
         '''</summary>
-        Friend ReadOnly Property ERR_TupleReservedMemberName() As String
+        Friend ReadOnly Property ERR_TupleLiteralDisallowsTypeChar() As String
             Get
-                Return ResourceManager.GetString("ERR_TupleReservedMemberName", resourceCulture)
+                Return ResourceManager.GetString("ERR_TupleLiteralDisallowsTypeChar", resourceCulture)
             End Get
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Tuple member name &apos;{0}&apos; is disallowed at any position..
+        '''  Looks up a localized string similar to Tuple element name &apos;{0}&apos; is only allowed at position {1}..
         '''</summary>
-        Friend ReadOnly Property ERR_TupleReservedMemberNameAnyPosition() As String
+        Friend ReadOnly Property ERR_TupleReservedElementName() As String
             Get
-                Return ResourceManager.GetString("ERR_TupleReservedMemberNameAnyPosition", resourceCulture)
+                Return ResourceManager.GetString("ERR_TupleReservedElementName", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Tuple element name &apos;{0}&apos; is disallowed at any position..
+        '''</summary>
+        Friend ReadOnly Property ERR_TupleReservedElementNameAnyPosition() As String
+            Get
+                Return ResourceManager.GetString("ERR_TupleReservedElementNameAnyPosition", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -3169,6 +3169,9 @@
   <data name="ERR_NewWithTupleTypeSyntax" xml:space="preserve">
     <value>'New' cannot be used with tuple type. Use a tuple literal expression instead.</value>
   </data>
+  <data name="ERR_PredefinedValueTupleTypeMustBeStruct" xml:space="preserve">
+    <value>Predefined type '{0}' must be a structure.</value>
+  </data>
   <data name="ERR_ExtensionMethodUncallable1" xml:space="preserve">
     <value>Extension method '{0}' has type constraints that can never be satisfied.</value>
   </data>

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -3166,6 +3166,9 @@
   <data name="ERR_TupleLiteralDisallowsTypeChar" xml:space="preserve">
     <value>Type characters cannot be used in tuple literals.</value>
   </data>
+  <data name="ERR_NewWithTupleTypeSyntax" xml:space="preserve">
+    <value>'New' cannot be used with tuple type. Use a tuple literal expression instead.</value>
+  </data>
   <data name="ERR_ExtensionMethodUncallable1" xml:space="preserve">
     <value>Extension method '{0}' has type constraints that can never be satisfied.</value>
   </data>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenEvents.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenEvents.vb
@@ -2583,7 +2583,7 @@ End Class
 #If Not ISSUE_14104_IS_FIXED Then
             compilation.AssertTheseDiagnostics(
 <expected>
-BC30299: 'Main' cannot inherit from class '' because '' is declared 'NotInheritable'.
+BC30258: Classes can inherit only from other classes.
     Inherits System.ValueTuple(Of Integer, Integer)
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 BC30506: Handles clause requires a WithEvents variable defined in the containing type or one of its base types.

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -1031,17 +1031,45 @@ Module C
         t.a17 = 42
         t.a12 = t.a17
         console.writeline(t.a12)
+
+        TestArray()
+        TestNullable()
     End Sub
+
+    Sub TestArray()
+        Dim t = New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+                    a5 as integer, a6 as integer, a7 as integer, a8 as integer,
+                    a9 as integer, a10 as Integer, a11 as Integer, a12 as Integer,
+                    a13 as integer, a14 as integer, a15 as integer, a16 as integer,
+                    a17 as integer, a18 as integer)() {Nothing}
+
+        t(0).a17 = 42
+        t(0).a12 = t(0).a17
+        console.writeline(t(0).a12)
+    End Sub
+
+        Sub TestNullable()
+        Dim t as New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+                    a5 as integer, a6 as integer, a7 as integer, a8 as integer,
+                    a9 as integer, a10 as Integer, a11 as Integer, a12 as Integer,
+                    a13 as integer, a14 as integer, a15 as integer, a16 as integer,
+                    a17 as integer, a18 as integer)?
+
+        console.writeline(t.HasValue)
+    End Sub
+
 End Module
 
     </file>
 </compilation>, expectedOutput:=<![CDATA[
 42
+42
+False
             ]]>, additionalRefs:=s_valueTupleRefs)
 
             verifier.VerifyIL("C.Main", <![CDATA[
 {
-  // Code size       64 (0x40)
+  // Code size       74 (0x4a)
   .maxstack  2
   .locals init (System.ValueTuple(Of Integer, Integer, Integer, Integer, Integer, Integer, Integer, (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)) V_0) //t
   IL_0000:  ldloca.s   V_0
@@ -1060,9 +1088,55 @@ End Module
   IL_0030:  ldfld      "System.ValueTuple(Of Integer, Integer, Integer, Integer, Integer, Integer, Integer, (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)).Rest As (Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer, Integer)"
   IL_0035:  ldfld      "System.ValueTuple(Of Integer, Integer, Integer, Integer, Integer, Integer, Integer, (Integer, Integer, Integer, Integer)).Item5 As Integer"
   IL_003a:  call       "Sub System.Console.WriteLine(Integer)"
-  IL_003f:  ret
+  IL_003f:  call       "Sub C.TestArray()"
+  IL_0044:  call       "Sub C.Testullable()"
+  IL_0049:  ret
 }
 ]]>)
+        End Sub
+
+        <Fact>
+        Public Sub TupleNewLongErr()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+
+Imports System
+Module C
+
+    Sub Main()
+        Dim t = New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+                    a5 as integer, a6 as integer, a7 as integer, a8 as integer,
+                    a9 as integer, a10 as Integer, a11 as Integer, a12 as String,
+                    a13 as integer, a14 as integer, a15 as integer, a16 as integer,
+                    a17 as integer, a18 as integer)
+
+        console.writeline(t.a12.Length)
+
+        Dim t1 As New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+            a5 as integer, a6 as integer, a7 as integer, a8 as integer,
+            a9 as integer, a10 as Integer, a11 as Integer, a12 as String,
+            a13 as integer, a14 as integer, a15 as integer, a16 as integer,
+            a17 as integer, a18 as integer)
+
+        console.writeline(t1.a12.Length)
+
+    End Sub
+End Module
+]]></file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            ' should not complain about missing constructor
+            comp.AssertTheseDiagnostics(
+<errors>
+BC37271: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
+        Dim t = New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC37271: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
+        Dim t1 As New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</errors>)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -51,6 +51,19 @@ namespace System.Runtime.CompilerServices
 End Namespace
 
 "
+
+        ReadOnly s_tupleattributes As String = "
+namespace System.Runtime.CompilerServices
+    <AttributeUsage(AttributeTargets.Field Or AttributeTargets.Parameter Or AttributeTargets.Property Or AttributeTargets.ReturnValue Or AttributeTargets.Class Or AttributeTargets.Struct )>
+    public class TupleElementNamesAttribute : Inherits Attribute
+        public Sub New(transformNames As String())
+	    End Sub
+    End Class
+End Namespace
+
+"
+
+
         ReadOnly s_trivial3uple As String = "
 Namespace System
     Public Structure ValueTuple(Of T1, T2, T3)
@@ -1089,7 +1102,7 @@ False
   IL_0035:  ldfld      "System.ValueTuple(Of Integer, Integer, Integer, Integer, Integer, Integer, Integer, (Integer, Integer, Integer, Integer)).Item5 As Integer"
   IL_003a:  call       "Sub System.Console.WriteLine(Integer)"
   IL_003f:  call       "Sub C.TestArray()"
-  IL_0044:  call       "Sub C.Testullable()"
+  IL_0044:  call       "Sub C.TestNullable()"
   IL_0049:  ret
 }
 ]]>)
@@ -15549,6 +15562,117 @@ BC30402: 'evtTest3' cannot implement event 'evtTest2' on interface 'I1' because 
 </errors>)
         End Sub
 
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct0()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+class C
+    Shared Sub Main()
+        Dim x as (a As Integer, b As String)
+        x.Item1 = 1
+        x.b = "2"
+ 
+        ' by the language rules tuple x is definitely assigned
+        ' since all its elements are definitely assigned
+        System.Console.WriteLine(x)
+    end sub
+end class
+
+namespace System
+    public class ValueTuple(Of T1, T2)
+        public Item1 as T1
+        public Item2 as T2
+
+        public Sub New(item1 as T1 , item2 as T2 )
+            Me.Item1 = item1
+            Me.Item2 = item2
+        end sub
+    End class
+end Namespace
+
+    <%= s_tupleattributes %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+        Dim x as (a As Integer, b As String)
+            ~
+</errors>)
+
+        End Sub
+
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct1()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+            <compilation name="Tuples">
+                <file name="a.vb">
+class C
+    Shared Sub Main()
+        Dim x = (1,2,3,4,5,6,7,8,9)
+ 
+        System.Console.WriteLine(x)
+    end sub
+end class
+
+namespace System
+    public class ValueTuple(Of T1, T2)
+        public Item1 as T1
+        public Item2 as T2
+
+        public Sub New(item1 as T1 , item2 as T2 )
+            Me.Item1 = item1
+            Me.Item2 = item2
+        end sub
+    End class
+
+    public class ValueTuple(Of T1, T2, T3, T4, T5, T6, T7, TRest)
+        public Item1 As T1
+        public Item2 As T2
+        public Item3 As T3
+        public Item4 As T4
+        public Item5 As T5
+        public Item6 As T6
+        public Item7 As T7
+        public Rest As TRest
+
+        public Sub New(item1 As T1, item2 As T2, item3 As T3, item4 As T4, item5 As T5, item6 As T6, item7 As T7, rest As TRest)
+            Item1 = item1
+            Item2 = item2
+            Item3 = item3
+            Item4 = item4
+            Item5 = item5
+            Item6 = item6
+            Item7 = item7
+            Rest = rest
+        end Sub
+
+    End Class
+end Namespace
+
+    <%= s_tupleattributes %>
+                </file>
+            </compilation>,
+            options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+        Dim x = (1,2,3,4,5,6,7,8,9)
+            ~
+BC37272: Predefined type 'ValueTuple`8' must be a structure.
+        Dim x = (1,2,3,4,5,6,7,8,9)
+            ~
+</errors>)
+        End Sub
+
         <Fact>
         Public Sub ConversionToBase()
             Dim compilation1 = CompilationUtils.CreateCompilationWithMscorlib(
@@ -15580,6 +15704,163 @@ BC33030: Conversion operators cannot convert from a base type.
     Public Shared Narrowing Operator CType(ByVal arg As Base(Of (Integer, Integer))) As Derived
                                      ~~~~~
 </errors>)
+        End Sub
+
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct2()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+class C
+    Shared Sub Main()
+    end sub
+
+    Shared Sub Test2(arg as (a As Integer, b As Integer))
+    End Sub
+end class
+
+namespace System
+    public class ValueTuple(Of T1, T2)
+        public Item1 as T1
+        public Item2 as T2
+
+        public Sub New(item1 as T1 , item2 as T2 )
+            Me.Item1 = item1
+            Me.Item2 = item2
+        end sub
+    End class
+end Namespace
+
+    <%= s_tupleattributes %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+</errors>)
+
+        End Sub
+
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct2i()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+class C
+    Shared Sub Main()
+    end sub
+
+    Shared Sub Test2(arg as (a As Integer, b As Integer))
+    End Sub
+end class
+
+namespace System
+    public interface ValueTuple(Of T1, T2)
+    End Interface
+end Namespace
+
+    <%= s_tupleattributes %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+</errors>)
+
+        End Sub
+
+
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct3()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+class C
+    Shared Sub Main()
+        Dim x as (a As Integer, b As String)() = Nothing
+ 
+        ' by the language rules tuple x is definitely assigned
+        ' since all its elements are definitely assigned
+        System.Console.WriteLine(x)
+    end sub
+end class
+
+namespace System
+    public class ValueTuple(Of T1, T2)
+        public Item1 as T1
+        public Item2 as T2
+
+        public Sub New(item1 as T1 , item2 as T2 )
+            Me.Item1 = item1
+            Me.Item2 = item2
+        end sub
+    End class
+end Namespace
+
+    <%= s_tupleattributes %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+        Dim x as (a As Integer, b As String)() = Nothing
+            ~
+</errors>)
+
+        End Sub
+
+        <WorkItem(11689, "https://github.com/dotnet/roslyn/issues/11689")>
+        <Fact>
+        Public Sub ValueTupleNotStruct4()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation name="Tuples">
+    <file name="a.vb">
+class C
+    Shared Sub Main()
+
+    end sub
+    
+    Shared Function Test2()as (a As Integer, b As Integer)
+    End Function
+end class
+
+namespace System
+    public class ValueTuple(Of T1, T2)
+        public Item1 as T1
+        public Item2 as T2
+
+        public Sub New(item1 as T1 , item2 as T2 )
+            Me.Item1 = item1
+            Me.Item2 = item2
+        end sub
+    End class
+end Namespace
+
+    <%= s_tupleattributes %>
+    </file>
+</compilation>,
+options:=TestOptions.DebugExe)
+
+            comp.AssertTheseEmitDiagnostics(
+<errors>
+BC37272: Predefined type 'ValueTuple`2' must be a structure.
+    Shared Function Test2()as (a As Integer, b As Integer)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+</errors>)
+
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -1143,10 +1143,10 @@ End Module
             ' should not complain about missing constructor
             comp.AssertTheseDiagnostics(
 <errors>
-BC37271: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
+BC37280: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
         Dim t = New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-BC37271: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
+BC37280: 'New' cannot be used with tuple type. Use a tuple literal expression instead.
         Dim t1 As New (a1 as Integer, a2 as Integer, a3 as Integer, a4 as integer,
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -15600,7 +15600,7 @@ options:=TestOptions.DebugExe)
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
         Dim x as (a As Integer, b As String)
             ~
 </errors>)
@@ -15664,10 +15664,10 @@ end Namespace
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
         Dim x = (1,2,3,4,5,6,7,8,9)
             ~
-BC37272: Predefined type 'ValueTuple`8' must be a structure.
+BC37281: Predefined type 'ValueTuple`8' must be a structure.
         Dim x = (1,2,3,4,5,6,7,8,9)
             ~
 </errors>)
@@ -15740,7 +15740,7 @@ options:=TestOptions.DebugExe)
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
 </errors>)
 
         End Sub
@@ -15772,7 +15772,7 @@ options:=TestOptions.DebugExe)
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
 </errors>)
 
         End Sub
@@ -15814,7 +15814,7 @@ options:=TestOptions.DebugExe)
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
         Dim x as (a As Integer, b As String)() = Nothing
             ~
 </errors>)
@@ -15856,7 +15856,7 @@ options:=TestOptions.DebugExe)
 
             comp.AssertTheseEmitDiagnostics(
 <errors>
-BC37272: Predefined type 'ValueTuple`2' must be a structure.
+BC37281: Predefined type 'ValueTuple`2' must be a structure.
     Shared Function Test2()as (a As Integer, b As Integer)
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 </errors>)

--- a/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/PDB/PDBTupleTests.vb
@@ -35,11 +35,11 @@ End Class
             <sequencePoints>
                 <entry offset="0x0" startLine="2" startColumn="5" endLine="2" endColumn="19"/>
                 <entry offset="0x1" startLine="3" startColumn="13" endLine="3" endColumn="163"/>
-                <entry offset="0x1b" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
+                <entry offset="0x1c" startLine="4" startColumn="5" endLine="4" endColumn="12"/>
             </sequencePoints>
-            <scope startOffset="0x0" endOffset="0x1c">
+            <scope startOffset="0x0" endOffset="0x1d">
                 <currentnamespace name=""/>
-                <local name="t" il_index="0" il_start="0x0" il_end="0x1c" attributes="0"/>
+                <local name="t" il_index="0" il_start="0x0" il_end="0x1d" attributes="0"/>
             </scope>
         </method>
     </methods>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -424,12 +424,46 @@ ToString]]>.Value)
 
         expr = ParseExpression("New Moo() From{1,2,3}")
         Assert.Equal(SyntaxKind.ObjectCreationExpression, expr.Kind)
+    End Sub
 
-        expr = ParseExpression("New (A, B)")
-        Assert.Equal(SyntaxKind.ObjectCreationExpression, expr.Kind)
+    <Fact>
+    Public Sub ParseNewTuple()
+        ParseAndVerify(<![CDATA[
+            Module Module1
+                Sub Main()
+                    Dim x = New (A, B)
+                    Dim y = New (A, B)()
+                    Dim y = New (A As Integer, B$)
+                End Sub
+            End Module
+        ]]>,
+<errors>
+    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="87" end="93"/>
+    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="126" End="132"/>
+    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="167" End="185"/>
+</errors>
+        )
 
-        expr = ParseExpression("New (A as Integer, B as integer)(1, 2)")
-        Assert.Equal(SyntaxKind.ObjectCreationExpression, expr.Kind)
+        ParseAndVerify(<![CDATA[
+            Module Module1
+                Sub Main()
+                    Dim x As New (A, B)
+                    Dim y As New (A, B)()
+                    Dim y As New (A As Integer, B$)
+                End Sub
+
+                Public Function Bar() As (Alice As (Alice As Integer, Bob As Integer)(), Bob As Integer)
+                    ' this is actually ok, since it is an array
+                    Return (New(Integer, Integer)() {(4, 5)}, 5)
+                End Function
+            End Module
+        ]]>,
+                       <errors>
+                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="88" end="94"/>
+                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="128" end="134"/>
+                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="170" end="188"/>
+                       </errors>
+        )
     End Sub
 
     <Fact>

--- a/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Parser/ParseExpression.vb
@@ -438,9 +438,9 @@ ToString]]>.Value)
             End Module
         ]]>,
 <errors>
-    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="87" end="93"/>
-    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="126" End="132"/>
-    <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="167" End="185"/>
+    <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="87" end="93"/>
+    <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="126" End="132"/>
+    <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="167" End="185"/>
 </errors>
         )
 
@@ -459,9 +459,9 @@ ToString]]>.Value)
             End Module
         ]]>,
                        <errors>
-                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="88" end="94"/>
-                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="128" end="134"/>
-                           <error id="37271" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="170" end="188"/>
+                           <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="88" end="94"/>
+                           <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="128" end="134"/>
+                           <error id="37280" message="'New' cannot be used with tuple type. Use a tuple literal expression instead." start="170" end="188"/>
                        </errors>
         )
     End Sub

--- a/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/TupleTests.vb
+++ b/src/ExpressionEvaluator/VisualBasic/Test/ExpressionCompiler/TupleTests.vb
@@ -217,9 +217,9 @@ class C
         Dim x = (1, 2)
     End Sub
 End Class"
-            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef}, options:=TestOptions.DebugDll)
-            WithRuntimeInstance(comp,
-                Sub(runtime)
+            Dim comp = CreateCompilationWithMscorlib({source}, references:={ValueTupleRef, SystemRuntimeFacadeRef}, options:=TestOptions.DebugDll)
+            WithRuntimeInstance(comp, references:={MscorlibRef, ValueTupleRef, SystemRuntimeFacadeRef},
+                validator:= Sub(runtime)
                     Dim context = CreateMethodContext(runtime, "C.M")
                     Dim errorMessage As String = Nothing
                     Dim testData = New CompilationTestData()
@@ -238,7 +238,7 @@ End Class"
                     Assert.Null(GetTupleElementNamesAttributeIfAny(method))
                     methodData.VerifyIL(
 "{
-  // Code size       43 (0x2b)
+  // Code size       48 (0x30)
   .maxstack  4
   .locals init (System.ValueTuple(Of Integer, Integer) V_0, //x
                 System.Guid V_1)
@@ -253,8 +253,9 @@ End Class"
   IL_001e:  ldstr      ""y""
   IL_0023:  call       ""Function Microsoft.VisualStudio.Debugger.Clr.IntrinsicMethods.GetVariableAddress(Of Object)(String) As Object""
   IL_0028:  ldloc.0
-  IL_0029:  stind.ref
-  IL_002a:  ret
+  IL_0029:  box        ""System.ValueTuple(Of Integer, Integer)""
+  IL_002e:  stind.ref
+  IL_002f:  ret
 }")
                 End Sub)
         End Sub


### PR DESCRIPTION
Fixes: #14260

== VB counterpart for:
Fixes: #10891 - Forbid constructing tuples via "new"
Fixes: #11689 - Enforce that ValueTuple types are structs

Note that #11689 requires validation that ValueTuple is a value type only in common cases, That is - to convey that cases where ValueTuple happens to be a Class, Enum, Delegate, etc are clearly not supported.

From the language prospective, tuples are value types composed of their elements. That is visible through the semantics of definite assignment, conversions, nullable lifting, async capturing and so on. This change intentionally introduces emit failures when underlying ValueTuple types are not structs. 
