### PR TITLE
Propagate delegate relaxation information for tuple conversions.

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
+++ b/src/Compilers/VisualBasic/Portable/Analysis/FlowAnalysis/AbstractFlowPass.vb
@@ -1375,6 +1375,14 @@ lUnsplitAndFinish:
             Return Nothing
         End Function
 
+        Public Overrides Function VisitRelaxationLambda(node As BoundRelaxationLambda) As BoundNode
+            Throw ExceptionUtilities.Unreachable
+        End Function
+
+        Public Overrides Function VisitConvertedTupleElements(node As BoundConvertedTupleElements) As BoundNode
+            Throw ExceptionUtilities.Unreachable
+        End Function
+
         Public Overrides Function VisitUserDefinedConversion(node As BoundUserDefinedConversion) As BoundNode
             VisitRvalue(node.UnderlyingExpression)
             Return Nothing

--- a/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
+++ b/src/Compilers/VisualBasic/Portable/BasicCodeAnalysis.vbproj
@@ -174,6 +174,7 @@
     <Compile Include="Binding\TypesOfImportedNamespacesMembersBinder.vb" />
     <Compile Include="Binding\UsingBlockBinder.vb" />
     <Compile Include="Binding\UsingInfo.vb" />
+    <Compile Include="BoundTree\BoundConvertedTupleElements.vb" />
     <Compile Include="BoundTree\BoundInterpolatedStringExpression.vb" />
     <Compile Include="BoundTree\BoundMyClassReference.vb" />
     <Compile Include="BoundTree\BoundMyBaseReference.vb" />

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundConvertedTupleElements.vb
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundConvertedTupleElements.vb
@@ -1,0 +1,19 @@
+﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+Imports Microsoft.CodeAnalysis.Text
+Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
+Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
+
+Namespace Microsoft.CodeAnalysis.VisualBasic
+
+    Partial Friend Class BoundConvertedTupleElements
+
+#If DEBUG Then
+        Private Sub Validate()
+            Debug.Assert(ElementPlaceholders.Length = ConvertedElements.Length)
+            Debug.Assert(Not ElementPlaceholders.Contains(Nothing))
+            Debug.Assert(Not ConvertedElements.Contains(Nothing))
+        End Sub
+#End If
+    End Class
+End Namespace

--- a/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
+++ b/src/Compilers/VisualBasic/Portable/BoundTree/BoundNodes.xml
@@ -452,20 +452,24 @@
         <Field Name="ExplicitCastInCode" Type="Boolean"/>
         <Field Name="ConstantValueOpt" PropertyOverrides="true" Type="ConstantValue" Null="allow"/>
 
-        <!-- Constructor symbol may only be not-null for conversion from Nothing to a ValueType.
-             In this case we check if the ValueType has parameterless constructor and if it is accessible.
-             If we find such a constructor, we store the symbol in bound node to be used
-             in emit phase. If ConstructorOpt in Nothing, 'initobj' will be used for ValueType construction.
-          -->
-        <Field Name="ConstructorOpt" Type="MethodSymbol" Null="allow"/>
-
-        <!-- If this is a lambda conversion which requires a stub, additional lambda 
-             representing the stub is stored here -->
-        <Field Name="RelaxationLambdaOpt" Type="BoundLambda" Null="allow" />
-        <!-- The placeholder of a captured receiver for the relaxation lambda -->
-        <Field Name="RelaxationReceiverPlaceholderOpt" Type="BoundRValuePlaceholder" Null="allow" />
+        <Field Name="ExtendedInfoOpt" Type="BoundExtendedConversionInfo" Null="allow"/>
     </Node>
 
+    <AbstractNode Name="BoundExtendedConversionInfo" Base="BoundNode"/>
+  
+    <!-- Captures information about relaxation lambda necessary for a conversion -->
+    <Node Name="BoundRelaxationLambda" Base="BoundExtendedConversionInfo">
+        <Field Name="Lambda" Type="BoundLambda" Null="disallow" />
+        <!-- The placeholder of a captured receiver for the relaxation lambda -->
+        <Field Name="ReceiverPlaceholderOpt" Type="BoundRValuePlaceholder" Null="allow" />
+    </Node>
+
+    <!-- Used when source is not a tuple literal -->
+    <Node Name="BoundConvertedTupleElements" Base="BoundExtendedConversionInfo" HasValidate="true">
+        <Field Name="ElementPlaceholders" Type="ImmutableArray(Of BoundRValuePlaceholder)" Null="disallow" />
+        <Field Name="ConvertedElements" Type="ImmutableArray(Of BoundExpression)" Null="disallow" />
+    </Node>
+  
     <!-- This node is created to represent a user-defined conversion operator call 
          It is used in place of BoundConversion.Operand and the initial operand of 
          the conversion is an argument (possibly converted) of the underlying call expression,

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitConversion.vb
@@ -1,5 +1,6 @@
 ﻿' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.Collections.Immutable
 Imports System.Reflection.Metadata
 Imports Microsoft.CodeAnalysis.VisualBasic.Symbols
 Imports PrimitiveTypeCode = Microsoft.Cci.PrimitiveTypeCode
@@ -211,8 +212,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
                         ' But first Pop off the Null reference cause we don't need it anymore.
                         _builder.EmitOpCode(ILOpCode.Pop)
 
+                        Dim constructor = GetParameterlessValueTypeConstructor(DirectCast(typeTo, NamedTypeSymbol))
+
                         'TODO: used
-                        EmitLoadDefaultValueOfTypeFromConstructorCall(conversion.ConstructorOpt, used:=True, syntaxNode:=conversion.Syntax)
+                        If constructor Is Nothing OrElse constructor.IsDefaultValueTypeConstructor() Then
+                            EmitInitObj(typeTo, used:=True, syntaxNode:=conversion.Syntax)
+                        Else
+                            ' before we use constructor symbol we need to report use site error if any
+                            Binder.ReportUseSiteError(_diagnostics, conversion.Syntax, constructor)
+
+                            EmitNewObj(constructor, ImmutableArray(Of BoundExpression).Empty, used:=True, syntaxNode:=conversion.Syntax)
+                        End If
+
                         _builder.EmitBranch(ILOpCode.Br_s, resultLabel)
 
                         _builder.MarkLabel(unboxLabel)
@@ -229,6 +240,32 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             End If
 
         End Sub
+
+        ''' <summary> 
+        ''' Returns parameterless value type constructor.
+        ''' </summary>
+        Private Function GetParameterlessValueTypeConstructor(typeTo As NamedTypeSymbol) As MethodSymbol
+            Debug.Assert(typeTo.IsValueType AndAlso Not typeTo.IsTypeParameter)
+
+            '  find valuetype parameterless constructor and check the accessibility
+            For Each constr In typeTo.InstanceConstructors
+                ' NOTE: we intentionally skip constructors with all 
+                '       optional parameters; this matches Dev10 behavior
+                If constr.ParameterCount = 0 Then
+                    '  check 'constr' 
+                    If AccessCheck.IsSymbolAccessible(constr, _method.ContainingType, typeTo, useSiteDiagnostics:=Nothing) Then
+                        Return constr
+                    End If
+
+                    '  exit for each in any case
+                    Return Nothing
+                End If
+            Next
+
+            ' This point should not be reachable, because if there is no constructor in the 
+            ' loaded value type, we should have generated a synthesized constructor.
+            Throw ExceptionUtilities.Unreachable
+        End Function
 
         Private Function IsUnboxingDirectCast(conversion As BoundDirectCast) As Boolean
             Dim typeTo As TypeSymbol = conversion.Type

--- a/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
+++ b/src/Compilers/VisualBasic/Portable/CodeGen/EmitExpression.vb
@@ -1542,17 +1542,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGen
             EmitLoadDefaultValueOfTypeFromNothingLiteral(type, used, syntaxNode)
         End Sub
 
-        Private Sub EmitLoadDefaultValueOfTypeFromConstructorCall(constructor As MethodSymbol,
-                                                                  used As Boolean,
-                                                                  syntaxNode As SyntaxNode)
-
-            If constructor.IsDefaultValueTypeConstructor() Then
-                EmitInitObj(constructor.ContainingType, used, syntaxNode)
-            Else
-                EmitNewObj(constructor, ImmutableArray(Of BoundExpression).Empty, used, syntaxNode)
-            End If
-        End Sub
-
         Private Sub EmitLoadDefaultValueOfTypeFromNothingLiteral(type As TypeSymbol, used As Boolean, syntaxNode As SyntaxNode)
             EmitInitObj(type, used, syntaxNode)
         End Sub

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Expressions.vb
@@ -363,8 +363,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Public Overrides Function VisitConversion(node As BoundConversion) As BoundNode
                 Dim rewritten = DirectCast(MyBase.VisitConversion(node), BoundConversion)
                 Dim operand As BoundExpression = rewritten.Operand
-                Debug.Assert(rewritten.RelaxationReceiverPlaceholderOpt Is Nothing)
-                Debug.Assert(rewritten.RelaxationLambdaOpt Is Nothing)
+                Debug.Assert(rewritten.ExtendedInfoOpt Is Nothing)
 
                 If Not NeedsSpill(operand) Then
                     Return rewritten
@@ -379,9 +378,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                                   rewritten.Checked,
                                                                   rewritten.ExplicitCastInCode,
                                                                   rewritten.ConstantValueOpt,
-                                                                  rewritten.ConstructorOpt,
-                                                                  rewritten.RelaxationLambdaOpt,
-                                                                  rewritten.RelaxationReceiverPlaceholderOpt,
+                                                                  rewritten.ExtendedInfoOpt,
                                                                   rewritten.Type))
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/Diagnostics/DiagnosticsPass_ExpressionLambdas.vb
@@ -311,7 +311,7 @@ lSelect:
             End If
 
             If Me.IsInExpressionLambda AndAlso (node.ConversionKind And ConversionKind.Lambda) <> 0 Then
-                VisitLambdaConversion(node.Operand, node.RelaxationLambdaOpt)
+                VisitLambdaConversion(node.Operand, DirectCast(node.ExtendedInfoOpt, BoundRelaxationLambda)?.Lambda)
             Else
                 MyBase.VisitConversion(node)
             End If

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_ConditionalExpresion.vb
@@ -228,7 +228,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If outConv IsNot Nothing Then
                 outConv = outConv.Update([call], outConv.ConversionKind, outConv.Checked, outConv.ExplicitCastInCode, outConv.ConstantValueOpt,
-                                            outConv.ConstructorOpt, outConv.RelaxationLambdaOpt, outConv.RelaxationReceiverPlaceholderOpt, outConv.Type)
+                                         outConv.ExtendedInfoOpt, outConv.Type)
             End If
 
             Dim newInOutConversionFlags As Byte = CByte(If(outConv IsNot Nothing, 2, 0) + If(innerConversionApplied, 1, 0))
@@ -241,8 +241,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             Return conversion.Update(userDefinedConv, newConversionKind,
-                                     conversion.Checked, conversion.ExplicitCastInCode, conversion.ConstantValueOpt, conversion.ConstructorOpt,
-                                     conversion.RelaxationLambdaOpt, conversion.RelaxationReceiverPlaceholderOpt, toType)
+                                     conversion.Checked, conversion.ExplicitCastInCode, conversion.ConstantValueOpt,
+                                     conversion.ExtendedInfoOpt, toType)
         End Function
 
     End Class

--- a/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/ExpressionLambdaRewriter/ExpressionLambdaRewriter_Conversion.vb
@@ -20,8 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Return Me.VisitInternal(node.Operand)
             End If
 
-            Debug.Assert(node.RelaxationLambdaOpt Is Nothing)
-            Debug.Assert(node.RelaxationReceiverPlaceholderOpt Is Nothing)
+            Debug.Assert(node.ExtendedInfoOpt Is Nothing)
             Return ConvertExpression(node.Operand, node.ConversionKind, node.Operand.Type, node.Type, node.Checked, node.ExplicitCastInCode, ConversionSemantics.[Default])
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.Analysis.vb
@@ -356,7 +356,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Function
 
             Public Overrides Function VisitConversion(conversion As BoundConversion) As BoundNode
-                Debug.Assert(conversion.RelaxationLambdaOpt Is Nothing AndAlso conversion.RelaxationReceiverPlaceholderOpt Is Nothing)
+                Debug.Assert(conversion.ExtendedInfoOpt Is Nothing)
 
                 Dim lambda As BoundLambda = TryCast(conversion.Operand, BoundLambda)
                 If lambda Is Nothing Then

--- a/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LambdaRewriter/LambdaRewriter.vb
@@ -933,7 +933,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Function
 
         Public Overrides Function VisitConversion(conversion As BoundConversion) As BoundNode
-            Debug.Assert(conversion.RelaxationLambdaOpt Is Nothing AndAlso conversion.RelaxationReceiverPlaceholderOpt Is Nothing)
+            Debug.Assert(conversion.ExtendedInfoOpt Is Nothing)
 
             Dim lambda As BoundLambda = TryCast(conversion.Operand, BoundLambda)
             If lambda Is Nothing Then
@@ -947,9 +947,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                            conversion.Checked,
                                            conversion.ExplicitCastInCode,
                                            conversion.ConstantValueOpt,
-                                           conversion.ConstructorOpt,
-                                           conversion.RelaxationLambdaOpt,
-                                           conversion.RelaxationReceiverPlaceholderOpt,
+                                           conversion.ExtendedInfoOpt,
                                            conversion.Type)
             End If
             Return result

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperators.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_BinaryOperators.vb
@@ -157,7 +157,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Dim cast = DirectCast(operand, BoundConversion)
                     Return cast.Update(ReplaceMyGroupCollectionPropertyGetWithUnderlyingField(cast.Operand),
                                        cast.ConversionKind, cast.Checked, cast.ExplicitCastInCode, cast.ConstantValueOpt,
-                                       cast.ConstructorOpt, cast.RelaxationLambdaOpt, cast.RelaxationReceiverPlaceholderOpt,
+                                       cast.ExtendedInfoOpt,
                                        cast.Type)
 
                 Case BoundKind.Call

--- a/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.vb
@@ -23,9 +23,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                        node.Checked,
                                        node.ExplicitCastInCode,
                                        node.ConstantValueOpt,
-                                       node.ConstructorOpt,
-                                       node.RelaxationLambdaOpt,
-                                       node.RelaxationReceiverPlaceholderOpt,
+                                       node.ExtendedInfoOpt,
                                        node.Type)
                 End If
 
@@ -50,7 +48,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End If
 
             ' Handle other conversions.
-            Debug.Assert(node.RelaxationReceiverPlaceholderOpt Is Nothing)
+            Debug.Assert(TryCast(node.ExtendedInfoOpt, BoundRelaxationLambda)?.ReceiverPlaceholderOpt Is Nothing)
 
             ' Optimization for object comparisons that are operands of a conversion to boolean.
             ' Must be done before the object comparison is visited.
@@ -95,13 +93,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 _inExpressionLambda = True
             End If
 
-            If node.RelaxationLambdaOpt IsNot Nothing Then
+            If node.ExtendedInfoOpt IsNot Nothing AndAlso node.ExtendedInfoOpt.Kind = BoundKind.RelaxationLambda Then
                 returnValue = RewriteLambdaRelaxationConversion(node)
 
             ElseIf (node.ConversionKind And ConversionKind.InterpolatedString) = ConversionKind.InterpolatedString Then
                 returnValue = RewriteInterpolatedStringConversion(node)
 
-            ElseIf (node.ConversionKind And ConversionKind.Tuple) <> 0 Then
+            ElseIf (node.ConversionKind And (ConversionKind.Tuple Or ConversionKind.Nullable)) = conversionKind.Tuple Then
                 returnValue = RewriteTupleConversion(node)
 
             Else
@@ -120,10 +118,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim rewrittenOperand = VisitExpression(node.Operand)
             Dim rewrittenType = DirectCast(VisitType(node.Type), NamedTypeSymbol)
 
-            Return MakeTupleConversion(syntax, rewrittenOperand, rewrittenType, node.Checked)
+            Return MakeTupleConversion(syntax, rewrittenOperand, rewrittenType, DirectCast(node.ExtendedInfoOpt, BoundConvertedTupleElements))
         End Function
 
-        Private Function MakeTupleConversion(syntax As SyntaxNode, rewrittenOperand As BoundExpression, destinationType As TypeSymbol, isChecked As Boolean) As BoundExpression
+        Private Function MakeTupleConversion(syntax As SyntaxNode, rewrittenOperand As BoundExpression, destinationType As TypeSymbol, convertedElements As BoundConvertedTupleElements) As BoundExpression
             If destinationType.IsSameTypeIgnoringAll(rewrittenOperand.Type) Then
                 'binder keeps some tuple conversions just for the purpose of semantic model
                 'otherwisw they are as good as identity conversions
@@ -169,60 +167,37 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End If
 
                 Dim fieldAccess = MakeTupleFieldAccess(syntax, field, savedTuple, constantValueOpt:=Nothing, isLValue:=False)
-                Dim elementType = destElementTypes(i)
-                Dim conv = Conversions.ClassifyConversion(fieldAccess.Type, elementType, useSiteDiagnostics:=Nothing)
 
-                Dim convertedFieldAccess = If(conv.Value Is Nothing,
-                                                TransformRewrittenConversion(factory.Convert(elementType, fieldAccess, conv.Key, isChecked)),
-                                                MakeUserDefinedTupleFieldConversion(factory, elementType, fieldAccess, conv.Value, isChecked))
-
-                fieldAccessorsBuilder.Add(convertedFieldAccess)
+                ' lower the conversion
+                AddPlaceholderReplacement(convertedElements.ElementPlaceholders(i), fieldAccess)
+                fieldAccessorsBuilder.Add(VisitExpression(convertedElements.ConvertedElements(i)))
+                RemovePlaceholderReplacement(convertedElements.ElementPlaceholders(i))
             Next
 
             Dim result = MakeTupleCreationExpression(syntax, DirectCast(destinationType, NamedTypeSymbol), fieldAccessorsBuilder.ToImmutableAndFree())
             Return factory.Sequence(tupleTemp, assignmentToTemp, result)
         End Function
 
-        Private Function MakeUserDefinedTupleFieldConversion(factory As SyntheticBoundNodeFactory, elementType As TypeSymbol, fieldAccess As BoundExpression, method As MethodSymbol, isChecked As Boolean) As BoundExpression
-            ' User defined conversion here would be applied like:
-            '                    field -> [predefined conv] -> [call] -> [predefined conv] -> result
-            '
-            ' NOTE: predefined conversions here may themselves be tuple conversions,
-            '       which may contain more tuple conversions and so on, so we have to lower them.
-            '       We do not want to lower the field access though, so use a placeholder instead.
-            Dim placeholder = New BoundRValuePlaceholder(fieldAccess.Syntax, fieldAccess.Type)
-
-            Dim convIn = factory.Convert(method.Parameters(0).Type, placeholder, isChecked)
-            Dim [call] = factory.Call(Nothing, method, convIn)
-            Dim convOut = factory.Convert(elementType, [call], isChecked)
-
-            ' lower the conversions
-            AddPlaceholderReplacement(placeholder, fieldAccess)
-            Dim result = VisitExpression(convOut)
-            RemovePlaceholderReplacement(placeholder)
-
-            Return result
-        End Function
-
         Private Function RewriteLambdaRelaxationConversion(node As BoundConversion) As BoundNode
             Dim returnValue As BoundNode
+            Dim relaxationLambda As BoundLambda = DirectCast(node.ExtendedInfoOpt, BoundRelaxationLambda).Lambda
 
             If _inExpressionLambda AndAlso
-                 NoParameterRelaxation(node.Operand, node.RelaxationLambdaOpt.LambdaSymbol) Then
+                 NoParameterRelaxation(node.Operand, relaxationLambda.LambdaSymbol) Then
 
                 ' COMPAT: skip relaxation in this case. ET can drop the return value of the inner lambda.
                 returnValue = MyBase.VisitConversion(
                     node.Update(node.Operand,
                                       node.ConversionKind, node.Checked, node.ExplicitCastInCode,
-                                      node.ConstantValueOpt, node.ConstructorOpt,
-                                      relaxationLambdaOpt:=Nothing, relaxationReceiverPlaceholderOpt:=Nothing, type:=node.Type))
+                                      node.ConstantValueOpt,
+                                      extendedInfoOpt:=Nothing, type:=node.Type))
 
                 returnValue = TransformRewrittenConversion(DirectCast(returnValue, BoundConversion))
             Else
-                returnValue = node.Update(VisitExpressionNode(node.RelaxationLambdaOpt),
+                returnValue = node.Update(VisitExpressionNode(relaxationLambda),
                                       node.ConversionKind, node.Checked, node.ExplicitCastInCode,
-                                      node.ConstantValueOpt, node.ConstructorOpt,
-                                      relaxationLambdaOpt:=Nothing, relaxationReceiverPlaceholderOpt:=Nothing, type:=node.Type)
+                                      node.ConstantValueOpt,
+                                      extendedInfoOpt:=Nothing, type:=node.Type)
             End If
 
             Return returnValue
@@ -297,30 +272,43 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Dim F As New SyntheticBoundNodeFactory(Me._topMethod, Me._currentMethodOrLambda, node.Syntax, Me._compilationState, Me._diagnostics)
             If (node.Operand.IsDefaultValueConstant) Then
                 Return F.Null(node.Type)
-            ElseIf (Not Me._inExpressionLambda AndAlso CouldPossiblyBeNothing(F, node.Operand)) Then
-                Dim savedOriginalValue = F.SynthesizedLocal(node.Operand.Type)
-                Dim checkIfNothing = F.ReferenceIsNothing(F.Local(savedOriginalValue, False))
-                Dim conversionIfNothing = F.Null(node.Type)
-                Dim convertedValue = New BoundDelegateCreationExpression(node.Syntax, F.Local(savedOriginalValue, False),
-                                                                            DirectCast(node.Operand.Type, NamedTypeSymbol).DelegateInvokeMethod,
-                                                                            node.RelaxationLambdaOpt,
-                                                                            node.RelaxationReceiverPlaceholderOpt,
-                                                                            methodGroupOpt:=Nothing,
-                                                                            type:=node.Type)
-                Dim conditionalResult As BoundExpression = F.TernaryConditionalExpression(condition:=checkIfNothing, ifTrue:=conversionIfNothing, ifFalse:=convertedValue)
-                Return F.Sequence(savedOriginalValue,
-                                  F.AssignmentExpression(F.Local(savedOriginalValue, True), VisitExpression(node.Operand)),
-                                  VisitExpression(conditionalResult))
             Else
-                Dim convertedValue = New BoundDelegateCreationExpression(node.Syntax, node.Operand,
+                Dim lambdaOpt As BoundLambda
+                Dim receiverPlaceholderOpt As BoundRValuePlaceholder
+
+                If node.ExtendedInfoOpt IsNot Nothing Then
+                    Dim relaxationLambda = DirectCast(node.ExtendedInfoOpt, BoundRelaxationLambda)
+                    lambdaOpt = relaxationLambda.Lambda
+                    receiverPlaceholderOpt = relaxationLambda.ReceiverPlaceholderOpt
+                Else
+                    lambdaOpt = Nothing
+                    receiverPlaceholderOpt = Nothing
+                End If
+
+                If (Not Me._inExpressionLambda AndAlso CouldPossiblyBeNothing(F, node.Operand)) Then
+                    Dim savedOriginalValue = F.SynthesizedLocal(node.Operand.Type)
+                    Dim checkIfNothing = F.ReferenceIsNothing(F.Local(savedOriginalValue, False))
+                    Dim conversionIfNothing = F.Null(node.Type)
+                    Dim convertedValue = New BoundDelegateCreationExpression(node.Syntax, F.Local(savedOriginalValue, False),
+                                                                                DirectCast(node.Operand.Type, NamedTypeSymbol).DelegateInvokeMethod,
+                                                                                lambdaOpt,
+                                                                                receiverPlaceholderOpt,
+                                                                                methodGroupOpt:=Nothing,
+                                                                                type:=node.Type)
+                    Dim conditionalResult As BoundExpression = F.TernaryConditionalExpression(condition:=checkIfNothing, ifTrue:=conversionIfNothing, ifFalse:=convertedValue)
+                    Return F.Sequence(savedOriginalValue,
+                                      F.AssignmentExpression(F.Local(savedOriginalValue, True), VisitExpression(node.Operand)),
+                                      VisitExpression(conditionalResult))
+                Else
+                    Dim convertedValue = New BoundDelegateCreationExpression(node.Syntax, node.Operand,
                                                                             DirectCast(node.Operand.Type, NamedTypeSymbol).DelegateInvokeMethod,
-                                                                            node.RelaxationLambdaOpt,
-                                                                            node.RelaxationReceiverPlaceholderOpt,
+                                                                            lambdaOpt,
+                                                                            receiverPlaceholderOpt,
                                                                             methodGroupOpt:=Nothing,
                                                                             type:=node.Type)
-                Return VisitExpression(convertedValue)
+                    Return VisitExpression(convertedValue)
+                End If
             End If
-
         End Function
 
         Private Function CouldPossiblyBeNothing(F As SyntheticBoundNodeFactory, node As BoundExpression) As Boolean
@@ -396,9 +384,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     node.Checked,
                                                     node.ExplicitCastInCode,
                                                     node.ConstantValueOpt,
-                                                    node.ConstructorOpt,
-                                                    node.RelaxationLambdaOpt,
-                                                    node.RelaxationReceiverPlaceholderOpt,
+                                                    node.ExtendedInfoOpt,
                                                     resultType.GetNullableUnderlyingType)),
                                     resultType)
 
@@ -431,9 +417,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         node.Checked,
                                         node.ExplicitCastInCode,
                                         node.ConstantValueOpt,
-                                        node.ConstructorOpt,
-                                        node.RelaxationLambdaOpt,
-                                        node.RelaxationReceiverPlaceholderOpt,
+                                        node.ExtendedInfoOpt,
                                         resultType))
             End If
 
@@ -498,6 +482,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Dim useSiteDiagnostics As HashSet(Of DiagnosticInfo) = Nothing
                 Dim convKind = Conversions.ClassifyConversion(operand.Type, unwrappedResultType, useSiteDiagnostics).Key
                 Debug.Assert(Conversions.ConversionExists(convKind))
+                Debug.Assert((convKind And ConversionKind.Tuple) = (node.ConversionKind And ConversionKind.Tuple))
 
                 ' Check for potential constant folding
                 Dim integerOverflow As Boolean = False
@@ -514,7 +499,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     _diagnostics.Add(node, useSiteDiagnostics)
 
                     If (convKind And ConversionKind.Tuple) <> 0 Then
-                        operand = MakeTupleConversion(node.Syntax, operand, unwrappedResultType, node.Checked)
+                        operand = MakeTupleConversion(node.Syntax, operand, unwrappedResultType, DirectCast(node.ExtendedInfoOpt, BoundConvertedTupleElements))
 
                     Else
                         operand = TransformRewrittenConversion(New BoundConversion(node.Syntax,
@@ -523,9 +508,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                                     node.Checked,
                                                     node.ExplicitCastInCode,
                                                     node.ConstantValueOpt,
-                                                    node.ConstructorOpt,
-                                                    node.RelaxationLambdaOpt,
-                                                    node.RelaxationReceiverPlaceholderOpt,
+                                                    node.ExtendedInfoOpt,
                                                     unwrappedResultType))
                     End If
                 End If
@@ -576,9 +559,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                             node.Checked,
                                             node.ExplicitCastInCode,
                                             node.ConstantValueOpt,
-                                            node.ConstructorOpt,
-                                            node.RelaxationLambdaOpt,
-                                            node.RelaxationReceiverPlaceholderOpt,
+                                            node.ExtendedInfoOpt,
                                             resultType.GetNullableUnderlyingType)),
                                 resultType)
             End If
@@ -600,9 +581,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                         node.Checked,
                                         node.ExplicitCastInCode,
                                         node.ConstantValueOpt,
-                                        node.ConstructorOpt,
-                                        node.RelaxationLambdaOpt,
-                                        node.RelaxationReceiverPlaceholderOpt,
+                                        node.ExtendedInfoOpt,
                                         resultType))
             End If
 
@@ -783,8 +762,6 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     result = RewriteAsDirectCast(rewrittenConversion)
                 Else
                     Debug.Assert(underlyingTypeTo.IsValueType)
-                    ' Find the parameterless constructor to be used in conversion of Nothing to a value type
-                    result = InitWithParameterlessValueTypeConstructor(rewrittenConversion, DirectCast(underlyingTypeTo, NamedTypeSymbol))
                 End If
 
             ElseIf operand.Kind = BoundKind.Lambda Then
@@ -837,59 +814,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 Else
                     Debug.Assert(underlyingTypeTo.IsValueType)
-                    ' Find the parameterless constructor to be used in emit phase, see 'CodeGenerator.EmitConversionExpression'
-                    result = InitWithParameterlessValueTypeConstructor(rewrittenConversion, DirectCast(underlyingTypeTo, NamedTypeSymbol))
                 End If
             End If
 
             Return result
-        End Function
-
-        ''' <summary> Given bound conversion node and the type the conversion is being done to initializes 
-        ''' bound conversion node with the reference to parameterless value type constructor and returns 
-        ''' modified bound node.
-        ''' In case the constructor is not accessible from current context, or there is no parameterless
-        ''' constructor found in the type (which should never happen, because in such cases a synthesized 
-        ''' constructor is supposed to be generated)
-        ''' </summary>
-        Private Function InitWithParameterlessValueTypeConstructor(node As BoundConversion, typeTo As NamedTypeSymbol) As BoundExpression
-            Debug.Assert(typeTo.IsValueType AndAlso Not typeTo.IsTypeParameter)
-            Debug.Assert(node.RelaxationLambdaOpt Is Nothing AndAlso node.RelaxationReceiverPlaceholderOpt Is Nothing)
-
-            '  find valuetype parameterless constructor and check the accessibility
-            For Each constr In typeTo.InstanceConstructors
-                ' NOTE: we intentionally skip constructors with all 
-                '       optional parameters; this matches Dev10 behavior
-                If constr.ParameterCount = 0 Then
-
-                    '  check 'constr' 
-                    If AccessCheck.IsSymbolAccessible(constr, Me._topMethod.ContainingType, typeTo, useSiteDiagnostics:=Nothing) Then
-                        ' before we use constructor symbol we need to report use site error if any
-                        Dim useSiteError = constr.GetUseSiteErrorInfo()
-                        If useSiteError IsNot Nothing Then
-                            ReportDiagnostic(node, useSiteError, Me._diagnostics)
-                        End If
-
-                        ' update bound node
-                        Return node.Update(node.Operand,
-                                           node.ConversionKind,
-                                           node.Checked,
-                                           node.ExplicitCastInCode,
-                                           node.ConstantValueOpt,
-                                           constr,
-                                           node.RelaxationLambdaOpt,
-                                           node.RelaxationReceiverPlaceholderOpt,
-                                           node.Type)
-                    End If
-
-                    '  exit for each in any case
-                    Return node
-                End If
-            Next
-
-            ' This point should not be reachable, because if there is no constructor in the 
-            ' loaded value type, we should have generated a synthesized constructor.
-            Throw ExceptionUtilities.Unreachable
         End Function
 
         Private Function RewriteReferenceTypeToCharArrayRankOneConversion(node As BoundConversion, typeFrom As TypeSymbol, typeTo As TypeSymbol) As BoundExpression


### PR DESCRIPTION
Fixes #14255.
Also fixes #14530.

@dotnet/roslyn-compiler, @VSadov, @jcouv Please review.