### PR TITLE
Fix root path being truncated when formatting errors

### DIFF
--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineDiagnosticFormatter.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineDiagnosticFormatter.cs
@@ -66,7 +66,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             var directory = PathUtilities.GetDirectoryName(normalizedPath);
             if (string.Compare(directory, 0, normalizedBaseDirectory, 0, normalizedBaseDirectory.Length, StringComparison.OrdinalIgnoreCase) == 0)
             {
-                return normalizedPath.Substring(normalizedBaseDirectory.Length + 1);
+                return PathUtilities.IsDirectorySeparator(normalizedBaseDirectory.Last())
+                    ? normalizedPath.Substring(normalizedBaseDirectory.Length)
+                    : normalizedPath.Substring(normalizedBaseDirectory.Length + 1);
             }
 
             return normalizedPath;

--- a/src/Compilers/CSharp/Portable/CommandLine/CommandLineDiagnosticFormatter.cs
+++ b/src/Compilers/CSharp/Portable/CommandLine/CommandLineDiagnosticFormatter.cs
@@ -63,12 +63,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                 return normalizedPath;
             }
 
-            var directory = PathUtilities.GetDirectoryName(normalizedPath);
-            if (string.Compare(directory, 0, normalizedBaseDirectory, 0, normalizedBaseDirectory.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            var normalizedDirectory = PathUtilities.GetDirectoryName(normalizedPath);
+            if (PathUtilities.IsSameDirectoryOrChildOf(normalizedDirectory, normalizedBaseDirectory))
             {
-                return PathUtilities.IsDirectorySeparator(normalizedBaseDirectory.Last())
-                    ? normalizedPath.Substring(normalizedBaseDirectory.Length)
-                    : normalizedPath.Substring(normalizedBaseDirectory.Length + 1);
+                return normalizedPath.Substring(
+                    PathUtilities.IsDirectorySeparator(normalizedBaseDirectory.Last())
+                        ? normalizedBaseDirectory.Length
+                        : normalizedBaseDirectory.Length + 1);
             }
 
             return normalizedPath;

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineDiagnosticFormatterTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineDiagnosticFormatterTests.cs
@@ -28,5 +28,17 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
             Assert.Equal(@"temp\a.cs", formatter.RelativizeNormalizedPath(@"X:\rootdir\dir\temp\a.cs"));
             Assert.Equal(@"Y:\rootdir\dir\a.cs", formatter.RelativizeNormalizedPath(@"Y:\rootdir\dir\a.cs"));
         }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(14725, "https://github.com/dotnet/roslyn/issues/14725")]
+        public void RelativizeNormalizedPathShouldHandleRootPaths()
+        {
+            var formatter = new CommandLineDiagnosticFormatter(
+                baseDirectory: @"C:\",
+                displayFullPaths: false,
+                displayEndLocations: false);
+
+            Assert.Equal(@"temp.cs", formatter.RelativizeNormalizedPath(@"c:\temp.cs"));
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/CommandLine/CommandLineDiagnosticFormatterTests.cs
+++ b/src/Compilers/CSharp/Test/CommandLine/CommandLineDiagnosticFormatterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
 
         [ConditionalFact(typeof(WindowsOnly))]
         [WorkItem(14725, "https://github.com/dotnet/roslyn/issues/14725")]
-        public void RelativizeNormalizedPathShouldHandleRootPaths()
+        public void RelativizeNormalizedPathShouldHandleRootPaths_1()
         {
             var formatter = new CommandLineDiagnosticFormatter(
                 baseDirectory: @"C:\",
@@ -39,6 +39,42 @@ namespace Microsoft.CodeAnalysis.CSharp.CommandLine.UnitTests
                 displayEndLocations: false);
 
             Assert.Equal(@"temp.cs", formatter.RelativizeNormalizedPath(@"c:\temp.cs"));
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(14725, "https://github.com/dotnet/roslyn/issues/14725")]
+        public void RelativizeNormalizedPathShouldHandleRootPaths_2()
+        {
+            var formatter = new CommandLineDiagnosticFormatter(
+                baseDirectory: @"C:\A\B",
+                displayFullPaths: false,
+                displayEndLocations: false);
+
+            Assert.Equal(@"C\D\temp.cs", formatter.RelativizeNormalizedPath(@"c:\A\B\C\D\temp.cs"));
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(14725, "https://github.com/dotnet/roslyn/issues/14725")]
+        public void RelativizeNormalizedPathShouldHandleDirectoriesWithSamePrefix_1()
+        {
+            var formatter = new CommandLineDiagnosticFormatter(
+                baseDirectory: @"C:\AB",
+                displayFullPaths: false,
+                displayEndLocations: false);
+
+            Assert.Equal(@"c:\ABCD\file.cs", formatter.RelativizeNormalizedPath(@"c:\ABCD\file.cs"));
+        }
+
+        [ConditionalFact(typeof(WindowsOnly))]
+        [WorkItem(14725, "https://github.com/dotnet/roslyn/issues/14725")]
+        public void RelativizeNormalizedPathShouldHandleDirectoriesWithSamePrefix_2()
+        {
+            var formatter = new CommandLineDiagnosticFormatter(
+                baseDirectory: @"C:\ABCD",
+                displayFullPaths: false,
+                displayEndLocations: false);
+
+            Assert.Equal(@"c:\AB\file.cs", formatter.RelativizeNormalizedPath(@"c:\AB\file.cs"));
         }
     }
 }

--- a/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/FileSystem/PathUtilitiesTests.cs
@@ -258,5 +258,42 @@ namespace Microsoft.CodeAnalysis.UnitTests.FileSystem
             Assert.False(
                 PathUtilities.ContainsPathComponent(@"c:\Package\temp", "packages", ignoreCase: false));
         }
+
+        [Fact]
+        public void IsSameDirectoryOrChildOfHandlesDifferentSlashes()
+        {
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:", @"C:\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH", @"C:\ABCD\EFGH\"));
+
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH"));
+            Assert.Equal(true, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCD\EFGH\", @"C:\ABCD\EFGH\"));
+        }
+
+        [Fact]
+        public void IsSameDirectoryOrChildOfNegativeTests()
+        {
+            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\", @"C:\ABCD"));
+            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABC", @"C:\ABCD"));
+            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\ABCDE", @"C:\ABCD"));
+
+            Assert.Equal(false, PathUtilities.IsSameDirectoryOrChildOf(@"C:\A\B\C", @"C:\A\B\C\D"));
+        }
     }
 }

--- a/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
+++ b/src/Compilers/Core/Portable/FileSystem/PathUtilities.cs
@@ -107,6 +107,25 @@ namespace Roslyn.Utilities
             return null;
         }
 
+        internal static bool IsSameDirectoryOrChildOf(string child, string parent)
+        {
+            parent = RemoveTrailingDirectorySeparator(parent);
+
+            while (child != null)
+            {
+                child = RemoveTrailingDirectorySeparator(child);
+
+                if (child.Equals(parent, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+
+                child = GetDirectoryName(child);
+            }
+
+            return false;
+        }
+
         public static string GetPathRoot(string path)
         {
             return GetPathRoot(path, IsUnixLikePlatform);


### PR DESCRIPTION
Fixes #14725 
@dotnet/roslyn-compiler 
