### PR TITLE
Ensure that implicitly added corelib reference for VB is added to Com…

### DIFF
--- a/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommandLineReference.cs
@@ -14,31 +14,28 @@ namespace Microsoft.CodeAnalysis
     /// </summary>
     public struct CommandLineReference : IEquatable<CommandLineReference>
     {
-        private readonly string _reference;
-        private readonly MetadataReferenceProperties _properties;
-
-        internal CommandLineReference(string reference, MetadataReferenceProperties properties)
+        internal CommandLineReference(string reference, MetadataReferenceProperties properties, bool isDefaultCoreLibReference = false)
         {
             Debug.Assert(!string.IsNullOrEmpty(reference));
-            _reference = reference;
-            _properties = properties;
+            Reference = reference;
+            Properties = properties;
+            IsDefaultCoreLibReference = isDefaultCoreLibReference;
         }
 
         /// <summary>
         /// Metadata file path or an assembly display name.
         /// </summary>
-        public string Reference
-        {
-            get { return _reference; }
-        }
+        public string Reference { get; }
 
         /// <summary>
         /// Metadata reference properties.
         /// </summary>
-        public MetadataReferenceProperties Properties
-        {
-            get { return _properties; }
-        }
+        public MetadataReferenceProperties Properties { get; }
+
+        /// <summary>
+        /// Flag indicating if this is an implicitly added core libary reference.
+        /// </summary>
+        internal bool IsDefaultCoreLibReference { get; }
 
         public override bool Equals(object obj)
         {
@@ -47,13 +44,13 @@ namespace Microsoft.CodeAnalysis
 
         public bool Equals(CommandLineReference other)
         {
-            return _reference == other._reference
-                && _properties.Equals(other._properties);
+            return Reference == other.Reference
+                && Properties.Equals(other.Properties);
         }
 
         public override int GetHashCode()
         {
-            return Hash.Combine(_reference, _properties.GetHashCode());
+            return Hash.Combine(Reference, Properties.GetHashCode());
         }
     }
 }

--- a/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
+++ b/src/Compilers/Core/Portable/CommandLine/CommonCommandLineArguments.cs
@@ -306,9 +306,14 @@ namespace Microsoft.CodeAnalysis
 
         internal virtual bool ResolveMetadataReferences(MetadataReferenceResolver metadataResolver, List<DiagnosticInfo> diagnosticsOpt, CommonMessageProvider messageProviderOpt, List<MetadataReference> resolved)
         {
+            return ResolveMetadataReferences(this.MetadataReferences, metadataResolver, diagnosticsOpt, messageProviderOpt, resolved);
+        }
+
+        internal static bool ResolveMetadataReferences(IEnumerable<CommandLineReference> metadataReferences, MetadataReferenceResolver metadataResolver, List<DiagnosticInfo> diagnosticsOpt, CommonMessageProvider messageProviderOpt, List<MetadataReference> resolved)
+        {
             bool result = true;
 
-            foreach (CommandLineReference cmdReference in MetadataReferences)
+            foreach (CommandLineReference cmdReference in metadataReferences)
             {
                 var references = ResolveMetadataReference(cmdReference, metadataResolver, diagnosticsOpt, messageProviderOpt);
                 if (!references.IsDefaultOrEmpty)

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineArguments.vb
@@ -2,6 +2,7 @@
 
 Imports System
 Imports System.Collections.Generic
+Imports System.Collections.Immutable
 Imports System.Collections.ObjectModel
 Imports System.Diagnostics
 Imports System.IO
@@ -54,10 +55,22 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             End Get
         End Property
 
-        Friend Property DefaultCoreLibraryReference As CommandLineReference?
-
         Friend Sub New()
         End Sub
+
+        Private Function GetExplicitMetadataReferences(<Out> ByRef defaultCoreLibraryReference As CommandLineReference?) As ImmutableArray(Of CommandLineReference)
+            defaultCoreLibraryReference = Nothing
+            Dim builder = ImmutableArray.CreateBuilder(Of CommandLineReference)
+            For Each reference In MetadataReferences
+                If reference.IsDefaultCoreLibReference Then
+                    defaultCoreLibraryReference = reference
+                Else
+                    builder.Add(reference)
+                End If
+            Next
+
+            Return builder.ToImmutable()
+        End Function
 
         Friend Overrides Function ResolveMetadataReferences(
             metadataResolver As MetadataReferenceResolver,
@@ -66,10 +79,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             resolved As List(Of MetadataReference)
             ) As Boolean
 
-            If MyBase.ResolveMetadataReferences(metadataResolver, diagnostics, messageProvider, resolved) Then
+            Dim defaultCoreLibraryReference As CommandLineReference? = Nothing
+            Dim explicitMetadataReferences = GetExplicitMetadataReferences(defaultCoreLibraryReference)
+            If ResolveMetadataReferences(explicitMetadataReferences, metadataResolver, diagnostics, messageProvider, resolved) Then
 
                 ' If there were no references, don't try to add default Cor library reference.
-                If Me.DefaultCoreLibraryReference IsNot Nothing AndAlso resolved.Count > 0 Then
+                If defaultCoreLibraryReference IsNot Nothing AndAlso resolved.Count > 0 Then
                     ' All references from arguments were resolved successfully. Let's see if we have a reference that can be used as a Cor library.
                     For Each reference In resolved
                         Dim refProps = reference.Properties
@@ -104,7 +119,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     Next
 
                     ' None of the supplied references could be used as a Cor library. Let's add a default one.
-                    Dim defaultCorLibrary = ResolveMetadataReference(Me.DefaultCoreLibraryReference.Value, metadataResolver, diagnostics, messageProvider).FirstOrDefault()
+                    Dim defaultCorLibrary = ResolveMetadataReference(defaultCoreLibraryReference.Value, metadataResolver, diagnostics, messageProvider).FirstOrDefault()
 
                     If defaultCorLibrary Is Nothing OrElse defaultCorLibrary.IsUnresolved Then
                         Debug.Assert(diagnostics Is Nothing OrElse diagnostics.Any())

--- a/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
+++ b/src/Compilers/VisualBasic/Portable/CommandLine/VisualBasicCommandLineParser.vb
@@ -1210,6 +1210,9 @@ lVbRuntimePlus:
 
             ' Locate default 'mscorlib.dll' or 'System.Runtime.dll', if any.
             Dim defaultCoreLibraryReference As CommandLineReference? = LoadCoreLibraryReference(sdkPaths, baseDirectory)
+            If (defaultCoreLibraryReference.HasValue) Then
+                metadataReferences.Add(defaultCoreLibraryReference.Value)
+            End If
 
             ' If /nostdlib is not specified, load System.dll
             ' Dev12 does it through combination of CompilerHost::InitStandardLibraryList and CompilerProject::AddStandardLibraries.
@@ -1405,7 +1408,6 @@ lVbRuntimePlus:
                 .OutputLevel = outputLevel,
                 .EmitPdb = emitPdb,
                 .SourceLink = sourceLink,
-                .DefaultCoreLibraryReference = defaultCoreLibraryReference,
                 .PreferredUILang = preferredUILang,
                 .ReportAnalyzer = reportAnalyzer,
                 .EmbeddedFiles = embeddedFiles.AsImmutable()
@@ -1427,7 +1429,7 @@ lVbRuntimePlus:
 
             If systemRuntimePath IsNot Nothing Then
                 If msCorLibPath Is Nothing Then
-                    Return New CommandLineReference(systemRuntimePath, New MetadataReferenceProperties(MetadataImageKind.Assembly))
+                    Return New CommandLineReference(systemRuntimePath, New MetadataReferenceProperties(MetadataImageKind.Assembly), isDefaultCoreLibReference:=True)
                 End If
 
                 ' Load System.Runtime.dll and see if it has any references
@@ -1436,7 +1438,7 @@ lVbRuntimePlus:
                         ' Prefer 'System.Runtime.dll' if it does not have any references
                         If metadata.GetModules()(0).Module.IsLinkedModule AndAlso
                            metadata.GetAssembly().AssemblyReferences.Length = 0 Then
-                            Return New CommandLineReference(systemRuntimePath, New MetadataReferenceProperties(MetadataImageKind.Assembly))
+                            Return New CommandLineReference(systemRuntimePath, New MetadataReferenceProperties(MetadataImageKind.Assembly), isDefaultCoreLibReference:=True)
                         End If
                     End Using
                 Catch
@@ -1444,7 +1446,7 @@ lVbRuntimePlus:
                 End Try
 
                 ' Otherwise prefer 'mscorlib.dll'
-                Return New CommandLineReference(msCorLibPath, New MetadataReferenceProperties(MetadataImageKind.Assembly))
+                Return New CommandLineReference(msCorLibPath, New MetadataReferenceProperties(MetadataImageKind.Assembly), isDefaultCoreLibReference:=True)
             End If
 
             If msCorLibPath IsNot Nothing Then

--- a/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/CommandLineTests.vb
@@ -3855,7 +3855,10 @@ End Class
         Public Sub AddModule()
             Dim parsedArgs = DefaultParse({"/nostdlib", "/vbruntime-", "/addMODULE:c:\,d:\x\y\z,abc,,", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify()
-            Assert.Equal(3, parsedArgs.MetadataReferences.Length)
+            Assert.Equal(4, parsedArgs.MetadataReferences.Length)
+            Dim explicitMetadataReferences = parsedArgs.MetadataReferences.Where(Function(m) Not m.IsDefaultCoreLibReference).ToImmutableArray
+            Assert.Equal(3, explicitMetadataReferences.Length)
+
             Assert.Equal("c:\", parsedArgs.MetadataReferences(0).Reference)
             Assert.Equal(MetadataImageKind.Module, parsedArgs.MetadataReferences(0).Properties.Kind)
             Assert.Equal("d:\x\y\z", parsedArgs.MetadataReferences(1).Reference)
@@ -3865,8 +3868,10 @@ End Class
             Assert.False(parsedArgs.MetadataReferences(0).Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
             Assert.False(parsedArgs.MetadataReferences(1).Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
             Assert.False(parsedArgs.MetadataReferences(2).Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
-            Assert.True(parsedArgs.DefaultCoreLibraryReference.Value.Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
-            Assert.Equal(MetadataImageKind.Assembly, parsedArgs.DefaultCoreLibraryReference.Value.Properties.Kind)
+
+            Dim defaultCoreLibReference = parsedArgs.MetadataReferences.Single(Function(m) m.IsDefaultCoreLibReference)
+            Assert.True(defaultCoreLibReference.Reference.EndsWith("mscorlib.dll", StringComparison.Ordinal))
+            Assert.Equal(MetadataImageKind.Assembly, defaultCoreLibReference.Properties.Kind)
 
             parsedArgs = DefaultParse({"/ADDMODULE", "a.vb"}, _baseDirectory)
             parsedArgs.Errors.Verify(Diagnostic(ERRID.ERR_ArgumentRequired).WithArguments("addmodule", ":<file_list>"))

--- a/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
+++ b/src/Compilers/VisualBasic/Test/CommandLine/TouchedFileLoggingTests.vb
@@ -212,11 +212,6 @@ End Class
                                                   <Out> ByRef expectedWrites As List(Of String))
             expectedReads = cmd.Arguments.MetadataReferences.Select(Function(r) r.Reference).ToList()
 
-            Dim coreLibrary = cmd.Arguments.DefaultCoreLibraryReference
-            If coreLibrary.HasValue Then
-                expectedReads.Add(coreLibrary.GetValueOrDefault().Reference)
-            End If
-
             For Each file In cmd.Arguments.SourceFiles
                 expectedReads.Add(file.Path)
             Next


### PR DESCRIPTION
…mandLineArguments.MetadataReferences so that new project systems that use the command line parser to push references to the workspace get this reference.

Fixes #14584