### PR TITLE
made OOP to be enabled only on 64bit OS and OOP process to be any cpu

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Remote/RemoteHostClientServiceFactory.RemoteHostClientService.cs
@@ -54,6 +54,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
                         return;
                     }
 
+                    // TODO: remove this once service hub supports running 1 service hub process per vs
+                    if (!Environment.Is64BitOperatingSystem)
+                    {
+                        // we don't support 32 bit OS from using service hub since it shares same service hub process
+                        // between multiple VS processes.
+                        return;
+                    }
+
                     // We enable the remote host if either RemoteHostTest or RemoteHost are on.
                     if (!_workspace.Options.GetOption(RemoteHostOptions.RemoteHostTest) &&
                         !_workspace.Options.GetOption(RemoteHostOptions.RemoteHost))

--- a/src/VisualStudio/Setup.Next/codeAnalysisService.servicehub.service.json
+++ b/src/VisualStudio/Setup.Next/codeAnalysisService.servicehub.service.json
@@ -1,6 +1,6 @@
 ﻿{
-  "host": "desktopClr.x86",
-  "hostId": "RoslynCodeAnalysisService32",
+  "host": "desktopClr",
+  "hostId": "RoslynCodeAnalysisService",
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
     "fullClassName": "Microsoft.CodeAnalysis.Remote.CodeAnalysisService",

--- a/src/VisualStudio/Setup.Next/remoteHostService.servicehub.service.json
+++ b/src/VisualStudio/Setup.Next/remoteHostService.servicehub.service.json
@@ -1,6 +1,6 @@
 ﻿{
-  "host": "desktopClr.x86",
-  "hostId": "RoslynCodeAnalysisService32",
+  "host": "desktopClr",
+  "hostId": "RoslynCodeAnalysisService",
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
     "fullClassName": "Microsoft.CodeAnalysis.Remote.RemoteHostService",

--- a/src/VisualStudio/Setup.Next/remoteSymbolSearchUpdateEngine.servicehub.service.json
+++ b/src/VisualStudio/Setup.Next/remoteSymbolSearchUpdateEngine.servicehub.service.json
@@ -1,6 +1,6 @@
 ﻿{
-  "host": "desktopClr.x86",
-  "hostId": "RoslynCodeAnalysisService32",
+  "host": "desktopClr",
+  "hostId": "RoslynCodeAnalysisService",
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
     "fullClassName": "Microsoft.CodeAnalysis.Remote.RemoteSymbolSearchUpdateEngine",

--- a/src/VisualStudio/Setup.Next/snapshotService.servicehub.service.json
+++ b/src/VisualStudio/Setup.Next/snapshotService.servicehub.service.json
@@ -1,6 +1,6 @@
 ﻿{
-  "host": "desktopClr.x86",
-  "hostId": "RoslynCodeAnalysisService32",
+  "host": "desktopClr",
+  "hostId": "RoslynCodeAnalysisService",
   "entryPoint": {
     "assemblyPath": "Microsoft.CodeAnalysis.Remote.ServiceHub.dll",
     "fullClassName": "Microsoft.CodeAnalysis.Remote.SnapshotService",


### PR DESCRIPTION
currently service hub process is shared per (vs, hive) pair. making it to be worse memory wise for 32bit OS.

so, we only turn on OOP in 64bit OS and create Any Cpu service hub host instead of x86.

so far, it looks like this cause about 500MB more VM to be used in service hub process.