### PR TITLE
harden CompileMethod

### DIFF
--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1075,9 +1075,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     return;
                                 }
 
-                                // "lowered" could be a BadBoundStatement, so do the cast only if there weren't 
-                                // any errors.
-                                Debug.Assert(lowered.Kind == BoundKind.StatementList);
+                                // Only do the cast if we haven't returned with some error diagnostics.
+                                // Otherwise, `lowered` might have been a BoundBadStatement.
                                 processedInitializers.LoweredInitializers = (BoundStatementList)lowered;
                             }
 

--- a/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
+++ b/src/Compilers/CSharp/Portable/Compiler/MethodCompiler.cs
@@ -1048,7 +1048,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                                 Debug.Assert(!instrumentForDynamicAnalysis);
                                 StateMachineTypeSymbol initializerStateMachineTypeOpt;
 
-                                processedInitializers.LoweredInitializers = (BoundStatementList)LowerBodyOrInitializer(
+                                var lowered = LowerBodyOrInitializer(
                                     methodSymbol,
                                     methodOrdinal,
                                     analyzedInitializers,
@@ -1065,10 +1065,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                                 // initializers can't produce state machines
                                 Debug.Assert((object)initializerStateMachineTypeOpt == null);
-
-                                Debug.Assert(processedInitializers.LoweredInitializers.Kind == BoundKind.StatementList);
                                 Debug.Assert(!hasErrors);
-                                hasErrors = processedInitializers.LoweredInitializers.HasAnyErrors || diagsForCurrentMethod.HasAnyErrors();
+                                hasErrors = lowered.HasAnyErrors || diagsForCurrentMethod.HasAnyErrors();
                                 SetGlobalErrorIfTrue(hasErrors);
 
                                 if (hasErrors)
@@ -1076,6 +1074,11 @@ namespace Microsoft.CodeAnalysis.CSharp
                                     _diagnostics.AddRange(diagsForCurrentMethod);
                                     return;
                                 }
+
+                                // "lowered" could be a BadBoundStatement, so do the cast only if there weren't 
+                                // any errors.
+                                Debug.Assert(lowered.Kind == BoundKind.StatementList);
+                                processedInitializers.LoweredInitializers = (BoundStatementList)lowered;
                             }
 
                             // initializers for global code have already been included in the body

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenConstructorInitTests.cs
@@ -589,5 +589,21 @@ public static class Module1
 }
 ");
         }
+
+        [WorkItem(217748, "https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=21774")]
+        [Fact]
+        public void BadExpressionConstructor()
+        {
+            string source =
+@"class C
+{
+    static dynamic F() => 0;
+    dynamic d = F() * 2;
+}";
+            CreateCompilationWithMscorlibAndSystemCore(source).VerifyEmitDiagnostics(
+                // (4,17): error CS0656: Missing compiler required member 'Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create'
+                //     dynamic d = F() * 2;
+                Diagnostic(ErrorCode.ERR_MissingPredefinedMember, "F()").WithArguments("Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo", "Create").WithLocation(4, 17));
+        }
     }
 }


### PR DESCRIPTION
closes [devdiv/217748](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=217748&triage=true)

~~@dotnet/roslyn-compiler Pretty sure that this is the correct fix for the linked Watson, but I'm having trouble making a unit test that exhibits the bug.  Any nudges in a promising direction would be much appreciated!~~

