### PR TITLE
Do not allow rename on the well known ValueTuple types

### DIFF
--- a/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
+++ b/src/EditorFeatures/Core/Implementation/RenameTracking/RenameTrackingTaggerProvider.TrackingSession.cs
@@ -194,7 +194,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     // Get the source symbol if possible
                     var sourceSymbol = await SymbolFinder.FindSourceDefinitionAsync(symbol, document.Project.Solution, _cancellationToken).ConfigureAwait(false) ?? symbol;
 
-                    if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
+                    if (!sourceSymbol.IsFromSource())
                     {
                         return TriggerIdentifierKind.NotRenamable;
                     }
@@ -217,7 +217,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.RenameTracking
                     return TriggerIdentifierKind.NotRenamable;
                 }
 
-                if (!sourceSymbol.Locations.All(loc => loc.IsInSource))
+                if (!sourceSymbol.IsFromSource())
                 {
                     return TriggerIdentifierKind.NotRenamable;
                 }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTaggerProviderTests.cs
@@ -1478,5 +1478,72 @@ End Class";
                 await state.AssertNoTag();
             }
         }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(14159, "https://github.com/dotnet/roslyn/issues/14159")]
+        public async Task RenameTrackingNotOnWellKnownValueTupleType()
+        {
+            var workspaceXml = @"
+<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" LanguageVersion=""7"">
+        <Document>
+using System;
+
+class C
+{
+    void M()
+    {
+        var x = new ValueTuple$$&lt;int&gt;();
+    }
+}
+
+namespace System
+{
+    public struct ValueTuple&lt;T1&gt;
+    {
+        public T1 Item1;
+    }
+}
+        </Document>
+    </Project>
+</Workspace>";
+            using (var state = await RenameTrackingTestState.CreateFromWorkspaceXmlAsync(workspaceXml, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("2");
+                await state.AssertNoTag();
+            }
+        }
+
+        [WpfFact]
+        [Trait(Traits.Feature, Traits.Features.RenameTracking)]
+        [WorkItem(14159, "https://github.com/dotnet/roslyn/issues/14159")]
+        public async Task RenameTrackingOnThingsCalledValueTupleThatAreNotTheWellKnownType()
+        {
+            var workspaceXml = @"
+<Workspace>
+    <Project Language=""C#"" CommonReferences=""true"" LanguageVersion=""7"">
+        <Document>
+class C
+{
+    void M()
+    {
+        var x = new ValueTuple$$&lt;int&gt;();
+    }
+}
+
+public struct ValueTuple&lt;T1&gt;
+{
+    public T1 Item1;
+}
+        </Document>
+    </Project>
+</Workspace>";
+            using (var state = await RenameTrackingTestState.CreateFromWorkspaceXmlAsync(workspaceXml, LanguageNames.CSharp))
+            {
+                state.EditorOperations.InsertText("2");
+                await state.AssertTag("ValueTuple", "ValueTuple2");
+            }
+        }
     }
 }

--- a/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
+++ b/src/EditorFeatures/Test/RenameTracking/RenameTrackingTestState.cs
@@ -60,6 +60,19 @@ namespace Microsoft.CodeAnalysis.Editor.UnitTests.RenameTracking
             return new RenameTrackingTestState(workspace, languageName, onBeforeGlobalSymbolRenamedReturnValue, onAfterGlobalSymbolRenamedReturnValue);
         }
 
+        public static async Task<RenameTrackingTestState> CreateFromWorkspaceXmlAsync(
+            string workspaceXml,
+            string languageName,
+            bool onBeforeGlobalSymbolRenamedReturnValue = true,
+            bool onAfterGlobalSymbolRenamedReturnValue = true)
+        {
+            var workspace = await TestWorkspace.CreateAsync(
+                workspaceXml, 
+                exportProvider: TestExportProvider.CreateExportProviderWithCSharpAndVisualBasic());
+
+            return new RenameTrackingTestState(workspace, languageName, onBeforeGlobalSymbolRenamedReturnValue, onAfterGlobalSymbolRenamedReturnValue);
+        }
+
         public RenameTrackingTestState(
             TestWorkspace workspace,
             string languageName,

--- a/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
+++ b/src/Workspaces/Core/Portable/Rename/RenameUtilities.cs
@@ -122,6 +122,11 @@ namespace Microsoft.CodeAnalysis.Rename
             var symbolInfo = semanticModel.GetSymbolInfo(token, cancellationToken);
             if (symbolInfo.Symbol != null)
             {
+                if (symbolInfo.Symbol.IsTupleType())
+                {
+                    return TokenRenameInfo.NoSymbolsTokenInfo;
+                }
+
                 return TokenRenameInfo.CreateSingleSymbolTokenInfo(symbolInfo.Symbol);
             }
 

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ISymbolExtensions.cs
@@ -168,6 +168,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
             return symbol?.Kind == SymbolKind.ArrayType;
         }
 
+        public static bool IsTupleType(this ISymbol symbol)
+        {
+            return (symbol as ITypeSymbol)?.IsTupleType ?? false;
+        }
+
         public static bool IsAnonymousFunction(this ISymbol symbol)
         {
             return (symbol as IMethodSymbol)?.MethodKind == MethodKind.AnonymousFunction;
@@ -817,6 +822,11 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 (method.MethodKind == MethodKind.EventAdd ||
                  method.MethodKind == MethodKind.EventRaise ||
                  method.MethodKind == MethodKind.EventRemove);
+        }
+
+        public static bool IsFromSource(this ISymbol symbol)
+        {
+            return symbol.Locations.Any() && symbol.Locations.All(location => location.IsInSource);
         }
 
         public static DeclarationModifiers GetSymbolModifiers(this ISymbol symbol)


### PR DESCRIPTION
Fixes #14159

The well-known ValueTuple types are very special in that you can ask for
the SymbolInfo on the ValueTuple token and not get back the ValueTuple
type. This means that the token we invoke rename on has no locations,
which Rename Tracking mistakenly interpreted as being okay to rename.
This has been fixed, and also the RenameUtilities.GetTokenRenameInfo
method has been updated to return NoSymbolsTokenInfo when it finds an
ITypeSymbol with IsTupleType.