### PR TITLE
Introduce local caching of "this" in async methods

### DIFF
--- a/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitExpression.cs
@@ -871,12 +871,21 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
         {
             var field = fieldAccess.FieldSymbol;
 
-            //TODO: For static field access this may require ..ctor to run. Is this a side-effect?
-            // Accessing unused instance field on a struct is a noop. Just emit the receiver.
-            if (!used && !field.IsVolatile && !field.IsStatic && fieldAccess.ReceiverOpt.Type.IsVerifierValue())
+            if (!used)
             {
-                EmitExpression(fieldAccess.ReceiverOpt, used: false);
-                return;
+                // fetching unused captured frame is a no-op (like reading "this")
+                if(field.IsCapturedFrame)
+                {
+                    return;
+                }
+
+                //TODO: For static field access this may require ..ctor to run. Is this a side-effect?
+                // Accessing unused instance field on a struct is a noop. Just emit the receiver.
+                if (!field.IsVolatile && !field.IsStatic && fieldAccess.ReceiverOpt.Type.IsVerifierValue())
+                {
+                    EmitExpression(fieldAccess.ReceiverOpt, used: false);
+                    return;
+                }
             }
 
             Debug.Assert(!field.IsConst || field.ContainingType.SpecialType == SpecialType.System_Decimal,
@@ -1278,8 +1287,18 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BoundKind.ThisReference:
                     //NOTE: these actually can be null if called from a different language
-                    //if that has already happen, we will just propagate the behavior.
+                    //however, we assume it is responsibility of the caller to nullcheck "this"
+                    //if we already have access to "this", we must be in a member and should 
+                    //not redo the check
                     return true;
+
+                case BoundKind.FieldAccess:
+                    // same reason as for "ThisReference"
+                    return ((BoundFieldAccess)receiver).FieldSymbol.IsCapturedFrame;
+
+                case BoundKind.Local:
+                    // same reason as for "ThisReference"
+                    return ((BoundLocal)receiver).LocalSymbol.SynthesizedKind == SynthesizedLocalKind.FrameCache;
 
                 case BoundKind.DelegateCreationExpression:
                     return true;
@@ -1294,9 +1313,6 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
                 case BoundKind.TypeOfOperator:
                     return true;
-
-                case BoundKind.FieldAccess:
-                    return ((BoundFieldAccess)receiver).FieldSymbol.IsCapturedFrame;
 
                 case BoundKind.ConditionalReceiver:
                     return true;

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -125,6 +125,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             bodyBuilder.Add(F.HiddenSequencePoint());
             bodyBuilder.Add(F.Assignment(F.Local(cachedState), F.Field(F.This(), stateField)));
+            bodyBuilder.Add(CacheThisIfNeeded());
 
             var exceptionLocal = F.SynthesizedLocal(F.WellKnownType(WellKnownType.System_Exception));
             bodyBuilder.Add(
@@ -194,6 +195,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             var locals = ArrayBuilder<LocalSymbol>.GetInstance();
             locals.Add(cachedState);
+            if ((object)cachedThis != null)
+            {
+                locals.Add(cachedThis);
+            }
+
             if ((object)_exprRetValue != null) locals.Add(_exprRetValue);
 
             var newBody =
@@ -425,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // this.state = cachedState = NotStartedStateMachine
                     F.Assignment(F.Field(F.This(), stateField), F.AssignmentExpression(F.Local(cachedState), F.Literal(StateMachineStates.NotStartedStateMachine))));
 
-            return F.Block(blockBuilder.ToImmutableAndFree());
+             return F.Block(blockBuilder.ToImmutableAndFree());
         }
 
         private BoundStatement GenerateAwaitOnCompletedDynamic(LocalSymbol awaiterTemp)

--- a/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/AsyncRewriter/AsyncMethodToStateMachineRewriter.cs
@@ -248,7 +248,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             BoundExpression expr = (BoundExpression)this.Visit(node.Expression);
-            return (expr != null) ? node.Update(expr) : (BoundStatement)F.Block();
+            return (expr != null) ? node.Update(expr) : (BoundStatement)F.StatementList();
         }
 
         public override BoundNode VisitAwaitExpression(BoundAwaitExpression node)
@@ -431,7 +431,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                     // this.state = cachedState = NotStartedStateMachine
                     F.Assignment(F.Field(F.This(), stateField), F.AssignmentExpression(F.Local(cachedState), F.Literal(StateMachineStates.NotStartedStateMachine))));
 
-             return F.Block(blockBuilder.ToImmutableAndFree());
+            return F.Block(blockBuilder.ToImmutableAndFree());
         }
 
         private BoundStatement GenerateAwaitOnCompletedDynamic(LocalSymbol awaiterTemp)

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -94,6 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // }
             // state_0:
             // state = -1;
+            // [optional: cachedThis = capturedThis;] 
             // [[rewritten body]]
             newBody = F.Block((object)cachedThis == null?
                                 ImmutableArray.Create(cachedState):

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorMethodToStateMachineRewriter.cs
@@ -95,11 +95,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             // state_0:
             // state = -1;
             // [[rewritten body]]
-            newBody = F.Block(ImmutableArray.Create(cachedState),
-                    F.Block(
-                        F.HiddenSequencePoint(),
-                        F.Assignment(F.Local(cachedState), F.Field(F.This(), stateField))
-                    ),
+            newBody = F.Block((object)cachedThis == null?
+                                ImmutableArray.Create(cachedState):
+                                ImmutableArray.Create(cachedState, cachedThis),
+
+                    F.HiddenSequencePoint(),
+                    F.Assignment(F.Local(cachedState), F.Field(F.This(), stateField)),
+                    CacheThisIfNeeded(),
                     Dispatch(),
                     GenerateReturn(finished: true),
                     F.Label(initialLabel),
@@ -386,8 +388,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             //      return;
             // }
             Debug.Assert(frame.parent.finalizeState == _currentFinallyFrame.finalizeState);
-            rewrittenHandler = F.Block(
+            rewrittenHandler = F.Block((object)this.cachedThis != null?
+                                            ImmutableArray.Create(this.cachedThis):
+                                            ImmutableArray<LocalSymbol>.Empty,
                                 F.Assignment(F.Field(F.This(), stateField), F.Literal(frame.parent.finalizeState)),
+                                CacheThisIfNeeded(),
                                 rewrittenHandler,
                                 F.Return()
                             );

--- a/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/IteratorRewriter/IteratorRewriter.cs
@@ -310,7 +310,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                             F.Assignment(F.Local(resultVariable), F.This()),       // result = this;
                             method.IsStatic || method.ThisParameter.Type.IsReferenceType ?   // if this is a reference type, no need to copy it since it is not assignable
                                 F.Goto(thisInitialized) :                          // goto thisInitialized
-                                (BoundStatement)F.Block()),
+                                (BoundStatement)F.StatementList()),
                     elseClauseOpt:
                         makeIterator // else result = new IteratorClass(0)
                         );

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -44,6 +44,8 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected readonly LocalSymbol cachedState;
 
+        protected readonly LocalSymbol cachedThis;
+
         private int _nextState;
 
         /// <summary>
@@ -135,6 +137,18 @@ namespace Microsoft.CodeAnalysis.CSharp
             foreach (var proxy in nonReusableLocalProxies)
             {
                 this.proxies.Add(proxy.Key, proxy.Value);
+            }
+
+            // create cache local for reference type "this" in Release
+            var thisParameter = originalMethod.ThisParameter;
+            CapturedSymbolReplacement thisProxy;
+            if ((object)thisParameter != null && 
+                thisParameter.Type.IsReferenceType &&
+                proxies.TryGetValue(thisParameter, out thisProxy) &&
+                F.Compilation.Options.OptimizationLevel == OptimizationLevel.Release)
+            {
+                var thisProxyReplacement = thisProxy.Replacement(F.Syntax, frameType => F.This());
+                this.cachedThis = F.SynthesizedLocal(thisProxyReplacement.Type, syntax: F.Syntax, kind: SynthesizedLocalKind.FrameCache);
             }
         }
 
@@ -739,8 +753,28 @@ namespace Microsoft.CodeAnalysis.CSharp
             return result;
         }
 
-        public override BoundNode VisitThisReference(BoundThisReference node)
+        protected BoundStatement CacheThisIfNeeded()
         {
+            // restore "this" cache, if there is a cache
+            if (this.cachedThis != null)
+            {
+                CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
+                var fetchThis = proxy.Replacement(F.Syntax, frameType => F.This());
+                return F.Assignment(F.Local(this.cachedThis), fetchThis);
+            }
+
+            // do nothing
+            return F.Block();
+        }
+
+        public sealed override BoundNode VisitThisReference(BoundThisReference node)
+        {
+            // if "this" is cached, return it.
+            if (this.cachedThis != null)
+            {
+                return F.Local(this.cachedThis);
+            }
+
             var thisParameter = this.OriginalMethod.ThisParameter;
             CapturedSymbolReplacement proxy;
             if ((object)thisParameter == null || !proxies.TryGetValue(thisParameter, out proxy))
@@ -768,6 +802,13 @@ namespace Microsoft.CodeAnalysis.CSharp
         public override BoundNode VisitBaseReference(BoundBaseReference node)
         {
             // TODO: fix up the type of the resulting node to be the base type
+
+            // if "this" is cached, return it.
+            if (this.cachedThis != null)
+            {
+                return F.Local(this.cachedThis);
+            }
+
             CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
             Debug.Assert(proxy != null);
             return proxy.Replacement(F.Syntax, frameType => F.This());

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/MethodToStateMachineRewriter.cs
@@ -44,6 +44,18 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// </summary>
         protected readonly LocalSymbol cachedState;
 
+        /// <summary>
+        /// Cached "this" local, used to store the captured "this", which is safe to cache locally since "this" 
+        /// is sematically immutable.
+        /// It would be hard for such caching to happen at JIT level (since JIT does not know that it never changes).
+        /// NOTE: this field is null when we are not caching "this" which happens when
+        ///       - not optimizing
+        ///       - method is not capturing "this" at all
+        ///       - containing type is a struct 
+        ///       (we could cache "this" as a ref local for struct containers, 
+        ///       but such caching would not save as much indirection and could actually 
+        ///       be done at JIT level, possibly more efficiently)
+        /// </summary>
         protected readonly LocalSymbol cachedThis;
 
         private int _nextState;
@@ -147,7 +159,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 proxies.TryGetValue(thisParameter, out thisProxy) &&
                 F.Compilation.Options.OptimizationLevel == OptimizationLevel.Release)
             {
-                var thisProxyReplacement = thisProxy.Replacement(F.Syntax, frameType => F.This());
+                BoundExpression thisProxyReplacement = thisProxy.Replacement(F.Syntax, frameType => F.This());
                 this.cachedThis = F.SynthesizedLocal(thisProxyReplacement.Type, syntax: F.Syntax, kind: SynthesizedLocalKind.FrameCache);
             }
         }
@@ -756,7 +768,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         protected BoundStatement CacheThisIfNeeded()
         {
             // restore "this" cache, if there is a cache
-            if (this.cachedThis != null)
+            if ((object)this.cachedThis != null)
             {
                 CapturedSymbolReplacement proxy = proxies[this.OriginalMethod.ThisParameter];
                 var fetchThis = proxy.Replacement(F.Syntax, frameType => F.This());
@@ -764,13 +776,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             // do nothing
-            return F.Block();
+            return F.StatementList();
         }
 
         public sealed override BoundNode VisitThisReference(BoundThisReference node)
         {
             // if "this" is cached, return it.
-            if (this.cachedThis != null)
+            if ((object)this.cachedThis != null)
             {
                 return F.Local(this.cachedThis);
             }
@@ -804,7 +816,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             // TODO: fix up the type of the resulting node to be the base type
 
             // if "this" is cached, return it.
-            if (this.cachedThis != null)
+            if ((object)this.cachedThis != null)
             {
                 return F.Local(this.cachedThis);
             }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineFieldSymbol.cs
@@ -14,6 +14,7 @@ namespace Microsoft.CodeAnalysis.CSharp
     internal sealed class StateMachineFieldSymbol : SynthesizedFieldSymbolBase, ISynthesizedMethodBodyImplementationSymbol
     {
         private readonly TypeSymbol _type;
+        private readonly bool _isThis;
 
         // -1 if the field doesn't represent a long-lived local or an awaiter.
         internal readonly int SlotIndex;
@@ -21,9 +22,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         internal readonly LocalSlotDebugInfo SlotDebugInfo;
 
         // Some fields need to be public since they are initialized directly by the kickoff method.
-        public StateMachineFieldSymbol(NamedTypeSymbol stateMachineType, TypeSymbol type, string name, bool isPublic)
+        public StateMachineFieldSymbol(NamedTypeSymbol stateMachineType, TypeSymbol type, string name, bool isPublic, bool isThis)
             : this(stateMachineType, type, name, new LocalSlotDebugInfo(SynthesizedLocalKind.LoweringTemp, LocalDebugId.None), slotIndex: -1, isPublic: isPublic)
         {
+            _isThis = isThis;
         }
 
         public StateMachineFieldSymbol(NamedTypeSymbol stateMachineType, TypeSymbol type, string name, SynthesizedLocalKind synthesizedKind, int slotIndex, bool isPublic)
@@ -60,6 +62,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         IMethodSymbol ISynthesizedMethodBodyImplementationSymbol.Method
         {
             get { return ((ISynthesizedMethodBodyImplementationSymbol)ContainingSymbol).Method; }
+        }
+
+        internal override bool IsCapturedFrame
+        {
+            get { return _isThis; }
         }
     }
 }

--- a/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/StateMachineRewriter/StateMachineRewriter.cs
@@ -208,13 +208,13 @@ namespace Microsoft.CodeAnalysis.CSharp
                     if (parameter.IsThis)
                     {
                         var containingType = method.ContainingType;
-                        var proxyField = F.StateMachineField(containingType, GeneratedNames.ThisProxyFieldName(), isPublic: true);
+                        var proxyField = F.StateMachineField(containingType, GeneratedNames.ThisProxyFieldName(), isPublic: true, isThis: true);
                         proxiesBuilder.Add(parameter, new CapturedToStateMachineFieldReplacement(proxyField, isReusable: false));
 
                         if (PreserveInitialParameterValues)
                         {
                             var initialThis = containingType.IsStructType() ?
-                                F.StateMachineField(containingType, GeneratedNames.StateMachineThisParameterProxyName(), isPublic: true) : proxyField;
+                                F.StateMachineField(containingType, GeneratedNames.StateMachineThisParameterProxyName(), isPublic: true, isThis: true) : proxyField;
 
                             initialParameters.Add(parameter, new CapturedToStateMachineFieldReplacement(initialThis, isReusable: false));
                         }

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -423,6 +423,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundBlock(Syntax, locals, localFunctions, statements) { WasCompilerGenerated = true };
         }
 
+        public BoundStatementList StatementList()
+        {
+            return StatementList(ImmutableArray<BoundStatement>.Empty);
+        }
+
         public BoundStatementList StatementList(ImmutableArray<BoundStatement> statements)
         {
             return new BoundStatementList(Syntax, statements) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -205,9 +205,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundHoistedFieldAccess(Syntax, field, field.Type);
         }
 
-        public StateMachineFieldSymbol StateMachineField(TypeSymbol type, string name, bool isPublic = false)
+        public StateMachineFieldSymbol StateMachineField(TypeSymbol type, string name, bool isPublic = false, bool isThis = false)
         {
-            var result = new StateMachineFieldSymbol(CurrentType, type, name, isPublic);
+            var result = new StateMachineFieldSymbol(CurrentType, type, name, isPublic, isThis);
             AddField(CurrentType, result);
             return result;
         }

--- a/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
+++ b/src/Compilers/CSharp/Test/Emit/BreakingChanges.cs
@@ -1149,7 +1149,102 @@ class Program
 }
 ";
             // Native print "++ ++ EX 2"
-            CompileAndVerify(source, expectedOutput: " ++ EX 1");
+            var verifier = CompileAndVerify(source, expectedOutput: " ++ EX 1");
+
+            // must not load "<>4__this"
+            verifier.VerifyIL("Program.test.<Foo>d__1.System.Collections.IEnumerator.MoveNext()", @"
+{
+  // Code size      101 (0x65)
+  .maxstack  2
+  .locals init (bool V_0,
+                int V_1)
+  .try
+  {
+    IL_0000:  ldarg.0
+    IL_0001:  ldfld      ""int Program.test.<Foo>d__1.<>1__state""
+    IL_0006:  stloc.1
+    IL_0007:  ldloc.1
+    IL_0008:  brfalse.s  IL_0012
+    IL_000a:  ldloc.1
+    IL_000b:  ldc.i4.1
+    IL_000c:  beq.s      IL_0033
+    IL_000e:  ldc.i4.0
+    IL_000f:  stloc.0
+    IL_0010:  leave.s    IL_0063
+    IL_0012:  ldarg.0
+    IL_0013:  ldc.i4.m1
+    IL_0014:  stfld      ""int Program.test.<Foo>d__1.<>1__state""
+    IL_0019:  ldarg.0
+    IL_001a:  ldc.i4.s   -3
+    IL_001c:  stfld      ""int Program.test.<Foo>d__1.<>1__state""
+    IL_0021:  ldarg.0
+    IL_0022:  ldnull
+    IL_0023:  stfld      ""object Program.test.<Foo>d__1.<>2__current""
+    IL_0028:  ldarg.0
+    IL_0029:  ldc.i4.1
+    IL_002a:  stfld      ""int Program.test.<Foo>d__1.<>1__state""
+    IL_002f:  ldc.i4.1
+    IL_0030:  stloc.0
+    IL_0031:  leave.s    IL_0063
+    IL_0033:  ldarg.0
+    IL_0034:  ldc.i4.s   -3
+    IL_0036:  stfld      ""int Program.test.<Foo>d__1.<>1__state""
+    .try
+    {
+      IL_003b:  ldc.i4.0
+      IL_003c:  stloc.0
+      IL_003d:  leave.s    IL_004a
+    }
+    catch object
+    {
+      IL_003f:  pop
+      IL_0040:  leave.s    IL_0042
+    }
+    IL_0042:  ldarg.0
+    IL_0043:  call       ""void Program.test.<Foo>d__1.<>m__Finally1()""
+    IL_0048:  br.s       IL_0052
+    IL_004a:  ldarg.0
+    IL_004b:  call       ""void Program.test.<Foo>d__1.<>m__Finally1()""
+    IL_0050:  leave.s    IL_0063
+    IL_0052:  leave.s    IL_005b
+  }
+  fault
+  {
+    IL_0054:  ldarg.0
+    IL_0055:  call       ""void Program.test.<Foo>d__1.Dispose()""
+    IL_005a:  endfinally
+  }
+  IL_005b:  ldarg.0
+  IL_005c:  call       ""void Program.test.<Foo>d__1.Dispose()""
+  IL_0061:  ldc.i4.1
+  IL_0062:  stloc.0
+  IL_0063:  ldloc.0
+  IL_0064:  ret
+}
+");
+
+            // must load "<>4__this"
+            verifier.VerifyIL("Program.test.<Foo>d__1.<>m__Finally1()", @"
+{
+  // Code size       42 (0x2a)
+  .maxstack  3
+  IL_0000:  ldarg.0
+  IL_0001:  ldc.i4.m1
+  IL_0002:  stfld      ""int Program.test.<Foo>d__1.<>1__state""
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""Program.test Program.test.<Foo>d__1.<>4__this""
+  IL_000d:  ldstr      ""++ ""
+  IL_0012:  call       ""void System.Console.Write(string)""
+  IL_0017:  dup
+  IL_0018:  ldfld      ""int Program.test.count""
+  IL_001d:  ldc.i4.1
+  IL_001e:  add
+  IL_001f:  stfld      ""int Program.test.count""
+  IL_0024:  newobj     ""System.Exception..ctor()""
+  IL_0029:  throw
+}
+");
+
         }
 
         [Fact, WorkItem(530587, "http://vstfdevdiv:8080/DevDiv2/DevDiv/_workitems/edit/530587")]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenAsyncLocalsTests.cs
@@ -499,7 +499,397 @@ class Test
             var expected = @"
 42
 ";
-            CompileAndVerify(source, expectedOutput: expected);
+            var verifier = CompileAndVerify(source, expectedOutput: expected);
+
+            verifier.VerifyIL("C.<F>d__1.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      199 (0xc7)
+  .maxstack  3
+  .locals init (int V_0,
+                C V_1,
+                int V_2,
+                C.<>c__DisplayClass1_0 V_3, //CS$<>8__locals0
+                System.Runtime.CompilerServices.TaskAwaiter<int> V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__1.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C C.<F>d__1.<>4__this""
+  IL_000d:  stloc.1
+  .try
+  {
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse.s  IL_006a
+    IL_0011:  newobj     ""C.<>c__DisplayClass1_0..ctor()""
+    IL_0016:  stloc.3
+    IL_0017:  ldloc.3
+    IL_0018:  ldloc.1
+    IL_0019:  ldfld      ""int C.x""
+    IL_001e:  stfld      ""int C.<>c__DisplayClass1_0.c""
+    IL_0023:  call       ""System.Threading.Tasks.TaskFactory System.Threading.Tasks.Task.Factory.get""
+    IL_0028:  ldloc.3
+    IL_0029:  ldftn      ""int C.<>c__DisplayClass1_0.<F>b__0()""
+    IL_002f:  newobj     ""System.Func<int>..ctor(object, System.IntPtr)""
+    IL_0034:  callvirt   ""System.Threading.Tasks.Task<int> System.Threading.Tasks.TaskFactory.StartNew<int>(System.Func<int>)""
+    IL_0039:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
+    IL_003e:  stloc.s    V_4
+    IL_0040:  ldloca.s   V_4
+    IL_0042:  call       ""bool System.Runtime.CompilerServices.TaskAwaiter<int>.IsCompleted.get""
+    IL_0047:  brtrue.s   IL_0087
+    IL_0049:  ldarg.0
+    IL_004a:  ldc.i4.0
+    IL_004b:  dup
+    IL_004c:  stloc.0
+    IL_004d:  stfld      ""int C.<F>d__1.<>1__state""
+    IL_0052:  ldarg.0
+    IL_0053:  ldloc.s    V_4
+    IL_0055:  stfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__1.<>u__1""
+    IL_005a:  ldarg.0
+    IL_005b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
+    IL_0060:  ldloca.s   V_4
+    IL_0062:  ldarg.0
+    IL_0063:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.TaskAwaiter<int>, C.<F>d__1>(ref System.Runtime.CompilerServices.TaskAwaiter<int>, ref C.<F>d__1)""
+    IL_0068:  leave.s    IL_00c6
+    IL_006a:  ldarg.0
+    IL_006b:  ldfld      ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__1.<>u__1""
+    IL_0070:  stloc.s    V_4
+    IL_0072:  ldarg.0
+    IL_0073:  ldflda     ""System.Runtime.CompilerServices.TaskAwaiter<int> C.<F>d__1.<>u__1""
+    IL_0078:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_007e:  ldarg.0
+    IL_007f:  ldc.i4.m1
+    IL_0080:  dup
+    IL_0081:  stloc.0
+    IL_0082:  stfld      ""int C.<F>d__1.<>1__state""
+    IL_0087:  ldloca.s   V_4
+    IL_0089:  call       ""int System.Runtime.CompilerServices.TaskAwaiter<int>.GetResult()""
+    IL_008e:  ldloca.s   V_4
+    IL_0090:  initobj    ""System.Runtime.CompilerServices.TaskAwaiter<int>""
+    IL_0096:  stloc.2
+    IL_0097:  leave.s    IL_00b2
+  }
+  catch System.Exception
+  {
+    IL_0099:  stloc.s    V_5
+    IL_009b:  ldarg.0
+    IL_009c:  ldc.i4.s   -2
+    IL_009e:  stfld      ""int C.<F>d__1.<>1__state""
+    IL_00a3:  ldarg.0
+    IL_00a4:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
+    IL_00a9:  ldloc.s    V_5
+    IL_00ab:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_00b0:  leave.s    IL_00c6
+  }
+  IL_00b2:  ldarg.0
+  IL_00b3:  ldc.i4.s   -2
+  IL_00b5:  stfld      ""int C.<F>d__1.<>1__state""
+  IL_00ba:  ldarg.0
+  IL_00bb:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__1.<>t__builder""
+  IL_00c0:  ldloc.2
+  IL_00c1:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_00c6:  ret
+}
+");
+
+        }
+
+        [Fact]
+        public void AsyncWithThisRef01()
+        {
+            var source = @"
+using System;
+using System.Threading.Tasks;
+
+class C
+{
+    int x => 14;
+
+    public async Task<int> F()
+    {
+        int c = this.x;
+        await Task.Yield();
+        c += this.x;
+        await Task.Yield();
+        c += this.x;
+        await Task.Yield();
+        await Task.Yield();
+        await Task.Yield();
+
+        return c;
+    }
+}
+
+class Test
+{
+    public static void Main()
+    {
+        Task<int> t = new C().F();
+        t.Wait(1000 * 60);
+        Console.WriteLine(t.Result);
+    }
+}";
+            var expected = @"
+42
+";
+            var verifier = CompileAndVerify(source, expectedOutput: expected);
+
+            verifier.VerifyIL("C.<F>d__2.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
+{
+  // Code size      652 (0x28c)
+  .maxstack  3
+  .locals init (int V_0,
+                C V_1,
+                int V_2,
+                System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter V_3,
+                System.Runtime.CompilerServices.YieldAwaitable V_4,
+                System.Exception V_5)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""int C.<F>d__2.<>1__state""
+  IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C C.<F>d__2.<>4__this""
+  IL_000d:  stloc.1
+  .try
+  {
+    IL_000e:  ldloc.0
+    IL_000f:  switch    (
+        IL_006f,
+        IL_00e8,
+        IL_0161,
+        IL_01c7,
+        IL_022a)
+    IL_0028:  ldarg.0
+    IL_0029:  ldloc.1
+    IL_002a:  call       ""int C.x.get""
+    IL_002f:  stfld      ""int C.<F>d__2.<c>5__1""
+    IL_0034:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0039:  stloc.s    V_4
+    IL_003b:  ldloca.s   V_4
+    IL_003d:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0042:  stloc.3
+    IL_0043:  ldloca.s   V_3
+    IL_0045:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_004a:  brtrue.s   IL_008b
+    IL_004c:  ldarg.0
+    IL_004d:  ldc.i4.0
+    IL_004e:  dup
+    IL_004f:  stloc.0
+    IL_0050:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0055:  ldarg.0
+    IL_0056:  ldloc.3
+    IL_0057:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_005c:  ldarg.0
+    IL_005d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0062:  ldloca.s   V_3
+    IL_0064:  ldarg.0
+    IL_0065:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_006a:  leave      IL_028b
+    IL_006f:  ldarg.0
+    IL_0070:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0075:  stloc.3
+    IL_0076:  ldarg.0
+    IL_0077:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_007c:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0082:  ldarg.0
+    IL_0083:  ldc.i4.m1
+    IL_0084:  dup
+    IL_0085:  stloc.0
+    IL_0086:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_008b:  ldloca.s   V_3
+    IL_008d:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0092:  ldloca.s   V_3
+    IL_0094:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_009a:  ldarg.0
+    IL_009b:  ldarg.0
+    IL_009c:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_00a1:  ldloc.1
+    IL_00a2:  call       ""int C.x.get""
+    IL_00a7:  add
+    IL_00a8:  stfld      ""int C.<F>d__2.<c>5__1""
+    IL_00ad:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_00b2:  stloc.s    V_4
+    IL_00b4:  ldloca.s   V_4
+    IL_00b6:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_00bb:  stloc.3
+    IL_00bc:  ldloca.s   V_3
+    IL_00be:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_00c3:  brtrue.s   IL_0104
+    IL_00c5:  ldarg.0
+    IL_00c6:  ldc.i4.1
+    IL_00c7:  dup
+    IL_00c8:  stloc.0
+    IL_00c9:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_00ce:  ldarg.0
+    IL_00cf:  ldloc.3
+    IL_00d0:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00d5:  ldarg.0
+    IL_00d6:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_00db:  ldloca.s   V_3
+    IL_00dd:  ldarg.0
+    IL_00de:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_00e3:  leave      IL_028b
+    IL_00e8:  ldarg.0
+    IL_00e9:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00ee:  stloc.3
+    IL_00ef:  ldarg.0
+    IL_00f0:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_00f5:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_00fb:  ldarg.0
+    IL_00fc:  ldc.i4.m1
+    IL_00fd:  dup
+    IL_00fe:  stloc.0
+    IL_00ff:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0104:  ldloca.s   V_3
+    IL_0106:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_010b:  ldloca.s   V_3
+    IL_010d:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0113:  ldarg.0
+    IL_0114:  ldarg.0
+    IL_0115:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_011a:  ldloc.1
+    IL_011b:  call       ""int C.x.get""
+    IL_0120:  add
+    IL_0121:  stfld      ""int C.<F>d__2.<c>5__1""
+    IL_0126:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_012b:  stloc.s    V_4
+    IL_012d:  ldloca.s   V_4
+    IL_012f:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0134:  stloc.3
+    IL_0135:  ldloca.s   V_3
+    IL_0137:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_013c:  brtrue.s   IL_017d
+    IL_013e:  ldarg.0
+    IL_013f:  ldc.i4.2
+    IL_0140:  dup
+    IL_0141:  stloc.0
+    IL_0142:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0147:  ldarg.0
+    IL_0148:  ldloc.3
+    IL_0149:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_014e:  ldarg.0
+    IL_014f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0154:  ldloca.s   V_3
+    IL_0156:  ldarg.0
+    IL_0157:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_015c:  leave      IL_028b
+    IL_0161:  ldarg.0
+    IL_0162:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0167:  stloc.3
+    IL_0168:  ldarg.0
+    IL_0169:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_016e:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0174:  ldarg.0
+    IL_0175:  ldc.i4.m1
+    IL_0176:  dup
+    IL_0177:  stloc.0
+    IL_0178:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_017d:  ldloca.s   V_3
+    IL_017f:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_0184:  ldloca.s   V_3
+    IL_0186:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_018c:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_0191:  stloc.s    V_4
+    IL_0193:  ldloca.s   V_4
+    IL_0195:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_019a:  stloc.3
+    IL_019b:  ldloca.s   V_3
+    IL_019d:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_01a2:  brtrue.s   IL_01e3
+    IL_01a4:  ldarg.0
+    IL_01a5:  ldc.i4.3
+    IL_01a6:  dup
+    IL_01a7:  stloc.0
+    IL_01a8:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_01ad:  ldarg.0
+    IL_01ae:  ldloc.3
+    IL_01af:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01b4:  ldarg.0
+    IL_01b5:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_01ba:  ldloca.s   V_3
+    IL_01bc:  ldarg.0
+    IL_01bd:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_01c2:  leave      IL_028b
+    IL_01c7:  ldarg.0
+    IL_01c8:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01cd:  stloc.3
+    IL_01ce:  ldarg.0
+    IL_01cf:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_01d4:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_01da:  ldarg.0
+    IL_01db:  ldc.i4.m1
+    IL_01dc:  dup
+    IL_01dd:  stloc.0
+    IL_01de:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_01e3:  ldloca.s   V_3
+    IL_01e5:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_01ea:  ldloca.s   V_3
+    IL_01ec:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_01f2:  call       ""System.Runtime.CompilerServices.YieldAwaitable System.Threading.Tasks.Task.Yield()""
+    IL_01f7:  stloc.s    V_4
+    IL_01f9:  ldloca.s   V_4
+    IL_01fb:  call       ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter System.Runtime.CompilerServices.YieldAwaitable.GetAwaiter()""
+    IL_0200:  stloc.3
+    IL_0201:  ldloca.s   V_3
+    IL_0203:  call       ""bool System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.IsCompleted.get""
+    IL_0208:  brtrue.s   IL_0246
+    IL_020a:  ldarg.0
+    IL_020b:  ldc.i4.4
+    IL_020c:  dup
+    IL_020d:  stloc.0
+    IL_020e:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0213:  ldarg.0
+    IL_0214:  ldloc.3
+    IL_0215:  stfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_021a:  ldarg.0
+    IL_021b:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_0220:  ldloca.s   V_3
+    IL_0222:  ldarg.0
+    IL_0223:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, C.<F>d__2>(ref System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter, ref C.<F>d__2)""
+    IL_0228:  leave.s    IL_028b
+    IL_022a:  ldarg.0
+    IL_022b:  ldfld      ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0230:  stloc.3
+    IL_0231:  ldarg.0
+    IL_0232:  ldflda     ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter C.<F>d__2.<>u__1""
+    IL_0237:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_023d:  ldarg.0
+    IL_023e:  ldc.i4.m1
+    IL_023f:  dup
+    IL_0240:  stloc.0
+    IL_0241:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0246:  ldloca.s   V_3
+    IL_0248:  call       ""void System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter.GetResult()""
+    IL_024d:  ldloca.s   V_3
+    IL_024f:  initobj    ""System.Runtime.CompilerServices.YieldAwaitable.YieldAwaiter""
+    IL_0255:  ldarg.0
+    IL_0256:  ldfld      ""int C.<F>d__2.<c>5__1""
+    IL_025b:  stloc.2
+    IL_025c:  leave.s    IL_0277
+  }
+  catch System.Exception
+  {
+    IL_025e:  stloc.s    V_5
+    IL_0260:  ldarg.0
+    IL_0261:  ldc.i4.s   -2
+    IL_0263:  stfld      ""int C.<F>d__2.<>1__state""
+    IL_0268:  ldarg.0
+    IL_0269:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+    IL_026e:  ldloc.s    V_5
+    IL_0270:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetException(System.Exception)""
+    IL_0275:  leave.s    IL_028b
+  }
+  IL_0277:  ldarg.0
+  IL_0278:  ldc.i4.s   -2
+  IL_027a:  stfld      ""int C.<F>d__2.<>1__state""
+  IL_027f:  ldarg.0
+  IL_0280:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int> C.<F>d__2.<>t__builder""
+  IL_0285:  ldloc.2
+  IL_0286:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<int>.SetResult(int)""
+  IL_028b:  ret
+}
+");
+
         }
 
         [Fact]

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDeconstructTests.cs
@@ -3970,7 +3970,7 @@ System.Console.Write($""{x1} {x2} {x3}"");
     IL_000d:  ldarg.0
     IL_000e:  ldfld      ""Script <<Initialize>>d__0.<>4__this""
     IL_0013:  ldflda     ""int x1""
-    IL_0018:  callvirt   ""(int, int) M(out int)""
+    IL_0018:  call       ""(int, int) M(out int)""
     IL_001d:  dup
     IL_001e:  ldfld      ""int System.ValueTuple<int, int>.Item1""
     IL_0023:  stloc.2

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenDynamicTests.cs
@@ -720,51 +720,54 @@ class C
 ";
             CompileAndVerifyIL(source, "C.<Run>d__1<T>.System.Collections.IEnumerator.MoveNext", @"
 {
-  // Code size      121 (0x79)
+  // Code size      123 (0x7b)
   .maxstack  4
-  .locals init (int V_0)
+  .locals init (int V_0,
+                C V_1)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<Run>d__1<T>.<>1__state""
   IL_0006:  stloc.0
-  IL_0007:  ldloc.0
-  IL_0008:  brfalse.s  IL_0010
-  IL_000a:  ldloc.0
-  IL_000b:  ldc.i4.1
-  IL_000c:  beq.s      IL_0070
-  IL_000e:  ldc.i4.0
-  IL_000f:  ret
-  IL_0010:  ldarg.0
-  IL_0011:  ldc.i4.m1
-  IL_0012:  stfld      ""int C.<Run>d__1<T>.<>1__state""
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C C.<Run>d__1<T>.<>4__this""
+  IL_000d:  stloc.1
+  IL_000e:  ldloc.0
+  IL_000f:  brfalse.s  IL_0017
+  IL_0011:  ldloc.0
+  IL_0012:  ldc.i4.1
+  IL_0013:  beq.s      IL_0072
+  IL_0015:  ldc.i4.0
+  IL_0016:  ret
   IL_0017:  ldarg.0
-  IL_0018:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
-  IL_001d:  brtrue.s   IL_0043
-  IL_001f:  ldc.i4.0
-  IL_0020:  ldtoken    ""T""
-  IL_0025:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_002a:  ldtoken    ""C""
-  IL_002f:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-  IL_0034:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-  IL_0039:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-  IL_003e:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
-  IL_0043:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
-  IL_0048:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, T> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>>.Target""
-  IL_004d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
-  IL_0052:  ldarg.0
-  IL_0053:  ldfld      ""C C.<Run>d__1<T>.<>4__this""
-  IL_0058:  ldfld      ""dynamic C.d""
-  IL_005d:  callvirt   ""T System.Func<System.Runtime.CompilerServices.CallSite, object, T>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-  IL_0062:  stfld      ""T C.<Run>d__1<T>.<>2__current""
-  IL_0067:  ldarg.0
-  IL_0068:  ldc.i4.1
-  IL_0069:  stfld      ""int C.<Run>d__1<T>.<>1__state""
-  IL_006e:  ldc.i4.1
-  IL_006f:  ret
-  IL_0070:  ldarg.0
-  IL_0071:  ldc.i4.m1
-  IL_0072:  stfld      ""int C.<Run>d__1<T>.<>1__state""
-  IL_0077:  ldc.i4.0
-  IL_0078:  ret
+  IL_0018:  ldc.i4.m1
+  IL_0019:  stfld      ""int C.<Run>d__1<T>.<>1__state""
+  IL_001e:  ldarg.0
+  IL_001f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
+  IL_0024:  brtrue.s   IL_004a
+  IL_0026:  ldc.i4.0
+  IL_0027:  ldtoken    ""T""
+  IL_002c:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_0031:  ldtoken    ""C""
+  IL_0036:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+  IL_003b:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+  IL_0040:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+  IL_0045:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
+  IL_004a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
+  IL_004f:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, T> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>>.Target""
+  IL_0054:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, T>> C.<>o__1<T>.<>p__0""
+  IL_0059:  ldloc.1
+  IL_005a:  ldfld      ""dynamic C.d""
+  IL_005f:  callvirt   ""T System.Func<System.Runtime.CompilerServices.CallSite, object, T>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+  IL_0064:  stfld      ""T C.<Run>d__1<T>.<>2__current""
+  IL_0069:  ldarg.0
+  IL_006a:  ldc.i4.1
+  IL_006b:  stfld      ""int C.<Run>d__1<T>.<>1__state""
+  IL_0070:  ldc.i4.1
+  IL_0071:  ret
+  IL_0072:  ldarg.0
+  IL_0073:  ldc.i4.m1
+  IL_0074:  stfld      ""int C.<Run>d__1<T>.<>1__state""
+  IL_0079:  ldc.i4.0
+  IL_007a:  ret
 }
 ");
         }
@@ -7415,72 +7418,74 @@ dynamic x = Color.F((dynamic)1);
             var verifier = CompileAndVerify(script);
             verifier.VerifyIL("<<Initialize>>d__0.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()",
 @"{
-  // Code size      161 (0xa1)
+  // Code size      158 (0x9e)
   .maxstack  10
-  .locals init (object V_0,
-                System.Exception V_1)
+  .locals init (Script V_0,
+                object V_1,
+                System.Exception V_2)
+  IL_0000:  ldarg.0
+  IL_0001:  ldfld      ""Script Script.<<Initialize>>d__0.<>4__this""
+  IL_0006:  stloc.0
   .try
   {
-    IL_0000:  ldarg.0
-    IL_0001:  ldfld      ""Script Script.<<Initialize>>d__0.<>4__this""
-    IL_0006:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
-    IL_000b:  brtrue.s   IL_0047
-    IL_000d:  ldc.i4.0
-    IL_000e:  ldstr      ""F""
-    IL_0013:  ldnull
-    IL_0014:  ldtoken    ""Script""
-    IL_0019:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_001e:  ldc.i4.2
-    IL_001f:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_0024:  dup
-    IL_0025:  ldc.i4.0
-    IL_0026:  ldc.i4.1
-    IL_0027:  ldnull
-    IL_0028:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_002d:  stelem.ref
-    IL_002e:  dup
-    IL_002f:  ldc.i4.1
-    IL_0030:  ldc.i4.0
-    IL_0031:  ldnull
-    IL_0032:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0037:  stelem.ref
-    IL_0038:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_003d:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_0042:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
-    IL_0047:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
-    IL_004c:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Target""
-    IL_0051:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
-    IL_0056:  ldarg.0
-    IL_0057:  ldfld      ""Script Script.<<Initialize>>d__0.<>4__this""
-    IL_005c:  ldfld      ""Color Script.Color""
-    IL_0061:  ldc.i4.1
-    IL_0062:  box        ""int""
-    IL_0067:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, Color, object)""
-    IL_006c:  stfld      ""dynamic Script.x""
-    IL_0071:  ldnull
-    IL_0072:  stloc.0
-    IL_0073:  leave.s    IL_008c
+    IL_0007:  ldloc.0
+    IL_0008:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+    IL_000d:  brtrue.s   IL_0049
+    IL_000f:  ldc.i4.0
+    IL_0010:  ldstr      ""F""
+    IL_0015:  ldnull
+    IL_0016:  ldtoken    ""Script""
+    IL_001b:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_0020:  ldc.i4.2
+    IL_0021:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0026:  dup
+    IL_0027:  ldc.i4.0
+    IL_0028:  ldc.i4.1
+    IL_0029:  ldnull
+    IL_002a:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_002f:  stelem.ref
+    IL_0030:  dup
+    IL_0031:  ldc.i4.1
+    IL_0032:  ldc.i4.0
+    IL_0033:  ldnull
+    IL_0034:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_0039:  stelem.ref
+    IL_003a:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_003f:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0044:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+    IL_0049:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+    IL_004e:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>>.Target""
+    IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>> Script.<>o__0.<>p__0""
+    IL_0058:  ldloc.0
+    IL_0059:  ldfld      ""Color Script.Color""
+    IL_005e:  ldc.i4.1
+    IL_005f:  box        ""int""
+    IL_0064:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, Color, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, Color, object)""
+    IL_0069:  stfld      ""dynamic Script.x""
+    IL_006e:  ldnull
+    IL_006f:  stloc.1
+    IL_0070:  leave.s    IL_0089
   }
   catch System.Exception
   {
-    IL_0075:  stloc.1
-    IL_0076:  ldarg.0
-    IL_0077:  ldc.i4.s   -2
-    IL_0079:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
-    IL_007e:  ldarg.0
-    IL_007f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
-    IL_0084:  ldloc.1
-    IL_0085:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_008a:  leave.s    IL_00a0
+    IL_0072:  stloc.2
+    IL_0073:  ldarg.0
+    IL_0074:  ldc.i4.s   -2
+    IL_0076:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
+    IL_007b:  ldarg.0
+    IL_007c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
+    IL_0081:  ldloc.2
+    IL_0082:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0087:  leave.s    IL_009d
   }
-  IL_008c:  ldarg.0
-  IL_008d:  ldc.i4.s   -2
-  IL_008f:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
-  IL_0094:  ldarg.0
-  IL_0095:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
-  IL_009a:  ldloc.0
-  IL_009b:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_00a0:  ret
+  IL_0089:  ldarg.0
+  IL_008a:  ldc.i4.s   -2
+  IL_008c:  stfld      ""int Script.<<Initialize>>d__0.<>1__state""
+  IL_0091:  ldarg.0
+  IL_0092:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> Script.<<Initialize>>d__0.<>t__builder""
+  IL_0097:  ldloc.1
+  IL_0098:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_009d:  ret
 }", realIL: true);
         }
 
@@ -14662,195 +14667,198 @@ class C
 
             CompileAndVerifyIL(source, "C.<>c__DisplayClass0_0.<<Main>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()", @"
 {
-  // Code size      534 (0x216)
+  // Code size      539 (0x21b)
   .maxstack  10
   .locals init (int V_0,
-                object V_1,
+                C.<>c__DisplayClass0_0 V_1,
                 object V_2,
-                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_3,
-                System.Runtime.CompilerServices.INotifyCompletion V_4,
-                System.Exception V_5)
+                object V_3,
+                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_4,
+                System.Runtime.CompilerServices.INotifyCompletion V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
   IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""C.<>c__DisplayClass0_0 C.<>c__DisplayClass0_0.<<Main>b__0>d.<>4__this""
+  IL_000d:  stloc.1
   .try
   {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0180
-    IL_000d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
-    IL_0012:  brtrue.s   IL_0044
-    IL_0014:  ldc.i4.0
-    IL_0015:  ldstr      ""GetAwaiter""
-    IL_001a:  ldnull
-    IL_001b:  ldtoken    ""C""
-    IL_0020:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0025:  ldc.i4.1
-    IL_0026:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_002b:  dup
-    IL_002c:  ldc.i4.0
-    IL_002d:  ldc.i4.0
-    IL_002e:  ldnull
-    IL_002f:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0034:  stelem.ref
-    IL_0035:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_003a:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_003f:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
-    IL_0044:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
-    IL_0049:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_004e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
-    IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
-    IL_0058:  brtrue.s   IL_0084
-    IL_005a:  ldc.i4.0
-    IL_005b:  ldtoken    ""C""
-    IL_0060:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0065:  ldc.i4.1
-    IL_0066:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_006b:  dup
-    IL_006c:  ldc.i4.0
-    IL_006d:  ldc.i4.0
-    IL_006e:  ldnull
-    IL_006f:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0074:  stelem.ref
-    IL_0075:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_007a:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_007f:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
-    IL_0084:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
-    IL_0089:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_008e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
-    IL_0093:  ldarg.0
-    IL_0094:  ldfld      ""C.<>c__DisplayClass0_0 C.<>c__DisplayClass0_0.<<Main>b__0>d.<>4__this""
-    IL_0099:  ldfld      ""dynamic C.<>c__DisplayClass0_0.d""
-    IL_009e:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_00a3:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_00a8:  stloc.2
-    IL_00a9:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
-    IL_00ae:  brtrue.s   IL_00d5
-    IL_00b0:  ldc.i4.s   16
-    IL_00b2:  ldtoken    ""bool""
-    IL_00b7:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00bc:  ldtoken    ""C""
-    IL_00c1:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c6:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-    IL_00cb:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_00d0:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
-    IL_00d5:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
-    IL_00da:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Target""
-    IL_00df:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
-    IL_00e4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
-    IL_00e9:  brtrue.s   IL_011a
-    IL_00eb:  ldc.i4.0
-    IL_00ec:  ldstr      ""IsCompleted""
-    IL_00f1:  ldtoken    ""C""
-    IL_00f6:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00fb:  ldc.i4.1
-    IL_00fc:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_0101:  dup
-    IL_0102:  ldc.i4.0
-    IL_0103:  ldc.i4.0
-    IL_0104:  ldnull
-    IL_0105:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_010a:  stelem.ref
-    IL_010b:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_0110:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_0115:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
-    IL_011a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
-    IL_011f:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_0124:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
-    IL_0129:  ldloc.2
-    IL_012a:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_012f:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, object, bool>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_0134:  brtrue.s   IL_0197
-    IL_0136:  ldarg.0
-    IL_0137:  ldc.i4.0
-    IL_0138:  dup
-    IL_0139:  stloc.0
-    IL_013a:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-    IL_013f:  ldarg.0
-    IL_0140:  ldloc.2
-    IL_0141:  stfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
-    IL_0146:  ldloc.2
-    IL_0147:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
-    IL_014c:  stloc.3
-    IL_014d:  ldloc.3
-    IL_014e:  brtrue.s   IL_016b
-    IL_0150:  ldloc.2
-    IL_0151:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
-    IL_0156:  stloc.s    V_4
-    IL_0158:  ldarg.0
-    IL_0159:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-    IL_015e:  ldloca.s   V_4
-    IL_0160:  ldarg.0
-    IL_0161:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, C.<>c__DisplayClass0_0.<<Main>b__0>d>(ref System.Runtime.CompilerServices.INotifyCompletion, ref C.<>c__DisplayClass0_0.<<Main>b__0>d)""
-    IL_0166:  ldnull
-    IL_0167:  stloc.s    V_4
-    IL_0169:  br.s       IL_0179
-    IL_016b:  ldarg.0
-    IL_016c:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-    IL_0171:  ldloca.s   V_3
-    IL_0173:  ldarg.0
-    IL_0174:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<>c__DisplayClass0_0.<<Main>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<>c__DisplayClass0_0.<<Main>b__0>d)""
-    IL_0179:  ldnull
-    IL_017a:  stloc.3
-    IL_017b:  leave      IL_0215
-    IL_0180:  ldarg.0
-    IL_0181:  ldfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
-    IL_0186:  stloc.2
-    IL_0187:  ldarg.0
-    IL_0188:  ldnull
-    IL_0189:  stfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
-    IL_018e:  ldarg.0
-    IL_018f:  ldc.i4.m1
-    IL_0190:  dup
-    IL_0191:  stloc.0
-    IL_0192:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-    IL_0197:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
-    IL_019c:  brtrue.s   IL_01ce
-    IL_019e:  ldc.i4.0
-    IL_019f:  ldstr      ""GetResult""
-    IL_01a4:  ldnull
-    IL_01a5:  ldtoken    ""C""
-    IL_01aa:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_01af:  ldc.i4.1
-    IL_01b0:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_01b5:  dup
-    IL_01b6:  ldc.i4.0
-    IL_01b7:  ldc.i4.0
-    IL_01b8:  ldnull
-    IL_01b9:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_01be:  stelem.ref
-    IL_01bf:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_01c4:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_01c9:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
-    IL_01ce:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
-    IL_01d3:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
-    IL_01d8:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
-    IL_01dd:  ldloc.2
-    IL_01de:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
-    IL_01e3:  ldnull
-    IL_01e4:  stloc.2
-    IL_01e5:  stloc.1
-    IL_01e6:  leave.s    IL_0201
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse    IL_0185
+    IL_0014:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
+    IL_0019:  brtrue.s   IL_004b
+    IL_001b:  ldc.i4.0
+    IL_001c:  ldstr      ""GetAwaiter""
+    IL_0021:  ldnull
+    IL_0022:  ldtoken    ""C""
+    IL_0027:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_002c:  ldc.i4.1
+    IL_002d:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0032:  dup
+    IL_0033:  ldc.i4.0
+    IL_0034:  ldc.i4.0
+    IL_0035:  ldnull
+    IL_0036:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_003b:  stelem.ref
+    IL_003c:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0041:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0046:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
+    IL_004b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
+    IL_0050:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_0055:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__0""
+    IL_005a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
+    IL_005f:  brtrue.s   IL_008b
+    IL_0061:  ldc.i4.0
+    IL_0062:  ldtoken    ""C""
+    IL_0067:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_006c:  ldc.i4.1
+    IL_006d:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0072:  dup
+    IL_0073:  ldc.i4.0
+    IL_0074:  ldc.i4.0
+    IL_0075:  ldnull
+    IL_0076:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_007b:  stelem.ref
+    IL_007c:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0081:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0086:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
+    IL_008b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
+    IL_0090:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_0095:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>o__0.<>p__0""
+    IL_009a:  ldloc.1
+    IL_009b:  ldfld      ""dynamic C.<>c__DisplayClass0_0.d""
+    IL_00a0:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_00a5:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_00aa:  stloc.3
+    IL_00ab:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
+    IL_00b0:  brtrue.s   IL_00d7
+    IL_00b2:  ldc.i4.s   16
+    IL_00b4:  ldtoken    ""bool""
+    IL_00b9:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_00be:  ldtoken    ""C""
+    IL_00c3:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_00c8:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+    IL_00cd:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_00d2:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
+    IL_00d7:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
+    IL_00dc:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>>.Target""
+    IL_00e1:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, bool>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__2""
+    IL_00e6:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
+    IL_00eb:  brtrue.s   IL_011c
+    IL_00ed:  ldc.i4.0
+    IL_00ee:  ldstr      ""IsCompleted""
+    IL_00f3:  ldtoken    ""C""
+    IL_00f8:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_00fd:  ldc.i4.1
+    IL_00fe:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0103:  dup
+    IL_0104:  ldc.i4.0
+    IL_0105:  ldc.i4.0
+    IL_0106:  ldnull
+    IL_0107:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_010c:  stelem.ref
+    IL_010d:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0112:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0117:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
+    IL_011c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
+    IL_0121:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_0126:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__1""
+    IL_012b:  ldloc.3
+    IL_012c:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_0131:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, object, bool>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_0136:  brtrue.s   IL_019c
+    IL_0138:  ldarg.0
+    IL_0139:  ldc.i4.0
+    IL_013a:  dup
+    IL_013b:  stloc.0
+    IL_013c:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+    IL_0141:  ldarg.0
+    IL_0142:  ldloc.3
+    IL_0143:  stfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
+    IL_0148:  ldloc.3
+    IL_0149:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
+    IL_014e:  stloc.s    V_4
+    IL_0150:  ldloc.s    V_4
+    IL_0152:  brtrue.s   IL_016f
+    IL_0154:  ldloc.3
+    IL_0155:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
+    IL_015a:  stloc.s    V_5
+    IL_015c:  ldarg.0
+    IL_015d:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+    IL_0162:  ldloca.s   V_5
+    IL_0164:  ldarg.0
+    IL_0165:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, C.<>c__DisplayClass0_0.<<Main>b__0>d>(ref System.Runtime.CompilerServices.INotifyCompletion, ref C.<>c__DisplayClass0_0.<<Main>b__0>d)""
+    IL_016a:  ldnull
+    IL_016b:  stloc.s    V_5
+    IL_016d:  br.s       IL_017d
+    IL_016f:  ldarg.0
+    IL_0170:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+    IL_0175:  ldloca.s   V_4
+    IL_0177:  ldarg.0
+    IL_0178:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, C.<>c__DisplayClass0_0.<<Main>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref C.<>c__DisplayClass0_0.<<Main>b__0>d)""
+    IL_017d:  ldnull
+    IL_017e:  stloc.s    V_4
+    IL_0180:  leave      IL_021a
+    IL_0185:  ldarg.0
+    IL_0186:  ldfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
+    IL_018b:  stloc.3
+    IL_018c:  ldarg.0
+    IL_018d:  ldnull
+    IL_018e:  stfld      ""object C.<>c__DisplayClass0_0.<<Main>b__0>d.<>u__1""
+    IL_0193:  ldarg.0
+    IL_0194:  ldc.i4.m1
+    IL_0195:  dup
+    IL_0196:  stloc.0
+    IL_0197:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+    IL_019c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
+    IL_01a1:  brtrue.s   IL_01d3
+    IL_01a3:  ldc.i4.0
+    IL_01a4:  ldstr      ""GetResult""
+    IL_01a9:  ldnull
+    IL_01aa:  ldtoken    ""C""
+    IL_01af:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_01b4:  ldc.i4.1
+    IL_01b5:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_01ba:  dup
+    IL_01bb:  ldc.i4.0
+    IL_01bc:  ldc.i4.0
+    IL_01bd:  ldnull
+    IL_01be:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_01c3:  stelem.ref
+    IL_01c4:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_01c9:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_01ce:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
+    IL_01d3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
+    IL_01d8:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, object, object> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>>.Target""
+    IL_01dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, object, object>> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>o.<>p__3""
+    IL_01e2:  ldloc.3
+    IL_01e3:  callvirt   ""object System.Func<System.Runtime.CompilerServices.CallSite, object, object>.Invoke(System.Runtime.CompilerServices.CallSite, object)""
+    IL_01e8:  ldnull
+    IL_01e9:  stloc.3
+    IL_01ea:  stloc.2
+    IL_01eb:  leave.s    IL_0206
   }
   catch System.Exception
   {
-    IL_01e8:  stloc.s    V_5
-    IL_01ea:  ldarg.0
-    IL_01eb:  ldc.i4.s   -2
-    IL_01ed:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-    IL_01f2:  ldarg.0
-    IL_01f3:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-    IL_01f8:  ldloc.s    V_5
-    IL_01fa:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_01ff:  leave.s    IL_0215
+    IL_01ed:  stloc.s    V_6
+    IL_01ef:  ldarg.0
+    IL_01f0:  ldc.i4.s   -2
+    IL_01f2:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+    IL_01f7:  ldarg.0
+    IL_01f8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+    IL_01fd:  ldloc.s    V_6
+    IL_01ff:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0204:  leave.s    IL_021a
   }
-  IL_0201:  ldarg.0
-  IL_0202:  ldc.i4.s   -2
-  IL_0204:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
-  IL_0209:  ldarg.0
-  IL_020a:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
-  IL_020f:  ldloc.1
-  IL_0210:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_0215:  ret
+  IL_0206:  ldarg.0
+  IL_0207:  ldc.i4.s   -2
+  IL_0209:  stfld      ""int C.<>c__DisplayClass0_0.<<Main>b__0>d.<>1__state""
+  IL_020e:  ldarg.0
+  IL_020f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> C.<>c__DisplayClass0_0.<<Main>b__0>d.<>t__builder""
+  IL_0214:  ldloc.2
+  IL_0215:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_021a:  ret
 }");
         }
 

--- a/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/EditAndContinue/LocalSlotMappingTests.cs
@@ -2884,7 +2884,7 @@ class C
   IL_0020:  ldarg.0
   IL_0021:  ldarg.0
   IL_0022:  ldfld      ""C C.<F>d__0.<>4__this""
-  IL_0027:  callvirt   ""System.Collections.Generic.IEnumerable<int> C.F()""
+  IL_0027:  call       ""System.Collections.Generic.IEnumerable<int> C.F()""
   IL_002c:  stfld      ""System.Collections.Generic.IEnumerable<int> C.<F>d__0.<>s__1""
   IL_0031:  ldarg.0
   IL_0032:  ldc.i4.0
@@ -2989,7 +2989,7 @@ class C
    -IL_0012:  ldarg.0
     IL_0013:  ldarg.0
     IL_0014:  ldfld      ""C C.<F>d__0.<>4__this""
-    IL_0019:  callvirt   ""System.Threading.Tasks.Task<int> C.F()""
+    IL_0019:  call       ""System.Threading.Tasks.Task<int> C.F()""
     IL_001e:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
     IL_0023:  ldarg.0
     IL_0024:  ldc.i4.0
@@ -3025,7 +3025,7 @@ class C
     IL_005b:  stfld      ""System.Threading.Tasks.Task<int> C.<F>d__0.<>s__1""
    -IL_0060:  ldarg.0
     IL_0061:  ldfld      ""C C.<F>d__0.<>4__this""
-    IL_0066:  callvirt   ""System.Threading.Tasks.Task<int> C.F()""
+    IL_0066:  call       ""System.Threading.Tasks.Task<int> C.F()""
     IL_006b:  callvirt   ""System.Runtime.CompilerServices.TaskAwaiter<int> System.Threading.Tasks.Task<int>.GetAwaiter()""
     IL_0070:  stloc.2
    ~IL_0071:  ldloca.s   V_2

--- a/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
+++ b/src/Compilers/Core/Portable/SynthesizedLocalKind.cs
@@ -27,6 +27,12 @@ namespace Microsoft.CodeAnalysis
     internal enum SynthesizedLocalKind
     {
         /// <summary>
+        /// Temp created for caching "this".
+        /// Technically it is long-lived, but will happen only in optimized code.
+        /// </summary>
+        FrameCache = -5,
+
+        /// <summary>
         /// Temp created for pattern matching by type.
         /// </summary>
         PatternMatchingTemp = -4,

--- a/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/AsyncRewriter/AsyncRewriter.AsyncMethodToClassRewriter.Await.vb
@@ -73,7 +73,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                     builder.AddStatement(
                         Me.F.If(
                             condition:=Me.F.Convert(Me.F.SpecialType(SpecialType.System_Boolean), rewrittenIsCompleted),
-                            thenClause:=Me.F.Block(),
+                            thenClause:=Me.F.StatementList(),
                             elseClause:=awaitForIncompleteTask))
                 Else
                     ' regular case

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.IteratorMethodToClassRewriter.vb
@@ -108,7 +108,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Private Function HandleReturn() As BoundStatement
                 If Me._exitLabel Is Nothing Then
                     ' did not see indirect returns
-                    Return F.Block()
+                    Return F.StatementList()
                 Else
                     '  _methodValue = False
                     ' exitlabel:

--- a/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/IteratorRewriter/IteratorRewriter.vb
@@ -216,7 +216,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                             F.Assignment(F.Local(resultVariable, True), F.Me),
                             If(Method.IsShared OrElse Method.MeParameter.Type.IsReferenceType,
                                     F.Goto(thisInitialized),
-                                    DirectCast(F.Block(), BoundStatement))
+                                    DirectCast(F.StatementList(), BoundStatement))
                         ),
                     elseClause:=
                         F.Assignment(F.Local(resultVariable, True), F.[New](StateMachineType.Constructor, F.Literal(0)))

--- a/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
+++ b/src/Compilers/VisualBasic/Portable/Lowering/SyntheticBoundNodeFactory.vb
@@ -357,6 +357,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
             Return Block(locals, ImmutableArray.Create(Of BoundStatement)(statements))
         End Function
 
+        Public Function StatementList() As BoundStatementList
+            Return StatementList(ImmutableArray(Of BoundStatement).Empty)
+        End Function
+
         Public Function StatementList(statements As ImmutableArray(Of BoundStatement)) As BoundStatementList
             Dim boundNode As New BoundStatementList(Syntax, statements)
             boundNode.SetWasCompilerGenerated()

--- a/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
+++ b/src/ExpressionEvaluator/CSharp/Test/ExpressionCompiler/DynamicTests.cs
@@ -1050,196 +1050,199 @@ class C
                 var methodData = testData.GetMethodData("<>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.System.Runtime.CompilerServices.IAsyncStateMachine.MoveNext()");
                 methodData.VerifyIL(@"
 {
-  // Code size      539 (0x21b)
+  // Code size      544 (0x220)
   .maxstack  10
   .locals init (int V_0,
-                object V_1,
+                <>x.<>c__DisplayClass0_0 V_1,
                 object V_2,
-                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_3,
-                System.Runtime.CompilerServices.INotifyCompletion V_4,
-                System.Exception V_5)
+                object V_3,
+                System.Runtime.CompilerServices.ICriticalNotifyCompletion V_4,
+                System.Runtime.CompilerServices.INotifyCompletion V_5,
+                System.Exception V_6)
   IL_0000:  ldarg.0
   IL_0001:  ldfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
   IL_0006:  stloc.0
+  IL_0007:  ldarg.0
+  IL_0008:  ldfld      ""<>x.<>c__DisplayClass0_0 <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>4__this""
+  IL_000d:  stloc.1
   .try
   {
-    IL_0007:  ldloc.0
-    IL_0008:  brfalse    IL_0185
-    IL_000d:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
-    IL_0012:  brtrue.s   IL_0044
-    IL_0014:  ldc.i4.0
-    IL_0015:  ldstr      ""GetAwaiter""
-    IL_001a:  ldnull
-    IL_001b:  ldtoken    ""C""
-    IL_0020:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0025:  ldc.i4.1
-    IL_0026:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_002b:  dup
-    IL_002c:  ldc.i4.0
-    IL_002d:  ldc.i4.0
-    IL_002e:  ldnull
-    IL_002f:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0034:  stelem.ref
-    IL_0035:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_003a:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_003f:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
-    IL_0044:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
-    IL_0049:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
-    IL_004e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
-    IL_0053:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
-    IL_0058:  brtrue.s   IL_0084
-    IL_005a:  ldc.i4.0
-    IL_005b:  ldtoken    ""C""
-    IL_0060:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0065:  ldc.i4.1
-    IL_0066:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_006b:  dup
-    IL_006c:  ldc.i4.0
-    IL_006d:  ldc.i4.0
-    IL_006e:  ldnull
-    IL_006f:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_0074:  stelem.ref
-    IL_0075:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_007a:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_007f:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
-    IL_0084:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
-    IL_0089:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
-    IL_008e:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
-    IL_0093:  ldarg.0
-    IL_0094:  ldfld      ""<>x.<>c__DisplayClass0_0 <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>4__this""
-    IL_0099:  ldfld      ""C <>x.<>c__DisplayClass0_0.<>4__this""
-    IL_009e:  ldfld      ""dynamic C.d""
-    IL_00a3:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_00a8:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_00ad:  stloc.2
-    IL_00ae:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
-    IL_00b3:  brtrue.s   IL_00da
-    IL_00b5:  ldc.i4.s   16
-    IL_00b7:  ldtoken    ""bool""
-    IL_00bc:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00c1:  ldtoken    ""C""
-    IL_00c6:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_00cb:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
-    IL_00d0:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_00d5:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
-    IL_00da:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
-    IL_00df:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>>.Target""
-    IL_00e4:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
-    IL_00e9:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
-    IL_00ee:  brtrue.s   IL_011f
-    IL_00f0:  ldc.i4.0
-    IL_00f1:  ldstr      ""IsCompleted""
-    IL_00f6:  ldtoken    ""C""
-    IL_00fb:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_0100:  ldc.i4.1
-    IL_0101:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_0106:  dup
-    IL_0107:  ldc.i4.0
-    IL_0108:  ldc.i4.0
-    IL_0109:  ldnull
-    IL_010a:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_010f:  stelem.ref
-    IL_0110:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_0115:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_011a:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
-    IL_011f:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
-    IL_0124:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
-    IL_0129:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
-    IL_012e:  ldloc.2
-    IL_012f:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_0134:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_0139:  brtrue.s   IL_019c
-    IL_013b:  ldarg.0
-    IL_013c:  ldc.i4.0
-    IL_013d:  dup
-    IL_013e:  stloc.0
-    IL_013f:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-    IL_0144:  ldarg.0
-    IL_0145:  ldloc.2
-    IL_0146:  stfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
-    IL_014b:  ldloc.2
-    IL_014c:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
-    IL_0151:  stloc.3
-    IL_0152:  ldloc.3
-    IL_0153:  brtrue.s   IL_0170
-    IL_0155:  ldloc.2
-    IL_0156:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
-    IL_015b:  stloc.s    V_4
-    IL_015d:  ldarg.0
-    IL_015e:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-    IL_0163:  ldloca.s   V_4
-    IL_0165:  ldarg.0
-    IL_0166:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d>(ref System.Runtime.CompilerServices.INotifyCompletion, ref <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d)""
-    IL_016b:  ldnull
-    IL_016c:  stloc.s    V_4
-    IL_016e:  br.s       IL_017e
-    IL_0170:  ldarg.0
-    IL_0171:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-    IL_0176:  ldloca.s   V_3
-    IL_0178:  ldarg.0
-    IL_0179:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d)""
-    IL_017e:  ldnull
-    IL_017f:  stloc.3
-    IL_0180:  leave      IL_021a
-    IL_0185:  ldarg.0
-    IL_0186:  ldfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
-    IL_018b:  stloc.2
-    IL_018c:  ldarg.0
-    IL_018d:  ldnull
-    IL_018e:  stfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
-    IL_0193:  ldarg.0
-    IL_0194:  ldc.i4.m1
-    IL_0195:  dup
-    IL_0196:  stloc.0
-    IL_0197:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-    IL_019c:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
-    IL_01a1:  brtrue.s   IL_01d3
-    IL_01a3:  ldc.i4.0
-    IL_01a4:  ldstr      ""GetResult""
-    IL_01a9:  ldnull
-    IL_01aa:  ldtoken    ""C""
-    IL_01af:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
-    IL_01b4:  ldc.i4.1
-    IL_01b5:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
-    IL_01ba:  dup
-    IL_01bb:  ldc.i4.0
-    IL_01bc:  ldc.i4.0
-    IL_01bd:  ldnull
-    IL_01be:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
-    IL_01c3:  stelem.ref
-    IL_01c4:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
-    IL_01c9:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
-    IL_01ce:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
-    IL_01d3:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
-    IL_01d8:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
-    IL_01dd:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
-    IL_01e2:  ldloc.2
-    IL_01e3:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
-    IL_01e8:  ldnull
-    IL_01e9:  stloc.2
-    IL_01ea:  stloc.1
-    IL_01eb:  leave.s    IL_0206
+    IL_000e:  ldloc.0
+    IL_000f:  brfalse    IL_018a
+    IL_0014:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
+    IL_0019:  brtrue.s   IL_004b
+    IL_001b:  ldc.i4.0
+    IL_001c:  ldstr      ""GetAwaiter""
+    IL_0021:  ldnull
+    IL_0022:  ldtoken    ""C""
+    IL_0027:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_002c:  ldc.i4.1
+    IL_002d:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0032:  dup
+    IL_0033:  ldc.i4.0
+    IL_0034:  ldc.i4.0
+    IL_0035:  ldnull
+    IL_0036:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_003b:  stelem.ref
+    IL_003c:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0041:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0046:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
+    IL_004b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
+    IL_0050:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
+    IL_0055:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__0""
+    IL_005a:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
+    IL_005f:  brtrue.s   IL_008b
+    IL_0061:  ldc.i4.0
+    IL_0062:  ldtoken    ""C""
+    IL_0067:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_006c:  ldc.i4.1
+    IL_006d:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0072:  dup
+    IL_0073:  ldc.i4.0
+    IL_0074:  ldc.i4.0
+    IL_0075:  ldnull
+    IL_0076:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_007b:  stelem.ref
+    IL_007c:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Invoke(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0081:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_0086:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
+    IL_008b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
+    IL_0090:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
+    IL_0095:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>o__0.<>p__0""
+    IL_009a:  ldloc.1
+    IL_009b:  ldfld      ""C <>x.<>c__DisplayClass0_0.<>4__this""
+    IL_00a0:  ldfld      ""dynamic C.d""
+    IL_00a5:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+    IL_00aa:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+    IL_00af:  stloc.3
+    IL_00b0:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
+    IL_00b5:  brtrue.s   IL_00dc
+    IL_00b7:  ldc.i4.s   16
+    IL_00b9:  ldtoken    ""bool""
+    IL_00be:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_00c3:  ldtoken    ""C""
+    IL_00c8:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_00cd:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.Convert(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, System.Type, System.Type)""
+    IL_00d2:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_00d7:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
+    IL_00dc:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
+    IL_00e1:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>>.Target""
+    IL_00e6:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__2""
+    IL_00eb:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
+    IL_00f0:  brtrue.s   IL_0121
+    IL_00f2:  ldc.i4.0
+    IL_00f3:  ldstr      ""IsCompleted""
+    IL_00f8:  ldtoken    ""C""
+    IL_00fd:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_0102:  ldc.i4.1
+    IL_0103:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_0108:  dup
+    IL_0109:  ldc.i4.0
+    IL_010a:  ldc.i4.0
+    IL_010b:  ldnull
+    IL_010c:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_0111:  stelem.ref
+    IL_0112:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.GetMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_0117:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_011c:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
+    IL_0121:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
+    IL_0126:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
+    IL_012b:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__1""
+    IL_0130:  ldloc.3
+    IL_0131:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+    IL_0136:  callvirt   ""bool System.Func<System.Runtime.CompilerServices.CallSite, dynamic, bool>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+    IL_013b:  brtrue.s   IL_01a1
+    IL_013d:  ldarg.0
+    IL_013e:  ldc.i4.0
+    IL_013f:  dup
+    IL_0140:  stloc.0
+    IL_0141:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+    IL_0146:  ldarg.0
+    IL_0147:  ldloc.3
+    IL_0148:  stfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
+    IL_014d:  ldloc.3
+    IL_014e:  isinst     ""System.Runtime.CompilerServices.ICriticalNotifyCompletion""
+    IL_0153:  stloc.s    V_4
+    IL_0155:  ldloc.s    V_4
+    IL_0157:  brtrue.s   IL_0174
+    IL_0159:  ldloc.3
+    IL_015a:  castclass  ""System.Runtime.CompilerServices.INotifyCompletion""
+    IL_015f:  stloc.s    V_5
+    IL_0161:  ldarg.0
+    IL_0162:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+    IL_0167:  ldloca.s   V_5
+    IL_0169:  ldarg.0
+    IL_016a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitOnCompleted<System.Runtime.CompilerServices.INotifyCompletion, <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d>(ref System.Runtime.CompilerServices.INotifyCompletion, ref <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d)""
+    IL_016f:  ldnull
+    IL_0170:  stloc.s    V_5
+    IL_0172:  br.s       IL_0182
+    IL_0174:  ldarg.0
+    IL_0175:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+    IL_017a:  ldloca.s   V_4
+    IL_017c:  ldarg.0
+    IL_017d:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.AwaitUnsafeOnCompleted<System.Runtime.CompilerServices.ICriticalNotifyCompletion, <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d>(ref System.Runtime.CompilerServices.ICriticalNotifyCompletion, ref <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d)""
+    IL_0182:  ldnull
+    IL_0183:  stloc.s    V_4
+    IL_0185:  leave      IL_021f
+    IL_018a:  ldarg.0
+    IL_018b:  ldfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
+    IL_0190:  stloc.3
+    IL_0191:  ldarg.0
+    IL_0192:  ldnull
+    IL_0193:  stfld      ""object <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>u__1""
+    IL_0198:  ldarg.0
+    IL_0199:  ldc.i4.m1
+    IL_019a:  dup
+    IL_019b:  stloc.0
+    IL_019c:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+    IL_01a1:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
+    IL_01a6:  brtrue.s   IL_01d8
+    IL_01a8:  ldc.i4.0
+    IL_01a9:  ldstr      ""GetResult""
+    IL_01ae:  ldnull
+    IL_01af:  ldtoken    ""C""
+    IL_01b4:  call       ""System.Type System.Type.GetTypeFromHandle(System.RuntimeTypeHandle)""
+    IL_01b9:  ldc.i4.1
+    IL_01ba:  newarr     ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo""
+    IL_01bf:  dup
+    IL_01c0:  ldc.i4.0
+    IL_01c1:  ldc.i4.0
+    IL_01c2:  ldnull
+    IL_01c3:  call       ""Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo.Create(Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfoFlags, string)""
+    IL_01c8:  stelem.ref
+    IL_01c9:  call       ""System.Runtime.CompilerServices.CallSiteBinder Microsoft.CSharp.RuntimeBinder.Binder.InvokeMember(Microsoft.CSharp.RuntimeBinder.CSharpBinderFlags, string, System.Collections.Generic.IEnumerable<System.Type>, System.Type, System.Collections.Generic.IEnumerable<Microsoft.CSharp.RuntimeBinder.CSharpArgumentInfo>)""
+    IL_01ce:  call       ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Create(System.Runtime.CompilerServices.CallSiteBinder)""
+    IL_01d3:  stsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
+    IL_01d8:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
+    IL_01dd:  ldfld      ""System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic> System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>>.Target""
+    IL_01e2:  ldsfld     ""System.Runtime.CompilerServices.CallSite<System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>o.<>p__3""
+    IL_01e7:  ldloc.3
+    IL_01e8:  callvirt   ""dynamic System.Func<System.Runtime.CompilerServices.CallSite, dynamic, dynamic>.Invoke(System.Runtime.CompilerServices.CallSite, dynamic)""
+    IL_01ed:  ldnull
+    IL_01ee:  stloc.3
+    IL_01ef:  stloc.2
+    IL_01f0:  leave.s    IL_020b
   }
   catch System.Exception
   {
-    IL_01ed:  stloc.s    V_5
-    IL_01ef:  ldarg.0
-    IL_01f0:  ldc.i4.s   -2
-    IL_01f2:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-    IL_01f7:  ldarg.0
-    IL_01f8:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-    IL_01fd:  ldloc.s    V_5
-    IL_01ff:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
-    IL_0204:  leave.s    IL_021a
+    IL_01f2:  stloc.s    V_6
+    IL_01f4:  ldarg.0
+    IL_01f5:  ldc.i4.s   -2
+    IL_01f7:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+    IL_01fc:  ldarg.0
+    IL_01fd:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+    IL_0202:  ldloc.s    V_6
+    IL_0204:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetException(System.Exception)""
+    IL_0209:  leave.s    IL_021f
   }
-  IL_0206:  ldarg.0
-  IL_0207:  ldc.i4.s   -2
-  IL_0209:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
-  IL_020e:  ldarg.0
-  IL_020f:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
-  IL_0214:  ldloc.1
-  IL_0215:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
-  IL_021a:  ret
+  IL_020b:  ldarg.0
+  IL_020c:  ldc.i4.s   -2
+  IL_020e:  stfld      ""int <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>1__state""
+  IL_0213:  ldarg.0
+  IL_0214:  ldflda     ""System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object> <>x.<>c__DisplayClass0_0.<<<>m0>b__0>d.<>t__builder""
+  IL_0219:  ldloc.2
+  IL_021a:  call       ""void System.Runtime.CompilerServices.AsyncTaskMethodBuilder<object>.SetResult(object)""
+  IL_021f:  ret
 }
 ");
             });


### PR DESCRIPTION
Introduce local caching of "this" in async methods

JIT has no knowledge that captured "this" is semantically readonly, so it would fetch the captured "this" repeatedly if instance members are accessed in the method (which is fairly common). Compiler has such knowledge and can help JIT by caching the reference into a local.

Also, we do not need to call nonvirtual methods off captured "this" via calvirt. For the same reasons we do not use calvirt when calling through the actual "this" directly.

Calvirt here has extra costs. It forces the JIT to insert IR for null checks and later JIT tries to proof that these checks might be unnecessary are unnecessary, which it often can't, since again, it does not have that knowledge that we have at compile time.

Related to: https://github.com/dotnet/coreclr/issues/7914

Fixes:https://github.com/dotnet/roslyn/issues/14873
