### PR TITLE
Add a hidden sequence point around the code that assigns pattern variables in switch

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/CompoundInstrumenter.cs
@@ -208,6 +208,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return Previous.InstrumentSwitchStatementExpression(original, rewrittenExpression, factory);
         }
 
+        public override BoundStatement InstrumentPatternSwitchBindCasePatternVariables(BoundStatement bindings)
+        {
+            return Previous.InstrumentPatternSwitchBindCasePatternVariables(bindings);
+        }
+
         public override BoundStatement InstrumentForEachStatementDeconstructionVariablesDeclaration(BoundForEachStatement original, BoundStatement iterationVarDecl)
         {
             return Previous.InstrumentForEachStatementDeconstructionVariablesDeclaration(original, iterationVarDecl);

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -431,5 +431,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return AddConditionSequencePoint(base.InstrumentSwitchStatementExpression(original, rewrittenExpression, factory), original.Syntax, factory);
         }
 
+        public override BoundStatement InstrumentPatternSwitchBindCasePatternVariables(BoundStatement bindings)
+        {
+            // Mark the code that binds pattern variables to their values as hidden.
+            // We do it to tell that this is not a part of previous statement.
+            return new BoundSequencePoint(null, base.InstrumentPatternSwitchBindCasePatternVariables(bindings));
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/Instrumenter.cs
@@ -298,5 +298,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             Debug.Assert(factory != null);
             return rewrittenExpression;
         }
+
+        public virtual BoundStatement InstrumentPatternSwitchBindCasePatternVariables(BoundStatement bindings)
+        {
+            return bindings;
+        }
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/PDB/PDBTests.cs
@@ -2305,9 +2305,12 @@ class Student : Person { public double GPA; }
         <entry offset=""0x0"" startLine=""19"" startColumn=""5"" endLine=""19"" endColumn=""6"" />
         <entry offset=""0x1"" startLine=""20"" startColumn=""9"" endLine=""20"" endColumn=""19"" />
         <entry offset=""0x4"" hidden=""true"" />
+        <entry offset=""0x32"" hidden=""true"" />
         <entry offset=""0x35"" startLine=""22"" startColumn=""28"" endLine=""22"" endColumn=""44"" />
         <entry offset=""0x49"" startLine=""23"" startColumn=""17"" endLine=""23"" endColumn=""57"" />
+        <entry offset=""0x6a"" hidden=""true"" />
         <entry offset=""0x6f"" startLine=""25"" startColumn=""17"" endLine=""25"" endColumn=""57"" />
+        <entry offset=""0x90"" hidden=""true"" />
         <entry offset=""0x95"" startLine=""27"" startColumn=""17"" endLine=""27"" endColumn=""59"" />
         <entry offset=""0xb1"" startLine=""29"" startColumn=""17"" endLine=""29"" endColumn=""43"" />
         <entry offset=""0xc5"" startLine=""31"" startColumn=""5"" endLine=""31"" endColumn=""6"" />


### PR DESCRIPTION
Fixes #14740

@AlekseyTs @agocke Please review. Hoping to get these reviewed and integrated by 6pm for RC
@dotnet/roslyn-compiler Additional reviews welcome
@MattGertz For ask mode