### PR TITLE
Enables CreateTupleTypeSymbol_UnderlyingTypeIsError test for VB

### DIFF
--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -6689,7 +6689,7 @@ fourth]]>)
 
         End Sub
 
-        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/13277")>
+        <Fact()>
         <WorkItem(13277, "https://github.com/dotnet/roslyn/issues/13277")>
         Public Sub CreateTupleTypeSymbol_UnderlyingTypeIsError()
 
@@ -6698,9 +6698,7 @@ fourth]]>)
             Dim intType As TypeSymbol = comp.GetSpecialType(SpecialType.System_Int32)
             Dim vt2 = comp.CreateErrorTypeSymbol(Nothing, "ValueTuple", 2).Construct(intType, intType)
 
-            Dim tuple = comp.CreateTupleTypeSymbol(vt2, Nothing)
-            ' Crashes in IsTupleCompatible
-
+            Assert.Throws(Of ArgumentException)(Function() comp.CreateTupleTypeSymbol(underlyingType:=vt2))
         End Sub
 
         <Fact>


### PR DESCRIPTION
Fixes: #13277