### PR TITLE
Add DateTime support back to serializer

### DIFF
--- a/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
+++ b/src/Compilers/Core/CodeAnalysisTest/ObjectSerializationTests.cs
@@ -528,6 +528,8 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestRoundTripMember(inputBool);
         }
 
+        private static readonly DateTime _testNow = DateTime.Now;
+
         [Fact]
         public void TestPrimitiveValues()
         {
@@ -562,6 +564,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestRoundTripValue(ELong.Value);
             TestRoundTripValue(EULong.Value);
             TestRoundTripValue(typeof(object));
+            TestRoundTripValue(_testNow);
         }
 
         [Fact]
@@ -638,6 +641,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             TestRoundTripMember(ELong.Value);
             TestRoundTripMember(EULong.Value);
             TestRoundTripMember(typeof(object));
+            TestRoundTripMember(_testNow);
         }
 
         [Fact]
@@ -783,6 +787,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             writer.WriteValue(ELong.Value);
             writer.WriteValue(EULong.Value);
             writer.WriteValue(typeof(object));
+            writer.WriteValue(_testNow);
         }
 
         private static void TestReadingPrimitiveValues(ObjectReader reader)
@@ -818,6 +823,7 @@ namespace Microsoft.CodeAnalysis.UnitTests
             Assert.Equal(ELong.Value, reader.ReadValue());
             Assert.Equal(EULong.Value, reader.ReadValue());
             Assert.Equal(typeof(object), (Type)reader.ReadValue());
+            Assert.Equal(_testNow, (DateTime)reader.ReadValue());
         }
 
         public enum EByte : byte

--- a/src/Compilers/Core/Portable/Serialization/StreamObjectReader.cs
+++ b/src/Compilers/Core/Portable/Serialization/StreamObjectReader.cs
@@ -372,6 +372,8 @@ namespace Roslyn.Utilities
                     return Variant.FromType(ReadType(kind));
                 case EncodingKind.Enum:
                     return Variant.FromBoxedEnum(ReadBoxedEnum());
+                case EncodingKind.DateTime:
+                    return Variant.FromDateTime(DateTime.FromBinary(_reader.ReadInt64()));
                 case EncodingKind.Array:
                 case EncodingKind.Array_0:
                 case EncodingKind.Array_1:

--- a/src/Compilers/Core/Portable/Serialization/StreamObjectWriter.cs
+++ b/src/Compilers/Core/Portable/Serialization/StreamObjectWriter.cs
@@ -302,6 +302,11 @@ namespace Roslyn.Utilities
                     WriteBoxedEnum(e, e.GetType());
                     break;
 
+                case VariantKind.DateTime:
+                    _writer.Write((byte)EncodingKind.DateTime);
+                    _writer.Write(value.AsDateTime().ToBinary());
+                    break;
+
                 case VariantKind.Type:
                     WriteType(value.AsType());
                     break;
@@ -1284,6 +1289,11 @@ namespace Roslyn.Utilities
             Enum,
 
             /// <summary>
+            /// A DateTime value
+            /// </summary>
+            DateTime,
+
+            /// <summary>
             /// An array with length encoded as compressed uint
             /// </summary>
             Array,
@@ -1339,6 +1349,7 @@ namespace Roslyn.Utilities
             String,
             Object,
             BoxedEnum,
+            DateTime,
             Array,
             Type
         }
@@ -1432,6 +1443,11 @@ namespace Roslyn.Utilities
             public static Variant FromBoxedEnum(object value)
             {
                 return new Variant(VariantKind.BoxedEnum, image: 0, instance: value);
+            }
+
+            public static Variant FromDateTime(DateTime value)
+            {
+                return new Variant(VariantKind.DateTime, image: value.ToBinary(), instance: null);
             }
 
             public static Variant FromType(Type value)
@@ -1545,6 +1561,12 @@ namespace Roslyn.Utilities
                 return _instance;
             }
 
+            public DateTime AsDateTime()
+            {
+                Debug.Assert(Kind == VariantKind.DateTime);
+                return DateTime.FromBinary((long)_image);
+            }
+
             public Type AsType()
             {
                 Debug.Assert(Kind == VariantKind.Type);
@@ -1628,6 +1650,10 @@ namespace Roslyn.Utilities
                     {
                         return FromDouble((double)value);
                     }
+                    else if (type == typeof(DateTime))
+                    {
+                        return FromDateTime((DateTime)value);
+                    }
                     else if (type.IsArray)
                     {
                         var instance = (Array)value;
@@ -1664,6 +1690,8 @@ namespace Roslyn.Utilities
                         return this.AsByte();
                     case VariantKind.Char:
                         return this.AsChar();
+                    case VariantKind.DateTime:
+                        return this.AsDateTime();
                     case VariantKind.Decimal:
                         return this.AsDecimal();
                     case VariantKind.Float4:

--- a/src/Compilers/VisualBasic/Test/Syntax/Syntax/SerializationTests.vb
+++ b/src/Compilers/VisualBasic/Test/Syntax/Syntax/SerializationTests.vb
@@ -38,6 +38,16 @@ End Class
         End Sub
 
         <Fact>
+        Public Sub TestRoundTripDateTimeLiteral()
+            Dim x As DateTime = #10/5/2015#
+            RoundTrip(<Foo>
+Public Class C
+    Private _x As DateTime = #10/5/2015#
+End Class
+</Foo>.Value)
+        End Sub
+
+        <Fact>
         Public Sub TestRoundTripSyntaxNodeWithDiagnostics()
             Dim text = <Foo>
 Public Class C


### PR DESCRIPTION
Fixes #14943 

This change adds back support for reading/writing DateTime time.  It doesn't add the public API back, but adds the support for reading/writing DateTime as a value via the WriteValue and ReadValue API's.

This is important for tree serialization because DateTime literal values are encoded in VB trees.

@dotnet/roslyn-ide please review
