### PR TITLE
Compiler server should be tolerant of corrupted application settings

### DIFF
--- a/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
+++ b/src/Compilers/Server/VBCSCompiler/DesktopBuildServerController.cs
@@ -24,9 +24,9 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         private readonly NameValueCollection _appSettings;
 
-        internal DesktopBuildServerController(NameValueCollection appSettings = null)
+        internal DesktopBuildServerController(NameValueCollection appSettings)
         {
-            _appSettings = appSettings ?? ConfigurationManager.AppSettings;
+            _appSettings = appSettings;
         }
 
         protected override IClientConnectionHost CreateClientConnectionHost(string pipeName)
@@ -118,7 +118,7 @@ namespace Microsoft.CodeAnalysis.CompilerServer
 
         internal static new int RunServer(string pipeName, IClientConnectionHost clientConnectionHost = null, IDiagnosticListener listener = null, TimeSpan? keepAlive = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            BuildServerController controller = new DesktopBuildServerController();
+            BuildServerController controller = new DesktopBuildServerController(new NameValueCollection());
             return controller.RunServer(pipeName, clientConnectionHost, listener, keepAlive, cancellationToken);
         }
     }

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -1,24 +1,29 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Configuration;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Pipes;
-using System.Linq;
-using System.Security.AccessControl;
-using System.Security.Principal;
-using System.Threading;
-using System.Threading.Tasks;
-using System.Globalization;
-using Microsoft.CodeAnalysis.CommandLine;
-using System.Runtime.InteropServices;
 
 namespace Microsoft.CodeAnalysis.CompilerServer
 {
     internal static class VBCSCompiler 
     {
-        public static int Main(string[] args) => new DesktopBuildServerController().Run(args);
+        public static int Main(string[] args)
+        {
+            NameValueCollection appSettings;
+            try
+            {
+                appSettings = ConfigurationManager.AppSettings;
+            }
+            catch
+            {
+                // It is possible for AppSettings to throw when the application or machine configuration 
+                // is corrupted.  This should not prevent the server from starting, but instead just revert
+                // to the default configuration.
+                appSettings = new NameValueCollection();
+            }
+
+            var controller = new DesktopBuildServerController(appSettings);
+            return controller.Run(args);
+        }
     }
 }

--- a/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
+++ b/src/Compilers/Server/VBCSCompiler/VBCSCompiler.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using Microsoft.CodeAnalysis.CommandLine;
+using System;
 using System.Collections.Specialized;
 using System.Configuration;
 
@@ -14,12 +16,13 @@ namespace Microsoft.CodeAnalysis.CompilerServer
             {
                 appSettings = ConfigurationManager.AppSettings;
             }
-            catch
+            catch (Exception ex)
             {
                 // It is possible for AppSettings to throw when the application or machine configuration 
                 // is corrupted.  This should not prevent the server from starting, but instead just revert
                 // to the default configuration.
                 appSettings = new NameValueCollection();
+                CompilerServerLogger.LogException(ex, "Error loading application settings");
             }
 
             var controller = new DesktopBuildServerController(appSettings);

--- a/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
+++ b/src/Compilers/Server/VBCSCompilerTests/VBCSCompilerServerTests.cs
@@ -3,6 +3,7 @@
 using Microsoft.CodeAnalysis.CommandLine;
 using System;
 using System.Collections;
+using System.Collections.Specialized;
 using System.IO.Pipes;
 using System.Text;
 using System.Threading;
@@ -17,7 +18,8 @@ namespace Microsoft.CodeAnalysis.CompilerServer.UnitTests
         {
             private static Task<int> RunShutdownAsync(string pipeName, bool waitForProcess = true, TimeSpan? timeout = null, CancellationToken cancellationToken = default(CancellationToken))
             {
-                return new DesktopBuildServerController().RunShutdownAsync(pipeName, waitForProcess, timeout, cancellationToken);
+                var appSettings = new NameValueCollection();
+                return new DesktopBuildServerController(appSettings).RunShutdownAsync(pipeName, waitForProcess, timeout, cancellationToken);
             }
 
             [Fact]


### PR DESCRIPTION
When a machine.config or app.config is corrupted it's possible for `ConfigurationManager.AppSettings` to throw an exception.  The compiler server was not tolerant of such a failure and as a result would terminate immediately after startup.

The compiler workflow is generally very tolerant of failures in the server.  It is an optimization only, and any crashes, bad results, etc ... are ignored and the workflow will fall back to the command line.  Failing on startup is one case the workflow does not handle well right now.  The workflow does not distinguish between a crash at startup and a very slow JIT situation (as is the case with old, single core machines).  As such it ends up adding an unnecessary 25 second delay to the compilation.  Issue #14265 tracks fixing this delay but it won't make RC.

Up until now only one incident of corrupted app settings was reported and it was considered an extremely unlikely problem (as it would break a lot of apps).  Going through VS feedback last night I found one other incident which could would be explained by this problem.  Hence it's possible this is more likley than originally thought (although still very rare) and decided to put it into RC.

closes #14288