### PR TITLE
Allow readonly autoprops to be used when generating a constructor

### DIFF
--- a/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
+++ b/src/EditorFeatures/CSharpTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.cs
@@ -591,5 +591,42 @@ withScriptOption: true);
 }",
 options: Option(CodeStyleOptions.QualifyFieldAccess, CodeStyleOptions.TrueWithSuggestionEnforcement));
         }
+
+        [WorkItem(13944, "https://github.com/dotnet/roslyn/issues/13944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        public async Task TestGetter_Only_Auto_Props()
+        {
+            await TestAsync(
+@"abstract class Contribution
+{
+  [|public string Title { get; }
+    public int Number { get; }|]
+}",
+@"abstract class Contribution
+{
+    public Contribution(string title, int number)
+    {
+        Title = title;
+        Number = number;
+    }
+
+    public string Title { get; }
+    public int Number { get; }
+}",
+options: Option(CodeStyleOptions.QualifyFieldAccess, CodeStyleOptions.TrueWithSuggestionEnforcement));
+        }
+
+        [WorkItem(13944, "https://github.com/dotnet/roslyn/issues/13944")]
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)]
+        public async Task TestAbstract_Getter_Only_Auto_Props()
+        {
+            await TestMissingAsync(
+@"abstract class Contribution
+{
+  [|public abstract string Title { get; }
+    public int Number { get; }|]
+}",
+options: Option(CodeStyleOptions.QualifyFieldAccess, CodeStyleOptions.TrueWithSuggestionEnforcement));
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -3096,7 +3096,7 @@ withScriptOption: true);
         {
             await TestAsync(
 @"class C { public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new [|C|] ( prop ) ; } } ",
-@"class C { public C ( int prop ) { Prop = prop ; } public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new C ( prop ) ; } } }",
+@"class C { public C ( int prop ) { Prop = prop ; } public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new C ( prop ) ; } }",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -3095,8 +3095,29 @@ withScriptOption: true);
         public async Task Support_Readonly_Properties()
         {
             await TestAsync(
-@"class C { public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new [|C|] ( prop ) ; } } ",
-@"class C { public C ( int prop ) { Prop = prop ; } public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new C ( prop ) ; } }",
+@"class C {
+    public int Prop { get ; }
+}
+
+class P { 
+    static void M ( ) { 
+        var prop = 42 ;
+        var c = new [|C|] ( prop ) ;
+    }
+} ",
+@"class C {
+    public C ( int prop ) {
+        Prop = prop ;
+    } 
+    public int Prop { get ; }
+}
+
+class P {
+    static void M ( ) {
+        var prop = 42 ;
+        var c = new C ( prop ) ;
+    }
+}",
 parseOptions: TestOptions.Regular,
 withScriptOption: true);
         }

--- a/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
+++ b/src/EditorFeatures/CSharpTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.cs
@@ -3089,5 +3089,16 @@ withScriptOption: true);
 parseOptions: TestOptions.Regular.WithLanguageVersion(CodeAnalysis.CSharp.LanguageVersion.CSharp6),
 withScriptOption: true);
         }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)]
+        [WorkItem(13749, "https://github.com/dotnet/roslyn/issues/13749")]
+        public async Task Support_Readonly_Properties()
+        {
+            await TestAsync(
+@"class C { public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new [|C|] ( prop ) ; } } ",
+@"class C { public C ( int prop ) { Prop = prop ; } public int Prop { get ; } } class P { static void M ( ) { var prop = 42 ; var c = new C ( prop ) ; } } }",
+parseOptions: TestOptions.Regular,
+withScriptOption: true);
+        }
     }
 }

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateFromMembers/GenerateConstructorFromMembers/GenerateConstructorFromMembersTests.vb
@@ -180,5 +180,35 @@ End Class",
 End Class",
 index:=0)
         End Function
+
+        <WorkItem(13944, "https://github.com/dotnet/roslyn/issues/13944")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)>
+        Public Async Function TestGetter_Only_Auto_Props() As Task
+            Await TestAsync(
+"Class Contribution
+  [|ReadOnly Property Title As String
+    ReadOnly Property Number As Integer|]
+End Class",
+"Class Contribution
+    Public Sub New(title As String, number As Integer)
+        Me.Title = title
+        Me.Number = number
+    End Sub
+
+    ReadOnly Property Title As String
+    ReadOnly Property Number As Integer
+End Class",
+index:=0)
+        End Function
+
+        <WorkItem(13944, "https://github.com/dotnet/roslyn/issues/13944")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructorFromMembers)>
+        Public Async Function TestAbstract_Getter_Only_Auto_Props() As Task
+            Await TestMissingAsync(
+"Class Contribution
+  [|MustOverride ReadOnly Property Title As String
+    ReadOnly Property Number As Integer|]
+End Class")
+        End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -1651,27 +1651,28 @@ end class")
         <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
         Public Async Function Support_Readonly_Properties() As Task
             Await TestAsync(
-"class C 
-    readonly property Prop as integer
-end class 
-module P 
-    sub M() 
-        dim prop = 42
-        dim c = new C([|prop|])
-    end sub
-end module",
-"class C
-    public sub new(prop As integer)
-        me.Prop = prop
-    end sub
-    readonly property Prop as integer
-end class
-module P
-    sub M()
-        dim prop = 42
-        dim c = new C(prop)
-    end sub
-end module")
+"Class C
+    ReadOnly Property Prop As Integer
+End Class
+Module P
+    Sub M()
+        Dim prop = 42
+        Dim c = New C([|prop|])
+    End Sub
+End Module",
+"Class C
+    Public Sub New(prop As Integer)
+        Me.Prop = prop
+    End Sub
+
+    ReadOnly Property Prop As Integer
+End Class
+Module P
+    Sub M()
+        Dim prop = 42
+        Dim c = New C(prop)
+    End Sub
+End Module")
         End Function
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/Diagnostics/GenerateConstructor/GenerateConstructorTests.vb
@@ -1646,5 +1646,32 @@ End Class")
     end function
 end class")
         End Function
+
+        <WorkItem(13749, "https://github.com/dotnet/roslyn/issues/13749")>
+        <Fact, Trait(Traits.Feature, Traits.Features.CodeActionsGenerateConstructor)>
+        Public Async Function Support_Readonly_Properties() As Task
+            Await TestAsync(
+"class C 
+    readonly property Prop as integer
+end class 
+module P 
+    sub M() 
+        dim prop = 42
+        dim c = new C([|prop|])
+    end sub
+end module",
+"class C
+    public sub new(prop As integer)
+        me.Prop = prop
+    end sub
+    readonly property Prop as integer
+end class
+module P
+    sub M()
+        dim prop = 42
+        dim c = new C(prop)
+    end sub
+end module")
+        End Function
     End Class
 End Namespace

--- a/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
+++ b/src/Features/Core/Portable/GenerateFromMembers/AbstractGenerateFromMembersService.cs
@@ -63,7 +63,7 @@ namespace Microsoft.CodeAnalysis.GenerateFromMembers
         {
             return symbol.TypeSwitch(
                 (IFieldSymbol field) => !field.IsConst,
-                (IPropertySymbol property) => property.SetMethod != null);
+                (IPropertySymbol property) => property.IsWritableInConstructor());
         }
 
         protected static bool IsInstanceFieldOrProperty(ISymbol symbol)

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -412,6 +412,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     {
                         var property = (IPropertySymbol)symbol;
                         return
+                            property.Parameters.Length == 0 &&
                             property.IsWritableInConstructor() &&
                             _service.IsConversionImplicit(_document.SemanticModel.Compilation, parameterType, property.Type);
                     }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -412,7 +412,7 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                     {
                         var property = (IPropertySymbol)symbol;
                         return
-                            property.Parameters.Length == 0 &&
+                            property.IsWritableInConstructor() &&
                             _service.IsConversionImplicit(_document.SemanticModel.Compilation, parameterType, property.Type);
                     }
                 }

--- a/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
+++ b/src/Features/Core/Portable/GenerateMember/GenerateConstructor/AbstractGenerateConstructorService.Editor.cs
@@ -413,7 +413,6 @@ namespace Microsoft.CodeAnalysis.GenerateMember.GenerateConstructor
                         var property = (IPropertySymbol)symbol;
                         return
                             property.Parameters.Length == 0 &&
-                            property.SetMethod != null &&
                             _service.IsConversionImplicit(_document.SemanticModel.Compilation, parameterType, property.Type);
                     }
                 }

--- a/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
+++ b/src/Features/Core/Portable/ReplacePropertyWithMethods/ReplacePropertyWithMethodsCodeRefactoringProvider.cs
@@ -146,9 +146,7 @@ namespace Microsoft.CodeAnalysis.ReplacePropertyWithMethods
 
         private static IFieldSymbol GetBackingField(IPropertySymbol property)
         {
-            var field = property.ContainingType.GetMembers()
-                                .OfType<IFieldSymbol>()
-                                .FirstOrDefault(f => property.Equals(f.AssociatedSymbol));
+            var field = property.GetBackingFieldIfAny();
             if (field == null)
             {
                 return null;

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -69,5 +69,19 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
                 property.SetMethod,
                 property.IsIndexer);
         }
+
+        public static bool IsWritableInConstructor(this IPropertySymbol property)
+        {
+            return property.Parameters.Length == 0 &&
+                   (property.SetMethod != null || ContainsBackingField(property));
+        }
+
+        public static IFieldSymbol GetBackingFieldIfAny(this IPropertySymbol property) =>
+            property.ContainingType.GetMembers()
+                                .OfType<IFieldSymbol>()
+                                .FirstOrDefault(f => property.Equals(f.AssociatedSymbol));
+
+        private static bool ContainsBackingField(IPropertySymbol property) =>
+            property.GetBackingFieldIfAny() != null;
     }
 }

--- a/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
+++ b/src/Workspaces/Core/Portable/Shared/Extensions/IPropertySymbolExtensions.cs
@@ -71,17 +71,14 @@ namespace Microsoft.CodeAnalysis.Shared.Extensions
         }
 
         public static bool IsWritableInConstructor(this IPropertySymbol property)
-        {
-            return property.Parameters.Length == 0 &&
-                   (property.SetMethod != null || ContainsBackingField(property));
-        }
+            => (property.SetMethod != null || ContainsBackingField(property));
 
-        public static IFieldSymbol GetBackingFieldIfAny(this IPropertySymbol property) =>
-            property.ContainingType.GetMembers()
-                                .OfType<IFieldSymbol>()
-                                .FirstOrDefault(f => property.Equals(f.AssociatedSymbol));
+        public static IFieldSymbol GetBackingFieldIfAny(this IPropertySymbol property)
+            => property.ContainingType.GetMembers()
+                .OfType<IFieldSymbol>()
+                .FirstOrDefault(f => property.Equals(f.AssociatedSymbol));
 
-        private static bool ContainsBackingField(IPropertySymbol property) =>
-            property.GetBackingFieldIfAny() != null;
+        private static bool ContainsBackingField(IPropertySymbol property)
+            => property.GetBackingFieldIfAny() != null;
     }
 }


### PR DESCRIPTION
Fixes 
https://github.com/dotnet/roslyn/issues/13749
https://github.com/dotnet/roslyn/issues/13944
https://github.com/dotnet/roslyn/issues/9022
@dotnet/roslyn-ide 