### PR TITLE
Remove obsolete code.

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/MemberSymbolExtensions.cs
@@ -332,29 +332,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         /// </summary>
         internal static bool IsDefaultValueTypeConstructor(this MethodSymbol method)
         {
-            if (!method.ContainingType.IsValueType)
-            {
-                return false;
-            }
-
-            if (!method.IsParameterlessConstructor() || !method.IsImplicitlyDeclared)
-            {
-                return false;
-            }
-
-            var container = method.ContainingType as SourceNamedTypeSymbol;
-            if ((object)container == null)
-            {
-                // synthesized ctor not from source -> must be default
-                return true;
-            }
-
-            // if we are here we have a struct in source for which a parameterless ctor was not provided by the user.
-            // So, are we ok with default behavior?
-            // Returning false will result in a production of synthesized parameterless ctor 
-
-            // this ctor is not default if we have instance initializers
-            return container.InstanceInitializers.IsDefaultOrEmpty;
+            return method.IsImplicitlyDeclared &&
+                   method.ContainingType.IsValueType &&
+                   method.IsParameterlessConstructor();
         }
 
         /// <summary>

--- a/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/FlowAnalysis/FlowDiagnosticTests.cs
@@ -931,9 +931,9 @@ public struct A
     // (7,11): warning CS0219: The variable 'a' is assigned but its value is never used
     //         A a = new A();
     Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "a").WithArguments("a").WithLocation(7, 11),
-    // (4,7): warning CS0414: The field 'A.a' is assigned but its value is never used
+    // (4,7): warning CS0169: The field 'A.a' is never used
     //     A a = new A(); // CS8036
-    Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "a").WithArguments("A.a").WithLocation(4, 7)
+    Diagnostic(ErrorCode.WRN_UnreferencedField, "a").WithArguments("A.a").WithLocation(4, 7)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/StructsTests.cs
@@ -32,9 +32,9 @@ public struct A
     // (4,7): error CS0523: Struct member 'A.a' of type 'A' causes a cycle in the struct layout
     //     A a = new A();   // CS8036
     Diagnostic(ErrorCode.ERR_StructLayoutCycle, "a").WithArguments("A.a", "A").WithLocation(4, 7),
-    // (4,7): warning CS0414: The field 'A.a' is assigned but its value is never used
+    // (4,7): warning CS0169: The field 'A.a' is never used
     //     A a = new A();   // CS8036
-    Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "a").WithArguments("A.a").WithLocation(4, 7)
+    Diagnostic(ErrorCode.WRN_UnreferencedField, "a").WithArguments("A.a").WithLocation(4, 7)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/FieldTests.cs
@@ -44,7 +44,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             comp.VerifyDiagnostics(
     // (3,16): error CS0573: 'S': cannot have instance property or field initializers in structs
     //     public int I = 9;
-    Diagnostic(ErrorCode.ERR_FieldInitializerInStruct, "I").WithArguments("S").WithLocation(3, 16)
+    Diagnostic(ErrorCode.ERR_FieldInitializerInStruct, "I").WithArguments("S").WithLocation(3, 16),
+    // (3,16): warning CS0649: Field 'S.I' is never assigned to, and will always have its default value 0
+    //     public int I = 9;
+    Diagnostic(ErrorCode.WRN_UnassignedInternalField, "I").WithArguments("S.I", "0").WithLocation(3, 16)
 );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Source/PropertyTests.cs
@@ -159,9 +159,9 @@ struct S
     // (5,9): error CS0102: The type 'S' already contains a definition for 'a'
     //     int a { get { return 1; } set {} }
     Diagnostic(ErrorCode.ERR_DuplicateNameInClass, "a").WithArguments("S", "a").WithLocation(5, 9),
-    // (4,9): warning CS0414: The field 'S.a' is assigned but its value is never used
+    // (4,9): warning CS0169: The field 'S.a' is never used
     //     int a = 2;
-    Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "a").WithArguments("S.a").WithLocation(4, 9)
+    Diagnostic(ErrorCode.WRN_UnreferencedField, "a").WithArguments("S.a").WithLocation(4, 9)
     );
         }
 

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/SymbolErrorTests.cs
@@ -10323,9 +10323,12 @@ Diagnostic(ErrorCode.ERR_InterfacesCantContainOperators, "+")
     // (13,13): error CS0573: 'cly': cannot have instance property or field initializers in structs
     //         int i = 7;           // CS8036
     Diagnostic(ErrorCode.ERR_FieldInitializerInStruct, "i").WithArguments("x.cly").WithLocation(13, 13),
-    // (13,13): warning CS0414: The field 'cly.i' is assigned but its value is never used
+    // (12,13): warning CS0169: The field 'cly.a' is never used
+    //         clx a = new clx();   // CS8036
+    Diagnostic(ErrorCode.WRN_UnreferencedField, "a").WithArguments("x.cly.a").WithLocation(12, 13),
+    // (13,13): warning CS0169: The field 'cly.i' is never used
     //         int i = 7;           // CS8036
-    Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "i").WithArguments("x.cly.i").WithLocation(13, 13),
+    Diagnostic(ErrorCode.WRN_UnreferencedField, "i").WithArguments("x.cly.i").WithLocation(13, 13),
     // (15,20): warning CS0414: The field 'cly.s' is assigned but its value is never used
     //         static int s = 2;    // no error
     Diagnostic(ErrorCode.WRN_UnreferencedFieldAssg, "s").WithArguments("x.cly.s").WithLocation(15, 20)

--- a/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/SymbolExtensions.vb
@@ -268,26 +268,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
         ''' </summary>
         <Extension()>
         Friend Function IsDefaultValueTypeConstructor(method As MethodSymbol) As Boolean
-            If Not method.ContainingType.IsValueType Then
-                Return False
-            End If
-
-            If Not method.IsParameterlessConstructor() OrElse Not method.IsImplicitlyDeclared Then
-                Return False
-            End If
-
-            Dim container As SourceNamedTypeSymbol = TryCast(method.ContainingType, SourceNamedTypeSymbol)
-            If container Is Nothing Then
-                ' synthesized ctor Not from source -> must be default
-                Return True
-            End If
-
-            ' if we are here we have a struct in source for which a parameterless ctor was not provided by the user.
-            ' So, are we ok with default behavior?
-            ' Returning false will result in a production of synthesized parameterless ctor 
-
-            ' this ctor is not default if we have instance initializers
-            Return container.InstanceInitializers.IsDefaultOrEmpty
+            Return method.IsImplicitlyDeclared AndAlso
+                   method.ContainingType.IsValueType AndAlso
+                   method.IsParameterlessConstructor()
         End Function
 
         <Extension()>


### PR DESCRIPTION
The code is related to the feature of supporting explicit parameter-less constructors in structures, which was removed. Also, the code in IsDefaultValueTypeConstructor helper wasn't properly handling constructed or retargeted symbols.

Fixes #14541.

@dotnet/roslyn-compiler, @VSadov Please review.