### PR TITLE
Don't dismiss intellisense if the user types a number after a dot.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
+++ b/src/EditorFeatures/Core/Implementation/IntelliSense/Completion/Controller.Session_FilterModel.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
@@ -131,13 +132,27 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
 
                 var filterResults = new List<FilterResult>();
 
-                var filterText = model.GetCurrentTextInSnapshot(model.OriginalList.Span, textSnapshot, textSpanToText);
+                var filterText = model.GetCurrentTextInSnapshot(
+                    model.OriginalList.Span, textSnapshot, textSpanToText);
 
-                // If the user was typing a number, then immediately dismiss completion.
+                // Check if the user is typing a number.  If so, only proceed if it's a number
+                // directly after a <dot>.  That's because it is actually reasonable for completion
+                // to be brought up after a <dot> and for the user to want to filter completion
+                // items based on a number that exists in the name of the item.  However, when 
+                // we are not after a dot (i.e. we're being brought up after <space> is typed)
+                // then we don't want to filter things.  Consider the user writing:
+                //
+                //      dim i =<space>
+                //
+                // We'll bring up the completion list here (as VB has completion on <space>). 
+                // If the user then types '3', we don't want to match against Int32.
                 var filterTextStartsWithANumber = filterText.Length > 0 && char.IsNumber(filterText[0]);
                 if (filterTextStartsWithANumber)
                 {
-                    return null;
+                    if (!IsAfterDot(model, textSnapshot, textSpanToText))
+                    {
+                        return null;
+                    }
                 }
 
                 foreach (var currentItem in model.TotalItems)
@@ -194,6 +209,17 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                 return HandleNormalFiltering(
                     model, document, filterReason, textSnapshot,
                     helper, recentItems, filterText, filterResults);
+            }
+
+            private Boolean IsAfterDot(Model model, ITextSnapshot textSnapshot, Dictionary<TextSpan, string> textSpanToText)
+            {
+                var span = model.OriginalList.Span;
+
+                // Move the span back one character if possible.
+                span = TextSpan.FromBounds(Math.Max(0, span.Start - 1), span.End);
+
+                var text = model.GetCurrentTextInSnapshot(span, textSnapshot, textSpanToText);
+                return text.Length > 0 && text[0] == '.';
             }
 
             private Model HandleNormalFiltering(
@@ -422,13 +448,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.IntelliSense.Completion
                     {
                         return true;
                     }
-                }
-
-                if (filterText.Length > 0 && IsAllDigits(filterText))
-                {
-                    // The user is just typing a number.  We never want this to match against
-                    // anything we would put in a completion list.
-                    return false;
                 }
 
                 return helper.MatchesFilterText(item, filterText, CultureInfo.CurrentCulture);

--- a/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
+++ b/src/EditorFeatures/Test2/IntelliSense/CSharpCompletionCommandHandlerTests.vb
@@ -2244,5 +2244,26 @@ class Program
                 Await state.AssertSelectedCompletionItem("DateTime")
             End Using
         End Function
+
+        <WorkItem(14465, "https://github.com/dotnet/roslyn/issues/14465")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.Completion)>
+        Public Async Function TypingNumberShouldNotDismiss1() As Task
+            Using state = TestState.CreateCSharpTestState(
+                <Document><![CDATA[
+class C
+{
+    void Moo1()
+    {
+        new C()$$
+    }
+}
+            ]]></Document>)
+
+                state.SendTypeChars(".")
+                Await state.AssertCompletionSession()
+                state.SendTypeChars("1")
+                Await state.AssertSelectedCompletionItem("Moo1")
+            End Using
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14465