### PR TITLE
add object dispose check to one missing place.

### DIFF
--- a/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
+++ b/src/VisualStudio/Core/Next/Remote/JsonRpcClient.cs
@@ -17,33 +17,64 @@ namespace Microsoft.VisualStudio.LanguageServices.Remote
     internal class JsonRpcClient : IDisposable
     {
         private readonly JsonRpc _rpc;
+        private readonly CancellationToken _cancellationToken;
 
-        public JsonRpcClient(Stream stream, object callbackTarget, bool useThisAsCallback)
+        public JsonRpcClient(
+            Stream stream, object callbackTarget, bool useThisAsCallback, CancellationToken cancellationToken)
         {
             var target = useThisAsCallback ? this : callbackTarget;
+            _cancellationToken = cancellationToken;
 
             _rpc = JsonRpc.Attach(stream, target);
             _rpc.Disconnected += OnDisconnected;
         }
 
-        public Task InvokeAsync(string targetName, params object[] arguments)
+        public async Task InvokeAsync(string targetName, params object[] arguments)
         {
-            return _rpc.InvokeAsync(targetName, arguments);
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                await _rpc.InvokeAsync(targetName, arguments).ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
         }
 
-        public Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
+        public async Task<T> InvokeAsync<T>(string targetName, params object[] arguments)
         {
-            return _rpc.InvokeAsync<T>(targetName, arguments);
+            _cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                return await _rpc.InvokeAsync<T>(targetName, arguments).ConfigureAwait(false);
+            }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                _cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
         }
 
-        public Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync, CancellationToken cancellationToken)
+        public Task InvokeAsync(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task> funcWithDirectStreamAsync)
         {
-            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
+            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, _cancellationToken);
         }
 
-        public Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync, CancellationToken cancellationToken)
+        public Task<T> InvokeAsync<T>(string targetName, IEnumerable<object> arguments, Func<Stream, CancellationToken, Task<T>> funcWithDirectStreamAsync)
         {
-            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, cancellationToken);
+            return Extensions.InvokeAsync(_rpc, targetName, arguments, funcWithDirectStreamAsync, _cancellationToken);
         }
 
         public void Dispose()

--- a/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
+++ b/src/Workspaces/Remote/ServiceHub/Shared/Extensions.cs
@@ -38,6 +38,15 @@ namespace Microsoft.CodeAnalysis.Remote
                     await task.ConfigureAwait(false);
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 // if cancelled due to us, throw cancellation exception.
@@ -75,6 +84,15 @@ namespace Microsoft.CodeAnalysis.Remote
                     return result;
                 }
             }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
+            }
             catch (OperationCanceledException)
             {
                 // if cancelled due to us, throw cancellation exception.
@@ -109,6 +127,15 @@ namespace Microsoft.CodeAnalysis.Remote
                     // wait task to finish
                     await task.ConfigureAwait(false);
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
             }
             catch (OperationCanceledException)
             {
@@ -146,6 +173,15 @@ namespace Microsoft.CodeAnalysis.Remote
 
                     return result;
                 }
+            }
+            catch (ObjectDisposedException)
+            {
+                // object disposed exception can be thrown from StreamJsonRpc if JsonRpc is disposed in the middle of read/write.
+                // the way we added cancellation support to the JsonRpc which doesn't support cancellation natively
+                // can cause this exception to happen. newer version supports cancellation token natively, but
+                // we can't use it now, so we will catch object disposed exception and check cancellation token
+                cancellationToken.ThrowIfCancellationRequested();
+                throw;
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
other consumer that uses OOP framework should access json rpc through this session object. so guarding this exception here is all we needed.

this intializeAsync method is added later and obviously, when I added, I forgot to guard it from object disposed check.