### PR TITLE
Fixed null exception for solution which has both C#/VB and typescript/javascript

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/Serializer.cs
+++ b/src/Workspaces/Core/Portable/Execution/Serializer.cs
@@ -199,7 +199,8 @@ namespace Microsoft.CodeAnalysis.Serialization
                 IOptionsSerializationService service;
                 if (_lazyLanguageSerializationService.TryGetValue(languageName, out service))
                 {
-                    if (service.CanSerialize(value))
+                    // language such as type script will not have the service
+                    if (service?.CanSerialize(value) == true)
                     {
                         return languageName;
                     }
@@ -223,7 +224,9 @@ namespace Microsoft.CodeAnalysis.Serialization
                 }
 
                 service = GetOptionsSerializationService(languageName);
-                if (service.CanSerialize(value))
+
+                // language such as type script will not have the service
+                if (service?.CanSerialize(value) == true)
                 {
                     return languageName;
                 }


### PR DESCRIPTION
Jason found a crash due to OOP when a solution contains both C#/VB and typescript/javascript

crash is due to code assuming a service always exist which is not true for typescript/javascript project.

* this doesn't always repro, it only repro if MEF import of HostServices load typescript language services before or in between C# and VB.