### PR TITLE
fail fast when extension manager is null

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/Diagnostics/VisualStudioWorkspaceDiagnosticAnalyzerProviderService.cs
@@ -43,6 +43,12 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Diagnostics
 
             // Get the analyzer assets for installed VSIX extensions through the VSIX extension manager.
             var extensionManager = workspace.GetVsService(assembly.GetType("Microsoft.VisualStudio.ExtensionManager.SVsExtensionManager"));
+            if (extensionManager == null)
+            {
+                // extension manager can't be null. if it is null, then VS is seriously broken.
+                // fail fast right away
+                FailFast.OnFatalException(new Exception("extension manager can't be null"));
+            }
 
             _hostDiagnosticAnalyzerInfo = GetHostAnalyzerPackagesWithName(extensionManager, assembly.GetType("Microsoft.VisualStudio.ExtensionManager.IExtensionContent"));
         }


### PR DESCRIPTION
made us to crash right away when extension manager is null to get better info on the situation.

if extension manager is null, vs is seriously broken.

fix https://devdiv.visualstudio.com/DevDiv/_workitems?path=Assigned%20to%20me&_a=query