### PR TITLE
Allow AsyncLazy.GetValue to be called on a background thread

### DIFF
--- a/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
+++ b/src/Workspaces/Core/Portable/Utilities/AsyncLazy`1.cs
@@ -223,7 +223,11 @@ namespace Roslyn.Utilities
                     StartAsynchronousComputation(newAsynchronousComputation.Value, requestToCompleteSynchronously: request, callerCancellationToken: cancellationToken);
                 }
 
-                return request.Task.WaitAndGetResult(cancellationToken);
+                // The reason we have synchronous codepaths in AsyncLazy is to support the synchronous requests for syntax trees
+                // that we may get from the compiler. Thus, it's entirely possible that this will be requested by the compiler or
+                // an analyzer on the background thread when another part of the IDE is requesting the same tree asynchronously.
+                // In that case we block the synchronous request on the asynchronous request, since that's better than alternatives.
+                return request.Task.WaitAndGetResult_CanCallOnBackground(cancellationToken);
             }
             else
             {


### PR DESCRIPTION
If AsyncLazy already has an asynchronous computation active, we will
block a synchronous request on that computation rather than trying to
do duplicate work. That might be the compiler requesting a tree
synchronously, which is totally allowed.

_Review:_ @dotnet/roslyn-ide, @CyrusNajmabadi, @heejaechang
