### PR TITLE
Fix JSON remoting for CodeLens

### DIFF
--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -124,13 +124,15 @@ namespace Microsoft.CodeAnalysis.CodeLens
             var symbol = semanticModel.GetDeclaredSymbol(node);
             var glyph = symbol?.GetGlyph();
             var startLinePosition = location.GetLineSpan().StartLinePosition;
+            var documentId = solution.GetDocument(location.SourceTree)?.Id;
 
             return new ReferenceLocationDescriptor(longName,
                 semanticModel.Language,
                 glyph,
                 startLinePosition.Line,
                 startLinePosition.Character,
-                solution.GetDocument(location.SourceTree)?.Id,
+                documentId.ProjectId.Id,
+                documentId.Id,
                 line.TrimEnd(),
                 referenceSpan.Start,
                 referenceSpan.Length,

--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -123,11 +123,13 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
             var symbol = semanticModel.GetDeclaredSymbol(node);
             var glyph = symbol?.GetGlyph();
+            var startLinePosition = location.GetLineSpan().StartLinePosition;
 
             return new ReferenceLocationDescriptor(longName,
                 semanticModel.Language,
                 glyph,
-                location,
+                startLinePosition.Line,
+                startLinePosition.Character,
                 solution.GetDocument(location.SourceTree)?.Id,
                 line.TrimEnd(),
                 referenceSpan.Start,

--- a/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
@@ -63,25 +63,6 @@ namespace Microsoft.CodeAnalysis.CodeLens
         /// </summary>
         public string AfterReferenceText2 { get; }
 
-        public ReferenceLocationDescriptor(string longDescription, string language, Glyph? glyph, Location location, DocumentId documentId, string referenceLineText, int referenceStart, int referenceLength, string beforeReferenceText1, string beforeReferenceText2, string afterReferenceText1, string afterReferenceText2)
-        {
-            LongDescription = longDescription;
-            Language = language;
-            Glyph = glyph;
-            var sourceText = location.GetLineSpan().StartLinePosition;
-            LineNumber = sourceText.Line;
-            ColumnNumber = sourceText.Character;
-            // We want to keep track of the location's document if it comes from a file in your solution.
-            DocumentId = documentId;
-            ReferenceLineText = referenceLineText;
-            ReferenceStart = referenceStart;
-            ReferenceLength = referenceLength;
-            BeforeReferenceText1 = beforeReferenceText1;
-            BeforeReferenceText2 = beforeReferenceText2;
-            AfterReferenceText1 = afterReferenceText1;
-            AfterReferenceText2 = afterReferenceText2;
-        }
-
         public ReferenceLocationDescriptor(string longDescription, string language, Glyph? glyph, int lineNumber, int columnNumber, DocumentId documentId, string referenceLineText, int referenceStart, int referenceLength, string beforeReferenceText1, string beforeReferenceText2, string afterReferenceText1, string afterReferenceText2)
         {
             LongDescription = longDescription;

--- a/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
+++ b/src/Features/Core/Portable/CodeLens/ReferenceLocationDescriptor.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
+
 namespace Microsoft.CodeAnalysis.CodeLens
 {
     /// <summary>
@@ -11,7 +13,9 @@ namespace Microsoft.CodeAnalysis.CodeLens
 
         public int ColumnNumber { get; }
 
-        public DocumentId DocumentId { get; }
+        public Guid ProjectGuid { get; }
+
+        public Guid DocumentGuid { get; }
 
         /// <summary>
         /// Language of the reference location
@@ -63,7 +67,7 @@ namespace Microsoft.CodeAnalysis.CodeLens
         /// </summary>
         public string AfterReferenceText2 { get; }
 
-        public ReferenceLocationDescriptor(string longDescription, string language, Glyph? glyph, int lineNumber, int columnNumber, DocumentId documentId, string referenceLineText, int referenceStart, int referenceLength, string beforeReferenceText1, string beforeReferenceText2, string afterReferenceText1, string afterReferenceText2)
+        public ReferenceLocationDescriptor(string longDescription, string language, Glyph? glyph, int lineNumber, int columnNumber, Guid projectGuid, Guid documentGuid, string referenceLineText, int referenceStart, int referenceLength, string beforeReferenceText1, string beforeReferenceText2, string afterReferenceText1, string afterReferenceText2)
         {
             LongDescription = longDescription;
             Language = language;
@@ -71,7 +75,8 @@ namespace Microsoft.CodeAnalysis.CodeLens
             LineNumber = lineNumber;
             ColumnNumber = columnNumber;
             // We want to keep track of the location's document if it comes from a file in your solution.
-            DocumentId = documentId;
+            ProjectGuid = projectGuid;
+            DocumentGuid = documentGuid;
             ReferenceLineText = referenceLineText;
             ReferenceStart = referenceStart;
             ReferenceLength = referenceLength;


### PR DESCRIPTION
With CodeLens processing moving out of process, all types that are returned need to be JSON serializable. The fact that ReferenceLocationDescriptor had two constructors confused the JSON serializer. This fixes that.

@heejaechang 