### PR TITLE
Use the RC SDK to build if you're on RC

### DIFF
--- a/Restore.cmd
+++ b/Restore.cmd
@@ -44,6 +44,9 @@ call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15.project.json"
 echo Restoring packages: Toolsets (Dev15 VS SDK 'Willow' build tools)
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15Willow.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 
+echo Restoring packages: Toolsets (Dev15 VS SDK RC build tools)
+call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\dev15rc.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
+
 echo Restoring packages: Roslyn SDK
 call "%NugetExe%" restore "%RoslynRoot%build\ToolsetPackages\roslynsdk.project.json" %NuGetAdditionalCommandLineArgs% || goto :RestoreFailed
 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -322,8 +322,13 @@
                        XmlInputPaths="source.extension.vsixmanifest"
                        OutputPaths="$(IntermediateOutputPath)source.extension.vsixmanifest" />
     <ItemGroup>
+      <!-- Note that `FindSourceVsixManifest` finds the first item in @None that matches the name.
+           Our template projects include other manifests as content that are in @None, so make
+           sure we put our tranformed item back at the beginning of the list. -->
       <None Remove="source.extension.vsixmanifest" />
-      <None Include="$(IntermediateOutputPath)source.extension.vsixmanifest" />
+      <_TempNoneForReordering Include="@(None)" />
+      <None Remove="@(None)" />
+      <None Include="source.extension.vsixmanifest;@(_TempNoneForReordering)" />
     </ItemGroup>
   </Target>
 

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -304,6 +304,29 @@
     </ItemGroup>
   </Target>
 
+  <ItemDefinitionGroup>
+    <NuGetPackageToIncludeInVsix>
+      <Visible>false</Visible>
+    </NuGetPackageToIncludeInVsix>
+  </ItemDefinitionGroup>
+
+  <!-- Currently, the Willow installer can't install vsixes that have a <Prerequisites> element
+       but the Dev15 RC SDK packages can NOT install vsixes without them as part of the build.
+       To work around this conflict, we include them in our manifest files, but if we're building
+       with something older than Dev15 RC (as we do for official builds that we insert into setup)
+       we'll run a transform to strip out the <Prerequisites> element. -->
+  <Target Name="RewriteVsixManifestOnOfficialBuild"
+          BeforeTargets="FindSourceVsixManifest"
+          Condition="'$(IsDev15RC)' != 'true'">
+    <XslTransformation XslInputPath="$(MSBuildThisFileDirectory)TransformVsixManifest.xslt"
+                       XmlInputPaths="source.extension.vsixmanifest"
+                       OutputPaths="$(IntermediateOutputPath)source.extension.vsixmanifest" />
+    <ItemGroup>
+      <None Remove="source.extension.vsixmanifest" />
+      <None Include="$(IntermediateOutputPath)source.extension.vsixmanifest" />
+    </ItemGroup>
+  </Target>
+
   <!-- This is a copy of the Microsoft.VisualStudio.SDK.EmbedInteropTypes NuGet package, but only the list of
        assemblies that we need. The package includes things like EnvDTE which are reasonable for consumers, but
        strange since we actually _implement_ DTE and use it as an exchange type with generics in a few places. -->

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -318,9 +318,10 @@
   <Target Name="RewriteVsixManifestOnOfficialBuild"
           BeforeTargets="FindSourceVsixManifest"
           Condition="'$(IsDev15RC)' != 'true'">
+    <MakeDir Directories="$(IntermediateOutputPath)" />
     <XslTransformation XslInputPath="$(MSBuildThisFileDirectory)TransformVsixManifest.xslt"
                        XmlInputPaths="source.extension.vsixmanifest"
-                       OutputPaths="$(IntermediateOutputPath)source.extension.vsixmanifest" />
+                       OutputPaths="$(IntermediateOutputPath)\source.extension.vsixmanifest" />
     <ItemGroup>
       <!-- Note that `FindSourceVsixManifest` finds the first item in @None that matches the name.
            Our template projects include other manifests as content that are in @None, so make
@@ -328,7 +329,7 @@
       <None Remove="source.extension.vsixmanifest" />
       <_TempNoneForReordering Include="@(None)" />
       <None Remove="@(None)" />
-      <None Include="source.extension.vsixmanifest;@(_TempNoneForReordering)" />
+      <None Include="$(IntermediateOutputPath)\source.extension.vsixmanifest;@(_TempNoneForReordering)" />
     </ItemGroup>
   </Target>
 

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -56,6 +56,8 @@
     <IsVSBeforeDev15Preview4 Condition="'$(registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\15.0@InstallDir)' != ''">true</IsVSBeforeDev15Preview4>
     <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
     <IsVSBeforeDev15Preview4 Condition="'$(IsVSBeforeDev15Preview4)' == 'true' AND Exists('$(MSBuildBinPath)\..\..\..\..\Common7\IDE\devenv.isolation.ini')">false</IsVSBeforeDev15Preview4>
+    <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\Common7\IDE\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>
+    <IsDev15RC Condition="Exists('$(MSBuildBinPath)\..\..\..\..\Common7\IDE\Microsoft.VisualStudio.ExtensionEngine.dll')">true</IsDev15RC>
   </PropertyGroup>
 
   <!-- Unix specific settings -->
@@ -186,6 +188,11 @@
     <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(IsVSBeforeDev15Preview4)' == 'true'">
       <PropertyGroup>
         <VisualStudioBuildToolsVersion>15.0.25201-dev15preview2</VisualStudioBuildToolsVersion>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(VisualStudioVersion)' == '15.0' AND '$(IsDev15RC)' == 'true'">
+      <PropertyGroup>
+        <VisualStudioBuildToolsVersion>15.0.25825-RC</VisualStudioBuildToolsVersion>
       </PropertyGroup>
     </When>
     <When Condition="'$(VisualStudioVersion)' == '15.0'">

--- a/build/Targets/TransformVsixManifest.xslt
+++ b/build/Targets/TransformVsixManifest.xslt
@@ -1,0 +1,14 @@
+<xsl:stylesheet version="1.0"
+ xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+ xmlns:vsix="http://schemas.microsoft.com/developer/vsx-schema/2011">
+
+ <xsl:output omit-xml-declaration="yes"/>
+
+    <xsl:template match="node()|@*">
+      <xsl:copy>
+         <xsl:apply-templates select="node()|@*"/>
+      </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="vsix:Prerequisites"/>
+</xsl:stylesheet>

--- a/build/Targets/TransformVsixManifest.xslt
+++ b/build/Targets/TransformVsixManifest.xslt
@@ -4,11 +4,14 @@
 
  <xsl:output omit-xml-declaration="yes"/>
 
+    <!-- Match every node and copy it to the output -->
     <xsl:template match="node()|@*">
       <xsl:copy>
          <xsl:apply-templates select="node()|@*"/>
       </xsl:copy>
     </xsl:template>
 
+    <!-- Now override that to do nothing if it matches our element, thus
+         omitting it from the output -->
     <xsl:template match="vsix:Prerequisites"/>
 </xsl:stylesheet>

--- a/build/ToolsetPackages/dev15rc.project.json
+++ b/build/ToolsetPackages/dev15rc.project.json
@@ -1,0 +1,9 @@
+{
+    "dependencies": {
+        "Microsoft.VSSDK.BuildTools": "15.0.25825-RC"
+    },
+    "frameworks": {
+        "net46": {}
+    }
+}
+

--- a/src/Compilers/Extension/source.extension.vsixmanifest
+++ b/src/Compilers/Extension/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Deployment/source.extension.vsixmanifest
+++ b/src/Deployment/source.extension.vsixmanifest
@@ -47,4 +47,7 @@
                  Location="|ExpressionEvaluatorPackage;VSIXContainerProjectOutputGroup|" 
                  Id="|ExpressionEvaluatorPackage;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
+++ b/src/ExpressionEvaluator/Package/source.extension.vsixmanifest
@@ -32,4 +32,7 @@
     <Asset Type="DebuggerEngineExtension" d:Source="Project" d:ProjectName="CSharpResultProvider.Portable" Path="|CSharpResultProvider.Portable;VsdConfigOutputGroup|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/Analyzers/CSharpAnalyzers/CSharpAnalyzers.Vsix/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CSharpAnalyzers" Path="|CSharpAnalyzers|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="CSharpAnalyzers" Path="|CSharpAnalyzers|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ConvertToAutoProperty/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ConvertToAutoProperty/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ConvertToAutoPropertyCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ConvertToConditional/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ConvertToConditional/Impl/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/CopyPasteWithUsing/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/CopyPasteWithUsing/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ImplementNotifyPropertyChangedCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/MakeConst/Impl/source.extension.vsixmanifest
@@ -38,4 +38,7 @@ governing permissions and limitations under the License.
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstCS.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstCS.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/CSharp/RefOutModifier/source.extension.vsixmanifest
+++ b/src/Samples/CSharp/RefOutModifier/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/Analyzers/BasicAnalyzers/BasicAnalyzers.Vsix/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="BasicAnalyzers" Path="|BasicAnalyzers|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="BasicAnalyzers" Path="|BasicAnalyzers|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/ConvertToAutoProperty/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ConvertToAutoPropertyVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/ImplementNotifyPropertyChanged/Impl/source.extension.vsixmanifest
@@ -37,4 +37,7 @@ governing permissions and limitations under the License.
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="ImplementNotifyPropertyChangedVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/MakeConst/Impl/source.extension.vsixmanifest
@@ -38,4 +38,7 @@ governing permissions and limitations under the License.
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="MakeConstVB.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="MakeConstVB.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Samples/VisualBasic/RemoveByVal/Impl/source.extension.vsixmanifest
+++ b/src/Samples/VisualBasic/RemoveByVal/Impl/source.extension.vsixmanifest
@@ -35,4 +35,7 @@ governing permissions and limitations under the License.
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
   </Dependencies>
   <Assets></Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Deployment/Current/source.extension.vsixmanifest
+++ b/src/Setup/Deployment/Current/source.extension.vsixmanifest
@@ -56,4 +56,7 @@
                  Location="|VisualStudioDiagnosticsWindow;VSIXContainerProjectOutputGroup|"
                  Id="|VisualStudioDiagnosticsWindow;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Deployment/Next/source.extension.vsixmanifest
+++ b/src/Setup/Deployment/Next/source.extension.vsixmanifest
@@ -65,4 +65,7 @@
                  Location="|VisualStudioDiagnosticsWindow;VSIXContainerProjectOutputGroup|"
                  Id="|VisualStudioDiagnosticsWindow;VSIXIdentifierProjectOutputGroup|" />
   </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/CodeRefactoring/Vsix/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/Diagnostic/Analyzer/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/Diagnostic/Analyzer/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/CSharp/Diagnostic/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/CSharp/Diagnostic/Vsix/source.extension.vsixmanifest
@@ -15,4 +15,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/CodeRefactoring/Vsix/source.extension.vsixmanifest
@@ -14,4 +14,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Analyzer/source.extension.vsixmanifest
@@ -18,4 +18,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/source.extension.vsixmanifest
+++ b/src/Setup/Templates/VisualBasic/Diagnostic/Vsix/source.extension.vsixmanifest
@@ -15,4 +15,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
     <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="$saferootprojectname$" Path="|$saferootprojectname$|"/>
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Setup/Templates/source.extension.vsixmanifest
+++ b/src/Setup/Templates/source.extension.vsixmanifest
@@ -30,4 +30,7 @@
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" AssemblyName="|%CurrentProject%;AssemblyName|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="SyntaxVisualizerExtension" Path="|SyntaxVisualizerExtension;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/Tools/RepoUtil/RepoData.json
+++ b/src/Tools/RepoUtil/RepoData.json
@@ -1,7 +1,7 @@
 ﻿{
     "fixedPackages": {
         "Microsoft.VisualStudio.Language.Intellisense": "14.3.25407",
-        "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25604-Preview4" ],
+        "Microsoft.VSSDK.BuildTools": [ "14.3.25420", "15.0.25201-dev15preview2","15.0.25604-Preview4", "15.0.25825-RC" ],
         "System.Reflection.Metadata": "1.0.21",
         "System.Collections.Immutable": "1.1.36",
         "Microsoft.VisualStudio.Editor": [ "14.3.25407", "15.0.25604-Preview4" ],

--- a/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/source.extension.vsixmanifest
+++ b/src/Tools/Source/SyntaxVisualizer/SyntaxVisualizerExtension/source.extension.vsixmanifest
@@ -19,4 +19,7 @@
 	<Assets>
 		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
 	</Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/RemoteHostClientMock/source.extension.vsixmanifest
+++ b/src/VisualStudio/RemoteHostClientMock/source.extension.vsixmanifest
@@ -17,4 +17,7 @@
   <Assets>
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup.Next/source.extension.vsixmanifest
@@ -33,4 +33,7 @@
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="codeAnalysisService.servicehub.service.json" />
     <Asset Type="Microsoft.ServiceHub.Service" d:Source="File" Path="remoteSymbolSearchUpdateEngine.servicehub.service.json" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/Setup/source.extension.vsixmanifest
+++ b/src/VisualStudio/Setup/source.extension.vsixmanifest
@@ -71,4 +71,7 @@
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.VisualBasic.Features.dll" />
     <Asset Type="Microsoft.VisualStudio.Analyzer" Path="Microsoft.CodeAnalysis.VisualBasic.EditorFeatures.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/TestSetup/source.extension.vsixmanifest
+++ b/src/VisualStudio/TestSetup/source.extension.vsixmanifest
@@ -20,4 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
     <Asset Type="Microsoft.VisualStudio.MefComponent" Path="Roslyn.Hosting.Diagnostics.dll" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioDiagnosticsToolWindow/source.extension.vsixmanifest
@@ -19,4 +19,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
+++ b/src/VisualStudio/VisualStudioInteractiveComponents/source.extension.vsixmanifest
@@ -39,4 +39,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="CSharpVisualStudioRepl" Path="|CSharpVisualStudioRepl|" />
     <Asset Type="Microsoft.VisualStudio.VsPackage" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" d:Source="Project" d:ProjectName="%CurrentProject%" />
   </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
This allows build to succeed at installing the extensions, so that it's
possible to debug changes.

The wrinkles here are that:
1. SDK's before the RC one don't know how to install on RC.
2. The RC SDK *requires* a <Prerequisites> element
3. The Willow installer fails to install vsixes that have a <Prerequisites> element.

To workaround 2 and 3, we are *not* adding the element yet, but and we're
suppressing the requirement for it by turning off manifest schema validation.

Once 3 is fixed, we'll add the <Prerequisites> and remove the bypass.