### PR TITLE
avoid loading dlls not needed

### DIFF
--- a/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAsset.cs
@@ -3,6 +3,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Serialization;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Execution
@@ -44,6 +46,49 @@ namespace Microsoft.CodeAnalysis.Execution
             {
                 objectWriter.WriteString(kind);
                 writer(objectWriter, CancellationToken.None);
+                return Checksum.Create(stream);
+            }
+        }
+    }
+
+    /// <summary>
+    /// workspace analyzer specific asset.
+    /// 
+    /// we need this to prevent dlls from other languages such as typescript, f#, xaml and etc
+    /// from loading at OOP start up.
+    /// 
+    /// unlike project analyzer, analyzer that got installed from vsix doesn't do shadow copying
+    /// so we don't need to load assembly to find out actual filepath.
+    /// 
+    /// this also will be temporary solution for RC since we will move to MVID for checksum soon
+    /// </summary>
+    internal sealed class WorkspaceAnalyzerReferenceAsset : CustomAsset
+    {
+        private readonly AnalyzerReference _reference;
+        private readonly Serializer _serializer;
+
+        public WorkspaceAnalyzerReferenceAsset(AnalyzerReference reference, Serializer serializer) :
+            base(CreateChecksum(reference), WellKnownSynchronizationKinds.AnalyzerReference)
+        {
+            _reference = reference;
+            _serializer = serializer;
+        }
+
+        public override Task WriteObjectToAsync(ObjectWriter writer, CancellationToken cancellationToken)
+        {
+            _serializer.SerializeAnalyzerReference(_reference, writer, cancellationToken);
+
+            return SpecializedTasks.EmptyTask;
+        }
+
+        private static Checksum CreateChecksum(AnalyzerReference reference)
+        {
+            using (var stream = SerializableBytes.CreateWritableStream())
+            using (var objectWriter = new ObjectWriter(stream))
+            {
+                objectWriter.WriteString(WellKnownSynchronizationKinds.AnalyzerReference);
+                objectWriter.WriteString(reference.FullPath);
+
                 return Checksum.Create(stream);
             }
         }

--- a/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
+++ b/src/Workspaces/Core/Portable/Execution/CustomAssetBuilder.cs
@@ -23,16 +23,14 @@ namespace Microsoft.CodeAnalysis.Execution
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            return new SimpleCustomAsset(WellKnownSynchronizationKinds.OptionSet, 
-                (writer, cancellationTokenOnStreamWriting) => 
+            return new SimpleCustomAsset(WellKnownSynchronizationKinds.OptionSet,
+                (writer, cancellationTokenOnStreamWriting) =>
                     _serializer.SerializeOptionSet(options, language, writer, cancellationTokenOnStreamWriting));
         }
 
         public CustomAsset Build(AnalyzerReference reference, CancellationToken cancellationToken)
         {
-            return new SimpleCustomAsset(WellKnownSynchronizationKinds.AnalyzerReference, 
-                (writer, cancellationTokenOnStreamWriting) => 
-                    _serializer.SerializeAnalyzerReference(reference, writer, cancellationTokenOnStreamWriting));
+            return new WorkspaceAnalyzerReferenceAsset(reference, _serializer);
         }
     }
 }


### PR DESCRIPTION
RPS found OOP causes vsix installed analyzer dlls to be loaded unfront. this should delay it until it is actually used. if not used, will never be loaded.