### PR TITLE
Fix CodeLens test indicators for OOP

### DIFF
--- a/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
+++ b/src/Features/Core/Portable/CodeLens/CodeLensReferencesService.cs
@@ -17,7 +17,8 @@ namespace Microsoft.CodeAnalysis.CodeLens
     {
         private static readonly SymbolDisplayFormat MethodDisplayFormat =
             new SymbolDisplayFormat(
-                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces);
+                typeQualificationStyle: SymbolDisplayTypeQualificationStyle.NameAndContainingTypesAndNamespaces,
+                memberOptions: SymbolDisplayMemberOptions.IncludeContainingType);
 
         private static async Task<T> FindAsync<T>(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             Func<CodeLensFindReferencesProgress, Task<T>> onResults, Func<CodeLensFindReferencesProgress, Task<T>> onCapped,
@@ -263,17 +264,10 @@ namespace Microsoft.CodeAnalysis.CodeLens
         public async Task<string> GetFullyQualifiedName(Solution solution, DocumentId documentId, SyntaxNode syntaxNode,
             CancellationToken cancellationToken)
         {
-            var commonLocation = syntaxNode.GetLocation();
-            var doc = solution.GetDocument(commonLocation.SourceTree);
-            if (doc == null)
-            {
-                return null;
-            }
-
-            var document = solution.GetDocument(doc.Id);
+            var document = solution.GetDocument(syntaxNode.GetLocation().SourceTree);
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-            return GetEnclosingMethod(semanticModel, commonLocation)?.ToDisplayString(MethodDisplayFormat);
+            return semanticModel.GetDeclaredSymbol(syntaxNode, cancellationToken)?.ToDisplayString(MethodDisplayFormat);
         }
     }
 }


### PR DESCRIPTION
When the OOP CodeLens work was originally done, the CodeLens test indicators were generally busted due to changes in the test window infrastructure. Somewhere along the line the test indicators were fixed and re-testing of OOP shows that there are several bugs in the CodeLens service that need to be fixed to keep the test indicators working when we move to OOP.

Specifically, we were incorrectly looking for the containing method when we should have just been using the method given to us, and we need to fully qualify the name.

@srivatsn @MattGertz 