### PR TITLE
Enable T completion for local func return type

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SpeculativeTCompletionProviderTests.cs
@@ -339,5 +339,51 @@ class Program
 
             await VerifyItemExistsAsync(markup, "T");
         }
+
+        [WorkItem(13480, "https://github.com/dotnet/roslyn/issues/13480")]
+        [Fact]
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]
+        public async Task LocalFunctionReturnType()
+        {
+            var markup = @"
+class C
+{
+    public void M()
+    {
+        $$
+    }
+}";
+            await VerifyItemExistsAsync(markup, "T");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14525")]
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]
+        public async Task LocalFunctionAfterAyncTask()
+        {
+            var markup = @"
+class C
+{
+    public void M()
+    {
+        async Task<$$>
+    }
+}";
+            await VerifyItemExistsAsync(markup, "T");
+        }
+
+        [Fact(Skip = "https://github.com/dotnet/roslyn/issues/14525")]
+        [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]
+        public async Task LocalFunctionAfterAsync()
+        {
+            var markup = @"
+class C
+{
+    public void M()
+    {
+        async $$
+    }
+}";
+            await VerifyItemIsAbsentAsync(markup, "T");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
+++ b/src/Features/CSharp/Portable/Completion/CompletionProviders/SpeculativeTCompletionProvider.cs
@@ -80,6 +80,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.Providers
 
             if ((!leftToken.GetPreviousTokenIfTouchingWord(position).IsKindOrHasMatchingText(SyntaxKind.AsyncKeyword) &&
                 syntaxTree.IsMemberDeclarationContext(testPosition, contextOpt: null, validModifiers: SyntaxKindSet.AllMemberModifiers, validTypeDeclarations: SyntaxKindSet.ClassInterfaceStructTypeDeclarations, canBePartial: false, cancellationToken: cancellationToken)) ||
+                syntaxTree.IsStatementContext(testPosition, leftToken, cancellationToken) ||
                 syntaxTree.IsGlobalMemberDeclarationContext(testPosition, SyntaxKindSet.AllGlobalMemberModifiers, cancellationToken) ||
                 syntaxTree.IsGlobalStatementContext(testPosition, cancellationToken) ||
                 syntaxTree.IsDelegateReturnTypeContext(testPosition, syntaxTree.FindTokenOnLeftOfPosition(testPosition, cancellationToken), cancellationToken))


### PR DESCRIPTION
This PR fixes speculative-T completion for the return type of local
functions. However, it doesn't include completion for generic arguments
to async local functions, which will require a significant change in the
parsing strategy and tree produced.

Fixes #13480.