### PR TITLE
Only hook up P2P refs to C# or VB projects in DPL.

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/VisualStudioProjectTracker_IVsSolutionLoadEvents.cs
@@ -278,7 +278,11 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             var addedProjectReferences = new HashSet<string>();
             foreach (var projectReferencePath in projectInfo.ReferencedProjectFilePaths)
             {
-                var referencedProject = ImmutableProjects.SingleOrDefault(p => StringComparer.OrdinalIgnoreCase.Equals(p.ProjectFilePath, projectReferencePath));
+                // NOTE: ImmutableProjects might contain projects for other languages like
+                // Xaml, or Typescript where the project file ends up being identical.
+                var referencedProject = ImmutableProjects.SingleOrDefault(
+                    p => (p.Language == LanguageNames.CSharp || p.Language == LanguageNames.VisualBasic)
+                         && StringComparer.OrdinalIgnoreCase.Equals(p.ProjectFilePath, projectReferencePath));
                 if (referencedProject == null)
                 {
                     referencedProject = GetOrCreateProjectFromArgumentsAndReferences(


### PR DESCRIPTION
It turns out that the ProjectTracker might know about Xaml projects
that have the same project file path as a C# or VB project.

Fixes internal issue 282125.