### PR TITLE
Unwrap aggregate exceptions before watson

### DIFF
--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -18,6 +18,13 @@ namespace Microsoft.CodeAnalysis
                 Debugger.Break();
             }
 
+            // don't fail fast with an aggregate exception that is masking true exception
+            var aggregate = exception as AggregateException;
+            if (aggregate != null && aggregate.InnerExceptions.Count == 1)
+            {
+                exception = aggregate.InnerExceptions[0];
+            }
+
             Environment.FailFast(exception.ToString(), exception);
         }
 

--- a/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
+++ b/src/Compilers/Core/Portable/InternalUtilities/FailFast.cs
@@ -18,12 +18,14 @@ namespace Microsoft.CodeAnalysis
                 Debugger.Break();
             }
 
+#if !NETFX20
             // don't fail fast with an aggregate exception that is masking true exception
             var aggregate = exception as AggregateException;
             if (aggregate != null && aggregate.InnerExceptions.Count == 1)
             {
                 exception = aggregate.InnerExceptions[0];
             }
+#endif
 
             Environment.FailFast(exception.ToString(), exception);
         }

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
@@ -76,7 +76,10 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DefineConstants>TRACE;DEBUG;NETFX20</DefineConstants>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Compile Include="..\Portable\Resources.Designer.cs">

--- a/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
+++ b/src/ExpressionEvaluator/Core/Source/ResultProvider/NetFX20/ResultProvider.NetFX20.csproj
@@ -80,7 +80,10 @@
     <DefineConstants>TRACE;DEBUG;NETFX20</DefineConstants>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DefineConstants>TRACE;NETFX20</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Portable\Resources.Designer.cs">
       <Link>Resources.Designer.cs</Link>


### PR DESCRIPTION
This change make it so we get better watson bucketing on exceptions in async code.

Because async code exceptions all get turned into AggregateExceptions as they are being propogated back through the code, all watson bucketing ends up denoting just that AggregateException occurred at the call stack related to the last async rethrow.  

This change makes it so the inner exception is used instead of the aggregate exception.  At least this will help us distinguish some kinds of bugs from others that originate in async code.

@dotnet/roslyn-ide @jaredpar @srivatsn @ManishJayaswal 