### PR TITLE
Run iterator validation for all block binding

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -2292,8 +2292,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Next.LookupLocalFunction(nameToken);
         }
 
+        protected virtual ImmutableArray<MethodSymbol> MethodSymbolsWithYield =>
+            ImmutableArray<MethodSymbol>.Empty;
+
         internal BoundBlock BindEmbeddedBlock(BlockSyntax node, DiagnosticBag diagnostics)
         {
+            ValidateIteratorMethods(Compilation, MethodSymbolsWithYield, diagnostics);
             return BindBlock(node, diagnostics);
         }
 
@@ -2303,6 +2307,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(binder != null);
 
             return binder.BindBlockParts(node, diagnostics);
+        }
+
+        private static void ValidateIteratorMethods(
+            CSharpCompilation compilation,
+            ImmutableArray<MethodSymbol> iteratorMethods,
+            DiagnosticBag diagnostics)
+        {
+            foreach (var iterator in iteratorMethods)
+            {
+                foreach (var parameter in iterator.Parameters)
+                {
+                    if (parameter.RefKind != RefKind.None)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_BadIteratorArgType, parameter.Locations[0]);
+                    }
+                    else if (parameter.Type.IsUnsafe())
+                    {
+                        diagnostics.Add(ErrorCode.ERR_UnsafeIteratorArgType, parameter.Locations[0]);
+                    }
+                }
+
+                if (iterator.IsVararg)
+                {
+                    // error CS1636: __arglist is not allowed in the parameter list of iterators
+                    diagnostics.Add(ErrorCode.ERR_VarargsIterator, iterator.Locations[0]);
+                }
+
+                if (((iterator as SourceMethodSymbol)?.IsUnsafe == true || (iterator as LocalFunctionSymbol)?.IsUnsafe == true)
+                    && compilation.Options.AllowUnsafe) // Don't cascade
+                {
+                    diagnostics.Add(ErrorCode.ERR_IllegalInnerUnsafe, iterator.Locations[0]);
+                }
+            }
         }
 
         private BoundBlock BindBlockParts(BlockSyntax node, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        protected override ImmutableArray<MethodSymbol> MethodSymbolsWithYield
+        private ImmutableArray<MethodSymbol> MethodSymbolsWithYield
         {
             get
             {
@@ -131,6 +131,36 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
 
                 return _methodSymbolsWithYield;
+            }
+        }
+
+        public void ValidateIteratorMethods(DiagnosticBag diagnostics)
+        {
+            foreach (var iterator in MethodSymbolsWithYield)
+            {
+                foreach (var parameter in iterator.Parameters)
+                {
+                    if (parameter.RefKind != RefKind.None)
+                    {
+                        diagnostics.Add(ErrorCode.ERR_BadIteratorArgType, parameter.Locations[0]);
+                    }
+                    else if (parameter.Type.IsUnsafe())
+                    {
+                        diagnostics.Add(ErrorCode.ERR_UnsafeIteratorArgType, parameter.Locations[0]);
+                    }
+                }
+
+                if (iterator.IsVararg)
+                {
+                    // error CS1636: __arglist is not allowed in the parameter list of iterators
+                    diagnostics.Add(ErrorCode.ERR_VarargsIterator, iterator.Locations[0]);
+                }
+
+                if (((iterator as SourceMethodSymbol)?.IsUnsafe == true || (iterator as LocalFunctionSymbol)?.IsUnsafe == true)
+                    && Compilation.Options.AllowUnsafe) // Don't cascade
+                {
+                    diagnostics.Add(ErrorCode.ERR_IllegalInnerUnsafe, iterator.Locations[0]);
+                }
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/ExecutableCodeBinder.cs
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
-        public ImmutableArray<MethodSymbol> MethodSymbolsWithYield
+        protected override ImmutableArray<MethodSymbol> MethodSymbolsWithYield
         {
             get
             {

--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -451,6 +451,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 returnType);
             lambdaBodyBinder = new ExecutableCodeBinder(_unboundLambda.Syntax, lambdaSymbol, ParameterBinder(lambdaSymbol, binder));
             block = BindLambdaBody(lambdaSymbol, lambdaBodyBinder, diagnostics);
+
+            ((ExecutableCodeBinder)lambdaBodyBinder).ValidateIteratorMethods(diagnostics);
             ValidateUnsafeParameters(diagnostics, parameters);
 
         haveLambdaBodyAndBinders:

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1541,52 +1541,18 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var compilation = method.DeclaringCompilation;
                 var factory = compilation.GetBinderFactory(sourceMethod.SyntaxTree);
 
-                var blockSyntax = sourceMethod.BodySyntax as BlockSyntax;
+                var bodySyntax = sourceMethod.BodySyntax;
 
-                if (blockSyntax != null)
+                if (bodySyntax != null)
                 {
-                    var inMethodBinder = factory.GetBinder(blockSyntax);
-
-                    var binder = new ExecutableCodeBinder(blockSyntax, sourceMethod, inMethodBinder);
-                    body = (BoundBlock)binder.BindEmbeddedBlock(blockSyntax, diagnostics);
+                    var inMethodBinder = factory.GetBinder(bodySyntax);
+                    var binder = new ExecutableCodeBinder(bodySyntax, sourceMethod, inMethodBinder);
                     importChain = binder.ImportChain;
 
-                    foreach (var iterator in binder.MethodSymbolsWithYield)
-                    {
-                        foreach (var parameter in iterator.Parameters)
-                        {
-                            if (parameter.RefKind != RefKind.None)
-                            {
-                                diagnostics.Add(ErrorCode.ERR_BadIteratorArgType, parameter.Locations[0]);
-                            }
-                            else if (parameter.Type.IsUnsafe())
-                            {
-                                diagnostics.Add(ErrorCode.ERR_UnsafeIteratorArgType, parameter.Locations[0]);
-                            }
-                        }
-
-                        if (iterator.IsVararg)
-                        {
-                            // error CS1636: __arglist is not allowed in the parameter list of iterators
-                            diagnostics.Add(ErrorCode.ERR_VarargsIterator, iterator.Locations[0]);
-                        }
-
-                        if (((iterator as SourceMethodSymbol)?.IsUnsafe == true || (iterator as LocalFunctionSymbol)?.IsUnsafe == true) && compilation.Options.AllowUnsafe) // Don't cascade
-                        {
-                            diagnostics.Add(ErrorCode.ERR_IllegalInnerUnsafe, iterator.Locations[0]);
-                        }
-                    }
-                }
-                else if (sourceMethod.IsExpressionBodied)
-                {
-                    var methodSyntax = sourceMethod.SyntaxNode;
-                    var arrowExpression = methodSyntax.GetExpressionBodySyntax();
-
-                    Binder binder = factory.GetBinder(arrowExpression);
-                    binder = new ExecutableCodeBinder(arrowExpression, sourceMethod, binder);
-                    importChain = binder.ImportChain;
-                    // Add locals
-                    body = binder.BindExpressionBodyAsBlock(arrowExpression, diagnostics);
+                    body = bodySyntax.Kind() == SyntaxKind.Block
+                        ? binder.BindEmbeddedBlock((BlockSyntax)bodySyntax, diagnostics)
+                        : binder.BindExpressionBodyAsBlock(
+                            (ArrowExpressionClauseSyntax)bodySyntax, diagnostics);
                 }
                 else
                 {

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1549,6 +1549,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     var binder = new ExecutableCodeBinder(bodySyntax, sourceMethod, inMethodBinder);
                     importChain = binder.ImportChain;
 
+                    binder.ValidateIteratorMethods(diagnostics);
+
                     body = bodySyntax.Kind() == SyntaxKind.Block
                         ? binder.BindEmbeddedBlock((BlockSyntax)bodySyntax, diagnostics)
                         : binder.BindExpressionBodyAsBlock(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
             : base(@event,
                    syntax.GetReference(),
-                   syntax.Body?.GetReference(),
+                   syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference(),
                    ImmutableArray.Create(syntax.Keyword.GetLocation()))
         {
             Debug.Assert(syntax != null);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceCustomEventAccessorSymbol.cs
@@ -29,7 +29,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             DiagnosticBag diagnostics)
             : base(@event,
                    syntax.GetReference(),
-                   syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference(),
+                   ((SyntaxNode)syntax.Body ?? syntax.ExpressionBody)?.GetReference(),
                    ImmutableArray.Create(syntax.Keyword.GetLocation()))
         {
             Debug.Assert(syntax != null);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -193,8 +193,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             AccessorDeclarationSyntax syntax,
             MethodKind methodKind,
             bool isAutoPropertyAccessor,
-            DiagnosticBag diagnostics) :
-            base(containingType, syntax.GetReference(), syntax.Body?.GetReference() ?? syntax.ExpressionBody?.GetReference(), location)
+            DiagnosticBag diagnostics)
+            : base(containingType,
+                   syntax.GetReference(),
+                   ((SyntaxNode)syntax.Body ?? syntax.ExpressionBody)?.GetReference(),
+                   location)
         {
             _property = property;
             _explicitInterfaceImplementations = explicitInterfaceImplementations;


### PR DESCRIPTION
Previously iterator validation was only run in MethodCompiler
for blocks which pass through that code path, resulting in missed
local functions inside lambda blocks, which don't pass through
BindMethodBody.

Fixes #13937