### PR TITLE
added parse option to vb compilation option

### DIFF
--- a/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/VisualBasic/Portable/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.NamedTupleElement = 791 -> Microso
 Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.TupleExpression = 788 -> Microsoft.CodeAnalysis.VisualBasic.SyntaxKind
 Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.TupleType = 789 -> Microsoft.CodeAnalysis.VisualBasic.SyntaxKind
 Microsoft.CodeAnalysis.VisualBasic.SyntaxKind.TypedTupleElement = 790 -> Microsoft.CodeAnalysis.VisualBasic.SyntaxKind
+Microsoft.CodeAnalysis.VisualBasic.VisualBasicCompilationOptions.ParseOptions() -> Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.New(languageVersion As Microsoft.CodeAnalysis.VisualBasic.LanguageVersion = Microsoft.CodeAnalysis.VisualBasic.LanguageVersion.Default, documentationMode As Microsoft.CodeAnalysis.DocumentationMode = Microsoft.CodeAnalysis.DocumentationMode.Parse, kind As Microsoft.CodeAnalysis.SourceCodeKind = Microsoft.CodeAnalysis.SourceCodeKind.Regular, preprocessorSymbols As System.Collections.Generic.IEnumerable(Of System.Collections.Generic.KeyValuePair(Of String, Object)) = Nothing) -> Void
 Microsoft.CodeAnalysis.VisualBasic.VisualBasicParseOptions.SpecifiedLanguageVersion() -> Microsoft.CodeAnalysis.VisualBasic.LanguageVersion
 Overridable Microsoft.CodeAnalysis.VisualBasic.VisualBasicSyntaxVisitor(Of TResult).VisitNamedTupleElement(node As Microsoft.CodeAnalysis.VisualBasic.Syntax.NamedTupleElementSyntax) -> TResult

--- a/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
+++ b/src/Compilers/VisualBasic/Portable/VisualBasicCompilationOptions.vb
@@ -368,7 +368,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         ''' Compilation level parse options.  Used when compiling synthetic embedded code such as My template
         ''' </summary>
         ''' <returns>The Parse Options Setting.</returns>
-        Friend ReadOnly Property ParseOptions As VisualBasicParseOptions
+        Public ReadOnly Property ParseOptions As VisualBasicParseOptions
             Get
                 Return _parseOptions
             End Get

--- a/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
+++ b/src/Workspaces/CoreTest/Execution/SnapshotSerializationTests.cs
@@ -440,6 +440,18 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.NotEqual(metadata, analyzer);
         }
 
+        [Fact]
+        public async Task VBParseOptionsInCompilationOptions()
+        {
+            var project = new AdhocWorkspace().CurrentSolution.AddProject("empty", "empty", LanguageNames.VisualBasic);
+            project = project.WithCompilationOptions(
+                ((VisualBasic.VisualBasicCompilationOptions)project.CompilationOptions).WithParseOptions((VisualBasic.VisualBasicParseOptions)project.ParseOptions));
+
+            var checksum = await project.State.GetChecksumAsync(CancellationToken.None).ConfigureAwait(false);
+
+            Assert.NotNull(checksum);
+        }
+
         private static async Task VerifyOptionSetsAsync(Workspace workspace, string language)
         {
             var assetBuilder = new CustomAssetBuilder(workspace.CurrentSolution);

--- a/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
+++ b/src/Workspaces/VisualBasic/Portable/Execution/VisualBasicOptionsSerializationService.vb
@@ -24,6 +24,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             writer.WriteBoolean(vbOptions.OptionExplicit)
             writer.WriteBoolean(vbOptions.OptionCompareText)
             writer.WriteBoolean(vbOptions.EmbedVbCoreRuntime)
+
+            ' save parse option for embeded types - My types
+            writer.WriteBoolean(vbOptions.ParseOptions IsNot Nothing)
+            If vbOptions.ParseOptions IsNot Nothing Then
+                WriteTo(vbOptions.ParseOptions, writer, cancellationToken)
+            End If
         End Sub
 
         Public Overrides Sub WriteTo(options As ParseOptions, writer As ObjectWriter, cancellationToken As CancellationToken)
@@ -85,9 +91,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Execution
             Dim optionCompareText = reader.ReadBoolean()
             Dim embedVbCoreRuntime = reader.ReadBoolean()
 
+            Dim hasParseOptions = reader.ReadBoolean()
+            Dim parseOption = If(hasParseOptions, DirectCast(ReadParseOptionsFrom(reader, cancellationToken), VisualBasicParseOptions), Nothing)
+
             Return New VisualBasicCompilationOptions(outputKind, moduleName, mainTypeName, scriptClassName,
                                                      globalImports, rootNamespace, optionStrict, optionInfer, optionExplicit,
-                                                     optionCompareText, Nothing,
+                                                     optionCompareText, parseOption,
                                                      embedVbCoreRuntime, optimizationLevel, checkOverflow,
                                                      cryptoKeyContainer, cryptoKeyFile, cryptoPublicKey, delaySign,
                                                      platform, generalDiagnosticOption, specificDiagnosticOptions, concurrentBuild, deterministic,


### PR DESCRIPTION
missing parse option in compilation option caused some vb My types to fail.