### PR TITLE
Use ResolveMetadataReferences in DPL

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionEvents.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.Shell.Interop;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Host;
 
 namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 {
@@ -25,8 +26,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             if (IsDeferredSolutionLoadEnabled())
             {
-                var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
-                LoadSolutionFromMSBuildAsync(deferredProjectWorkspaceService, _solutionParsingCancellationTokenSource.Token).FireAndForget();
+                LoadSolutionFromMSBuildAsync(_solutionParsingCancellationTokenSource.Token).FireAndForget();
             }
 
             return VSConstants.S_OK;

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -328,14 +328,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
             foreach (var reference in commandLineArguments.ResolveMetadataReferences(project.CurrentCompilationOptions.MetadataReferenceResolver))
             {
-                // References that don't exist on disk will come back prepended with "Unresolved: ".  We'll strip that off 
-                // and still add them, so that if they appear, we'll load them (maybe they are outputs of other parts of the build).
-                const string unresolved = "Unresolved: ";
-                var path = reference.Display;
-                if (path.StartsWith(unresolved))
-                {
-                    path = path.Substring(unresolved.Length);
-                }
+                // Some references may fail to be resolved - if they are, we'll still pass them
+                // through, in case they come into existence later (they may be built by other 
+                // parts of the build system).
+                var unresolvedReference = reference as UnresolvedMetadataReference;
+                var path = unresolvedReference == null
+                    ? ((PortableExecutableReference)reference).FilePath
+                    : unresolvedReference.Reference;
 
                 string possibleProjectReference;
                 if (targetPathsToProjectPaths.TryGetValue(path, out possibleProjectReference) &&

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -34,14 +34,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         }
 
         private async Task LoadSolutionFromMSBuildAsync(
-            IDeferredProjectWorkspaceService deferredProjectWorkspaceService,
             CancellationToken cancellationToken)
         {
             AssertIsForeground();
             InitializeOutputPane();
 
             // Continue on the UI thread for these operations, since we are touching the VisualStudioWorkspace, etc.
-            await PopulateWorkspaceFromDeferredProjectInfoAsync(deferredProjectWorkspaceService, cancellationToken).ConfigureAwait(true);
+            await PopulateWorkspaceFromDeferredProjectInfoAsync(cancellationToken).ConfigureAwait(true);
         }
 
         [Conditional("DEBUG")]
@@ -104,7 +103,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         }
 
         private async Task PopulateWorkspaceFromDeferredProjectInfoAsync(
-            IDeferredProjectWorkspaceService deferredProjectWorkspaceService,
             CancellationToken cancellationToken)
         {
             // NOTE: We need to check cancellationToken after each await, in case the user has
@@ -127,6 +125,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             if (solutionConfig != null)
             {
                 // Capture the context so that we come back on the UI thread, and do the actual project creation there.
+                var deferredProjectWorkspaceService = _workspaceServices.GetService<IDeferredProjectWorkspaceService>();
                 projectInfos = await deferredProjectWorkspaceService.GetDeferredProjectInfoForConfigurationAsync(
                     $"{solutionConfig.Name}|{solutionConfig.PlatformName}",
                     cancellationToken).ConfigureAwait(true);
@@ -139,11 +138,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             OutputToOutputWindow($"Creating projects - start");
             start = DateTimeOffset.UtcNow;
             var targetPathsToProjectPaths = BuildTargetPathMap(projectInfos);
+            var analyzerAssemblyLoader = _workspaceServices.GetRequiredService<IAnalyzerService>().GetLoader();
             foreach (var projectFilename in projectInfos.Keys)
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 GetOrCreateProjectFromArgumentsAndReferences(
                     workspaceProjectContextFactory,
+                    analyzerAssemblyLoader,
                     projectFilename,
                     projectInfos,
                     targetPathsToProjectPaths);
@@ -185,6 +186,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
 
         private AbstractProject GetOrCreateProjectFromArgumentsAndReferences(
             IWorkspaceProjectContextFactory workspaceProjectContextFactory,
+            IAnalyzerAssemblyLoader analyzerAssemblyLoader,
             string projectFilename,
             IReadOnlyDictionary<string, DeferredProjectInformation> allProjectInfos,
             IReadOnlyDictionary<string, string> targetPathsToProjectPaths)
@@ -263,6 +265,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 hierarchy: null,
                 binOutputPath: outputPath);
 
+            project = (AbstractProject)projectContext;
             projectContext.SetOptions(projectInfo.CommandLineArguments.Join(" "));
 
             foreach (var sourceFile in commandLineArguments.SourceFiles)
@@ -287,6 +290,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 {
                     referencedProject = GetOrCreateProjectFromArgumentsAndReferences(
                         workspaceProjectContextFactory,
+                        analyzerAssemblyLoader,
                         projectReferencePath,
                         allProjectInfos,
                         targetPathsToProjectPaths);
@@ -322,22 +326,31 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
                 }
             }
 
-            foreach (var reference in commandLineArguments.MetadataReferences)
+            foreach (var reference in commandLineArguments.ResolveMetadataReferences(project.CurrentCompilationOptions.MetadataReferenceResolver))
             {
+                // References that don't exist on disk will come back prepended with "Unresolved: ".  We'll strip that off 
+                // and still add them, so that if they appear, we'll load them (maybe they are outputs of other parts of the build).
+                const string unresolved = "Unresolved: ";
+                var path = reference.Display;
+                if (path.StartsWith(unresolved))
+                {
+                    path = path.Substring(unresolved.Length);
+                }
+
                 string possibleProjectReference;
-                if (targetPathsToProjectPaths.TryGetValue(reference.Reference, out possibleProjectReference) &&
+                if (targetPathsToProjectPaths.TryGetValue(path, out possibleProjectReference) &&
                     addedProjectReferences.Contains(possibleProjectReference))
                 {
                     // We already added a P2P reference for this, we don't need to add the file reference too.
                     continue;
                 }
 
-                projectContext.AddMetadataReference(reference.Reference, reference.Properties);
+                projectContext.AddMetadataReference(path, reference.Properties);
             }
 
-            foreach (var reference in commandLineArguments.AnalyzerReferences)
+            foreach (var reference in commandLineArguments.ResolveAnalyzerReferences(analyzerAssemblyLoader))
             {
-                var path = reference.FilePath;
+                var path = reference.FullPath;
                 if (!PathUtilities.IsAbsolute(path))
                 {
                     path = PathUtilities.CombineAbsoluteAndRelativePaths(


### PR DESCRIPTION
Because VB implicitly adds a reference to either mscorlib or System.Runtime
we need to do that in CPSProject for CPS-based projects in VB, like
Lightweight solution load.

Fixes #14433 and #14584