### PR TITLE
Add System.ValueTuple to Microsoft.Net.Compilers.nuspec

### DIFF
--- a/src/NuGet/Microsoft.Net.Compilers.nuspec
+++ b/src/NuGet/Microsoft.Net.Compilers.nuspec
@@ -68,5 +68,6 @@ Supported Platforms:
     <file src="System.Xml.XmlDocument.dll" target="tools" />
     <file src="System.Xml.XPath.dll" target="tools" />
     <file src="System.Xml.XPath.XDocument.dll" target="tools" />
+    <file src="System.ValueTuple.dll" target="tools" />
   </files>
 </package>


### PR DESCRIPTION
o	Customer scenario – Installing Microsoft.Net.Compilers NuGet package won't install the required dependency System.ValueTuple.dll. Running csi.exe from the package won't work.
o	Bugs this fixes:  https://github.com/dotnet/roslyn/issues/14857
o	Workarounds, if any – manually copy System.ValueTuple.dll to the installed package in the NuGet cache (every time the NuGet cache is cleared).
o	Risk – Small
o	Performance impact: None
o	Is this a regression from a previous update? Yes. csi.exe from the package worked before.
o	Root cause analysis: We have now a script validating the .nuspec file.
o	How was the bug found? Ad-hoc.

The change only affects our RC nuget packages. It doesn't affect VS RC.