### PR TITLE
Ensures cached lambda has matching return type

### DIFF
--- a/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/UnboundLambda.cs
@@ -427,10 +427,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             MethodSymbol cacheKey = GetCacheKey(delegateType);
 
             BoundLambda returnInferenceLambda;
-            if (_returnInferenceCache.TryGetValue(cacheKey, out returnInferenceLambda) && returnInferenceLambda.InferredFromSingleType)
+            if (_returnInferenceCache.TryGetValue(cacheKey, out returnInferenceLambda) && returnInferenceLambda.InferredFromSingleType && returnInferenceLambda.Symbol.ReturnType == returnType)
             {
                 lambdaSymbol = returnInferenceLambda.Symbol;
-                Debug.Assert(lambdaSymbol.ReturnType == returnType);
                 Debug.Assert(lambdaSymbol.RefKind == refKind);
 
                 lambdaBodyBinder = returnInferenceLambda.Binder;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenExprLambdaTests.cs
@@ -486,6 +486,47 @@ class Program : TestBase
         }
 
         [Fact]
+        public void ConversionAppliedInLambdaForNonMatchingTypes()
+        {
+            var program = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ConsoleApplication2
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var invoices = new List<Invoice>().AsQueryable();
+            var oneTimeCharges = new List<OneTimeCharge>().AsQueryable();
+            var otcCharges = invoices.Join(oneTimeCharges, inv => inv.InvoiceId, otc => otc.Invoice, (inv, otc) => inv.InvoiceId);
+            Console.Write('k');
+        }        
+    }
+
+    public class OneTimeCharge
+    {
+        public int OneTimeChargeId { get; set; }
+        public int? Invoice { get; set; }
+    }
+
+    public class Invoice
+    {
+        public int InvoiceId { get; set; }
+    }    
+}
+";
+
+            CompileAndVerify(
+                sources: new string[] { program, ExpressionTestLibrary },
+                additionalRefs: new[] { ExpressionAssemblyRef },
+                expectedOutput: @"k")
+                .VerifyDiagnostics();
+        }
+
+        [Fact]
         public void Addition()
         {
             var source =


### PR DESCRIPTION
[Merging 55d5c69d876ab25c3221f67bdf23cacebae26df8 from @enkafan in `master`]

Cached lambdas were being used in situations where the return type was
different. This forces building a new lambda body and binding for those
cases.

