### PR TITLE
Strip off underscores when generating constructors from fields.

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -202,5 +202,24 @@ index: 0,
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }
+
+        [WorkItem(14219, "https://github.com/dotnet/roslyn/issues/14219")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        public async Task TestUnderscoreInName1()
+        {
+            await TestAsync(
+@"class Program { [|int _field ;|] } ",
+@"class Program { int _field ; public Program ( int field ) { _field = field ; } } ");
+        }
+
+        [WorkItem(14219, "https://github.com/dotnet/roslyn/issues/14219")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        public async Task TestUnderscoreInName_PreferThis()
+        {
+            await TestAsync(
+@"class Program { [|int _field ;|] } ",
+@"class Program { int _field ; public Program ( int field ) { this._field = field ; } } ",
+options: Option(CodeStyleOptions.QualifyFieldAccess, CodeStyleOptions.TrueWithSuggestionEnforcement));
+        }
     }
 }

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -97,11 +97,13 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
                     refKind: RefKind.None,
                     isParams: false,
                     type: type,
-                    name: symbol.Name.ToCamelCase()));
+                    name: symbol.Name.ToCamelCase().TrimStart(s_underscore)));
             }
 
             return parameters;
         }
+
+        private static readonly char[] s_underscore = { '_' };
 
         protected IMethodSymbol GetDelegatedConstructor(
             INamedTypeSymbol containingType,

--- a/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
+++ b/src/Workspaces/CSharp/Portable/Extensions/SemanticModelExtensions.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions
                 arguments.Select(a => a.NameColon != null)).ToList();
 
             var parameterNames = reservedNames.Concat(
-                arguments.Select(a => semanticModel.GenerateNameForArgument(a))).ToList();
+                arguments.Select(semanticModel.GenerateNameForArgument)).ToList();
 
             return GenerateNames(reservedNames, isFixed, parameterNames);
         }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/ICodeDefinitionFactoryExtensions.cs
@@ -197,9 +197,10 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                     if (TryGetValue(parameterToExistingFieldMap, parameterName, out fieldName) ||
                         TryGetValue(parameterToNewFieldMap, parameterName, out fieldName))
                     {
+                        var fieldAccess = factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(fieldName))
+                                                 .WithAdditionalAnnotations(Simplifier.Annotation);
                         var assignExpression = factory.AssignmentStatement(
-                            factory.MemberAccessExpression(factory.ThisExpression(), factory.IdentifierName(fieldName)),
-                            factory.IdentifierName(parameterName));
+                            fieldAccess, factory.IdentifierName(parameterName));
                         var statement = factory.ExpressionStatement(assignExpression);
                         yield return statement;
                     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14219