### PR TITLE
Handle IWorkspaceProjectContext creation requests with broken BinTarg…

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CSharpHelpers.cs
@@ -44,9 +44,21 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim
         public static CPSProject CreateCSharpCPSProject(TestEnvironment environment, string projectName, Guid projectGuid, params string[] commandLineArguments)
         {
             var projectFilePath = Path.GetTempPath();
-            var hierarchy = environment.CreateHierarchy(projectName, projectFilePath, "CSharp");
             var binOutputPath = GetOutputPathFromArguments(commandLineArguments) ?? Path.Combine(projectFilePath, projectName + ".dll");
 
+            return CreateCSharpCPSProject(environment, projectName, projectFilePath, binOutputPath, projectGuid, commandLineArguments);
+        }
+
+        public static CPSProject CreateCSharpCPSProject(TestEnvironment environment, string projectName, string binOutputPath, params string[] commandLineArguments)
+        {
+            var projectFilePath = Path.GetTempPath();
+            return CreateCSharpCPSProject(environment, projectName, projectFilePath, binOutputPath, projectGuid: Guid.NewGuid(), commandLineArguments: commandLineArguments);
+        }
+
+        public static CPSProject CreateCSharpCPSProject(TestEnvironment environment, string projectName, string projectFilePath, string binOutputPath, Guid projectGuid, params string[] commandLineArguments)
+        {
+            var hierarchy = environment.CreateHierarchy(projectName, projectFilePath, "CSharp");
+            
             var cpsProject = CPSProjectFactory.CreateCPSProject(
                 environment.ProjectTracker,
                 environment.ServiceProvider,

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
@@ -40,9 +40,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 else if (!PathUtilities.IsAbsolute(binOutputPath))
                 {
                     // Make it a rooted path.
-                    var basePath = !string.IsNullOrEmpty(projectFilePath) && Path.IsPathRooted(projectFilePath) ?
-                        PathUtilities.GetDirectoryName(projectFilePath) :
-                        Path.GetTempPath();
+                    var basePath = PathUtilities.IsAbsolute(projectFilePath) ? PathUtilities.GetDirectoryName(projectFilePath) : Path.GetTempPath();
                     binOutputPath = PathUtilities.CombineAbsoluteAndRelativePaths(basePath, binOutputPath);
                 }
             }

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
@@ -39,7 +39,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 else if (!Path.IsPathRooted(binOutputPath))
                 {
                     // Make it a rooted path.
-                    binOutputPath = Path.Combine(Path.GetTempPath(), binOutputPath);
+                    var basePath = !string.IsNullOrEmpty(projectFilePath) && Path.IsPathRooted(projectFilePath) ?
+                        Path.GetDirectoryName(projectFilePath) :
+                        Path.GetTempPath();
+                    binOutputPath = Path.Combine(basePath, binOutputPath);
                 }
             }
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using System.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
@@ -27,6 +28,21 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             : base(projectTracker, reportExternalErrorCreatorOpt, projectDisplayName, projectFilePath,
                    hierarchy, language, projectGuid, serviceProvider, visualStudioWorkspaceOpt, hostDiagnosticUpdateSourceOpt, commandLineParserServiceOpt)
         {
+            if (binOutputPath != null)
+            {
+                // Ensure that binOutputPath is either null or a rooted path.
+                // CPS might provide such invalid paths during initialization or when project is in unrestored state.
+                if (binOutputPath == String.Empty)
+                {
+                    binOutputPath = null;
+                }
+                else if (!Path.IsPathRooted(binOutputPath))
+                {
+                    // Make it a rooted path.
+                    binOutputPath = Path.Combine(Path.GetTempPath(), binOutputPath);
+                }
+            }
+
             // We need to ensure that the bin output path for the project has been initialized before we hookup the project with the project tracker.
             SetBinOutputPathAndRelatedData(binOutputPath);
 

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.Host;
 using Microsoft.VisualStudio.LanguageServices.Implementation.TaskList;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.CPS
 {
@@ -36,13 +37,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
                 {
                     binOutputPath = null;
                 }
-                else if (!Path.IsPathRooted(binOutputPath))
+                else if (!PathUtilities.IsAbsolute(binOutputPath))
                 {
                     // Make it a rooted path.
                     var basePath = !string.IsNullOrEmpty(projectFilePath) && Path.IsPathRooted(projectFilePath) ?
-                        Path.GetDirectoryName(projectFilePath) :
+                        PathUtilities.GetDirectoryName(projectFilePath) :
                         Path.GetTempPath();
-                    binOutputPath = Path.Combine(basePath, binOutputPath);
+                    binOutputPath = PathUtilities.CombineAbsoluteAndRelativePaths(basePath, binOutputPath);
                 }
             }
 


### PR DESCRIPTION
…etPath

CPS might provide such invalid paths during initialization or when project is in unrestored state. Now we handle these cases to ensure that BinOutputPath is either null or a rooted path.

Fixes #14520