### PR TITLE
Fixing a crash in SuppressDefaultTupleElements

### DIFF
--- a/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
+++ b/src/EditorFeatures/CSharpTest/Completion/CompletionProviders/SymbolCompletionProviderTests.cs
@@ -8904,6 +8904,23 @@ class C
             await VerifyItemExistsAsync(markup, "Item3");
         }
 
+        [WorkItem(14546, "https://github.com/dotnet/roslyn/issues/14546")]
+        [Fact, Trait(Traits.Feature, Traits.Features.Completion)]
+        public async Task TupleElementsCompletionOffMethodGroup()
+        {
+            var markup = @"
+class C
+{
+    void foo()
+    {
+        new object().ToString.$$
+    }
+}" + TestResources.NetFX.ValueTuple.tuplelib_cs;
+
+            // should not crash
+            await VerifyItemExistsAsync(markup, "ToString");            
+        }
+
         [Fact]
         [Trait(Traits.Feature, Traits.Features.Completion)]
         [Test.Utilities.CompilerTrait(Test.Utilities.CompilerFeature.LocalFunctions)]

--- a/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
+++ b/src/Workspaces/Core/Portable/Recommendations/AbstractRecommendationService.cs
@@ -81,7 +81,7 @@ namespace Microsoft.CodeAnalysis.Recommendations
         protected static ImmutableArray<ISymbol> SuppressDefaultTupleElements(
             INamespaceOrTypeSymbol container, ImmutableArray<ISymbol> symbols)
         {
-            if (!container.IsType)
+            if (container?.IsType != true)
             {
                 return symbols;
             }


### PR DESCRIPTION
We were missing a null check fo the container. In broken code it can be null.
Fixes: #14546