### PR TITLE
Change CallerMemberName behavior in local functions to use member name

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -64,7 +64,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             set
             {
                 _currentMethod = value;
-                if ((object)value != null && value.MethodKind != MethodKind.AnonymousFunction)
+                if ((object)value != null &&
+                    value.MethodKind != MethodKind.AnonymousFunction &&
+                    value.MethodKind != MethodKind.LocalFunction)
                 {
                     _topLevelMethod = value;
                     _currentType = value.ContainingType;

--- a/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Attributes/AttributeTests_CallerInfoAttributes.cs
@@ -1006,6 +1006,49 @@ name: LambdaCaller
         }
 
         [Fact]
+        public void TestCallerMemberName_LocalFunction()
+        {
+            string source = @"
+using System.Runtime.CompilerServices;
+using System;
+
+class D
+{
+    public void LocalFunctionCaller()
+    {
+        void Local()
+        {
+            void LocalNested() => Test.Log();
+            LocalNested();
+        }
+        Local();
+    }
+}
+
+class Test
+{
+    public static int Log([CallerMemberName] string callerName = """")
+    {
+        Console.WriteLine(""name: "" + callerName);
+        return 1;
+    }
+
+    public static void Main()
+    {
+        var d = new D();
+        d.LocalFunctionCaller();
+    }
+}";
+
+            var expected = @"
+name: LocalFunctionCaller
+";
+
+            var compilation = CreateCompilationWithMscorlib45(source, references: new MetadataReference[] { SystemRef }, options: TestOptions.ReleaseExe);
+            CompileAndVerify(compilation, expectedOutput: expected);
+        }
+
+        [Fact]
         public void TestCallerMemberName_Operator()
         {
             string source = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -168,7 +168,7 @@ LocalFuncName();
 Console.Write(' ');
 CallerMemberName();
 ";
-            VerifyOutputInMain(source, "LocalFuncName Main", "System", "System.Runtime.CompilerServices");
+            VerifyOutputInMain(source, "Main Main", "System", "System.Runtime.CompilerServices");
         }
 
 


### PR DESCRIPTION
Local functions previously used the local function name but, as local functions
are not members, this was inappropriate.

Fixes #13268