### PR TITLE
Add default Dev15 location

### DIFF
--- a/SetDevCommandPrompt.cmd
+++ b/SetDevCommandPrompt.cmd
@@ -3,6 +3,9 @@
 :: prefer building with Dev15
 
 set CommonToolsDir=%VS150COMNTOOLS%
+
+:: VS150COMNTOOLS is not set globally any more, so fall back to default preview location before trying Dev14
+if not exist "%CommonToolsDir%" set CommonToolsDir=%ProgramFiles(x86)%\\Microsoft Visual Studio\\VS15Preview\\Common7\\Tools\\
 if not exist "%CommonToolsDir%" set CommonToolsDir=%VS140COMNTOOLS%
 if not exist "%CommonToolsDir%" exit /b 1
 

--- a/netci.groovy
+++ b/netci.groovy
@@ -202,7 +202,6 @@ commitPullList.each { isPr ->
       batchFile("""set TEMP=%WORKSPACE%\\Binaries\\Temp
 mkdir %TEMP%
 set TMP=%TEMP%
-set VS150COMNTOOLS=%ProgramFiles(x86)%\\Microsoft Visual Studio\\VS15Preview\\Common7\\Tools\\
 .\\cibuild.cmd /debug /testVsi""")
     }
   }


### PR DESCRIPTION
Since Dev15 doesn't set a global tools location, we need to look at the default preview location when running things like integration tests (both open and closed) which don't start in an existing dev shell. If you're running in a dev shell, we won't override that location, though.

@Pilchie @jasonmalinowski @jaredpar This is the alternative, it seems like, to changing netci.groovy for both Open and Closed. If we take this path, I'll abandon the PR on the Closed side.