### PR TITLE
Updating the 'locate-vs.ps1' script to return an empty string if there are no Dev15 instances installed on the machine.

### DIFF
--- a/build/scripts/locate-vs.ps1
+++ b/build/scripts/locate-vs.ps1
@@ -51,6 +51,6 @@ try
 }
 catch
 {
-  Write-Host "Error: $($_.Exception.Message)"
-  Exit 1
+  # Return an empty string and let the caller fallback or handle this as appropriate
+  return ""
 }


### PR DESCRIPTION
FYI. @jaredpar 

The parsing in the `SetDevCommandPrompt.cmd` file was attempting to set `CommonToolsDir` to the exception message on a Dev14 only machine, which could potentially include quotes and break various things.

We weren't doing anything with the exception message anyways (including printing it) so I just dropped it entirely in favor of returning an empty string and allowing the caller to print their own error message.

The original error message just stated that no instances of Dev15 could be located and included the HRESULT code.