### PR TITLE
Use the binder that owns local function scope for name conflict errors

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder.cs
@@ -145,7 +145,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
 
         /// <summary>
-        /// Some nodes have special binder's for their contents (like Block's)
+        /// Some nodes have special binders for their contents (like Blocks)
         /// </summary>
         internal virtual Binder GetBinder(SyntaxNode node)
         {

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -448,29 +448,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         private BoundStatement BindLocalFunctionStatement(LocalFunctionStatementSyntax node, DiagnosticBag diagnostics)
         {
-            var binder = GetBinder(node);
-            Debug.Assert(binder != null);
-
-            return binder.BindLocalFunctionStatementParts(node, diagnostics);
-        }
-
-        private BoundStatement BindLocalFunctionStatementParts(LocalFunctionStatementSyntax node, DiagnosticBag diagnostics)
-        {
             // already defined symbol in containing block
             var localSymbol = this.LookupLocalFunction(node.Identifier);
 
-            var hasErrors = false;
-
-            // In error scenarios with misplaced code, it is possible we can't bind the local declaration.
-            // This occurs through the semantic model.  In that case concoct a plausible result.
-            if (localSymbol == null)
-            {
-                localSymbol = new LocalFunctionSymbol(this, this.ContainingMemberOrLambda, node);
-            }
-            else
-            {
-                hasErrors |= this.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
-            }
+            var binder = localSymbol.ScopeBinder;
+            var hasErrors = binder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
             BoundBlock block;
             if (node.Body != null)
@@ -485,7 +467,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 block = null;
                 hasErrors = true;
-                // TODO: add a message for this?
+                // TODO(https://github.com/dotnet/roslyn/issues/14900): Better error message
                 diagnostics.Add(ErrorCode.ERR_ConcreteMissingBody, localSymbol.Locations[0], localSymbol);
             }
 

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -451,8 +451,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             // already defined symbol in containing block
             var localSymbol = this.LookupLocalFunction(node.Identifier);
 
-            var binder = localSymbol.ScopeBinder;
-            var hasErrors = binder.ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
+            var hasErrors = localSymbol.ScopeBinder
+                .ValidateDeclarationNameConflictsInScope(localSymbol, diagnostics);
 
             BoundBlock block;
             if (node.Body != null)

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -223,19 +223,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 var oldMethod = _containingMemberOrLambda;
                 _containingMemberOrLambda = match;
-                Binder addToMap;
-                if (match.IsGenericMethod)
-                {
-                    addToMap = new WithMethodTypeParametersBinder(match, _enclosing);
-                }
-                else
-                {
-                    addToMap = _enclosing;
-                }
 
                 if (body != null)
                 {
-                    Visit(body, new InMethodBinder(match, addToMap));
+                    Binder binder = match.IsGenericMethod
+                        ? new WithMethodTypeParametersBinder(match, _enclosing)
+                        : _enclosing;
+
+                    Visit(body, new InMethodBinder(match, binder));
                 }
 
                 _containingMemberOrLambda = oldMethod;

--- a/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalBinderFactory.cs
@@ -233,8 +233,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     addToMap = _enclosing;
                 }
 
-                AddToMap(node, addToMap);
-
                 if (body != null)
                 {
                     Visit(body, new InMethodBinder(match, addToMap));

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -98,6 +98,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _diagnostics = diagnostics.ToReadOnlyAndFree();
         }
 
+        /// <summary>
+        /// Binder that owns the scope for the local function symbol, namely the scope where the
+        /// local function is declared.
+        /// </summary>
+        internal Binder ScopeBinder => _syntax.TypeParameterList == null
+            ? _binder
+            : _binder.Next; // If there are type parameters, this binder is wrapped
+                            // in a WithMethodTypeParametersBinder
+
         internal void GrabDiagnostics(DiagnosticBag addTo)
         {
             // force lazy init
@@ -328,15 +337,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 var location = identifier.GetLocation();
                 var name = identifier.ValueText;
 
-                // TODO: Add diagnostic checks for nested local functions (and containing method)
-                if (name == this.Name)
+                foreach (var @param in result)
                 {
-                    diagnostics.Add(ErrorCode.ERR_TypeVariableSameAsParent, location, name);
-                }
-
-                for (int i = 0; i < result.Count; i++)
-                {
-                    if (name == result[i].Name)
+                    if (name == @param.Name)
                     {
                         diagnostics.Add(ErrorCode.ERR_DuplicateTypeParameter, location, name);
                         break;

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -53,10 +53,37 @@ class C
             Local<int, int>();
         }
     }
+    public void M2<T>()
+    {
+        {
+            int Local<T>() => 0;
+            Local<int>();
+        }
+        {
+            int Local1<V>()
+            {
+                int Local2<V>() => 0;
+                return Local2<int>();
+            }
+            Local1<int>();
+        }
+        {
+            int T() => 0;
+            T();
+        }
+        {
+            int Local1<V>()
+            {
+                int V() => 0;
+                return V();
+            }
+            Local1<int>();
+        }
+    }
     public void V<V>() { }
 }";
-            CreateCompilationWithMscorlib(src)
-                .VerifyDiagnostics(
+            var comp = CreateCompilationWithMscorlib(src);
+            comp.VerifyDiagnostics(
                 // (9,23): error CS0136: A local or parameter named 'T' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //             int Local<T>() => 0; // Should conflict with above
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "T").WithArguments("T").WithLocation(9, 23),
@@ -65,7 +92,19 @@ class C
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "T").WithArguments("T").WithLocation(14, 19),
                 // (18,26): error CS0692: Duplicate type parameter 'T'
                 //             int Local<T, T>() => 0;
-                Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(18, 26));
+                Diagnostic(ErrorCode.ERR_DuplicateTypeParameter, "T").WithArguments("T").WithLocation(18, 26),
+                // (25,23): warning CS0693: Type parameter 'T' has the same name as the type parameter from outer type 'C.M2<T>()'
+                //             int Local<T>() => 0;
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(25, 23),
+                // (31,28): warning CS0693: Type parameter 'V' has the same name as the type parameter from outer type 'Local1<V>()'
+                //                 int Local2<V>() => 0;
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "V").WithArguments("V", "Local1<V>()").WithLocation(31, 28),
+                // (37,17): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
+                //             int T() => 0;
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(37, 17),
+                // (43,21): error CS0412: 'V': a parameter, local variable, or local function cannot have the same name as a method type parameter
+                //                 int V() => 0;
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "V").WithArguments("V").WithLocation(43, 21));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/LocalFunctionTests.cs
@@ -79,6 +79,32 @@ class C
             }
             Local1<int>();
         }
+        {
+            int Local1<V>()
+            {
+                int Local2<U>()
+                {
+                    // Conflicts with method type parameter
+                    int T() => 0;
+                    return T();
+                }
+                return Local2<int>();
+            }
+            Local1<int>();
+        }
+        {
+            int Local1<V>()
+            {
+                int Local2<U>()
+                {
+                    // Shadows M.2<T>
+                    int Local3<T>() => 0;
+                    return Local3<int>();
+                }
+                return Local2<int>();
+            }
+            Local1<int>();
+        }
     }
     public void V<V>() { }
 }";
@@ -104,7 +130,13 @@ class C
                 Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(37, 17),
                 // (43,21): error CS0412: 'V': a parameter, local variable, or local function cannot have the same name as a method type parameter
                 //                 int V() => 0;
-                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "V").WithArguments("V").WithLocation(43, 21));
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "V").WithArguments("V").WithLocation(43, 21),
+                // (54,25): error CS0412: 'T': a parameter, local variable, or local function cannot have the same name as a method type parameter
+                //                     int T() => 0;
+                Diagnostic(ErrorCode.ERR_LocalSameNameAsTypeParam, "T").WithArguments("T").WithLocation(54, 25),
+                // (67,32): warning CS0693: Type parameter 'T' has the same name as the type parameter from outer type 'C.M2<T>()'
+                //                     int Local3<T>() => 0;
+                Diagnostic(ErrorCode.WRN_TypeParameterSameAsOuterTypeParameter, "T").WithArguments("T", "C.M2<T>()").WithLocation(67, 32));
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -16,6 +16,67 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
     public class PatternMatchingTests_Scope : PatternMatchingTestBase
     {
         [Fact]
+        [WorkItem(13029, "https://github.com/dotnet/roslyn/issues/13029")]
+        public void ScopeOfLocalFunction()
+        {
+            var source =
+@"
+public class X
+{
+    public static void Main()
+    {
+    }
+
+    bool Dummy(params object[] x) { return true; }
+
+    void Test14(int val)
+    {
+        switch (val)
+        {
+            case 1 when TakeOutParam(true, out var x14):
+                void x14() {return;};
+                break;
+            case 2:
+                x14();
+                break;
+        }
+
+        switch (val)
+        {
+            case 1 when Dummy(1 is var x14):
+                void x14() {return;};
+                break;
+            case 2:
+                x14();
+                break;
+        }
+    }
+
+    static bool TakeOutParam<T>(T y, out T x) 
+    {
+        x = y;
+        return true;
+    }
+}
+";
+            var compilation = CreateCompilationWithMscorlib45(source, options: TestOptions.DebugExe, parseOptions: TestOptions.Regular);
+
+            compilation.VerifyDiagnostics(
+                // (14,52): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //             case 1 when TakeOutParam(true, out var x14):
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(14, 52),
+                // (15,22): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //                 void x14() {return;};
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(15, 22),
+                // (24,40): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //             case 1 when Dummy(1 is var x14):
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(24, 40),
+                // (25,22): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
+                //                 void x14() {return;};
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(25, 22));
+        }
+
+        [Fact]
         public void ScopeOfPatternVariables_ExpressionStatement_01()
         {
             var source =

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/PatternMatchingTests_Scope.cs
@@ -65,15 +65,9 @@ public class X
                 // (14,52): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //             case 1 when TakeOutParam(true, out var x14):
                 Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(14, 52),
-                // (15,22): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //                 void x14() {return;};
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(15, 22),
                 // (24,40): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
                 //             case 1 when Dummy(1 is var x14):
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(24, 40),
-                // (25,22): error CS0136: A local or parameter named 'x14' cannot be declared in this scope because that name is used in an enclosing local scope to define a local or parameter
-                //                 void x14() {return;};
-                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(25, 22));
+                Diagnostic(ErrorCode.ERR_LocalIllegallyOverrides, "x14").WithArguments("x14").WithLocation(24, 40));
         }
 
         [Fact]


### PR DESCRIPTION
I believe the definite assignment errors were fixed by changing the design of local functions
to allow forward calls to local functions in scope.

This should fix the extra errors around name conflicts.

Fixes #13029