### PR TITLE
add fail fast on exceptional situation

### DIFF
--- a/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
+++ b/src/Features/Core/Portable/Diagnostics/EngineV2/DiagnosticIncrementalAnalyzer.StateManager.cs
@@ -133,6 +133,12 @@ namespace Microsoft.CodeAnalysis.Diagnostics.EngineV2
 
                 // we always include compiler analyzer in build only state
                 var compilerAnalyzer = _analyzerManager.GetCompilerDiagnosticAnalyzer(project.Language);
+                if (compilerAnalyzer == null)
+                {
+                    // only way to get here is if MEF is corrupted.
+                    FailFast.OnFatalException(new Exception("How can this happen?"));
+                }
+
                 StateSet compilerStateSet;
                 if (hostStateSetMap.TryGetValue(compilerAnalyzer, out compilerStateSet))
                 {


### PR DESCRIPTION
the situation can't happen unless MEF is corrupted. added fast fail so that we can see the situation in the dump more easily.

fix for https://devdiv.visualstudio.com/DevDiv/_workitems?path=Assigned%20to%20me&_a=query
