### PR TITLE
Fixing the cibuild.cmd script to no longer explicitly require MSBuild 14.0

### DIFF
--- a/build/scripts/test-determinism.ps1
+++ b/build/scripts/test-determinism.ps1
@@ -27,11 +27,6 @@ function Run-Build()
     $debugDir = join-path $rootDir "Binaries\Debug"
     $objDir = join-path $rootDir "Binaries\Obj"
 
-    # Temporarily forcing MSBuild 14.0 here to work around a bug in 15.0
-    # MSBuild bug: https://github.com/Microsoft/msbuild/issues/1183
-    # Roslyn tracking bug: https://github.com/dotnet/roslyn/issues/14451
-    $msbuild = "c:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe" 
-
     # Create directories that may or may not exist to make the script execution below 
     # clean in either case.
     mkdir $debugDir -errorAction SilentlyContinue | out-null
@@ -43,10 +38,10 @@ function Run-Build()
     write-host "Cleaning the Binaries"
     rm -re -fo $debugDir
     rm -re -fo $objDir
-    & $msbuild /nologo /v:m /nodeReuse:false /t:clean $sln
+    & msbuild /nologo /v:m /nodeReuse:false /t:clean $sln
 
     write-host "Building the Solution"
-    & $msbuild /nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir '/p:Features="debug-determinism;pdb-path-determinism"' /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln
+    & msbuild /nologo /v:m /nodeReuse:false /m /p:DebugDeterminism=true /p:BootstrapBuildPath=$script:buildDir '/p:Features="debug-determinism;pdb-path-determinism"' /p:UseRoslynAnalyzers=false $pathMapBuildOption $sln
 
     popd
 }

--- a/cibuild.cmd
+++ b/cibuild.cmd
@@ -109,10 +109,7 @@ if defined TestPerfRun (
     exit /b 0
 )
 
-REM Temporarily forcing MSBuild 14.0 here to work around a bug in 15.0
-REM MSBuild bug: https://github.com/Microsoft/msbuild/issues/1183
-REM Roslyn tracking bug: https://github.com/dotnet/roslyn/issues/14451
-"c:\Program Files (x86)\MSBuild\14.0\bin\MSBuild.exe" %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath="%bindir%\Bootstrap" BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /p:TestVsi=%TestVsi% /p:RunProcessWatchdog=%RunProcessWatchdog% /p:BuildStartTime=%BuildStartTime% /p:"ProcDumpExe=%ProcDumpExe%" /p:BuildTimeLimit=%BuildTimeLimit% /p:PathMap="%RoslynRoot%=q:\roslyn" /p:Feature=pdb-path-determinism /fileloggerparameters:LogFile="%bindir%\Build.log";verbosity=diagnostic /p:DeployExtension=false || goto :BuildFailed
+msbuild %MSBuildAdditionalCommandLineArgs% /p:BootstrapBuildPath="%bindir%\Bootstrap" BuildAndTest.proj /p:Configuration=%BuildConfiguration% /p:Test64=%Test64% /p:TestVsi=%TestVsi% /p:RunProcessWatchdog=%RunProcessWatchdog% /p:BuildStartTime=%BuildStartTime% /p:"ProcDumpExe=%ProcDumpExe%" /p:BuildTimeLimit=%BuildTimeLimit% /p:PathMap="%RoslynRoot%=q:\roslyn" /p:Feature=pdb-path-determinism /fileloggerparameters:LogFile="%bindir%\Build.log";verbosity=diagnostic /p:DeployExtension=false || goto :BuildFailed
 powershell -noprofile -executionPolicy RemoteSigned -file "%RoslynRoot%\build\scripts\check-msbuild.ps1" "%bindir%\Build.log" || goto :BuildFailed
 
 call :TerminateBuildProcesses


### PR DESCRIPTION
FYI. @dotnet/roslyn-infrastructure, @jaredpar 