### PR TITLE
Strengthen the check that detects nullable lifting for a user-defined conversion during lowering.

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LocalRewriter/LocalRewriter_Conversion.cs
@@ -550,7 +550,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 // Lifted conversion, wrap return type in Nullable
                 // The conversion only needs to happen for non-nullable valuetypes
                 if (rewrittenOperand.Type.IsNullableType() &&
-                        conversion.Method.ParameterTypes[0] == rewrittenOperand.Type.GetNullableUnderlyingType() &&
+                        conversion.Method.ParameterTypes[0].Equals(rewrittenOperand.Type.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions) &&
                         !userDefinedConversionRewrittenType.IsNullableType() &&
                         userDefinedConversionRewrittenType.IsValueType)
                 {
@@ -983,11 +983,15 @@ namespace Microsoft.CodeAnalysis.CSharp
             TypeSymbol rewrittenType)
         {
             Debug.Assert((object)conversion.Method != null && !conversion.Method.ReturnsVoid && conversion.Method.ParameterCount == 1);
-            if (rewrittenOperand.Type != conversion.Method.ParameterTypes[0])
+            if (rewrittenOperand.Type.IsNullableType())
             {
-                Debug.Assert(rewrittenOperand.Type.IsNullableType());
-                Debug.Assert(rewrittenOperand.Type.GetNullableUnderlyingType() == conversion.Method.ParameterTypes[0]);
-                return RewriteLiftedUserDefinedConversion(syntax, rewrittenOperand, conversion, rewrittenType);
+                var parameterType = conversion.Method.ParameterTypes[0];
+                if (parameterType.Equals(rewrittenOperand.Type.GetNullableUnderlyingType(), TypeCompareKind.AllIgnoreOptions) &&
+                    !parameterType.IsNullableType() &&
+                    parameterType.IsValueType)
+                {
+                    return RewriteLiftedUserDefinedConversion(syntax, rewrittenOperand, conversion, rewrittenType);
+                }
             }
 
             BoundExpression result =

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17200,6 +17200,231 @@ BC41009: The tuple element name 'd' is ignored because a different name is speci
 
         End Sub
 
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_01()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Test((X1:=1, Y1:=2))
+        Dim t1 = (X1:=3, Y1:=4)
+        Test(t1)
+        Test((5, 6))
+        Dim t2 = (7, 8)
+        Test(t2)
+    End Sub
+
+    Shared Sub Test(val As AA)
+    End Sub
+End Class
+
+Public Class AA
+    Public Shared Widening Operator CType(x As (X1 As Integer, Y1 As Integer)) As AA
+        System.Console.WriteLine(x)	
+        return new AA()
+    End Operator
+End Class
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="
+(1, 2)
+(3, 4)
+(5, 6)
+(7, 8)
+")
+        End Sub
+
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_02()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Test((X1:=1, Y1:=2))
+        Dim t1 = (X1:=3, Y1:=4)
+        Test(t1)
+        Test((5, 6))
+        Dim t2 = (7, 8)
+        Test(t2)
+    End Sub
+
+    Shared Sub Test(val As AA?)
+    End Sub
+End Class
+
+Public Structure AA
+    Public Shared Widening Operator CType(x As (X1 As Integer, Y1 As Integer)) As AA
+        System.Console.WriteLine(x)	
+        return new AA()
+    End Operator
+End Structure
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="
+(1, 2)
+(3, 4)
+(5, 6)
+(7, 8)
+")
+        End Sub
+
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_03()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim t1 As (X1 as Integer, Y1 as Integer)?  = (X1:=3, Y1:=4)
+        Test(t1)
+        Dim t2 As (Integer, Integer)? = (7, 8)
+        Test(t2)
+        System.Console.WriteLine("--")	
+        t1 = Nothing
+        Test(t1)
+        t2 = Nothing
+        Test(t2)
+        System.Console.WriteLine("--")	
+    End Sub
+
+    Shared Sub Test(val As AA?)
+    End Sub
+End Class
+
+Public Structure AA
+    Public Shared Widening Operator CType(x As (X1 As Integer, Y1 As Integer)) As AA
+        System.Console.WriteLine(x)	
+        return new AA()
+    End Operator
+End Structure
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="
+(3, 4)
+(7, 8)
+--
+--
+")
+        End Sub
+
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_04()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Test(new AA())
+    End Sub
+
+    Shared Sub Test(val As (X1 As Integer, Y1 As Integer))
+        System.Console.WriteLine(val)
+    End Sub
+End Class
+
+Public Class AA
+    Public Shared Widening Operator CType(x As AA) As (Integer, Integer)
+        return (1, 2)
+    End Operator
+End Class
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="(1, 2)")
+        End Sub
+
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_05()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Test(new AA())
+    End Sub
+
+    Shared Sub Test(val As (X1 As Integer, Y1 As Integer))
+        System.Console.WriteLine(val)
+    End Sub
+End Class
+
+Public Class AA
+    Public Shared Widening Operator CType(x As AA) As (X1 As Integer, Y1 As Integer)
+        return (1, 2)
+    End Operator
+End Class
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="(1, 2)")
+        End Sub
+
+        <Fact>
+        <WorkItem(269808, "https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808")>
+        Public Sub UserDefinedConversionsAndNameMismatch_06()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Shared Sub Main()
+        Dim t1 As BB(Of (X1 as Integer, Y1 as Integer))? = New BB(Of (X1 as Integer, Y1 as Integer))()
+        Test(t1)
+        Dim t2 As BB(Of (Integer, Integer))? = New BB(Of (Integer, Integer))()
+        Test(t2)
+        System.Console.WriteLine("--")	
+        t1 = Nothing
+        Test(t1)
+        t2 = Nothing
+        Test(t2)
+        System.Console.WriteLine("--")	
+    End Sub
+
+    Shared Sub Test(val As AA?)
+    End Sub
+End Class
+
+Public Structure AA
+    Public Shared Widening Operator CType(x As BB(Of (X1 As Integer, Y1 As Integer))) As AA
+        System.Console.WriteLine("implicit operator AA")	
+        return new AA()
+    End Operator
+End Structure
+
+Public Structure BB(Of T)
+End Structure
+    </file>
+</compilation>,
+options:=TestOptions.ReleaseExe, additionalRefs:=s_valueTupleRefs)
+
+            CompileAndVerify(comp, expectedOutput:="
+implicit operator AA
+implicit operator AA
+--
+--
+")
+        End Sub
+
     End Class
 
 End Namespace


### PR DESCRIPTION
Type comparison should ignore insignificant differences like tuple name mismatch, etc.
Fixes https://devdiv.visualstudio.com/DevDiv/_workitems?id=269808.

@dotnet/roslyn-compiler, @VSadov Please review.