### PR TITLE
Note unused field definitions in abstract classes

### DIFF
--- a/docs/compilers/CSharp/Compiler Breaking Changes.md
+++ b/docs/compilers/CSharp/Compiler Breaking Changes.md
@@ -10,3 +10,5 @@ Each entry should include a short description of the break, followed by either a
    native compiler generated no warnings/errors and emitted code that would always throw when executed.
    Roslyn produces an error in this situation. See [#11341](https://github.com/dotnet/roslyn/pull/11341) for when this decision was made,
    [#11256](https://github.com/dotnet/roslyn/pull/11256) for when it was discovered, and [#10463](https://github.com/dotnet/roslyn/issues/10463) for the original issue that led to this.
+3. Native compiler used to generate warnings (169, 414, 649) on unused/unassigned fields of abstract classes.
+   Roslyn 1 (VS 2015) didn't produce these warnings. With [#14628](https://github.com/dotnet/roslyn/pull/14628) these warnings should be reported again.

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceDelegateMethodSymbol.cs
@@ -16,7 +16,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
     {
         private ImmutableArray<ParameterSymbol> _parameters;
         private readonly TypeSymbol _returnType;
-        private readonly RefKind _refKind;
 
         protected SourceDelegateMethodSymbol(
             SourceMemberContainerTypeSymbol delegateType,
@@ -35,8 +34,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             Debug.Assert(_parameters.IsDefault);
             _parameters = parameters;
         }
-
-        internal override RefKind RefKind => _refKind;
 
         internal static void AddDelegateMembers(
             SourceMemberContainerTypeSymbol delegateType,

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -552,38 +552,35 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             {
                 if (!_flags.FieldDefinitionsNoted)
                 {
-                    if (!this.IsAbstract)
+                    var assembly = (SourceAssemblySymbol)ContainingAssembly;
+
+                    Accessibility containerEffectiveAccessibility = EffectiveAccessibility();
+
+                    foreach (var member in _lazyMembersAndInitializers.NonTypeNonIndexerMembers)
                     {
-                        var assembly = (SourceAssemblySymbol)ContainingAssembly;
-
-                        Accessibility containerEffectiveAccessibility = EffectiveAccessibility();
-
-                        foreach (var member in _lazyMembersAndInitializers.NonTypeNonIndexerMembers)
+                        FieldSymbol field;
+                        if (!member.IsFieldOrFieldLikeEvent(out field) || field.IsConst || field.IsFixed)
                         {
-                            FieldSymbol field;
-                            if (!member.IsFieldOrFieldLikeEvent(out field) || field.IsConst || field.IsFixed)
-                            {
-                                continue;
-                            }
+                            continue;
+                        }
 
-                            Accessibility fieldDeclaredAccessibility = field.DeclaredAccessibility;
-                            if (fieldDeclaredAccessibility == Accessibility.Private)
-                            {
-                                // mark private fields as tentatively unassigned and unread unless we discover otherwise.
-                                assembly.NoteFieldDefinition(field, isInternal: false, isUnread: true);
-                            }
-                            else if (containerEffectiveAccessibility == Accessibility.Private)
-                            {
-                                // mark effectively private fields as tentatively unassigned unless we discover otherwise.
-                                assembly.NoteFieldDefinition(field, isInternal: false, isUnread: false);
-                            }
-                            else if (fieldDeclaredAccessibility == Accessibility.Internal || containerEffectiveAccessibility == Accessibility.Internal)
-                            {
-                                // mark effectively internal fields as tentatively unassigned unless we discover otherwise.
-                                // NOTE: These fields will be reported as unassigned only if internals are not visible from this assembly.
-                                // See property SourceAssemblySymbol.UnusedFieldWarnings.
-                                assembly.NoteFieldDefinition(field, isInternal: true, isUnread: false);
-                            }
+                        Accessibility fieldDeclaredAccessibility = field.DeclaredAccessibility;
+                        if (fieldDeclaredAccessibility == Accessibility.Private)
+                        {
+                            // mark private fields as tentatively unassigned and unread unless we discover otherwise.
+                            assembly.NoteFieldDefinition(field, isInternal: false, isUnread: true);
+                        }
+                        else if (containerEffectiveAccessibility == Accessibility.Private)
+                        {
+                            // mark effectively private fields as tentatively unassigned unless we discover otherwise.
+                            assembly.NoteFieldDefinition(field, isInternal: false, isUnread: false);
+                        }
+                        else if (fieldDeclaredAccessibility == Accessibility.Internal || containerEffectiveAccessibility == Accessibility.Internal)
+                        {
+                            // mark effectively internal fields as tentatively unassigned unless we discover otherwise.
+                            // NOTE: These fields will be reported as unassigned only if internals are not visible from this assembly.
+                            // See property SourceAssemblySymbol.UnusedFieldWarnings.
+                            assembly.NoteFieldDefinition(field, isInternal: true, isUnread: false);
                         }
                     }
                     _flags.SetFieldDefinitionsNoted();

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenOverridingAndHiding.cs
@@ -1631,26 +1631,28 @@ Derived2.Field3");
             comp.VerifyDiagnostics(
                 // (12,21): warning CS0108: 'Base.Derived.Method()' hides inherited member 'Base.Method()'. Use the new keyword if hiding was intended.
                 //         static void Method() { Console.WriteLine("Derived.Method()"); }
-                Diagnostic(ErrorCode.WRN_NewRequired, "Method").WithArguments("Base.Derived.Method()", "Base.Method()"),
+                Diagnostic(ErrorCode.WRN_NewRequired, "Method").WithArguments("Base.Derived.Method()", "Base.Method()").WithLocation(12, 21),
                 // (62,13): warning CS0108: 'Base2.Derived2.Field' hides inherited member 'Base2.Field'. Use the new keyword if hiding was intended.
                 //         int Field = 2;
-                Diagnostic(ErrorCode.WRN_NewRequired, "Field").WithArguments("Base2.Derived2.Field", "Base2.Field"),
+                Diagnostic(ErrorCode.WRN_NewRequired, "Field").WithArguments("Base2.Derived2.Field", "Base2.Field").WithLocation(62, 13),
                 // (63,20): warning CS0108: 'Base2.Derived2.Field2' hides inherited member 'Base2.Field2'. Use the new keyword if hiding was intended.
                 //         public int Field2 = 3;
-                Diagnostic(ErrorCode.WRN_NewRequired, "Field2").WithArguments("Base2.Derived2.Field2", "Base2.Field2"),
+                Diagnostic(ErrorCode.WRN_NewRequired, "Field2").WithArguments("Base2.Derived2.Field2", "Base2.Field2").WithLocation(63, 20),
                 // (74,22): warning CS0108: 'Base2.Derived2.Type2<T>' hides inherited member 'Base2.Type2<T>'. Use the new keyword if hiding was intended.
                 //         public class Type2<T>
-                Diagnostic(ErrorCode.WRN_NewRequired, "Type2").WithArguments("Base2.Derived2.Type2<T>", "Base2.Type2<T>"),
+                Diagnostic(ErrorCode.WRN_NewRequired, "Type2").WithArguments("Base2.Derived2.Type2<T>", "Base2.Type2<T>").WithLocation(74, 22),
                 // (99,13): warning CS0109: The member 'Derived3.Field' does not hide an inherited member. The new keyword is not required.
                 //     new int Field = 2;
-                Diagnostic(ErrorCode.WRN_NewNotRequired, "Field").WithArguments("Derived3.Field"),
+                Diagnostic(ErrorCode.WRN_NewNotRequired, "Field").WithArguments("Derived3.Field").WithLocation(99, 13),
                 // (101,26): warning CS0108: 'Derived3.Field2' hides inherited member 'Base3.Field2'. Use the new keyword if hiding was intended.
                 //     protected static int Field2 = 1;
-                Diagnostic(ErrorCode.WRN_NewRequired, "Field2").WithArguments("Derived3.Field2", "Base3.Field2"),
+                Diagnostic(ErrorCode.WRN_NewRequired, "Field2").WithArguments("Derived3.Field2", "Base3.Field2").WithLocation(101, 26),
                 // (92,9): warning CS0414: The field 'Base3.Field' is assigned but its value is never used
                 //     int Field = 1;
-                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "Field").WithArguments("Base3.Field")
-                );
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "Field").WithArguments("Base3.Field").WithLocation(92, 9),
+                // (99,13): warning CS0414: The field 'Derived3.Field' is assigned but its value is never used
+                //     new int Field = 2;
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "Field").WithArguments("Derived3.Field").WithLocation(99, 13));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -2024,9 +2024,38 @@ public class OperationExecutor
         #endregion
 
         [Fact, WorkItem(545347, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545347")]
-        public void FieldInAbstractClass()
+        public void FieldInAbstractClass_UnusedField()
         {
-            CreateCompilationWithMscorlib(@"abstract class AbstractType { public int Kind; }").VerifyDiagnostics();
+            var text = @"
+abstract class AbstractType
+{
+    public int Kind;
+}";
+
+            CreateCompilationWithMscorlib(text).VerifyDiagnostics(
+                // (4,16): warning CS0649: Field 'AbstractType.Kind' is never assigned to, and will always have its default value 0
+                //     public int Kind;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "Kind").WithArguments("AbstractType.Kind", "0").WithLocation(4, 16));
+        }
+
+        [Fact, WorkItem(545347, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545347")]
+        public void FieldInAbstractClass_FieldUsedInChildType()
+        {
+            var text = @"
+abstract class AbstractType
+{
+    public int Kind;
+}
+class ChildType : AbstractType
+{
+    public ChildType()
+    {
+        this.Kind = 1;
+    }
+}
+";
+
+            CreateCompilationWithMscorlib(text).VerifyDiagnostics();
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/AccessCheckTests.cs
@@ -1153,5 +1153,91 @@ public class TestClass1 { }
 ///////////////";
             CreateCompilationWithMscorlib(source).GetDiagnostics();
         }
+
+        [Fact, WorkItem(13652, "https://github.com/dotnet/roslyn/issues/13652")]
+        public void UnusedFieldInAbstractClassShouldTriggerWarning()
+        {
+            var text = @"
+abstract class Class1
+{
+    private int _UnusedField;
+}";
+            CompileAndVerify(text).VerifyDiagnostics(
+                // (4,21): warning CS0169: The field 'Class1._UnusedField' is never used
+                //         private int _UnusedField;
+                Diagnostic(ErrorCode.WRN_UnreferencedField, "_UnusedField").WithArguments("Class1._UnusedField").WithLocation(4, 17));
+        }
+
+        [Fact, WorkItem(13652, "https://github.com/dotnet/roslyn/issues/13652")]
+        public void AssignedButNotReadFieldInAbstractClassShouldTriggerWarning()
+        {
+            var text = @"
+abstract class Class1
+{
+    private int _AssignedButNotReadField;
+
+    public Class1()
+    {
+        _AssignedButNotReadField = 1;
+    }
+}";
+            CompileAndVerify(text).VerifyDiagnostics(
+                // (4,21): warning CS0414: The field 'Class1._AssignedButNotReadField' is assigned but its value is never used
+                //         private int _AssignedButNotReadField;
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "_AssignedButNotReadField").WithArguments("Class1._AssignedButNotReadField").WithLocation(4, 17));
+        }
+
+        [Fact, WorkItem(13652, "https://github.com/dotnet/roslyn/issues/13652")]
+        public void UsedButNotAssignedFieldInAbstractClassShouldTriggerWarning()
+        {
+            var text = @"
+internal abstract class Class1
+{
+    protected int _UnAssignedField1;
+
+    public Class1()
+    {
+        System.Console.WriteLine(_UnAssignedField1);
+    }
+}";
+            CompileAndVerify(text).VerifyDiagnostics(
+                // (4,18): warning CS0649: Field 'Class1._UnAssignedField1' is never assigned to, and will always have its default value 0
+                //     internal int _UnAssignedField;
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "_UnAssignedField1").WithArguments("Class1._UnAssignedField1", "0").WithLocation(4, 19));
+        }
+
+        [Fact, WorkItem(13652, "https://github.com/dotnet/roslyn/issues/13652")]
+        public void UsedButNotAssignedFieldInAbstractInternalClassWithIVTsShouldNotTriggerWarning()
+        {
+            var text = @"
+[assembly:System.Runtime.CompilerServices.InternalsVisibleTo(""Test2.dll"")]
+
+internal abstract class Class1
+{
+    protected int _UnAssignedField1;
+
+    public Class1()
+    {
+        System.Console.WriteLine(_UnAssignedField1);
+    }
+}";
+            CompileAndVerify(text).VerifyDiagnostics();
+        }
+
+        [Fact, WorkItem(13652, "https://github.com/dotnet/roslyn/issues/13652")]
+        public void UsedButNotAssignedFieldInAbstractPublicClassShouldNotTriggerWarning()
+        {
+            var text = @"
+public abstract class Class1
+{
+    protected int _UnAssignedField1;
+
+    public Class1()
+    {
+        System.Console.WriteLine(_UnAssignedField1);
+    }
+}";
+            CompileAndVerify(text).VerifyDiagnostics();
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/SemanticErrorTests.cs
@@ -19951,11 +19951,6 @@ class MyClass
         table[p] = o;
     }
 }
-
-abstract class Foo
-{
-    public int x; // no diagnostic when in abstract class (for no apparent reason except that's the way Dev10 does it)
-}
 ";
             var comp = CreateCompilationWithMscorlib(text);
             comp.VerifyDiagnostics(

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/OverriddenOrHiddenMembersTests.cs
@@ -2543,12 +2543,18 @@ class D : C
             Assert.Equal(0, ohmD.HiddenMembers.Length);
 
             comp.VerifyDiagnostics(
-                // (19,41): error CS1715: 'D.E': type must be 'System.Func<int>' to match overridden member 'C.E'
+                // (19,41): error CS1715: 'D.E': type must be 'Func<int>' to match overridden member 'C.E'
                 //     public override event System.Action E;
-                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "E").WithArguments("D.E", "C.E", "System.Func<int>"),
+                Diagnostic(ErrorCode.ERR_CantChangeTypeOnOverride, "E").WithArguments("D.E", "C.E", "System.Func<int>").WithLocation(19, 41),
                 // (19,41): warning CS0067: The event 'D.E' is never used
                 //     public override event System.Action E;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("D.E"));
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("D.E").WithLocation(19, 41),
+                // (9,41): warning CS0067: The event 'B.E' is never used
+                //     public override event System.Action E;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("B.E").WithLocation(9, 41),
+                // (14,47): warning CS0067: The event 'C.E' is never used
+                //     public new virtual event System.Func<int> E;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "E").WithArguments("C.E").WithLocation(14, 47));
         }
 
         [WorkItem(545653, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/545653")]

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -921,7 +921,10 @@ class M
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,22): error CS0068: 'I.d': event in interface cannot have initializer
                 //     event MyDelegate d = new MyDelegate(M.f);   // CS0068
-                Diagnostic(ErrorCode.ERR_InterfaceEventInitializer, "d").WithArguments("I.d"));
+                Diagnostic(ErrorCode.ERR_InterfaceEventInitializer, "d").WithArguments("I.d").WithLocation(6, 22),
+                // (6,22): warning CS0067: The event 'I.d' is never used
+                //     event MyDelegate d = new MyDelegate(M.f);   // CS0068
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "d").WithArguments("I.d").WithLocation(6, 22));
         }
 
         [Fact]
@@ -979,7 +982,10 @@ abstract class Test
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (6,29): error CS0074: 'Test.e': abstract event cannot have initializer
                 //     public abstract event D e = null;   // CS0074
-                Diagnostic(ErrorCode.ERR_AbstractEventInitializer, "e").WithArguments("Test.e"));
+                Diagnostic(ErrorCode.ERR_AbstractEventInitializer, "e").WithArguments("Test.e").WithLocation(6, 29),
+                // (6,29): warning CS0414: The field 'Test.e' is assigned but its value is never used
+                //     public abstract event D e = null;   // CS0074
+                Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "e").WithArguments("Test.e").WithLocation(6, 29));
         }
 
         [Fact]
@@ -1991,7 +1997,9 @@ abstract class B : A
             var comp = DiagnosticsUtils.VerifyErrorsAndGetCompilationWithMscorlib(text,
                 new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 7, Column = 51 },
                 new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 8, Column = 47 },
-                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 9, Column = 50 });
+                new ErrorDescription { Code = (int)ErrorCode.ERR_StaticNotVirtual, Line = 9, Column = 50 },
+                new ErrorDescription { Code = (int)ErrorCode.WRN_UnreferencedEvent, Line = 7, Column = 51, IsWarning = true },
+                new ErrorDescription { Code = (int)ErrorCode.WRN_UnreferencedEvent, Line = 8, Column = 47, IsWarning = true });
         }
 
         [Fact]
@@ -2069,16 +2077,19 @@ class B : A
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
                 // (9,51): error CS0113: A member 'B.Q' marked as override cannot be marked as new or virtual
                 //     internal virtual override event System.Action Q;
-                Diagnostic(ErrorCode.ERR_OverrideNotNew, "Q").WithArguments("B.Q"),
+                Diagnostic(ErrorCode.ERR_OverrideNotNew, "Q").WithArguments("B.Q").WithLocation(9, 51),
                 // (8,48): error CS0113: A member 'B.P' marked as override cannot be marked as new or virtual
                 //     protected new override event System.Action P;
-                Diagnostic(ErrorCode.ERR_OverrideNotNew, "P").WithArguments("B.P"),
+                Diagnostic(ErrorCode.ERR_OverrideNotNew, "P").WithArguments("B.P").WithLocation(8, 48),
                 // (8,48): warning CS0067: The event 'B.P' is never used
                 //     protected new override event System.Action P;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "P").WithArguments("B.P"),
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "P").WithArguments("B.P").WithLocation(8, 48),
                 // (9,51): warning CS0067: The event 'B.Q' is never used
                 //     internal virtual override event System.Action Q;
-                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Q").WithArguments("B.Q"));
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Q").WithArguments("B.Q").WithLocation(9, 51),
+                // (4,42): warning CS0067: The event 'A.Q' is never used
+                //     internal virtual event System.Action Q;
+                Diagnostic(ErrorCode.WRN_UnreferencedEvent, "Q").WithArguments("A.Q").WithLocation(4, 42));
         }
 
         [Fact]
@@ -8935,16 +8946,18 @@ namespace NS
 }
 ";
             CreateCompilationWithMscorlib(text).VerifyDiagnostics(
-                // (31,32): error CS0533: 'NS.A3.foo' hides inherited abstract member 'NS.B3.foo()'
+                // (31,32): error CS0533: 'A3.foo' hides inherited abstract member 'B3.foo()'
                 //         new protected double[] foo;  // CS0533
-                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("NS.A3.foo", "NS.B3.foo()"),
+                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("NS.A3.foo", "NS.B3.foo()").WithLocation(31, 32),
                 // (9,24): error CS0533: 'A1.foo' hides inherited abstract member 'B1.foo'
                 //     new protected enum foo { } // CS0533
-                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("A1.foo", "B1.foo"),
+                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("A1.foo", "B1.foo").WithLocation(9, 24),
                 // (18,36): error CS0533: 'A1.A2.foo' hides inherited abstract member 'A1.B2.foo()'
                 //         new public delegate object foo(); // CS0533
-                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("A1.A2.foo", "A1.B2.foo()")
-                );
+                Diagnostic(ErrorCode.ERR_HidingAbstractMethod, "foo").WithArguments("A1.A2.foo", "A1.B2.foo()").WithLocation(18, 36),
+                // (31,32): warning CS0649: Field 'A3.foo' is never assigned to, and will always have its default value null
+                //         new protected double[] foo;  // CS0533
+                Diagnostic(ErrorCode.WRN_UnassignedInternalField, "foo").WithArguments("NS.A3.foo", "null").WithLocation(31, 32));
         }
 
         [WorkItem(540464, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/540464")]

--- a/src/Compilers/Test/Utilities/CSharp/DiagnosticTestUtilities.cs
+++ b/src/Compilers/Test/Utilities/CSharp/DiagnosticTestUtilities.cs
@@ -182,7 +182,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
                     Assert.True(experr.Column == acterr.Column, String.Format("Col {0}!={1}", experr.Column, acterr.Column));
                 }
 
-                Assert.Equal(experr.IsWarning, acterr.IsWarning);
+                Assert.True(experr.IsWarning == acterr.IsWarning, String.Format("IsWarning {0}!={1}", experr.IsWarning, acterr.IsWarning));
 
                 //if the expected contains parameters, validate those too.
                 if (experr.Parameters != null)

--- a/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
+++ b/src/Features/Core/Portable/Completion/CompletionServiceWithProviders.cs
@@ -86,7 +86,6 @@ namespace Microsoft.CodeAnalysis.Completion
         }
 
         private ImmutableArray<CompletionProvider> _testProviders = ImmutableArray<CompletionProvider>.Empty;
-        private object p;
 
         internal void SetTestProviders(IEnumerable<CompletionProvider> testProviders)
         {

--- a/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
+++ b/src/Features/Core/Portable/DocumentationComments/AbstractDocumentationCommentFormattingService.cs
@@ -11,9 +11,6 @@ namespace Microsoft.CodeAnalysis.DocumentationComments
 {
     internal abstract class AbstractDocumentationCommentFormattingService : IDocumentationCommentFormattingService
     {
-        private int _position;
-        private SemanticModel _semanticModel;
-
         private class FormatterState
         {
             private bool _anyNonWhitespaceSinceLastPara;

--- a/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
+++ b/src/VisualStudio/CSharp/Impl/ProjectSystemShim/CSharpProjectShim.cs
@@ -38,7 +38,6 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.ProjectSystemShim
         private ICSharpProjectRoot _projectRoot;
 
         private OutputKind _outputKind = OutputKind.DynamicallyLinkedLibrary;
-        private Platform _platform = Platform.AnyCpu;
         private string _mainTypeName;
         private object[] _options = new object[(int)CompilerOptions.LARGEST_OPTION_ID];
 

--- a/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory_UndoRedo.cs
+++ b/src/VisualStudio/Core/Def/Packaging/PackageInstallerServiceFactory_UndoRedo.cs
@@ -51,6 +51,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Packaging
                 IOleUndoManager undoManager)
             {
                 this.packageInstallerService = packageInstallerService;
+                this.source = source;
                 this.packageName = packageName;
                 this.versionOpt = versionOpt;
                 this.dte = dte;

--- a/src/VisualStudio/Core/Impl/Options/AbstractRadioButtonViewModel.cs
+++ b/src/VisualStudio/Core/Impl/Options/AbstractRadioButtonViewModel.cs
@@ -13,7 +13,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private readonly AbstractOptionPreviewViewModel _info;
         internal readonly string Preview;
         private bool _isChecked;
-        private string _groupName;
 
         public string Description { get; }
         public string GroupName { get; }


### PR DESCRIPTION
Fixes #13652 
@dotnet/roslyn-compiler 