### PR TITLE
Don't rely on %RoslynRoot% being set

### DIFF
--- a/SetDevCommandPrompt.cmd
+++ b/SetDevCommandPrompt.cmd
@@ -4,7 +4,7 @@
 set CommonToolsDir=%VS150COMNTOOLS%
 
 :: VS150COMNTOOLS is not set globally any more, so fall back to using the managed query api before trying Dev14
-if not exist "%CommonToolsDir%" for /f "usebackq delims=" %%v in (`powershell -noprofile -executionPolicy Bypass -file "%RoslynRoot%build\scripts\locate-vs.ps1"`) do set "CommonToolsDir=%%v"
+if not exist "%CommonToolsDir%" for /f "usebackq delims=" %%v in (`powershell -noprofile -executionPolicy Bypass -file "%~dp0build\scripts\locate-vs.ps1"`) do set "CommonToolsDir=%%v"
 if not exist "%CommonToolsDir%" set CommonToolsDir=%VS140COMNTOOLS%
 if not exist "%CommonToolsDir%" exit /b 1
 


### PR DESCRIPTION
Tagging @dotnet/roslyn-infrastructure and @tannergooding