### PR TITLE
Fix capturing of a generic type in local functions

### DIFF
--- a/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/LambdaRewriter/LambdaRewriter.LocalFunctionReferenceRewriter.cs
@@ -206,9 +206,10 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     Debug.Assert(frameType is LambdaFrame);
 
-                    if (frameType.IsGenericType)
+                    if (frameType.Arity > 0)
                     {
                         var typeParameters = ((LambdaFrame)frameType).ConstructedFromTypeParameters;
+                        Debug.Assert(typeParameters.Length == frameType.Arity);
                         var subst = this.TypeMap.SubstituteTypeParameters(typeParameters);
                         frameType = frameType.Construct(subst);
                     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -30,6 +30,114 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenLocalFunctionTests : CSharpTestBase
     {
         [Fact]
+        public void VS15Pre3BugTest()
+        {
+            var src = @"
+using System;
+using System.Collections.Generic;
+
+class Test<T>
+{
+    T Value;
+
+    public bool Foo(IEqualityComparer<T> comparer)
+    {
+        bool local(T tmp)
+        {
+            return comparer.Equals(tmp, this.Value);
+        }
+        return local(this.Value);
+    }
+}
+";
+            var comp = CompileAndVerify(src);
+        }
+
+        [Fact]
+        public void CaptureGenericField()
+        {
+            var src = @"
+using System;
+class C<T>
+{
+    T Value = default(T);
+    public void M()
+    {
+        void L()
+        {
+            Console.WriteLine(Value);
+        }
+        var f = (Action)(() => L());
+        f();
+    }
+}
+class C2
+{
+    public static void Main(string[] args) => new C<int>().M();
+}
+";
+            VerifyOutput(src, "0");
+        }
+
+        [Fact]
+        public void CaptureGenericParam()
+        {
+            var src = @"
+using System;
+class C<T>
+{
+    T Value = default(T);
+    public void M<U>(U val2)
+    {
+        void L()
+        {
+            Console.WriteLine(Value);
+            Console.WriteLine(val2);
+        }
+        var f = (Action)(() => L());
+        f();
+    }
+}
+class C2
+{
+    public static void Main(string[] args) => new C<int>().M(10);
+}
+";
+            VerifyOutput(src, @"0
+10");
+        }
+
+        [Fact]
+        public void CaptureGenericParamInGenericLocalFunc()
+        {
+            var src = @"
+using System;
+class C<T>
+{
+    T Value = default(T);
+    public void M<U>(U v1)
+    {
+        void L<V>(V v2) where V : T
+        {
+            Console.WriteLine(Value);
+            Console.WriteLine(v1);
+            Console.WriteLine(v2);
+        }
+        var f = (Action)(() => L<T>(Value));
+        f();
+    }
+}
+class C2
+{
+    public static void Main(string[] args) => new C<int>().M(10);
+}
+";
+            VerifyOutput(src, @"0
+10
+0");
+        }
+
+        [Fact]
         public void DeepNestedLocalFuncsWithDifferentCaptures()
         {
             var src = @"

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenLocalFunctionTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Test.Utilities;
 using Microsoft.CodeAnalysis.Test.Utilities;
+using Roslyn.Test.Utilities;
 using System;
 using Xunit;
 
@@ -30,7 +31,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests.CodeGen
     public class CodeGenLocalFunctionTests : CSharpTestBase
     {
         [Fact]
-        public void VS15Pre3BugTest()
+        [WorkItem(243633, "https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_workitems/edit/243633")]
+        public void CaptureGenericFieldAndParameter()
         {
             var src = @"
 using System;


### PR DESCRIPTION
This changes our generic-lowering logic to use 'Arity' instead of
'IsGenericType' to figure out whether or not a local function frame
needs generic subsitution. We previously used IsGenericType, which is
inappropriate because it also considers whether or not the containing
type of the frame is generic. The containing type is necessarily already
subsituted when calling a local function, so it will never be possible
to substite type parameters.

Instead, we should use Arity of the frame, which is only non-zero if the
frame itself is generic, regardless of the containing type.