### PR TITLE
catch watson failures closer to serialization

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -10638,15 +10638,6 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The stream cannot be read from..
-        /// </summary>
-        internal static string TheStreamCannotBeReadFrom {
-            get {
-                return ResourceManager.GetString("TheStreamCannotBeReadFrom", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to This method can only be used to create tokens - {0} is not a token kind..
         /// </summary>
         internal static string ThisMethodCanOnlyBeUsedToCreateTokens {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4230,9 +4230,6 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="WrongNumberOfTypeArguments" xml:space="preserve">
     <value>Wrong number of type arguments</value>
   </data>
-  <data name="TheStreamCannotBeReadFrom" xml:space="preserve">
-    <value>The stream cannot be read from.</value>
-  </data>
   <data name="NameConflictForName" xml:space="preserve">
     <value>Name conflict for name {0}</value>
   </data>

--- a/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/CSharpSyntaxNode.cs
@@ -201,13 +201,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             if (!stream.CanRead)
             {
-                throw new InvalidOperationException(CSharpResources.TheStreamCannotBeReadFrom);
+                throw new InvalidOperationException(CodeAnalysisResources.TheStreamCannotBeReadFrom);
             }
 
-            using (var reader = new ObjectReader(stream, defaultData: GetDefaultObjectReaderData(), binder: s_defaultBinder))
+            try
             {
-                var root = (Syntax.InternalSyntax.CSharpSyntaxNode)reader.ReadValue();
-                return root.CreateRed();
+                using (var reader = new ObjectReader(stream, defaultData: GetDefaultObjectReaderData(), binder: s_defaultBinder))
+                {
+                    var root = (Syntax.InternalSyntax.CSharpSyntaxNode)reader.ReadValue();
+                    return root.CreateRed();
+                }
+            }
+            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            {
+                throw ExceptionUtilities.Unreachable;
             }
         }
 

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.Designer.cs
@@ -1289,6 +1289,15 @@ namespace Microsoft.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The stream cannot be read from..
+        /// </summary>
+        internal static string TheStreamCannotBeReadFrom {
+            get {
+                return ResourceManager.GetString("TheStreamCannotBeReadFrom", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The stream cannot be written to..
         /// </summary>
         internal static string TheStreamCannotBeWrittenTo {

--- a/src/Compilers/Core/Portable/CodeAnalysisResources.resx
+++ b/src/Compilers/Core/Portable/CodeAnalysisResources.resx
@@ -579,4 +579,7 @@
   <data name="SeparatorIsExpected" xml:space="preserve">
     <value>separator is expected</value>
   </data>
+  <data name="TheStreamCannotBeReadFrom" xml:space="preserve">
+    <value>The stream cannot be read from.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #14504 

Adds watson checks when SyntaxTrees are serialized and deserialized. This should help find problems in serialization, so the dumps have better information for tracking down the problems.

This is the same as #14506 except fixed and in RC branch.

@dotnet/roslyn-ide @jaredpar @VSadov  please review