### PR TITLE
Updating the open integration jobs to use the new image.

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -204,7 +204,7 @@ set TMP=%TEMP%
 
   def triggerPhraseOnly = true
   def triggerPhraseExtra = "open-vsi"
-  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-preview5')
+  Utilities.setMachineAffinity(myJob, 'Windows_NT', 'latest-or-auto-dev15-rc')
   addRoslynJob(myJob, jobName, branchName, isPr, triggerPhraseExtra, triggerPhraseOnly)
 }
 


### PR DESCRIPTION
FYI. @jasonmalinowski, @jaredpar, @Pilchie, @genlu, @dotnet/roslyn-infrastructure 

New image, should be available to move to if/when we want. It does not contain Dev14 (this PR just updates the open-vsi job, I'll let infraswat update the other jobs as appropriate).