### PR TITLE
Mark default parameters of operators as non-bound

### DIFF
--- a/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Binding/BinderFactory.vb
@@ -387,8 +387,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                                  SyntaxKind.GetAccessorStatement,
                                  SyntaxKind.AddHandlerAccessorStatement,
                                  SyntaxKind.RemoveHandlerAccessorStatement,
-                                 SyntaxKind.RaiseEventAccessorStatement
-                                ' Default values are not valid (and not bound) for lambda parameters or property accessors
+                                 SyntaxKind.RaiseEventAccessorStatement,
+                                 SyntaxKind.OperatorStatement
+                                ' Default values are not valid (and not bound) for these types of statements
                                 Return Nothing
 
                             Case Else


### PR DESCRIPTION
Fixes #14688 
@dotnet/roslyn-compiler 
@dotnet/roslyn-ide 
Tagging IDE because it is originally a crash in the ClassificationService.
