### PR TITLE
Disable Roslyn EnC handler for non-Roslyn languages

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -152,7 +152,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (visualStudioWorkspaceOpt != null)
             {
-                this.EditAndContinueImplOpt = new VsENCRebuildableProjectImpl(this);
+                if (Language == LanguageNames.CSharp || Language == LanguageNames.VisualBasic)
+                {
+                    this.EditAndContinueImplOpt = new VsENCRebuildableProjectImpl(this);
+                }
+
                 this.MetadataService = visualStudioWorkspaceOpt.Services.GetService<IMetadataService>();
             }
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14360 and internal bug 269607