### PR TITLE
Ensures cached lambda has matching return type for UnboundLambda binding

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -427,10 +427,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol cacheKey = GetCacheKey(delegateType);
 
             BoundLambda returnInferenceLambda;
-            if (_returnInferenceCache.TryGetValue(cacheKey, out returnInferenceLambda) && returnInferenceLambda.InferredFromSingleType)
+            if (_returnInferenceCache.TryGetValue(cacheKey, out returnInferenceLambda) && returnInferenceLambda.InferredFromSingleType && returnInferenceLambda.Symbol.ReturnType == returnType)
             {
                 lambdaSymbol = returnInferenceLambda.Symbol;
-                Debug.Assert(lambdaSymbol.ReturnType == returnType);
                 Debug.Assert(lambdaSymbol.RefKind == refKind);
 
                 lambdaBodyBinder = returnInferenceLambda.Binder;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -486,6 +486,47 @@ class Program : TestBase
         }
 
         [Fact]
+        public void ConversionAppliedInLambdaForNonMatchingTypes()
+        {
+            var program = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConsoleApplication2
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var invoices = new List<Invoice>().AsQueryable();
+            var oneTimeCharges = new List<OneTimeCharge>().AsQueryable();
+            var otcCharges = invoices.Join(oneTimeCharges, inv => inv.InvoiceId, otc => otc.Invoice, (inv, otc) => inv.InvoiceId);
+            Console.Write('k');
+        }        
+    }
+
+    public class OneTimeCharge
+    {
+        public int OneTimeChargeId { get; set; }
+        public int? Invoice { get; set; }
+    }
+
+    public class Invoice
+    {
+        public int InvoiceId { get; set; }
+    }    
+}
+";
+
+            CompileAndVerify(
+                sources: new string[] { program, ExpressionTestLibrary },
+                additionalRefs: new[] { ExpressionAssemblyRef },
+                expectedOutput: @"k")
+                .VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Addition()
         {
             var source =


### PR DESCRIPTION
Cached lambdas were being used in situations where the return type was different. This forces building a new lambda body and binding for those cases.

Honestly I'm not 100% sure if this issue is the use of the cached value, or if the caching itself needs to be tweaked. This broke in commit 6c9e18649f576bd9df1e0db8ad21bfbce0454704 by @cston which touched quite a bit in this area so tracking down the precise issue might be beyond me. 

This would resolve #14722