### PR TITLE
IsMakingProgress should compute current token position properly

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -25,7 +25,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private SyntaxToken _currentToken;
         private ArrayElement<SyntaxToken>[] _lexedTokens;
         private GreenNode _prevTokenTrailingTrivia;
-        private int _firstToken;
+        private int _firstToken; // The position of the first token in _lexedTokens. Summed with _tokenOffset, we get the position of the current token.
         private int _tokenOffset;
         private int _tokenCount;
         private int _resetCount;
@@ -1079,11 +1079,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         ///     while (IsMakingProgress(ref tokenProgress))
         /// It should be used as a guardrail, not as a crutch, so it asserts if no progress was made.
         /// </summary>
-        protected bool IsMakingProgress(ref int lastTokenOffset)
+        protected bool IsMakingProgress(ref int lastTokenPosition)
         {
-            if (_tokenOffset > lastTokenOffset)
+            var currentPosition = _firstToken + _tokenOffset;
+            if (currentPosition > lastTokenPosition)
             {
-                lastTokenOffset = _tokenOffset;
+                lastTokenPosition = currentPosition;
                 return true;
             }
 

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -25,8 +25,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private SyntaxToken _currentToken;
         private ArrayElement<SyntaxToken>[] _lexedTokens;
         private GreenNode _prevTokenTrailingTrivia;
-        private int _firstToken; // The position of the first token in _lexedTokens. Summed with _tokenOffset, we get the position of the current token.
-        private int _tokenOffset;
+        private int _firstToken; // The position of _lexedTokens[0] (or _blendedTokens[0]).
+        private int _tokenOffset; // The index of the current token within _lexedTokens or _blendedTokens.
         private int _tokenCount;
         private int _resetCount;
         private int _resetStart;
@@ -135,7 +135,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         protected ResetPoint GetResetPoint()
         {
-            var pos = _firstToken + _tokenOffset;
+            var pos = CurrentTokenPosition;
             if (_resetCount == 0)
             {
                 _resetStart = pos; // low water mark
@@ -1081,15 +1081,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// </summary>
         protected bool IsMakingProgress(ref int lastTokenPosition)
         {
-            var currentPosition = _firstToken + _tokenOffset;
-            if (currentPosition > lastTokenPosition)
+            var pos = CurrentTokenPosition;
+            if (pos > lastTokenPosition)
             {
-                lastTokenPosition = currentPosition;
+                lastTokenPosition = pos;
                 return true;
             }
 
             Debug.Assert(false);
             return false;
         }
+
+        private int CurrentTokenPosition => _firstToken + _tokenOffset;
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -19902,5 +19902,27 @@ namespace ConsoleApplication5
             Assert.Equal("ref (System.Int32, dynamic) ClassLibrary1.C1.Foo.get", b.GetMethod.ToTestDisplayString());
         }
 
+        [Fact]
+        [WorkItem(14649, "https://github.com/dotnet/roslyn/issues/14649")]
+        public void ParseLongLambda()
+        {
+            string filler = string.Join("\r\n", Enumerable.Range(1, 2000).Select(i => $"int y{i}"));
+            string parameters = string.Join(", ", Enumerable.Range(1, 200).Select(i => $"int x{i}"));
+            string text = @"
+class C
+{
+    " + filler + @"
+    public void M()
+    {
+        N((" + parameters + @") => 1);
+    }
+}
+";
+            // This is designed to trigger a shift of the array of lexed tokens (see AddLexedTokenSlot) while
+            // parsing lambda parameters
+            var tree = SyntaxFactory.ParseSyntaxTree(text, CSharpParseOptions.Default);
+            // no assertion
+        }
+
     }
 }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -19906,8 +19906,8 @@ namespace ConsoleApplication5
         [WorkItem(14649, "https://github.com/dotnet/roslyn/issues/14649")]
         public void ParseLongLambda()
         {
-            string filler = string.Join("\r\n", Enumerable.Range(1, 2000).Select(i => $"int y{i}"));
-            string parameters = string.Join(", ", Enumerable.Range(1, 200).Select(i => $"int x{i}"));
+            string filler = string.Join("\r\n", Enumerable.Range(1, 1000).Select(i => $"int y{i};"));
+            string parameters = string.Join(", ", Enumerable.Range(1, 2000).Select(i => $"int x{i}"));
             string text = @"
 class C
 {


### PR DESCRIPTION
The progress check I added in parsing of lambda parameters was incorrect. To check progress, it used an incorrect computation of the position of the current token (only looking at `_tokenOffset`). The correct computation is `_firstToken + _tokenOffset`.

Fixes https://github.com/dotnet/roslyn/issues/14649
@dotnet/roslyn-compiler 