### PR TITLE
Revert removal of MissingNamespaceId

### DIFF
--- a/src/VisualStudio/Xaml/Impl/Diagnostics/XamlDiagnosticIds.cs
+++ b/src/VisualStudio/Xaml/Impl/Diagnostics/XamlDiagnosticIds.cs
@@ -5,5 +5,6 @@ namespace Microsoft.CodeAnalysis.Editor.Xaml.Diagnostics
     internal static class XamlDiagnosticIds
     {
         public const string UnnecessaryNamespacesId = "XAML1103";
+        public const string MissingNamespaceId = "XAML0002";
     }
 }


### PR DESCRIPTION
Putting back this id that was removed in #14566 to a fix build break when Roslyn is inserted into VS.
/cc @MattGertz for Ask Mode Approval
/cc @ManishJayaswal @jasonmalinowski @Pilchie @mgoertz-msft 