### PR TITLE
Localize strings in DataGrid headers

### DIFF
--- a/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.Designer.cs
@@ -488,6 +488,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Description.
+        /// </summary>
+        internal static string Description {
+            get {
+                return ResourceManager.GetString("Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to _Deselect All.
         /// </summary>
         internal static string Deselect_All {
@@ -1434,6 +1443,15 @@ namespace Microsoft.VisualStudio.LanguageServices {
         internal static string Prefer_predefined_type {
             get {
                 return ResourceManager.GetString("Prefer_predefined_type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preference.
+        /// </summary>
+        internal static string Preference {
+            get {
+                return ResourceManager.GetString("Preference", resourceCulture);
             }
         }
         

--- a/src/VisualStudio/Core/Def/ServicesVSResources.resx
+++ b/src/VisualStudio/Core/Def/ServicesVSResources.resx
@@ -816,4 +816,10 @@ Additional information: {1}</value>
   <data name="Prefer_null_propagation" xml:space="preserve">
     <value>Prefer null propagation</value>
   </data>
+  <data name="Description" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Preference" xml:space="preserve">
+    <value>Preference</value>
+  </data>
 </root>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml
@@ -82,7 +82,7 @@
             <DataGrid.Columns>
                 <DataGridTextColumn
                     x:Name="description" 
-                    Header="Description"
+                    Header="{x:Static local:GridOptionPreviewControl.DescriptionHeader}"
                     Binding="{Binding Description, Mode=OneWay}" 
                     Width="4.5*"
                     IsReadOnly="True">
@@ -98,7 +98,7 @@
                 </DataGridTextColumn>
                 <DataGridTemplateColumn 
                     x:Name="preference" 
-                    Header="Preference"
+                    Header="{x:Static local:GridOptionPreviewControl.PreferenceHeader}"
                     Width="3*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -113,7 +113,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn 
                     x:Name="severity" 
-                    Header="Severity"
+                    Header="{x:Static local:GridOptionPreviewControl.SeverityHeader}"
                     Width="2.5*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/GridOptionPreviewControl.xaml.cs
@@ -14,6 +14,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options
         private readonly IServiceProvider _serviceProvider;
         private readonly Func<OptionSet, IServiceProvider, AbstractOptionPreviewViewModel> _createViewModel;
 
+        public static string DescriptionHeader => ServicesVSResources.Description;
+        public static string PreferenceHeader => ServicesVSResources.Preference;
+        public static string SeverityHeader => ServicesVSResources.Severity;
+
         internal GridOptionPreviewControl(IServiceProvider serviceProvider, 
             Func<OptionSet, IServiceProvider, 
             AbstractOptionPreviewViewModel> createViewModel) 

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml
@@ -109,7 +109,7 @@
             <DataGrid.Columns>
                 <DataGridTemplateColumn 
                     x:Name="selectable" 
-                    Header="Reorder"
+                    Header="{x:Static style:NamingStyleOptionPageControl.ReorderHeader}"
                     Width="Auto">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -145,7 +145,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn 
                     x:Name="symbolSpec" 
-                    Header="Specification"
+                    Header="{x:Static style:NamingStyleOptionPageControl.SpecificationHeader}"
                     Width="3*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
@@ -162,7 +162,7 @@
                 </DataGridTemplateColumn>
                 <DataGridTemplateColumn 
                     x:Name="style"
-                    Header="Style"
+                    Header="{x:Static style:NamingStyleOptionPageControl.StyleHeader}"
                     Width="3*">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>

--- a/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
+++ b/src/VisualStudio/Core/Impl/Options/Style/NamingPreferences/NamingStyleOptionPageControl.xaml.cs
@@ -18,6 +18,10 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.Options.Style
 {
     internal partial class NamingStyleOptionPageControl : AbstractOptionPageControl
     {
+        public static string ReorderHeader => ServicesVSResources.Reorder;
+        public static string SpecificationHeader => ServicesVSResources.Specification;
+        public static string StyleHeader => ServicesVSResources.Style;
+
         private NamingStyleOptionPageViewModel _viewModel;
         private readonly string _languageName;
         private readonly INotificationService _notificationService;


### PR DESCRIPTION
Fixes #12669. Addresses one part of #9674

Fixes both the general code styles page and the naming styles page

**Ask Mode Info**

**Customer scenario**: The column headers for the general code styles page and the naming styles page will not be localized, making it difficult for users with non-English languages to use.
**Bugs this fixes**: #12669 completely, and #9674 partially (the part that overlaps with #12669)
**Workarounds**: None
**Risk**: Very low
**Performance impact**: Essentially none, this is just 6 instances of WPF databinding when the option pages are shown.
**Is this a regression from a previous update?**: No, this has been broken since the UI was introduced
**Root cause analysis**:  It was skipped as part of the original feature work. For the general style page, I do not know why it was skipped. For Naming Styles, it was skipped because I didn't know how to properly databind DataGridColumnHeaders (they're trickier than normal bindings, but not by much once you know how to do it)
**How was the bug found?**: Ad hoc testing (see screenshot from #9674) and code review (#12669)
