### PR TITLE
Don't fire both VB and C# events for NavTo.  

### DIFF
--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -20,7 +20,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             private readonly ItemDisplayFactory _displayFactory;
             private readonly INavigateToCallback _callback;
             private readonly string _searchPattern;
-            private readonly bool _searchCurrentDocument;
+            private readonly bool SearchCurrentDocument;
             private readonly Document _currentDocument;
             private readonly ProgressTracker _progress;
             private readonly IAsynchronousOperationListener _asyncListener;
@@ -39,12 +39,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 _displayFactory = displayFactory;
                 _callback = callback;
                 _searchPattern = searchPattern;
-                _searchCurrentDocument = searchCurrentDocument;
+                SearchCurrentDocument = searchCurrentDocument;
                 _cancellationToken = cancellationToken;
                 _progress = new ProgressTracker(callback.ReportProgress);
                 _asyncListener = asyncListener;
 
-                if (_searchCurrentDocument)
+                if (SearchCurrentDocument)
                 {
                     var documentService = _solution.Workspace.Services.GetService<IDocumentTrackingService>();
                     var activeId = documentService.GetActiveDocument();
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             {
                 try
                 {
-                    using (var navigateToSearch = Logger.LogBlock(FunctionId.NavigateTo_Search, _cancellationToken))
+                    using (var navigateToSearch = Logger.LogBlock(FunctionId.NavigateTo_Search, CreateLogMessage(_cancellationToken), _cancellationToken))
                     using (var asyncToken = _asyncListener.BeginAsyncOperation(GetType() + ".Search"))
                     {
                         _progress.AddItems(_solution.Projects.Count());
@@ -77,6 +77,13 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
                 }
             }
 
+            private LogMessage CreateLogMessage(CancellationToken cancellationToken)
+                => KeyValueLogMessage.Create(d =>
+                {
+                    d[nameof(cancellationToken.IsCancellationRequested)] = cancellationToken.IsCancellationRequested;
+                    d[nameof(SearchCurrentDocument)] = SearchCurrentDocument;
+                });
+
             private async Task SearchAsync(Project project)
             {
                 try
@@ -91,7 +98,7 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
 
             private async Task SearchAsyncWorker(Project project)
             {
-                if (_searchCurrentDocument && _currentDocument?.Project != project)
+                if (SearchCurrentDocument && _currentDocument?.Project != project)
                 {
                     return;
                 }

--- a/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
+++ b/src/EditorFeatures/Core/Implementation/NavigateTo/NavigateToItemProvider.Searcher.cs
@@ -80,7 +80,6 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.NavigateTo
             private LogMessage CreateLogMessage(CancellationToken cancellationToken)
                 => KeyValueLogMessage.Create(d =>
                 {
-                    d[nameof(cancellationToken.IsCancellationRequested)] = cancellationToken.IsCancellationRequested;
                     d[nameof(SearchCurrentDocument)] = SearchCurrentDocument;
                 });
 

--- a/src/VisualStudio/Core/Def/Telemetry/CodeMarkerLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/CodeMarkerLogger.cs
@@ -13,29 +13,20 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
     {
         public static readonly CodeMarkerLogger Instance = new CodeMarkerLogger();
 
-        private static readonly Dictionary<FunctionId, List<Tuple<CodeMarkerId, CodeMarkerId>>> s_blockMap
-            = new Dictionary<FunctionId, List<Tuple<CodeMarkerId, CodeMarkerId>>>()
+        private static readonly Dictionary<FunctionId, List<Tuple<CodeMarkerId, CodeMarkerId>>> s_blockMap =
+            new Dictionary<FunctionId, List<Tuple<CodeMarkerId, CodeMarkerId>>>()
             {
-                { FunctionId.NavigateTo_Search, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpNavigateToStartSearch, CodeMarkerEvent.perfVSCSharpNavigateToEndSearch),
-                        Tuple.Create(CodeMarkerEvent.perfVBNavigateToStartSearch, CodeMarkerEvent.perfVBNavigateToEndSearch),
-                    }
+                { FunctionId.NavigateTo_Search, new List<Tuple<CodeMarkerId, CodeMarkerId>>
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpNavigateToStartSearch, CodeMarkerEvent.perfVSCSharpNavigateToEndSearch), }
                 },
                 { FunctionId.Rename_InlineSession, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpRenameStart, CodeMarkerEvent.perfVSCSharpRenameEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpRenameStart, CodeMarkerEvent.perfVSCSharpRenameEnd) }
                 },
                 { FunctionId.Rename_FindLinkedSpans, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpRenameFindDefinitionStart, CodeMarkerEvent.perfVSCSharpRenameFindDefinitionEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpRenameFindDefinitionStart, CodeMarkerEvent.perfVSCSharpRenameFindDefinitionEnd) }
                 },
                 { FunctionId.WinformDesigner_GenerateXML, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpGetXmlStart, CodeMarkerEvent.perfVSCSharpGetXmlEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpGetXmlStart, CodeMarkerEvent.perfVSCSharpGetXmlEnd) }
                 },
                 { FunctionId.BackgroundCompiler_BuildCompilationsAsync, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
                     {
@@ -44,14 +35,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                     }
                 },
                 { FunctionId.FindReference, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpFindAllReferencesStart, CodeMarkerEvent.perfVSCSharpFindAllReferencesEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpFindAllReferencesStart, CodeMarkerEvent.perfVSCSharpFindAllReferencesEnd) }
                 },
                 { FunctionId.SmartTags_SmartTagInitializeFixes, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVBSmartTagInitializeFixesBegin, CodeMarkerEvent.perfVBSmartTagInitializeFixesEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVBSmartTagInitializeFixesBegin, CodeMarkerEvent.perfVBSmartTagInitializeFixesEnd) }
                 },
                 { FunctionId.SmartTags_ApplyQuickFix, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
                     {
@@ -60,24 +47,16 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                     }
                 },
                 { FunctionId.LineCommit_CommitRegion, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVBCompilerPrettyListBegin, CodeMarkerEvent.perfVBCompilerPrettyListEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVBCompilerPrettyListBegin, CodeMarkerEvent.perfVBCompilerPrettyListEnd) }
                 },
                 { FunctionId.Tagger_Outlining_TagProducer_ProduceTags, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVBCompilerStartOutliningBegin, CodeMarkerEvent.perfVBCompilerStartOutliningEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVBCompilerStartOutliningBegin, CodeMarkerEvent.perfVBCompilerStartOutliningEnd) }
                 },
                 { FunctionId.Tagger_LineSeparator_TagProducer_ProduceTags, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVBCompilerUpdateLineSeparatorsBegin, CodeMarkerEvent.perfVBCompilerUpdateLineSeparatorsEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVBCompilerUpdateLineSeparatorsBegin, CodeMarkerEvent.perfVBCompilerUpdateLineSeparatorsEnd) }
                 },
                 { FunctionId.NavigationBar_ComputeModelAsync, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVBCompilerDropDownLoadBegin, CodeMarkerEvent.perfVBCompilerDropDownLoadEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVBCompilerDropDownLoadBegin, CodeMarkerEvent.perfVBCompilerDropDownLoadEnd) }
                 },
                 { FunctionId.Completion_ModelComputer_DoInBackground, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
                     {
@@ -86,19 +65,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
                     }
                 },
                 { FunctionId.SignatureHelp_ModelComputation_UpdateModelInBackground, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpParamHelpStart, CodeMarkerEvent.perfVSCSharpParamHelpEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpParamHelpStart, CodeMarkerEvent.perfVSCSharpParamHelpEnd) }
                 },
                 { FunctionId.Formatting_Format, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpFormatStart, CodeMarkerEvent.perfVSCSharpFormatEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpFormatStart, CodeMarkerEvent.perfVSCSharpFormatEnd) }
                 },
                 { FunctionId.Formatting_ApplyResultToBuffer, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
-                    {
-                        Tuple.Create(CodeMarkerEvent.perfVSCSharpCommitStart, CodeMarkerEvent.perfVSCSharpCommitEnd)
-                    }
+                    { Tuple.Create(CodeMarkerEvent.perfVSCSharpCommitStart, CodeMarkerEvent.perfVSCSharpCommitEnd) }
                 },
                 { FunctionId.SmartTags_RefreshSession, new List<Tuple<CodeMarkerId, CodeMarkerId>>()
                     {

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryActivityLogger.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryActivityLogger.cs
@@ -17,7 +17,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         private static readonly HashSet<FunctionId> s_functionIds
             = new HashSet<FunctionId>()
             {
-                FunctionId.NavigateTo_Search,
                 FunctionId.Rename_CommitCore,
                 FunctionId.CommandHandler_FindAllReference,
                 FunctionId.CommandHandler_FormatCommand

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryCache.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryCache.cs
@@ -18,14 +18,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
         private static readonly ConcurrentDictionary<Key, string> s_propertyMap = new ConcurrentDictionary<Key, string>();
 
         public static string GetEventName(this FunctionId functionId, string eventKey = null)
-        {
-            return s_eventMap.GetOrAdd(new Key(functionId, eventKey), CreateEventName);
-        }
+            => s_eventMap.GetOrAdd(new Key(functionId, eventKey), CreateEventName);
 
         public static string GetPropertyName(this FunctionId functionId, string propertyKey)
-        {
-            return s_propertyMap.GetOrAdd(new Key(functionId, propertyKey), CreatePropertyName);
-        }
+            => s_propertyMap.GetOrAdd(new Key(functionId, propertyKey), CreatePropertyName);
 
         private static Func<Key, string> CreateEventName = key =>
             (EventPrefix + Enum.GetName(typeof(FunctionId), key.FunctionId).Replace('_', '/') + (key.ItemKey == null ? string.Empty : ("/" + key.ItemKey))).ToLowerInvariant();
@@ -45,19 +41,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             }
 
             public override int GetHashCode()
-            {
-                return Hash.Combine((int)FunctionId, ItemKey == null ? 0 : ItemKey.GetHashCode());
-            }
+                => Hash.Combine((int)FunctionId, ItemKey == null ? 0 : ItemKey.GetHashCode());
 
-            public override bool Equals(object obj)
-            {
-                return obj is Key && Equals((Key)obj);
-            }
+            public override bool Equals(object obj) => Equals((Key)obj);
 
             public bool Equals(Key key)
-            {
-                return this.FunctionId == key.FunctionId && this.ItemKey == key.ItemKey;
-            }
+                => this.FunctionId == key.FunctionId && this.ItemKey == key.ItemKey;
         }
     }
 }

--- a/src/VisualStudio/Core/Def/Telemetry/VSTelemetryCache.cs
+++ b/src/VisualStudio/Core/Def/Telemetry/VSTelemetryCache.cs
@@ -27,15 +27,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Telemetry
             return s_propertyMap.GetOrAdd(new Key(functionId, propertyKey), CreatePropertyName);
         }
 
-        private static string CreateEventName(Key key)
-        {
-            return (EventPrefix + Enum.GetName(typeof(FunctionId), key.FunctionId).Replace('_', '/') + (key.ItemKey == null ? string.Empty : ("/" + key.ItemKey))).ToLowerInvariant();
-        }
+        private static Func<Key, string> CreateEventName = key =>
+            (EventPrefix + Enum.GetName(typeof(FunctionId), key.FunctionId).Replace('_', '/') + (key.ItemKey == null ? string.Empty : ("/" + key.ItemKey))).ToLowerInvariant();
 
-        private static string CreatePropertyName(Key key)
-        {
-            return (PropertyPrefix + Enum.GetName(typeof(FunctionId), key.FunctionId).Replace('_', '.') + "." + key.ItemKey).ToLowerInvariant();
-        }
+        private static Func<Key, string> CreatePropertyName = key =>
+            (PropertyPrefix + Enum.GetName(typeof(FunctionId), key.FunctionId).Replace('_', '.') + "." + key.ItemKey).ToLowerInvariant();
 
         private struct Key : IEquatable<Key>
         {


### PR DESCRIPTION
We really only need one set of events moving forward to track performance.

Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=208668&triage=true&_a=edit
