### PR TITLE
Do not offer use-object intiializer on code that references the variable being initialized.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseObjectInitializer/UseObjectInitializerTests.cs
@@ -50,6 +50,101 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.UnitTests.UseObjectInitializer
         }
 
         [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue1Async()
+        {
+            await TestAsync(
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        var c = [||]new C();
+        c.i = 1;
+        c.i = c.i + 1;
+    }
+}",
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        var c = new C()
+        {
+            i = 1
+        };
+        c.i = c.i + 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue2Async()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        var c = [||]new C();
+        c.i = c.i + 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue3Async()
+        {
+            await TestAsync(
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        C c;
+        c = [||]new C();
+        c.i = 1;
+        c.i = c.i + 1;
+    }
+}",
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        C c;
+        c = new C()
+        {
+            i = 1
+        };
+        c.i = c.i + 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
+        public async Task TestDoNotUpdateAssignmentThatReferencesInitializedValue4Async()
+        {
+            await TestMissingAsync(
+@"class C
+{
+    int i;
+
+    void M()
+    {
+        C c;
+        c = [||]new C();
+        c.i = c.i + 1;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseObjectInitializer)]
         public async Task TestOnAssignmentExpression()
         {
             await TestAsync(

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/Serialization/SerializableNamingRule.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/NamingStyles/Serialization/SerializableNamingRule.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
-using System.Linq;
 using System.Xml.Linq;
 
 namespace Microsoft.CodeAnalysis.Diagnostics.Analyzers.NamingStyles

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -294,8 +294,8 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 return false;
             }
 
-            SyntaxNode left, right;
-            _syntaxFacts.GetPartsOfAssignmentStatement(_containingStatement, out left, out right);
+            _syntaxFacts.GetPartsOfAssignmentStatement(
+                _containingStatement, out var left, out var right);
             if (right != _objectCreationExpression)
             {
                 return false;

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -7,6 +7,8 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Options;
+using System;
+using System.Linq;
 
 namespace Microsoft.CodeAnalysis.UseObjectInitializer
 {
@@ -236,8 +238,8 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                     break;
                 }
 
-                SyntaxNode left, right;
-                _syntaxFacts.GetPartsOfAssignmentStatement(statement, out left, out right);
+                _syntaxFacts.GetPartsOfAssignmentStatement(
+                    statement, out var left, out var right);
 
                 var rightExpression = right as TExpressionSyntax;
                 var leftMemberAccess = left as TMemberAccessExpressionSyntax;
@@ -248,6 +250,27 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
 
                 var expression = (TExpressionSyntax)_syntaxFacts.GetExpressionOfMemberAccessExpression(leftMemberAccess);
                 if (!ValuePatternMatches(expression))
+                {
+                    break;
+                }
+
+                // Don't offer this fix if the value we're initializing is itself referenced
+                // on the RHS of the assignment.  For example:
+                //
+                //      var v = new X();
+                //      v.Prop = v.Prop.WithSomething();
+                //
+                // Or with
+                //
+                //      v = new X();
+                //      v.Prop = v.Prop.WithSomething();
+                //
+                // In the first case, 'v' is being initialized, and so will not be available 
+                // in the object initializer we create.
+                // 
+                // In the second case we'd change semantics because we'd access the old value 
+                // before the new value got written.
+                if (ExpressionContainsValuePattern(rightExpression))
                 {
                     break;
                 }
@@ -269,6 +292,22 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
             }
 
             return matches.ToImmutableAndFree();
+        }
+
+        private bool ExpressionContainsValuePattern(TExpressionSyntax expression)
+        {
+            foreach (var subExpression in expression.DescendantNodesAndSelf().OfType<TExpressionSyntax>())
+            {
+                if (!_syntaxFacts.IsNameOfMemberAccessExpression(subExpression))
+                {
+                    if (ValuePatternMatches(subExpression))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         private bool ValuePatternMatches(TExpressionSyntax expression)


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14988