### PR TITLE
Remove comments when moving a type.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.cs
@@ -374,6 +374,50 @@ class Class2 { }";
         }
 
         [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
+        [WorkItem(14484, "https://github.com/dotnet/roslyn/issues/14484")]
+        public async Task MoveNestedTypeToNewFile_Comments1()
+        {
+            var code =
+@"namespace N1
+{
+    /// Outer doc comment.
+    class Class1
+    {
+        /// Inner doc comment
+        [||]class Class2
+        {
+        }
+    }
+}";
+
+            var codeAfterMove =
+@"namespace N1
+{
+    /// Outer doc comment.
+    partial class Class1
+    {
+    }
+}";
+
+            var expectedDocumentName = "Class2.cs";
+
+            var destinationDocumentText =
+@"namespace N1
+{
+    partial class Class1
+    {
+        /// Inner doc comment
+        class Class2
+        {
+        }
+    }
+}";
+            await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText,
+                compareTokens: false);
+        }
+
+        [WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)]
         public async Task MoveNestedTypeToNewFile_Simple_DottedName()
         {
             var code =

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/MoveType/MoveTypeTests.MoveToNewFile.vb
@@ -106,5 +106,38 @@ End Class
 </File>
             Await TestMoveTypeToNewFileAsync(code, codeAfterMove, expectedDocumentName, destinationDocumentText, index:=1)
         End Function
+
+        <WorkItem(14484, "https://github.com/dotnet/roslyn/issues/14484")>
+        <WpfFact, Trait(Traits.Feature, Traits.Features.CodeActionsMoveType)>
+        Public Async Function MoveNestedTypeToNewFile_RemoveComments() As Task
+            Dim code =
+<File>
+''' Outer comment
+Public Class Class1
+    ''' Inner comment
+    Class Class2[||]
+    End Class
+End Class
+</File>
+            Dim codeAfterMove =
+<File>
+''' Outer comment
+Public Partial Class Class1
+End Class
+</File>
+            Dim expectedDocumentName = "Class1.Class2.vb"
+
+            Dim destinationDocumentText =
+<File>
+Public Partial Class Class1
+    ''' Inner comment
+    Class Class2
+    End Class
+End Class
+</File>
+            Await TestMoveTypeToNewFileAsync(
+                code, codeAfterMove, expectedDocumentName, destinationDocumentText,
+                index:=1, compareTokens:=False)
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
+++ b/src/Features/Core/Portable/CodeRefactorings/MoveType/AbstractMoveTypeService.MoveTypeEditor.cs
@@ -83,7 +83,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 // Make the type chain above this new type partial.  Also, remove any 
                 // attributes from the containing partial types.  We don't want to create
                 // duplicate attributes on things.
-                AddPartialModifiersToTypeChain(documentEditor, removeAttributes: true);
+                AddPartialModifiersToTypeChain(documentEditor, removeAttributesAndComments: true);
 
                 // remove things that are not being moved, from the forked document.
                 var membersToRemove = GetMembersToRemove(root);
@@ -121,7 +121,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                 // Make the type chain above the type we're moving 'partial'.  
                 // However, keep all the attributes on these types as theses are the 
                 // original attributes and we don't want to mess with them. 
-                AddPartialModifiersToTypeChain(documentEditor, removeAttributes: false);
+                AddPartialModifiersToTypeChain(documentEditor, removeAttributesAndComments: false);
                 documentEditor.RemoveNode(State.TypeNode, SyntaxRemoveOptions.KeepNoTrivia);
 
                 var updatedDocument = documentEditor.GetChangedDocument();
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
             /// if a nested type is being moved, this ensures its containing type is partial.
             /// </summary>
             private void AddPartialModifiersToTypeChain(
-                DocumentEditor documentEditor, bool removeAttributes)
+                DocumentEditor documentEditor, bool removeAttributesAndComments)
             {
                 var semanticFacts = State.SemanticDocument.Document.GetLanguageService<ISemanticFactsService>();
                 var typeChain = State.TypeNode.Ancestors().OfType<TTypeDeclarationSyntax>();
@@ -199,9 +199,10 @@ namespace Microsoft.CodeAnalysis.CodeRefactorings.MoveType
                         documentEditor.SetModifiers(node, DeclarationModifiers.Partial);
                     }
 
-                    if (removeAttributes)
+                    if (removeAttributesAndComments)
                     {
                         documentEditor.RemoveAllAttributes(node);
+                        documentEditor.RemoveAllComments(node);
                     }
                 }
             }

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3452,6 +3452,10 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
 
             return root;
         }
+
+        internal override bool IsRegularOrDocComment(SyntaxTrivia trivia)
+            => trivia.IsRegularOrDocComment();
+
         #endregion
 
         #region Statements and Expressions

--- a/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxEditorExtensions.cs
@@ -21,6 +21,11 @@ namespace Microsoft.CodeAnalysis.Editing
             editor.ReplaceNode(declaration, (d, g) => g.RemoveAllAttributes(d));
         }
 
+        internal static void RemoveAllComments(this SyntaxEditor editor, SyntaxNode declaration)
+        {
+            editor.ReplaceNode(declaration, (d, g) => g.RemoveAllComments(d));
+        }
+
         public static void SetName(this SyntaxEditor editor, SyntaxNode declaration, string name)
         {
             editor.ReplaceNode(declaration, (d, g) => g.WithName(d, name));

--- a/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
+++ b/src/Workspaces/Core/Portable/Editing/SyntaxGenerator.cs
@@ -802,6 +802,14 @@ namespace Microsoft.CodeAnalysis.Editing
             return this.RemoveNodes(declaration, this.GetAttributes(declaration).Concat(this.GetReturnAttributes(declaration)));
         }
 
+        internal SyntaxNode RemoveAllComments(SyntaxNode declaration)
+        {
+            return declaration.WithLeadingTrivia(declaration.GetLeadingTrivia().Where(t => !IsRegularOrDocComment(t)))
+                              .WithTrailingTrivia(declaration.GetTrailingTrivia().Where(t => !IsRegularOrDocComment(t)));
+        }
+
+        internal abstract bool IsRegularOrDocComment(SyntaxTrivia trivia);
+
         /// <summary>
         /// Gets the attributes of a declaration, not including the return attributes.
         /// </summary>

--- a/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
+++ b/src/Workspaces/VisualBasic/Portable/CodeGeneration/VisualBasicSyntaxGenerator.vb
@@ -3878,6 +3878,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.CodeGeneration
                 DirectCast(expression, ExpressionSyntax))
 
         End Function
+
+        Friend Overrides Function IsRegularOrDocComment(trivia As SyntaxTrivia) As Boolean
+            Return trivia.IsRegularOrDocComment()
+        End Function
+
 #End Region
 
     End Class

--- a/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaExtensions.vb
+++ b/src/Workspaces/VisualBasic/Portable/Extensions/SyntaxTriviaExtensions.vb
@@ -22,5 +22,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Extensions
             Return trivia.Kind = SyntaxKind.WhitespaceTrivia OrElse
                    trivia.Kind = SyntaxKind.EndOfLineTrivia
         End Function
+
+        <Extension>
+        Public Function IsRegularOrDocComment(trivia As SyntaxTrivia) As Boolean
+            Return trivia.Kind = SyntaxKind.CommentTrivia OrElse trivia.Kind = SyntaxKind.DocumentationCommentTrivia
+        End Function
     End Module
 End Namespace


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14484