### PR TITLE
Skip enclosing parens in ancestors to find the when clause of a switch case

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Roslyn.Utilities;
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.CSharp
 {
@@ -388,7 +389,8 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override BoundStatement InstrumentPatternSwitchWhenClauseConditionalGotoBody(BoundExpression original, BoundStatement ifConditionGotoBody)
         {
-            WhenClauseSyntax whenClause = (WhenClauseSyntax)original.Syntax.Parent;
+            WhenClauseSyntax whenClause = original.Syntax.FirstAncestorOrSelf<WhenClauseSyntax>();
+            Debug.Assert(whenClause != null);
 
             return new BoundSequencePointWithSpan(
                 syntax: whenClause,

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DynamicAnalysisInjector.cs
@@ -233,12 +233,14 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundStatement InstrumentPatternSwitchWhenClauseConditionalGotoBody(BoundExpression original, BoundStatement ifConditionGotoBody)
         {
             ifConditionGotoBody = base.InstrumentPatternSwitchWhenClauseConditionalGotoBody(original, ifConditionGotoBody);
+            WhenClauseSyntax whenClause = original.Syntax.FirstAncestorOrSelf<WhenClauseSyntax>();
+            Debug.Assert(whenClause != null);
 
-            // Instrument the statement using a factory with the same syntax as the statement, so that the instrumentation appears to be part of the statement.
-            SyntheticBoundNodeFactory statementFactory = new SyntheticBoundNodeFactory(_method, original.Syntax, _methodBodyFactory.CompilationState, _diagnostics);
+            // Instrument the statement using a factory with the same syntax as the clause, so that the instrumentation appears to be part of the clause.
+            SyntheticBoundNodeFactory statementFactory = new SyntheticBoundNodeFactory(_method, whenClause, _methodBodyFactory.CompilationState, _diagnostics);
 
             // Instrument using the span of the expression
-            return statementFactory.StatementList(AddAnalysisPoint(original.Syntax, statementFactory), ifConditionGotoBody);
+            return statementFactory.StatementList(AddAnalysisPoint(whenClause, statementFactory), ifConditionGotoBody);
         }
 
         public override BoundStatement InstrumentUsingTargetCapture(BoundUsingStatement original, BoundStatement usingTargetCapture)

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -256,7 +256,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public virtual BoundStatement InstrumentPatternSwitchWhenClauseConditionalGotoBody(BoundExpression original, BoundStatement ifConditionGotoBody)
         {
             Debug.Assert(!original.WasCompilerGenerated);
-            Debug.Assert(original.Syntax.Parent.Kind() == SyntaxKind.WhenClause);
+            Debug.Assert(original.Syntax.FirstAncestorOrSelf<WhenClauseSyntax>() != null);
             return ifConditionGotoBody;
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/DynamicAnalysis/DynamicAnalysisResourceTests.cs
@@ -392,6 +392,8 @@ public class C
         {
             case Student s when s.GPA > 3.5:
                 return $""Student {s.Name} ({s.GPA:N1})"";
+            case Student s when (s.GPA < 2.0):
+                return $""Failing Student {s.Name} ({s.GPA:N1})"";
             case Student s:
                 return $""Student {s.Name} ({s.GPA:N1})"";
             case Teacher t:
@@ -423,12 +425,14 @@ class Student : Person { public double GPA; }
                 new SpanResult(10, 8, 10, 19, "Operate(s)"));
 
             VerifySpans(reader, reader.Methods[1], sourceLines,
-                new SpanResult(13, 4, 26, 5, "static string Operate(Person p)"),
-                new SpanResult(17, 32, 17, 43, "s.GPA > 3.5"),
+                new SpanResult(13, 4, 28, 5, "static string Operate(Person p)"),
+                new SpanResult(17, 27, 17, 43, "when s.GPA > 3.5"),
+                new SpanResult(19, 27, 19, 45, "when (s.GPA < 2.0)"),
                 new SpanResult(18, 16, 18, 56, "return $\"Student {s.Name} ({s.GPA:N1})\""),
-                new SpanResult(20, 16, 20, 56, "return $\"Student {s.Name} ({s.GPA:N1})\""),
-                new SpanResult(22, 16, 22, 58, "return $\"Teacher {t.Name} of {t.Subject}\""),
-                new SpanResult(24, 16, 24, 42, "return $\"Person {p.Name}\""),
+                new SpanResult(20, 16, 20, 64, "return $\"Failing Student {s.Name} ({s.GPA:N1})\""),
+                new SpanResult(22, 16, 22, 56, "return $\"Student {s.Name} ({s.GPA:N1})\""),
+                new SpanResult(24, 16, 24, 58, "return $\"Teacher {t.Name} of {t.Subject}\""),
+                new SpanResult(26, 16, 26, 42, "return $\"Person {p.Name}\""),
                 new SpanResult(15, 16, 15, 17, "p"));
         }
 

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternSwitchTests.cs
@@ -1674,5 +1674,44 @@ class Program
             compilation.VerifyDiagnostics();
             CompileAndVerify(compilation, expectedOutput: "12");
         }
+
+        [Fact, WorkItem(14707, "https://github.com/dotnet/roslyn/issues/14707")]
+        public void ParenthesizedGuardClause()
+        {
+            var source =
+@"class Program
+{
+    public static void Main(string[] args)
+    {
+        object[] oa = { null, new Rectangle(1, 1), new Rectangle(1, 2) };
+        foreach (object o in oa)
+        {
+            switch (o)
+            {
+                case Rectangle s when (s.Length == s.Height):
+                    System.Console.WriteLine($""S {s.Length}"");
+                    break;
+                case Rectangle r when ((true && (r.Length != r.Height))):
+                    System.Console.WriteLine($""R {r.Height} {r.Length}"");
+                    break;
+                default:
+                    System.Console.WriteLine($""other"");
+                    break;
+            }
+        }
+    }
+}
+class Rectangle
+{
+    public int Height, Length;
+    public Rectangle(int x, int y) { Height = x; Length = y; }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe);
+            compilation.VerifyDiagnostics();
+            CompileAndVerify(compilation, expectedOutput: @"other
+S 1
+R 1 2");
+        }
     }
 }


### PR DESCRIPTION
Fixes #14707
@AlekseyTs @agocke Please review
@dotnet/roslyn-compiler Additional review welcome.
@MattGertz For RC ask mode

This fixes a compiler crash when parens are used around a switch case's when clause expression.
The fix is small and focused, and therefore low risk.