### PR TITLE
Breakpoint and instrumentation support for new C# 7 language features

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -194,16 +194,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </remarks>
         public override BoundStatement InstrumentForEachStatementCollectionVarDeclaration(BoundForEachStatement original, BoundStatement collectionVarDecl)
         {
-            // NOTE: This is slightly different from Dev10.  In Dev10, when you stop the debugger
-            // on the collection expression, you can see the (uninitialized) iteration variable.
-            // In Roslyn, you cannot because the iteration variable is re-declared in each iteration
-            // of the loop and is, therefore, not yet in scope.
-            if (original.Syntax is ForEachComponentStatementSyntax)
-            {
-                return InstrumentForEachStatementDeconstructionVariablesDeclaration(original, collectionVarDecl);
-            }
-
-            var forEachSyntax = (ForEachStatementSyntax)original.Syntax;
+            var forEachSyntax = (CommonForEachStatementSyntax)original.Syntax;
             return new BoundSequencePoint(forEachSyntax.Expression,
                                           base.InstrumentForEachStatementCollectionVarDeclaration(original, collectionVarDecl));
         }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundStatement InstrumentForEachStatementCollectionVarDeclaration(BoundForEachStatement original, BoundStatement collectionVarDecl)
         {
             Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax.Kind() == SyntaxKind.ForEachStatement);
+            Debug.Assert(original.Syntax is CommonForEachStatementSyntax);
             return collectionVarDecl;
         }
 

--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_ReturnStatement.cs
@@ -41,9 +41,10 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     return true;
                 }
-                var sourceMethod = method as SourceMethodSymbol;
-                return sourceMethod != null
-                    && sourceMethod.IsExpressionBodied;
+
+                return
+                    (method as SourceMethodSymbol)?.IsExpressionBodied ??
+                    (method as LocalFunctionSymbol)?.IsExpressionBodied ?? false;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -290,6 +290,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         public bool IsUnsafe => (_declarationModifiers & DeclarationModifiers.Unsafe) != 0;
 
+        internal bool IsExpressionBodied => _syntax.Body == null && _syntax.ExpressionBody != null;
+
         public override DllImportData GetDllImportData() => null;
 
         internal override ImmutableArray<string> GetAppliedConditionalSymbols() => ImmutableArray<string>.Empty;

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
@@ -122,5 +122,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         {
             get { return true; }
         }
+
+        internal override bool IsExpressionBodied
+        {
+            get
+            {
+                var syntax = GetSyntax();
+                var hasBody = syntax.Body != null;
+                var hasExpressionBody = syntax.ExpressionBody != null;
+                return !hasBody && hasExpressionBody;
+            }
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
+++ b/src/Compilers/CSharp/Test/Emit/CSharpCompilerEmitTest.csproj
@@ -124,6 +124,7 @@
     <Compile Include="CodeGen\IndexerTests.cs" />
     <Compile Include="CodeGen\CodeGenLockTests.cs" />
     <Compile Include="CodeGen\ObjectAndCollectionInitializerTests.cs" />
+    <Compile Include="CodeGen\PropertyTests.cs" />
     <Compile Include="CodeGen\SwitchTests.cs" />
     <Compile Include="CodeGen\UnsafeTests.cs" />
     <Compile Include="CodeGen\WinMdDelegateTests.cs" />

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/EventTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/EventTests.cs
@@ -819,5 +819,43 @@ struct C
 }
 ");
         }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        [CompilerTrait(CompilerFeature.ExpressionBody)]
+        public void ExpressionBodedEvent()
+        {
+            var source = @"
+class C
+{
+    public int x;
+    public event System.Action E
+    {
+        add => x = 1;
+        remove => x = 0;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyIL("C.E.add", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.1
+  IL_0002:  stfld      ""int C.x""
+  IL_0007:  ret
+}
+");
+            verifier.VerifyIL("C.E.remove", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.0
+  IL_0002:  stfld      ""int C.x""
+  IL_0007:  ret
+}
+");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/PropertyTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
+using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
+{
+    public class PropertyTests : EmitMetadataTestBase
+    {
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        [CompilerTrait(CompilerFeature.ExpressionBody)]
+        public void ExpressionBodedProperty()
+        {
+            var source = @"
+class C
+{
+    public int x;
+    public int X
+    {
+        set => x = value;
+        get => x;
+    }
+}";
+            var compilation = CreateCompilationWithMscorlib(source, options: TestOptions.DebugDll);
+            var verifier = CompileAndVerify(compilation);
+            verifier.VerifyIL("C.X.get", @"
+{
+  // Code size        7 (0x7)
+  .maxstack  1
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.x""
+  IL_0006:  ret
+}
+");
+            verifier.VerifyIL("C.X.set", @"
+{
+  // Code size        8 (0x8)
+  .maxstack  2
+  IL_0000:  ldarg.0
+  IL_0001:  ldarg.1
+  IL_0002:  stfld      ""int C.x""
+  IL_0007:  ret
+}
+");
+        }
+    }
+}

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicInstrumentationTests.cs
@@ -1374,6 +1374,7 @@ True
 Method 3
 File 1
 True
+True
 False
 True
 False
@@ -1403,6 +1404,166 @@ True
 
             CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
             verifier.VerifyDiagnostics(Diagnostic(ErrorCode.WRN_UnassignedInternalField, "Subject").WithArguments("Teacher.Subject", "null").WithLocation(37, 40));
+        }
+
+        [Fact]
+        public void DeconstructionStatementCoverage()
+        {
+            string source = @"
+using System;
+
+public class C
+{
+    public static void Main() // Method 1
+    {
+        TestMain2();
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
+    }
+
+    static void TestMain2() // Method 2
+    {
+        var (x, y) = new C();
+    }
+
+    static void TestMain3() // Method 3
+    {
+        var (x, y) = new C();
+    }
+
+    public C() // Method 4
+    {
+    }
+
+    public void Deconstruct(out int x, out int y) // Method 5
+    {
+        x = 1;
+        y = 2;
+    }
+}
+";
+            string expectedOutput = @"Flushing
+Method 1
+File 1
+True
+True
+True
+Method 2
+File 1
+True
+True
+Method 4
+File 1
+True
+Method 5
+File 1
+True
+True
+True
+Method 7
+File 1
+True
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+";
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
+        }
+
+        [Fact]
+        public void DeconstructionForeachStatementCoverage()
+        {
+            string source = @"
+using System;
+
+public class C
+{
+    public static void Main() // Method 1
+    {
+        TestMain2(new C[] { new C() });
+        TestMain3(new C[] { });
+        Microsoft.CodeAnalysis.Runtime.Instrumentation.FlushPayload();
+    }
+
+    static void TestMain2(C[] a) // Method 2
+    {
+        foreach (
+            var (x, y)
+            in a)
+            ;
+    }
+
+    static void TestMain3(C[] a) // Method 3
+    {
+        foreach (
+            var (x, y)
+            in a)
+            ;
+    }
+
+    public C() // Method 4
+    {
+    }
+
+    public void Deconstruct(out int x, out int y) // Method 5
+    {
+        x = 1;
+        y = 2;
+    }
+}
+";
+            string expectedOutput = @"Flushing
+Method 1
+File 1
+True
+True
+True
+True
+Method 2
+File 1
+True
+True
+True
+Method 3
+File 1
+True
+False
+False
+Method 4
+File 1
+True
+Method 5
+File 1
+True
+True
+True
+Method 7
+File 1
+True
+True
+False
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+True
+";
+            CompilationVerifier verifier = CompileAndVerify(source + InstrumentationHelperSource, expectedOutput: expectedOutput);
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5109,6 +5109,128 @@ class C
 </symbols>");
         }
 
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void ExpressionBodiedConstructor()
+        {
+            var comp = CreateCompilationWithMscorlib45(@"
+using System;
+
+class C
+{
+    public int X;
+    public C(Int32 x) => X = x;
+}");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyPdb(@"<symbols>
+  <methods>
+    <method containingType=""C"" name="".ctor"" parameterNames=""x"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""1"" />
+        </using>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""5"" endLine=""7"" endColumn=""22"" />
+        <entry offset=""0x6"" startLine=""7"" startColumn=""26"" endLine=""7"" endColumn=""31"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0xe"">
+        <namespace name=""System"" />
+      </scope>
+    </method>
+  </methods>
+</symbols>");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void ExpressionBodiedDestructor()
+        {
+            var comp = CreateCompilationWithMscorlib45(@"
+class C
+{
+    public int X;
+    ~C() => X = 0;
+}");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyPdb(@"<symbols>
+  <methods>
+    <method containingType=""C"" name=""Finalize"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""5"" startColumn=""13"" endLine=""5"" endColumn=""18"" />
+        <entry offset=""0x9"" hidden=""true"" />
+        <entry offset=""0x10"" hidden=""true"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void ExpressionBodiedAccessor()
+        {
+            var comp = CreateCompilationWithMscorlib45(@"
+class C
+{
+    public int x;
+    public int X
+    {
+        get => x;
+        set => x = value;
+    }
+    public event System.Action E
+    {
+        add => x = 1;
+        remove => x = 0;
+    }
+}");
+            comp.VerifyDiagnostics();
+
+            comp.VerifyPdb(@"<symbols>
+  <methods>
+    <method containingType=""C"" name=""get_X"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""16"" endLine=""7"" endColumn=""17"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""C"" name=""set_X"" parameterNames=""value"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""get_X"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""8"" startColumn=""16"" endLine=""8"" endColumn=""25"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""C"" name=""add_E"" parameterNames=""value"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""get_X"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""12"" startColumn=""16"" endLine=""12"" endColumn=""21"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""C"" name=""remove_E"" parameterNames=""value"">
+      <customDebugInfo>
+        <forward declaringType=""C"" methodName=""get_X"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""13"" startColumn=""19"" endLine=""13"" endColumn=""24"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
+
         #endregion
 
         #region Synthesized Methods

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -5636,5 +5636,73 @@ partial class C
   </methods>
 </symbols>");
         }
+
+        [WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        [Fact]
+        public void LocalFunctionSequencePoints()
+        {
+            string source =
+@"class Program
+{
+    static int Main(string[] args)
+    {                                                // 4
+        int Local1(string[] a)
+            =>
+            a.Length;                                // 7
+        int Local2(string[] a)
+        {                                            // 9
+            return a.Length;                         // 10
+        }                                            // 11
+        return Local1(args) + Local2(args);          // 12
+    }                                                // 13
+}";
+            var c = CreateCompilationWithMscorlibAndSystemCore(source, options: TestOptions.DebugDll);
+            c.VerifyPdb(
+@"<symbols>
+  <methods>
+    <method containingType=""Program"" name=""Main"" parameterNames=""args"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""0"" />
+        </encLocalSlotMap>
+        <encLambdaMap>
+          <methodOrdinal>0</methodOrdinal>
+          <lambda offset=""99"" />
+          <lambda offset=""202"" />
+        </encLambdaMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
+        <entry offset=""0x3"" startLine=""12"" startColumn=""9"" endLine=""12"" endColumn=""44"" />
+        <entry offset=""0x13"" startLine=""13"" startColumn=""5"" endLine=""13"" endColumn=""6"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""Program"" name=""&lt;Main&gt;g__Local10_0"" parameterNames=""a"">
+      <customDebugInfo>
+        <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""21"" />
+      </sequencePoints>
+    </method>
+    <method containingType=""Program"" name=""&lt;Main&gt;g__Local20_1"" parameterNames=""a"">
+      <customDebugInfo>
+        <forward declaringType=""Program"" methodName=""Main"" parameterNames=""args"" />
+        <encLocalSlotMap>
+          <slot kind=""21"" offset=""202"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
+        <entry offset=""0x1"" startLine=""10"" startColumn=""13"" endLine=""10"" endColumn=""29"" />
+        <entry offset=""0x7"" startLine=""11"" startColumn=""9"" endLine=""11"" endColumn=""10"" />
+      </sequencePoints>
+    </method>
+  </methods>
+</symbols>");
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTupleTests.cs
@@ -207,5 +207,60 @@ string.Format(@"<symbols>
     "_\u1200_",
     "\u1200"));
         }
+
+        [Fact]
+        public void DeconstructionForeach()
+        {
+            var source =
+@"class C
+{
+    static void F(System.Collections.Generic.IEnumerable<(int a, int b)> ie)
+    { //4,5
+        foreach (         //5,9
+            var (a, b)    //6,13
+            in            //7,13
+            ie)           //8,13
+        { //9,9
+        } //10,9
+    } //11,5
+}";
+            var comp = CreateCompilationWithMscorlib(source, new[] { ValueTupleRef }, options: TestOptions.DebugDll);
+            comp.VerifyPdb(
+string.Format(@"<symbols>
+  <methods>
+    <method containingType=""C"" name=""F"" parameterNames=""ie"">
+      <customDebugInfo>
+        <using>
+          <namespace usingCount=""0"" />
+        </using>
+        <encLocalSlotMap>
+          <slot kind=""5"" offset=""17"" />
+          <slot kind=""0"" offset=""59"" />
+          <slot kind=""0"" offset=""62"" />
+          <slot kind=""temp"" />
+        </encLocalSlotMap>
+      </customDebugInfo>
+      <sequencePoints>
+        <entry offset=""0x0"" startLine=""4"" startColumn=""5"" endLine=""4"" endColumn=""6"" />
+        <entry offset=""0x1"" startLine=""5"" startColumn=""9"" endLine=""5"" endColumn=""16"" />
+        <entry offset=""0x2"" startLine=""8"" startColumn=""13"" endLine=""8"" endColumn=""15"" />
+        <entry offset=""0x9"" hidden=""true"" />
+        <entry offset=""0xb"" startLine=""6"" startColumn=""13"" endLine=""6"" endColumn=""23"" />
+        <entry offset=""0x20"" startLine=""9"" startColumn=""9"" endLine=""9"" endColumn=""10"" />
+        <entry offset=""0x21"" startLine=""10"" startColumn=""9"" endLine=""10"" endColumn=""10"" />
+        <entry offset=""0x22"" startLine=""7"" startColumn=""13"" endLine=""7"" endColumn=""15"" />
+        <entry offset=""0x2c"" hidden=""true"" />
+        <entry offset=""0x37"" startLine=""11"" startColumn=""5"" endLine=""11"" endColumn=""6"" />
+      </sequencePoints>
+      <scope startOffset=""0x0"" endOffset=""0x38"">
+        <scope startOffset=""0xb"" endOffset=""0x22"">
+          <local name=""a"" il_index=""1"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
+          <local name=""b"" il_index=""2"" il_start=""0xb"" il_end=""0x22"" attributes=""0"" />
+        </scope>
+      </scope>
+    </method>
+  </methods>
+</symbols>"));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -3986,5 +3986,148 @@ $$        int
     public int Id { get { return 42; } set { [|}|] $$}
 }");
         }
+
+        [Fact]
+        public void WhenClause_1()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+$$      case string s [|when b|]:
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void WhenClause_2()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s [|whe$$n b|]:
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void WhenClause_3()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s [|when b|]:$$
+        break;
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_1()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+$$      case string s:
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_2()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      $$case string s:
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void PatternSwitchCase_3()
+        {
+            TestSpan(
+@"class C
+{
+  string s;
+  bool b;
+  void Foo()
+  {
+    switch (s)
+    {
+      case string s:$$
+      default:
+        [|break;|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void DeconstructionDeclarationStatement_1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+$$    [|var (x, y) = (1, 2);|]
+  }
+}");
+        }
+
+        [Fact]
+        public void DeconstructionDeclarationStatement_2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|var (x, y) = $$(1, 2);|]
+  }
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -391,6 +391,21 @@ $$    (
 }");
         }
 
+        [Fact]
+        public void ForEachDeconstructionStatementExpression()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) in [|Foo().B$$ar()|])
+    {
+    }
+  }
+}");
+        }
+
         #region Lambdas
 
         [Fact]
@@ -2498,6 +2513,255 @@ expr().blah())
   void Foo()
   {
     foreach (var v in expr().blah())
+  $$ [|{|]
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionKeyword1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+$$    [|foreach|] (var (x, y) in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionKeyword2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|fo$$reach|] (var (x, y) in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionKeyword3()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|foreach|]    $$    
+(var (x, y) in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionKeyword4()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|foreach|]        
+$$         (var (x, y) in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionKeyword5()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|foreach|] $$(var (x, y) in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionType1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (   $$   
+[|var (x, y)|] in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionType2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach ([|v$$ar (x, y)|] in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionIdentifier()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach ([|var (v$$v, y)|] in expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionIn1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) [|i$$n|] expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionIn2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) 
+$$         [|in|] expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionIn3()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) 
+         [|in|] $$
+expr().blah())
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionExpr1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) in [|expr($$).blah()|])
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionExpr2()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) in [|expr().blah()|]   
+     $$    )
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionExpr3()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) in 
+   $$ [|expr().blah()|]   
+     )
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionStatement()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    [|foreach|](var (x, y) in expr().blah())    $$ 
+    {
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void OnForEachDeconstructionBlock1()
+        {
+            TestSpan(
+@"class C
+{
+  void Foo()
+  {
+    foreach (var (x, y) in expr().blah())
   $$ [|{|]
     }
   }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -4393,5 +4393,185 @@ $$    [|var (x, y) = (1, 2);|]
   }
 }");
         }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody1()
+        {
+            TestSpan(
+@"class C
+{
+    public int Id { get => [|12$$3|]; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody2()
+        {
+            TestSpan(
+@"class C
+{
+    public int Id { get $$=> [|123|]; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody3()
+        {
+            TestSpan(
+@"class C
+{
+    $$public int Id { get => [|123|]; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody4()
+        {
+            TestSpan(
+@"class C
+{
+    public int Id { get => [|123|];   $$ }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody5()
+        {
+            TestSpan(
+@"class C
+{
+$$    public event Action Foo { add => [|123|]; remove => 456; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody6()
+        {
+            TestSpan(
+@"class C
+{
+    public event Action Foo { add => [|123|];$$ remove => 456; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody7()
+        {
+            TestSpan(
+@"class C
+{
+    public event Action Foo { add => 123; $$remove => [|456|]; }
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnAccessorExpressionBody8()
+        {
+            TestSpan(
+@"class C
+{
+    public event Action Foo { add => 123; remove => [|456|]; }$$
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnCtorExpressionBody1()
+        {
+            TestSpan(
+@"class C
+{
+$$    public C() => [|x = 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnCtorExpressionBody2()
+        {
+            TestSpan(
+@"class C
+{
+    public C() => $$[|x = 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnCtorExpressionBody3()
+        {
+            TestSpan(
+@"class C
+{
+    public C() => [|x =$$ 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnCtorExpressionBody4()
+        {
+            TestSpan(
+@"class C
+{
+    public C() => [|x = 1|]$$;
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnCtorExpressionBody5()
+        {
+            TestSpan(
+@"class C
+{
+    public C() => [|x = 1|];$$
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnDtorExpressionBody1()
+        {
+            TestSpan(
+@"class C
+{
+$$    public ~C() => [|x = 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnDtorExpressionBody2()
+        {
+            TestSpan(
+@"class C
+{
+    public ~C() => $$[|x = 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnDtorExpressionBody3()
+        {
+            TestSpan(
+@"class C
+{
+    public ~C() => [|x =$$ 1|];
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnDtorExpressionBody4()
+        {
+            TestSpan(
+@"class C
+{
+    public ~C() => [|x = 1|]$$;
+}");
+        }
+
+        [Fact, WorkItem(14438, "https://github.com/dotnet/roslyn/issues/14438")]
+        public void OnDtorExpressionBody5()
+        {
+            TestSpan(
+@"class C
+{
+    public ~C() => [|x = 1|];$$
+}");
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
+++ b/src/EditorFeatures/CSharpTest/EditAndContinue/BreakpointSpansTests.cs
@@ -4573,5 +4573,92 @@ $$    public ~C() => [|x = 1|];
     public ~C() => [|x = 1|];$$
 }");
         }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_1()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+$$        int Local(object[] a)
+        [|{|]
+            return a.Length;
+        }
+    }
+}");
+        }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_2()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+        int Local(object[] a)$$
+        [|{|]
+            return a.Length;
+        }
+    }
+}");
+        }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_3()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+        int Local(object[] a)
+$$        [|{|]
+            return a.Length;
+        }
+    }
+}");
+        }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_4()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+$$        int Local(object[] a) => [|a.Length|];
+    }
+}");
+        }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_5()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+        int Local(object$$[] a) => [|a.Length|];
+    }
+}");
+        }
+
+        [Fact, WorkItem(14437, "https://github.com/dotnet/roslyn/issues/14437")]
+        public void OnLocalFunctionDecl_6()
+        {
+            TestSpan(
+@"class C
+{
+    static void M()
+    {
+        int Local(object[] a) => [|a.Length|];$$
+    }
+}");
+        }
     }
 }

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -193,6 +193,15 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.DefaultSwitchLabel:
                     return TryCreateSpanForSwitchLabel((SwitchLabelSyntax)node, position);
 
+                case SyntaxKind.CasePatternSwitchLabel:
+                    var caseClause = (CasePatternSwitchLabelSyntax)node;
+                    return caseClause.WhenClause == null
+                        ? TryCreateSpanForSwitchLabel((SwitchLabelSyntax)node, position)
+                        : CreateSpan(caseClause.WhenClause);
+
+                case SyntaxKind.WhenClause:
+                    return CreateSpan(node);
+
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
                     var body = ((AccessorDeclarationSyntax)node).Body;
@@ -535,6 +544,7 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 case SyntaxKind.ThrowStatement:
                 case SyntaxKind.ExpressionStatement:
                 case SyntaxKind.EmptyStatement:
+                case SyntaxKind.DeconstructionDeclarationStatement:
                 default:
                     // Fallback case.  If it was none of the above types of statements, then we make a span
                     // over the entire statement.  Note: this is not a very desirable thing to do (as

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -291,6 +291,12 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     var groupClause = (GroupClauseSyntax)node;
                     return TryCreateSpanForNode(groupClause.GroupExpression, position);
 
+                case SyntaxKind.LocalFunctionStatement:
+                    var localFunction = (LocalFunctionStatementSyntax)node;
+                    return (localFunction.Body != null) ?
+                        TryCreateSpanForNode(localFunction.Body, position) :
+                        TryCreateSpanForNode(localFunction.ExpressionBody.Expression, position);
+
                 default:
                     var expression = node as ExpressionSyntax;
                     if (expression != null)

--- a/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
+++ b/src/Features/CSharp/Portable/EditAndContinue/BreakpointSpans.cs
@@ -149,19 +149,11 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
             switch (node.Kind())
             {
                 case SyntaxKind.MethodDeclaration:
-                    var methodDeclaration = (MethodDeclarationSyntax)node;
-                    return (methodDeclaration.Body != null) ? CreateSpanForBlock(methodDeclaration.Body, position) : methodDeclaration.ExpressionBody?.Expression.Span;
-
                 case SyntaxKind.OperatorDeclaration:
-                    var operatorDeclaration = (OperatorDeclarationSyntax)node;
-                    return (operatorDeclaration.Body != null) ? CreateSpanForBlock(operatorDeclaration.Body, position) : operatorDeclaration.ExpressionBody?.Expression.Span;
-
                 case SyntaxKind.ConversionOperatorDeclaration:
-                    var conversionDeclaration = (ConversionOperatorDeclarationSyntax)node;
-                    return (conversionDeclaration.Body != null) ? CreateSpanForBlock(conversionDeclaration.Body, position) : conversionDeclaration.ExpressionBody?.Expression.Span;
-
                 case SyntaxKind.DestructorDeclaration:
-                    return TryCreateSpanForNode(((DestructorDeclarationSyntax)node).Body, position);
+                    var methodDeclaration = (BaseMethodDeclarationSyntax)node;
+                    return (methodDeclaration.Body != null) ? CreateSpanForBlock(methodDeclaration.Body, position) : methodDeclaration.ExpressionBody?.Expression.Span;
 
                 case SyntaxKind.ConstructorDeclaration:
                     return CreateSpanForConstructorDeclaration((ConstructorDeclarationSyntax)node);
@@ -204,18 +196,22 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
 
                 case SyntaxKind.GetAccessorDeclaration:
                 case SyntaxKind.SetAccessorDeclaration:
-                    var body = ((AccessorDeclarationSyntax)node).Body;
-                    if (body == null)
-                    {
-                        return CreateSpan(node);
-                    }
-
-                    return TryCreateSpanForNode(body, position);
-
                 case SyntaxKind.AddAccessorDeclaration:
                 case SyntaxKind.RemoveAccessorDeclaration:
                 case SyntaxKind.UnknownAccessorDeclaration:
-                    return TryCreateSpanForNode(((AccessorDeclarationSyntax)node).Body, position);
+                    var accessor = (AccessorDeclarationSyntax)node;
+                    if (accessor.ExpressionBody != null)
+                    {
+                        return CreateSpan(accessor.ExpressionBody.Expression);
+                    }
+                    else if (accessor.Body != null)
+                    {
+                        return TryCreateSpanForNode(accessor.Body, position);
+                    }
+                    else
+                    {
+                        return CreateSpan(node);
+                    }
 
                 case SyntaxKind.PropertyDeclaration:
                     var property = (PropertyDeclarationSyntax)node;
@@ -250,8 +246,10 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                     return CreateSpanForAccessors(indexer.AccessorList.Accessors, position);
 
                 case SyntaxKind.EventDeclaration:
-                    var evnt = (EventDeclarationSyntax)node;
-                    return evnt.AccessorList.Accessors.Select(a => TryCreateSpanForNode(a, position)).FirstOrDefault();
+                    // event Action P { add [|{|] ... } remove { ... } }
+                    // event Action P { [|add;|] [|remove;|] }
+                    var @event = (EventDeclarationSyntax)node;
+                    return CreateSpanForAccessors(@event.AccessorList.Accessors, position);
 
                 case SyntaxKind.BaseConstructorInitializer:
                 case SyntaxKind.ThisConstructorInitializer:
@@ -317,12 +315,18 @@ namespace Microsoft.CodeAnalysis.CSharp.EditAndContinue
                 return CreateSpanForConstructorInitializer(constructorSyntax.Initializer);
             }
 
+            if (constructorSyntax.ExpressionBody != null)
+            {
+                return constructorSyntax.ExpressionBody.Expression.Span;
+            }
+
             // static ctor doesn't have a default initializer:
             if (constructorSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
                 return CreateSpan(constructorSyntax.Body.OpenBraceToken);
             }
 
+            // the declaration is the span of the implicit initializer
             return CreateSpan(constructorSyntax.Modifiers, constructorSyntax.Identifier, constructorSyntax.ParameterList.CloseParenToken);
         }
 


### PR DESCRIPTION
This is a work in progress. I will send it out for review when all of the relevant issues have been addressed. The issues that will be addressed in this PR (ideally one commit per issue) are:

- [x] #14519 Breakpoints for pattern switch and the when clause
- [x] #14439 Sequence points and breakpoints for deconstruction foreach statement
- [x] #14438 Sequence points and breakpoints for expression-bodied members
- [x] #14437 Enable setting a breakpoint in a local function
- [x] #14337 Add support for /instrument codecoverage for new language features
