### PR TITLE
Use operand.Display property when printing method group types to diagnostics

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -1784,10 +1784,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 ImmutableArray<MethodSymbol> originalUserDefinedConversions = conversion.OriginalUserDefinedConversions;
                 if (originalUserDefinedConversions.Length > 1)
                 {
-                    // Method groups always have null types
-                    var operandType = (operand.Kind == BoundKind.MethodGroup) ? (object)MessageID.IDS_SK_METHOD.Localize() : operand.Type;
-
-                    diagnostics.Add(ErrorCode.ERR_AmbigUDConv, syntax.Location, originalUserDefinedConversions[0], originalUserDefinedConversions[1], operandType, targetType);
+                    diagnostics.Add(ErrorCode.ERR_AmbigUDConv, syntax.Location, originalUserDefinedConversions[0], originalUserDefinedConversions[1], operand.Display, targetType);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/MethodBodyModelTests.cs
@@ -989,9 +989,9 @@ class Program
             var tree = Parse(text);
             var comp = CreateCompilationWithMscorlib(tree);
             comp.GetMethodBodyDiagnostics().Verify(
-                // (23,15): error CS0457: Ambiguous user defined conversions 'D.explicit operator D(Foo)' and 'D.implicit operator D(Action)' when converting from 'method' to 'D'
+                // (23,15): error CS0457: Ambiguous user defined conversions 'D.explicit operator D(Foo)' and 'D.implicit operator D(Action)' when converting from 'method group' to 'D'
                 //          D d = (D) Main;
-                Diagnostic(ErrorCode.ERR_AmbigUDConv, "(D) Main").WithArguments("D.explicit operator D(Foo)", "D.implicit operator D(System.Action)", "method", "D").WithLocation(23, 15)
+                Diagnostic(ErrorCode.ERR_AmbigUDConv, "(D) Main").WithArguments("D.explicit operator D(Foo)", "D.implicit operator D(System.Action)", "method group", "D").WithLocation(23, 15)
                 );
         }
     }


### PR DESCRIPTION
Follow up on #14463
@dotnet/roslyn-compiler 
/cc @AlekseyTs