### PR TITLE
Updating `RoslynProjectType=UnitTestNext` to not set `_CopyReferences=false`

### DIFF
--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -32,7 +32,6 @@
     </When>
     <When Condition="'$(RoslynProjectType)' == 'UnitTestNext'">
       <PropertyGroup>
-        <_CopyReferences>false</_CopyReferences>
         <OutDir>$(OutDir)UnitTests\Next\</OutDir>
       </PropertyGroup>
     </When>


### PR DESCRIPTION
FYI. @jaredpar 