### PR TITLE
fix null exception happening due to OOP analyzer engine not providing right AnalyzerOptions

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
+++ b/src/Features/Core/Portable/Diagnostics/AbstractHostDiagnosticUpdateSource.cs
@@ -105,6 +105,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics
             }
         }
 
+        public void ClearAnalyzerDiagnostics(ProjectId projectId)
+        {
+            foreach (var analyzer in _analyzerHostDiagnosticsMap.Keys)
+            {
+                ClearAnalyzerDiagnostics(analyzer, projectId);
+            }
+        }
+
         private void ClearAnalyzerDiagnostics(DiagnosticAnalyzer analyzer, ProjectId projectId)
         {
             ImmutableHashSet<DiagnosticData> existing;

--- a/src/Features/Core/Portable/Features.csproj
+++ b/src/Features/Core/Portable/Features.csproj
@@ -58,6 +58,7 @@
     <InternalsVisibleTo Include="MonoDevelop.Refactoring" />
     <InternalsVisibleTo Include="MonoDevelop.CSharpBinding" />
     <InternalsVisibleTo Include="MonoDevelop.VBNetBinding" />
+    <InternalsVisibleTo Include="Microsoft.CodeAnalysis.Remote.Workspaces" />
     <InternalsVisibleToTest Include="Roslyn.DebuggerVisualizers" />
     <InternalsVisibleTo Include="Roslyn.Hosting.Diagnostics" />
     <InternalsVisibleToTest Include="Roslyn.InteractiveHost.UnitTests" />

--- a/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
+++ b/src/VisualStudio/Core/Def/Implementation/TaskList/HostDiagnosticUpdateSource.cs
@@ -98,6 +98,8 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.TaskList
                     RaiseDiagnosticsRemovedForProject(projectId, key);
                 }
             }
+
+            ClearAnalyzerDiagnostics(projectId);
         }
 
         public void ClearDiagnosticsForProject(ProjectId projectId, object key)

--- a/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
+++ b/src/Workspaces/Remote/Core/Diagnostics/DiagnosticComputer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.CodeAnalysis.Remote.Diagnostics
             // TODO: can we support analyzerExceptionFilter in remote host? 
             //       right now, host doesn't support watson, we might try to use new NonFatal watson API?
             var analyzerOptions = new CompilationWithAnalyzersOptions(
-                    options: _project.AnalyzerOptions,
+                    options: new WorkspaceAnalyzerOptions(_project.AnalyzerOptions, _project.Solution.Workspace),
                     onAnalyzerException: OnAnalyzerException,
                     analyzerExceptionFilter: null,
                     concurrentAnalysis: true,


### PR DESCRIPTION
this is port of https://github.com/dotnet/roslyn/pull/14631

basically, root issue is that OOP analyzer engine doesn't feed in right AnalyzerOption type to compiler which later IDE analyzer can cast back to access workspace options.

this causes, when FSA is enabled, many IDE analyzers to throw null exception which show up in error list since engine didn't feed in right type.

this fix the issue by feeding in right type.