### PR TITLE
Add NamingPreferences to the SimplificationOptionProvider

### DIFF
--- a/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
+++ b/src/Workspaces/Core/Portable/Simplification/SimplificationOptionProvider.cs
@@ -18,7 +18,8 @@ namespace Microsoft.CodeAnalysis.Simplification
                 SimplificationOptions.PreferImplicitTypeInference,
                 SimplificationOptions.PreferImplicitTypeInLocalDeclaration,
                 SimplificationOptions.AllowSimplificationToGenericType,
-                SimplificationOptions.AllowSimplificationToBaseType
+                SimplificationOptions.AllowSimplificationToBaseType,
+                SimplificationOptions.NamingPreferences
             }.ToImmutableArray();
 
         public IEnumerable<IOption> GetOptions()


### PR DESCRIPTION
This allows the VSI option resetter to reset the option (so that stale
default values aren't used).