### PR TITLE
Don't crash if you rename a file and change or remove the extension

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MiscellaneousFilesWorkspace.cs
@@ -239,8 +239,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
                 else
                 {
-                    // We should now claim this
-                    AttachToDocument(docCookie, moniker);
+                    // We should now try to claim this. The moniker we have here is the moniker after the rename if we're currently processing
+                    // a rename. It's possible in that case that this is being closed by the other workspace due to that rename. If the rename
+                    // is changing or removing the file extension, we wouldn't want to try attaching, which is why we have to re-check
+                    // the moniker. Once we observe the rename later in OnAfterAttributeChangeEx we'll completely disconnect.
+                    if (TryGetLanguageInformation(moniker) != null)
+                    {
+                        AttachToDocument(docCookie, moniker);
+                    }
                 }
             }
             else if (IsClaimedByAnotherWorkspace(workspaceRegistration))


### PR DESCRIPTION
If you use Solution Explorer to rename a file and the extension were to change or get deleted, we might crash. That's really bad, and we shouldn't do that.

The problem was another fun example where different systems might see the rename first: if the document provider saw the RDT rename first, it'd close a document that the MiscellaneousFilesWorkspace was tracking. However, it saw things after the rename and in one place but hadn't seen the rename yet from the RDT.

*Review:* @dotnet/roslyn-ide