### PR TITLE
Add pre-requisites section to vsix manifests

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -45,6 +45,9 @@ call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15.project.json"
 echo Restoring packages: Toolsets (Dev15 VS SDK 'Willow' build tools)
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15Willow.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 
+echo Restoring packages: Toolsets (Dev15 VS SDK RC build tools)
+call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15rc.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
+
 echo Restoring packages: Roslyn SDK
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\roslynsdk.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -137,6 +137,8 @@
     <IsVSBeforeDev15Preview4 Condition="'$(OS)' == 'Windows_NT' AND '$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
     <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
     <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
+    <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\..\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>
+    <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\..\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>
   </PropertyGroup>
 
   <Choose>
@@ -148,10 +150,15 @@
           </PropertyGroup>
         </When>
 
+        <When Condition="'$(IsDev15RC)' == 'true'">
+          <PropertyGroup>
+            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath>
+          </PropertyGroup>
+        </When>
+
         <Otherwise>
           <PropertyGroup>
-            <!-- TODO: Detect Preview 4/5 versus RC -->
-            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath>
+            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
           </PropertyGroup>
         </Otherwise>
       </Choose>

--- a/build/Targets/Settings.targets
+++ b/build/Targets/Settings.targets
@@ -150,7 +150,8 @@
 
         <Otherwise>
           <PropertyGroup>
-            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25604-Preview4</VisualStudioBuildToolsNuGetPackagePath>
+            <!-- TODO: Detect Preview 4/5 versus RC -->
+            <VisualStudioBuildToolsNuGetPackagePath>$(NuGetPackageRoot)\Microsoft.VSSDK.BuildTools\15.0.25825-RC</VisualStudioBuildToolsNuGetPackagePath>
           </PropertyGroup>
         </Otherwise>
       </Choose>

--- a/build/ToolsetPackages/dev15rc.project.json
+++ b/build/ToolsetPackages/dev15rc.project.json
@@ -1,0 +1,9 @@
+{
+    "dependencies": {
+        "Microsoft.VSSDK.BuildTools": "15.0.25825-RC"
+    },
+    "frameworks": {
+        "net46": {}
+    }
+}
+

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -112,7 +112,7 @@ if defined TestPerfRun (
 REM Temporarily forcing MSBuild 14.0 here to work around a bug in 15.0
 REM MSBuild bug: https://github.com/Microsoft/msbuild/issues/1183
 REM Roslyn tracking bug: https://github.com/dotnet/roslyn/issues/14451
-"c:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe" %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath="%bindir%\Bootstrap" BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /p:TestVsi=%TestVsi% /p:RunProcessWatchdog=%RunProcessWatchdog% /p:BuildStartTime=%BuildStartTime% /p:"ProcDumpExe=%ProcDumpExe%" /p:BuildTimeLimit=%BuildTimeLimit% /p:PathMap="%RoslynRoot%=q:\roslyn" /p:Feature=pdb-path-determinism /fileloggerparameters:LogFile="%bindir%\Build.log";verbosity=diagnostic || goto :BuildFailed
+"c:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe" %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath="%bindir%\Bootstrap" BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /p:TestVsi=%TestVsi% /p:RunProcessWatchdog=%RunProcessWatchdog% /p:BuildStartTime=%BuildStartTime% /p:"ProcDumpExe=%ProcDumpExe%" /p:BuildTimeLimit=%BuildTimeLimit% /p:PathMap="%RoslynRoot%=q:\roslyn" /p:Feature=pdb-path-determinism /fileloggerparameters:LogFile="%bindir%\Build.log";verbosity=diagnostic /p:DeployExtension=false || goto :BuildFailed
 powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\check-msbuild.ps1" "%bindir%\Build.log" || goto :BuildFailed
 
 call :TerminateBuildProcesses

--- a/src/Compilers/Extension/source.extension.vsixmanifest
+++ b/src/Compilers/Extension/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -47,4 +47,7 @@
                  Location="|ExpressionEvaluatorPackage;VSIXContainerProjectOutputGroup|" 
                  Id="|ExpressionEvaluatorPackage;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
+++ b/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
@@ -32,4 +32,7 @@
     <Asset Type="DebuggerEngineExtension" d:Source="Project" d:ProjectName="CSharpResultProvider.Portable" Path="|CSharpResultProvider.Portable;VsdConfigOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CSharpAnalyzers" Path="|CSharpAnalyzers|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="CSharpAnalyzers" Path="|CSharpAnalyzers|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ConvertToAutoProperty/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ConvertToAutoProperty/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ConvertToAutoPropertyCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ConvertToConditional/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ConvertToConditional/Impl/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/CopyPasteWithUsing/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/CopyPasteWithUsing/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ImplementNotifyPropertyChangedCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
@@ -38,4 +38,7 @@ governing permissions and limitations under the License.
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstCS.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/RefOutModifier/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/RefOutModifier/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="BasicAnalyzers" Path="|BasicAnalyzers|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="BasicAnalyzers" Path="|BasicAnalyzers|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ConvertToAutoPropertyVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ImplementNotifyPropertyChangedVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
@@ -38,4 +38,7 @@ governing permissions and limitations under the License.
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstVB.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/RemoveByVal/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/RemoveByVal/Impl/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Deployment/Current/source.extension.vsixmanifest
+++ b/src/Setup/Deployment/Current/source.extension.vsixmanifest
@@ -56,4 +56,7 @@
                  Location="|VisualStudioDiagnosticsWindow;VSIXContainerProjectOutputGroup|"
                  Id="|VisualStudioDiagnosticsWindow;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Deployment/Next/source.extension.vsixmanifest
+++ b/src/Setup/Deployment/Next/source.extension.vsixmanifest
@@ -65,4 +65,7 @@
                  Location="|VisualStudioDiagnosticsWindow;VSIXContainerProjectOutputGroup|"
                  Id="|VisualStudioDiagnosticsWindow;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/Diagnostic/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/Diagnostic/Vsix/source.extension.vsixmanifest
@@ -15,4 +15,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/source.extension.vsixmanifest
@@ -15,4 +15,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/source.extension.vsixmanifest
+++ b/src/Setup/Templates/source.extension.vsixmanifest
@@ -30,4 +30,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="SyntaxVisualizerExtension" Path="|SyntaxVisualizerExtension;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Tools/MicroBuild/Build.proj
+++ b/src/Tools/MicroBuild/Build.proj
@@ -22,14 +22,14 @@
   <Target Name="Build">
     <Exec Command="Restore.cmd /clean" WorkingDirectory="$(ProjectDir)" Condition="'$(SkipRestore)' != 'true'" />
 
-    <MSBuild Projects="$(ProjectDir)Roslyn.sln" BuildInParallel="true" />
+    <MSBuild Projects="$(ProjectDir)Roslyn.sln" BuildInParallel="true" Properties="DeployExtension=false" />
     <MSBuild Projects="$(ProjectDir)src\Dependencies\Dependencies.sln" BuildInParallel="true" />
-    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep1.proj" />
+    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep1.proj" Properties="DeployExtension=false" />
 
     <MSBuild Projects="$(MSBuildThisFileDirectory)RunSignTool.proj" Properties="SignRoslynArgs=$(SignRoslynArgs)" />
 
     <MSBuild Projects="$(ProjectDir)src\NuGet\NuGet.proj" />
-    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties)" />
+    <MSBuild Projects="$(ProjectDir)src\Setup\SetupStep2.proj" Properties="$(SetupStep2Properties);DeployExtension=false" />
 
     <MSBuild Projects="$(ProjectDir)BuildAndTest.proj" Targets="Test" Condition="'$(SkipTest)' != 'true'" />
 

--- a/src/Tools/RepoUtil/RepoData.json
+++ b/src/Tools/RepoUtil/RepoData.json
@@ -1,7 +1,7 @@
 ﻿{
     "fixedPackages": {
         "Microsoft.VisualStudio.Language.Intellisense": "14.3.25407",
-        "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25604-Preview4" ],
+        "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25201-dev15preview2","15.0.25604-Preview4", "15.0.25825-RC" ],
         "System.Reflection.Metadata": "1.0.21",
         "System.Collections.Immutable": "1.1.36",
         "Microsoft.VisualStudio.Editor": [ "14.3.25407", "15.0.25604-Preview4" ],

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/source.extension.vsixmanifest
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/source.extension.vsixmanifest
@@ -19,4 +19,7 @@
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
 	</Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/RemoteHostClientMock/source.extension.vsixmanifest
+++ b/src/VisualStudio/RemoteHostClientMock/source.extension.vsixmanifest
@@ -17,4 +17,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
@@ -33,4 +33,7 @@
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="codeAnalysisService.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="remoteSymbolSearchUpdateEngine.servicehub.service.json" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -71,4 +71,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/TestSetup/source.extension.vsixmanifest
+++ b/src/VisualStudio/TestSetup/source.extension.vsixmanifest
@@ -20,4 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Hosting.Diagnostics.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
@@ -19,4 +19,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
@@ -39,4 +39,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CSharpVisualStudioRepl" Path="|CSharpVisualStudioRepl|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Note that this breaks the ability to build with earlier preview 5 builds, and possibly the ability of the build tools to install the extension on Dev14 machines.