### PR TITLE
Fix parsing of "e is nameof" to retain compatibility

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -29,9 +29,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     break;
             }
 
-            // If it is a nameof, skip the 'if' and parse as a constant pattern.
+            // If it starts with 'nameof(', skip the 'if' and parse as a constant pattern.
             if (SyntaxFacts.IsPredefinedType(tk) ||
-                (tk == SyntaxKind.IdentifierToken && this.CurrentToken.ContextualKind != SyntaxKind.NameOfKeyword))
+                (tk == SyntaxKind.IdentifierToken &&
+                  (this.CurrentToken.ContextualKind != SyntaxKind.NameOfKeyword || this.PeekToken(1).Kind != SyntaxKind.OpenParenToken)))
             {
                 var resetPoint = this.GetResetPoint();
                 try
@@ -82,6 +83,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 // But it still might be a pattern such as (operand is 3) or (operand is nameof(x))
                 node = _syntaxFactory.ConstantPattern(this.ParseExpressionCore());
             }
+
             return node;
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests.cs
@@ -3423,5 +3423,42 @@ B";
                 Diagnostic(ErrorCode.ERR_UnexpectedToken, "A is B < C").WithArguments(",").WithLocation(1, 1)
                 );
         }
+
+        [Fact, WorkItem(14636, "https://github.com/dotnet/roslyn/issues/14636")]
+        public void NameofPattern()
+        {
+            var source =
+@"using System;
+
+class Program
+{
+    public static void Main(string[] args)
+    {
+        M(""a"");
+        M(""b"");
+        M(null);
+        M(new nameof());
+    }
+    public static void M(object a)
+    {
+        Console.WriteLine(a is nameof(a));
+        Console.WriteLine(a is nameof);
+    }
+}
+class nameof { }
+";
+            var expectedOutput =
+@"True
+False
+False
+False
+False
+False
+False
+True";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            var comp = CompileAndVerify(compilation, expectedOutput: expectedOutput);
+        }
     }
 }


### PR DESCRIPTION
Fixes #14636 

@dotnet/roslyn-compiler Please review.
