### PR TITLE
Port changes from #13024 to VB for various tuple fixes

### DIFF
--- a/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
+++ b/src/Compilers/CSharp/Portable/CSharpResources.Designer.cs
@@ -4670,7 +4670,7 @@ namespace Microsoft.CodeAnalysis.CSharp {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Type &apos;{0}&apos; from assembly &apos;{1}&apos; cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type..
+        ///   Looks up a localized string similar to Type &apos;{0}&apos; from assembly &apos;{1}&apos; cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type..
         /// </summary>
         internal static string ERR_GenericsUsedAcrossAssemblies {
             get {

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -4063,7 +4063,7 @@ To embed interop type information for both assemblies, use /link for references 
 To remove the warning, you can use /reference instead (set the Embed Interop Types property to False). In this case, a primary interop assembly (PIA) provides interop type information.</value>
   </data>
   <data name="ERR_GenericsUsedAcrossAssemblies" xml:space="preserve">
-    <value>Type '{0}' from assembly '{1}' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.</value>
+    <value>Type '{0}' from assembly '{1}' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.</value>
   </data>
   <data name="ERR_NoCanonicalView" xml:space="preserve">
     <value>Cannot find the interop type that matches the embedded interop type '{0}'. Are you missing an assembly reference?</value>

--- a/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
+++ b/src/Compilers/CSharp/Test/Emit/Emit/NoPiaEmbedTypes.cs
@@ -4756,7 +4756,7 @@ class UsePia5
 ";
 
             DiagnosticDescription[] expected = {
-                // error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies).WithArguments("System.Collections.Generic.List<ITest33>", "Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
                                                };
 
@@ -4827,7 +4827,7 @@ class UsePia5
 ";
 
             DiagnosticDescription[] expected = {
-                // (10,17): error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (10,17): error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 //         ITest34 y = null;
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "y = null").WithArguments("System.Collections.Generic.List<ITest33>", "Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
             };
@@ -4996,7 +4996,7 @@ class UsePia5
 ";
 
             DiagnosticDescription[] expected = {
-                // error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies).WithArguments("System.Collections.Generic.List<ITest33>", "Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
                                                };
 
@@ -5074,7 +5074,7 @@ public class UsePia5 : ITest34
 ";
 
             DiagnosticDescription[] expected = {
-                // (5,24): error CS1769: Type 'List<ValueTuple<ITest33, ITest33>>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (5,24): error CS1769: Type 'List<ValueTuple<ITest33, ITest33>>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 // public class UsePia5 : ITest34
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "ITest34").WithArguments("System.Collections.Generic.List<ValueTuple<ITest33, ITest33>>", "Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(5, 24)
             };
@@ -5156,7 +5156,7 @@ class UsePia5
 ";
 
             DiagnosticDescription[] expected = {
-                // (10,17): error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (10,17): error CS1769: Type 'System.Collections.Generic.List<ITest33>' from assembly 'Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 //         ITest34 y = null;
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "y = null").WithArguments("System.Collections.Generic.List<ITest33>", "Pia2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
             };

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/BindingTests.cs
@@ -1417,13 +1417,13 @@ public class Test
     }
 }", references: new List<MetadataReference>() { TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1 })
 .VerifyDiagnostics(
-    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // using ClassAlias = Class1;
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
-    // (7,28): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (7,28): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     //         int a = ClassAlias.Class1Foo();
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1Foo").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
-    // (8,28): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (8,28): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     //         int b = ClassAlias.Class1Foo();
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1Foo").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
             );
@@ -1449,7 +1449,7 @@ public class Test
     }
 }", references: new List<MetadataReference>() { TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1 })
 .VerifyDiagnostics(
-    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // using ClassAlias = Class1;
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")
             );
@@ -1474,7 +1474,7 @@ public class Test
     void m2(ClassAlias p) { }
 }", references: new List<MetadataReference>() { TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1 })
 .VerifyDiagnostics(
-    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // using ClassAlias = Class1;
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
     // (6,16): warning CS0414: The field 'Test.b' is assigned but its value is never used
@@ -1510,13 +1510,13 @@ public class Test
     }
 }", references: new List<MetadataReference>() { TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1 })
 .VerifyDiagnostics(
-                // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (2,20): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 // using ClassAlias = Class1;
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "Class1").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
-                // (9,9): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (9,9): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 //         System.Console.WriteLine(a);
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "System.Console.WriteLine").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"),
-                // (10,9): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+                // (10,9): error CS1769: Type 'System.Collections.Generic.List<FooStruct>' from assembly 'NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
                 //         System.Console.WriteLine(b);
                 Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "System.Console.WriteLine").WithArguments("System.Collections.Generic.List<FooStruct>", "NoPIAGenerics1-Asm1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
 
@@ -1559,7 +1559,7 @@ public class BarImpl : IBar
             CSharpCompilation comp3 = CreateCompilationWithMscorlib(source3, new MetadataReference[] { new CSharpCompilationReference(comp2), new CSharpCompilationReference(comp1, embedInteropTypes: true) });
 
             comp3.VerifyDiagnostics(
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1567,10 +1567,10 @@ public class BarImpl : IBar
             comp3 = CreateCompilationWithMscorlib(source3, new MetadataReference[] { comp2.EmitToImageReference(), comp1.EmitToImageReference().WithEmbedInteropTypes(true) });
 
             comp3.VerifyDiagnostics(
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24),
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_1, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1615,7 +1615,7 @@ public class BarImpl : IBar
     // (4,24): error CS0539: 'BarImpl.Moniker' in explicit interface declaration is not a member of interface
     //     ImageMoniker? IBar.Moniker    
     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Moniker").WithArguments("BarImpl.Moniker").WithLocation(4, 24),
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1626,7 +1626,7 @@ public class BarImpl : IBar
     // (4,24): error CS0539: 'BarImpl.Moniker' in explicit interface declaration is not a member of interface
     //     ImageMoniker? IBar.Moniker    
     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "Moniker").WithArguments("BarImpl.Moniker").WithLocation(4, 24),
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_2, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1666,7 +1666,7 @@ public class BarImpl : IBar
             CSharpCompilation comp3 = CreateCompilationWithMscorlib(source3, new MetadataReference[] { new CSharpCompilationReference(comp2), new CSharpCompilationReference(comp1, embedInteropTypes: true) });
 
             comp3.VerifyDiagnostics(
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1674,7 +1674,7 @@ public class BarImpl : IBar
             comp3 = CreateCompilationWithMscorlib(source3, new MetadataReference[] { comp2.EmitToImageReference(), comp1.EmitToImageReference().WithEmbedInteropTypes(true) });
 
             comp3.VerifyDiagnostics(
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_3, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1717,7 +1717,7 @@ public class BarImpl : IBar
     // (4,15): error CS0539: 'BarImpl.SetMoniker(ImageMoniker?)' in explicit interface declaration is not a member of interface
     //     void IBar.SetMoniker(ImageMoniker? moniker)
     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "SetMoniker").WithArguments("BarImpl.SetMoniker(ImageMoniker?)").WithLocation(4, 15),
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );
@@ -1728,7 +1728,7 @@ public class BarImpl : IBar
     // (4,15): error CS0539: 'BarImpl.SetMoniker(ImageMoniker?)' in explicit interface declaration is not a member of interface
     //     void IBar.SetMoniker(ImageMoniker? moniker)
     Diagnostic(ErrorCode.ERR_InterfaceMemberNotFound, "SetMoniker").WithArguments("BarImpl.SetMoniker(ImageMoniker?)").WithLocation(4, 15),
-    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+    // (2,24): error CS1769: Type 'ImageMoniker?' from assembly 'Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     // public class BarImpl : IBar
     Diagnostic(ErrorCode.ERR_GenericsUsedAcrossAssemblies, "IBar").WithArguments("ImageMoniker?", "Bar948674_4, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null").WithLocation(2, 24)
                 );

--- a/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
+++ b/src/Compilers/CSharp/Test/Symbol/Symbols/Retargeting/NoPia.cs
@@ -1506,7 +1506,7 @@ public class C
 
             var expectedDiagnostics = new[]
             {
-              // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
+                // (8,12): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.
                 //     public (int, int) TestTuple()
                 Diagnostic(ErrorCode.ERR_GenericsUsedInNoPIAType, "(int, int)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(8, 12),
                 // (4,19): error CS1768: Type 'ValueTuple<T1, T2>' cannot be embedded because it has a generic argument. Consider setting the 'Embed Interop Types' property to false.

--- a/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
+++ b/src/Compilers/VisualBasic/Portable/Compilation/ClsComplianceChecker.vb
@@ -558,6 +558,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Sub
 
         Private Sub ReportNonCompliantTypeArguments(type As NamedTypeSymbol, context As NamedTypeSymbol, diagnosticSymbol As Symbol)
+            If type.IsTupleType Then
+                type = type.TupleUnderlyingType
+            End If
+
             For Each typeArg In type.TypeArgumentsNoUseSiteDiagnostics
                 If Not IsCompliantType(typeArg, context) Then
                     Me.AddDiagnostic(diagnosticSymbol, ERRID.WRN_TypeNotCLSCompliant1, typeArg)
@@ -593,6 +597,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
             If Not IsTrue(GetDeclaredOrInheritedCompliance(type.OriginalDefinition)) Then
                 Return False
+            End If
+
+            If type.IsTupleType Then
+                Return IsCompliantType(type.TupleUnderlyingType)
             End If
 
             ' NOTE: Type arguments are checked separately (see HasNonCompliantTypeArguments)

--- a/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/EditAndContinue/VisualBasicSymbolMatcher.vb
@@ -396,6 +396,13 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                     Dim typeMap = TypeSubstitution.Create(otherDef, otherTypeParameters, otherTypeArguments, False)
                     Return otherDef.Construct(typeMap)
+                ElseIf type.IsTupleType Then
+                    Dim otherDef = DirectCast(Me.Visit(type.TupleUnderlyingType), NamedTypeSymbol)
+                    If otherDef Is Nothing OrElse Not otherDef.IsTupleOrCompatibleWithTupleOfCardinality(type.TupleElementTypes.Length) Then
+                        Return Nothing
+                    End If
+
+                    Return TupleTypeSymbol.Create(otherDef, type.TupleElementNames)
                 End If
 
                 Debug.Assert(type.IsDefinition)
@@ -546,7 +553,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
 
                 Return Me._comparer.Equals(method.ReturnType, other.ReturnType) AndAlso
                     method.Parameters.SequenceEqual(other.Parameters, AddressOf Me.AreParametersEqual) AndAlso
-                    method.TypeArguments.SequenceEqual(other.TypeArguments, AddressOf Me.AreTypesEqual)
+                    method.TypeParameters.SequenceEqual(other.TypeParameters, AddressOf Me.AreTypesEqual)
             End Function
 
             Private Shared Function SubstituteTypeParameters(method As MethodSymbol) As MethodSymbol
@@ -563,6 +570,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit
                 Debug.Assert(s_nameComparer.Equals(type.Name, other.Name))
                 Debug.Assert(Not type.HasTypeArgumentsCustomModifiers)
                 Debug.Assert(Not other.HasTypeArgumentsCustomModifiers)
+
+                ' Tuple types should be unwrapped to their underlying type before getting here (see MatchSymbols.VisitNamedType)
+                Debug.Assert(Not type.IsTupleType)
+                Debug.Assert(Not other.IsTupleType)
+
                 Return type.TypeArgumentsNoUseSiteDiagnostics.SequenceEqual(other.TypeArgumentsNoUseSiteDiagnostics, AddressOf Me.AreTypesEqual)
             End Function
 

--- a/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
+++ b/src/Compilers/VisualBasic/Portable/Emit/NoPia/EmbeddedTypesManager.vb
@@ -194,6 +194,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Emit.NoPia
                     TypeKind.Enum,
                     TypeKind.Delegate
 
+                    If type.IsTupleType Then
+                        type = type.TupleUnderlyingType
+                    End If
+
                     If type.ContainingType IsNot Nothing Then
                         ' We do not support nesting for embedded types.
                         ' ERRID.ERR_InvalidInteropType/ERR_NoPIANestedType

--- a/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
+++ b/src/Compilers/VisualBasic/Portable/Semantics/AccessCheck.vb
@@ -576,6 +576,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 End Select
             Loop
 
+            If exposedNamedType.IsTupleType Then
+                exposedNamedType = exposedNamedType.TupleUnderlyingType
+            End If
+
             ' For a generic type, verify exposure of each of the type arguments.
             Dim possiblyGeneric As NamedTypeSymbol = exposedNamedType
 

--- a/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
+++ b/src/Compilers/VisualBasic/Portable/SymbolDisplay/SymbolDisplayVisitor.Types.vb
@@ -191,7 +191,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
         Private Sub AddNameAndTypeArgumentsOrParameters(symbol As INamedTypeSymbol, noEscaping As Boolean)
             Dim partKind As SymbolDisplayPartKind
-            Dim symbolName = symbol.Name
+            Dim symbolName As String = Nothing
             Dim skipTypeArguments As Boolean = False
 
             If symbol.IsAnonymousType Then
@@ -208,6 +208,27 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
 
                 ' Fall back to displaying the underlying type.
                 symbol = symbol.TupleUnderlyingType
+            End If
+
+            ' It would be nice to handle C# NoPia symbols too, but it's not worth the effort.
+
+            Dim illegalGenericInstantiationSymbol = TryCast(symbol, NoPiaIllegalGenericInstantiationSymbol)
+            If illegalGenericInstantiationSymbol IsNot Nothing Then
+                symbol = illegalGenericInstantiationSymbol.UnderlyingSymbol
+            Else
+                Dim ambiguousCanonicalTypeSymbol = TryCast(symbol, NoPiaAmbiguousCanonicalTypeSymbol)
+                If ambiguousCanonicalTypeSymbol IsNot Nothing Then
+                    symbol = ambiguousCanonicalTypeSymbol.FirstCandidate
+                Else
+                    Dim missingCanonicalTypeSymbol = TryCast(symbol, NoPiaMissingCanonicalTypeSymbol)
+                    If missingCanonicalTypeSymbol IsNot Nothing Then
+                        symbolName = missingCanonicalTypeSymbol.FullTypeName
+                    End If
+                End If
+            End If
+
+            If symbolName Is Nothing Then
+                symbolName = symbol.Name
             End If
 
             If format.MiscellaneousOptions.IncludesOption(SymbolDisplayMiscellaneousOptions.UseErrorTypeSymbolName) AndAlso

--- a/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Metadata/PE/MetadataDecoder.vb
@@ -204,6 +204,10 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Metadata.PE
                     End If
 
                     Do
+                        If symbol.IsTupleType Then
+                            Return IsOrClosedOverATypeFromAssemblies(symbol.TupleUnderlyingType, assemblies)
+                        End If
+
                         For Each typeArgument In symbol.TypeArgumentsNoUseSiteDiagnostics
                             If IsOrClosedOverATypeFromAssemblies(typeArgument, assemblies) Then
                                 Return True

--- a/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Retargeting/RetargetingSymbolTranslator.vb
@@ -549,6 +549,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols.Retargeting
 
                     Case SymbolKind.ErrorType, SymbolKind.NamedType
                         Dim namedType = DirectCast(symbol, NamedTypeSymbol)
+                        If namedType.IsTupleType Then
+                            namedType = namedType.TupleUnderlyingType
+                        End If
 
                         If symbol.OriginalDefinition.ContainingModule Is _retargetingModule.UnderlyingModule AndAlso
                             namedType.IsExplicitDefinitionOfNoPiaLocalType Then

--- a/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/Tuples/TupleTypeSymbol.vb
@@ -330,6 +330,11 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End If
 
             Dim tupleUnderlyingType As NamedTypeSymbol = TupleTypeSymbol.GetTupleUnderlyingType(elementTypes, syntax, compilation, diagnostics)
+            If DirectCast(compilation.SourceModule, SourceModuleSymbol).AnyReferencedAssembliesAreLinked Then
+                ' Complain about unembeddable types from linked assemblies.
+                Emit.NoPia.EmbeddedTypesManager.IsValidEmbeddableType(tupleUnderlyingType, syntax, diagnostics)
+            End If
+
             Return TupleTypeSymbol.Create(locationOpt, tupleUnderlyingType, elementLocations, elementNames)
         End Function
 

--- a/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
+++ b/src/Compilers/VisualBasic/Portable/Utilities/TypeUnification.vb
@@ -243,8 +243,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
                 Case SymbolKind.NamedType, SymbolKind.ErrorType
                     Dim namedType As NamedTypeSymbol = DirectCast(type, NamedTypeSymbol)
                     While namedType IsNot Nothing
-                        For Each typeArg In namedType.TypeArgumentsNoUseSiteDiagnostics
-                            If Contains(typeArg, typeParam) Then
+                        Dim typeParts = If(namedType.IsTupleType, namedType.TupleElementTypes, namedType.TypeArgumentsNoUseSiteDiagnostics)
+                        For Each typePart In typeParts
+                            If Contains(typePart, typeParam) Then
                                 Return True
                             End If
                         Next

--- a/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
+++ b/src/Compilers/VisualBasic/Portable/VBResources.Designer.vb
@@ -1865,7 +1865,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
-        '''  Looks up a localized string similar to Type &apos;{0}&apos; cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type..
+        '''  Looks up a localized string similar to Type &apos;{0}&apos; cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type..
         '''</summary>
         Friend ReadOnly Property ERR_CannotUseGenericTypeAcrossAssemblyBoundaries() As String
             Get
@@ -3140,6 +3140,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_DuplicateProcDef1() As String
             Get
                 Return ResourceManager.GetString("ERR_DuplicateProcDef1", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to &apos;{0}&apos; has multiple definitions with identical signatures with different tuple element names, including &apos;{1}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_DuplicateProcDefWithDifferentTupleNames2() As String
+            Get
+                Return ResourceManager.GetString("ERR_DuplicateProcDefWithDifferentTupleNames2", resourceCulture)
             End Get
         End Property
         
@@ -5216,6 +5225,15 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         End Property
         
         '''<summary>
+        '''  Looks up a localized string similar to &apos;{0}&apos; cannot implement {1} &apos;{2}&apos; on interface &apos;{3}&apos; because the tuple element names in &apos;{4}&apos; do not match those in &apos;{5}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_ImplementingInterfaceWithDifferentTupleNames5() As String
+            Get
+                Return ResourceManager.GetString("ERR_ImplementingInterfaceWithDifferentTupleNames5", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
         '''  Looks up a localized string similar to Type parameter not allowed in &apos;Implements&apos; clause..
         '''</summary>
         Friend ReadOnly Property ERR_ImplementsGenericParam() As String
@@ -5573,6 +5591,78 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property ERR_InterfaceImplementedTwice1() As String
             Get
                 Return ResourceManager.GetString("ERR_InterfaceImplementedTwice1", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; can be implemented only once by this type, but already appears with different tuple element names, as &apos;{1}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceImplementedTwiceWithDifferentTupleNames2() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceImplementedTwiceWithDifferentTupleNames2", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; can be implemented only once by this type, but already appears with different tuple element names, as &apos;{1}&apos; (via &apos;{2}&apos;)..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceImplementedTwiceWithDifferentTupleNames3() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceImplementedTwiceWithDifferentTupleNames3", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; (via &apos;{1}&apos;) can be implemented only once by this type, but already appears with different tuple element names, as &apos;{2}&apos; (via &apos;{3}&apos;)..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceImplementedTwiceWithDifferentTupleNames4() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceImplementedTwiceWithDifferentTupleNames4", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; (via &apos;{1}&apos;) can be implemented only once by this type, but already appears with different tuple element names, as &apos;{2}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceImplementedTwiceWithDifferentTupleNamesReverse3() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceImplementedTwiceWithDifferentTupleNamesReverse3", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; can be inherited only once by this interface, but already appears with different tuple element names, as &apos;{1}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceInheritedTwiceWithDifferentTupleNames2() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceInheritedTwiceWithDifferentTupleNames2", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; can be inherited only once by this interface, but already appears with different tuple element names, as &apos;{1}&apos; (via &apos;{2}&apos;)..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceInheritedTwiceWithDifferentTupleNames3() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceInheritedTwiceWithDifferentTupleNames3", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; (via &apos;{1}&apos;) can be inherited only once by this interface, but already appears with different tuple element names, as &apos;{2}&apos; (via &apos;{3}&apos;)..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceInheritedTwiceWithDifferentTupleNames4() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceInheritedTwiceWithDifferentTupleNames4", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Interface &apos;{0}&apos; (via &apos;{1}&apos;) can be inherited only once by this interface, but already appears with different tuple element names, as &apos;{2}&apos;..
+        '''</summary>
+        Friend ReadOnly Property ERR_InterfaceInheritedTwiceWithDifferentTupleNamesReverse3() As String
+            Get
+                Return ResourceManager.GetString("ERR_InterfaceInheritedTwiceWithDifferentTupleNamesReverse3", resourceCulture)
             End Get
         End Property
         
@@ -11346,9 +11436,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         '''<summary>
         '''  Looks up a localized string similar to Predefined type &apos;{0}&apos; is not defined or imported..
         '''</summary>
-        Friend ReadOnly Property ERR_ValueTupleTypeRefResolutionError() As String
+        Friend ReadOnly Property ERR_ValueTupleTypeRefResolutionError1() As String
             Get
-                Return ResourceManager.GetString("ERR_ValueTupleTypeRefResolutionError", resourceCulture)
+                Return ResourceManager.GetString("ERR_ValueTupleTypeRefResolutionError1", resourceCulture)
             End Get
         End Property
         
@@ -13482,6 +13572,24 @@ Namespace Microsoft.CodeAnalysis.VisualBasic
         Friend ReadOnly Property WRN_InvalidAssemblyName_Title() As String
             Get
                 Return ResourceManager.GetString("WRN_InvalidAssemblyName_Title", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to &apos;{0}&apos; cannot override &apos;{1}&apos; because they differ by their tuple element names..
+        '''</summary>
+        Friend ReadOnly Property WRN_InvalidOverrideDueToTupleNames2() As String
+            Get
+                Return ResourceManager.GetString("WRN_InvalidOverrideDueToTupleNames2", resourceCulture)
+            End Get
+        End Property
+        
+        '''<summary>
+        '''  Looks up a localized string similar to Member cannot override because it differs by its tuple element names..
+        '''</summary>
+        Friend ReadOnly Property WRN_InvalidOverrideDueToTupleNames2_Title() As String
+            Get
+                Return ResourceManager.GetString("WRN_InvalidOverrideDueToTupleNames2_Title", resourceCulture)
             End Get
         End Property
         

--- a/src/Compilers/VisualBasic/Portable/VBResources.resx
+++ b/src/Compilers/VisualBasic/Portable/VBResources.resx
@@ -3476,7 +3476,7 @@
     <value>Type '{0}' cannot be embedded because it has generic argument. Consider disabling the embedding of interop types.</value>
   </data>
   <data name="ERR_CannotUseGenericTypeAcrossAssemblyBoundaries" xml:space="preserve">
-    <value>Type '{0}' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.</value>
+    <value>Type '{0}' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.</value>
   </data>
   <data name="WRN_UseOfObsoleteSymbol2" xml:space="preserve">
     <value>'{0}' is obsolete: '{1}'.</value>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -15407,12 +15407,12 @@ End Class
 </compilation>,
 additionalRefs:=s_valueTupleRefs)
 
-            comp.AssertTheseDiagnostics(
-<errors>
-BC30508: 'M' cannot expose type 'C.C2' in namespace '&lt;Default&gt;' through class 'C'.
+            Dim expectedErrors = <errors><![CDATA[
+BC30508: 'M' cannot expose type 'C.C2' in namespace '<Default>' through class 'C'.
     Public Function M() As (C2, Integer)
                            ~~~~~~~~~~~~~
-</errors>)
+                 ]]></errors>
+            comp.AssertTheseDiagnostics(expectedErrors)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -15320,6 +15320,12 @@ End Interface
 Public Class C1
     Implements I0(Of (a As Integer, b As Integer)), I0(Of (notA As Integer, notB As Integer))
 End Class
+Public Class C2
+    Implements I0(Of (a As Integer, b As Integer)), I0(Of (a As Integer, b As Integer))
+End Class
+Public Class C3
+    Implements I0(Of Integer), I0(Of Integer)
+End Class
     </file>
 </compilation>,
 additionalRefs:=s_valueTupleRefs)
@@ -15329,8 +15335,84 @@ additionalRefs:=s_valueTupleRefs)
 BC37272: Interface 'I0(Of (notA As Integer, notB As Integer))' can be implemented only once by this type, but already appears with different tuple element names, as 'I0(Of (a As Integer, b As Integer))'.
     Implements I0(Of (a As Integer, b As Integer)), I0(Of (notA As Integer, notB As Integer))
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC31033: Interface 'I0(Of (a As Integer, b As Integer))' can be implemented only once by this type.
+    Implements I0(Of (a As Integer, b As Integer)), I0(Of (a As Integer, b As Integer))
+                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+BC31033: Interface 'I0(Of Integer)' can be implemented only once by this type.
+    Implements I0(Of Integer), I0(Of Integer)
+                               ~~~~~~~~~~~~~~
 </errors>)
+            Dim tree = comp.SyntaxTrees.First()
+            Dim model = comp.GetSemanticModel(tree)
+            Dim nodes = tree.GetCompilationUnitRoot().DescendantNodes()
 
+            Dim c1 = model.GetDeclaredSymbol(nodes.OfType(Of TypeBlockSyntax)().Skip(1).First())
+            Assert.Equal("C1", c1.Name)
+            Assert.Equal(2, c1.AllInterfaces.Count)
+            Assert.Equal("I0(Of (a As System.Int32, b As System.Int32))", c1.Interfaces(0).ToTestDisplayString())
+            Assert.Equal("I0(Of (notA As System.Int32, notB As System.Int32))", c1.Interfaces(1).ToTestDisplayString())
+
+            Dim c2 = model.GetDeclaredSymbol(nodes.OfType(Of TypeBlockSyntax)().Skip(2).First())
+            Assert.Equal("C2", c2.Name)
+            Assert.Equal(1, c2.AllInterfaces.Count)
+            Assert.Equal("I0(Of (a As System.Int32, b As System.Int32))", c2.Interfaces(0).ToTestDisplayString())
+
+            Dim c3 = model.GetDeclaredSymbol(nodes.OfType(Of TypeBlockSyntax)().Skip(3).First())
+            Assert.Equal("C3", c3.Name)
+            Assert.Equal(1, c3.AllInterfaces.Count)
+            Assert.Equal("I0(Of System.Int32)", c3.Interfaces(0).ToTestDisplayString())
+        End Sub
+
+        <Fact>
+        Public Sub AccessCheckLooksInsideTuples()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Public Function M() As (C2.C3, Integer)
+        Throw New System.Exception()
+    End Function
+End Class
+Public Class C2
+    Private Class C3
+    End Class
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30389: 'C2.C3' is not accessible in this context because it is 'Private'.
+    Public Function M() As (C2.C3, Integer)
+                            ~~~~~
+</errors>)
+        End Sub
+
+        <Fact>
+        Public Sub AccessCheckLooksInsideTuples2()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb">
+Public Class C
+    Public Function M() As (C2, Integer)
+        Throw New System.Exception()
+    End Function
+    Private Class C2
+    End Class
+End Class
+    </file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30508: 'M' cannot expose type 'C.C2' in namespace '&lt;Default&gt;' through class 'C'.
+    Public Function M() As (C2, Integer)
+                           ~~~~~~~~~~~~~
+</errors>)
         End Sub
 
         <Fact>
@@ -15662,6 +15744,26 @@ BC32072: Cannot implement interface 'I0(Of (a As T2, b As T2))' because its impl
         End Sub
 
         <Fact>
+        Public Sub InterfaceUnification2()
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Public Interface I0(Of T1)
+End Interface
+Public Class Derived(Of T)
+    Implements I0(Of Derived(Of (T, T))), I0(Of T)
+End Class
+     ]]></file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+</errors>)
+            ' Didn't run out of memory in trying to substitute T with Derived(Of (T, T)) in a loop
+        End Sub
+
+        <Fact>
         Public Sub AmbiguousExtensionMethodWithDifferentTupleNames()
 
             Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(
@@ -15950,6 +16052,28 @@ BC40001: 'Public Overrides Property P5 As (c As (notA As Integer, notB As Intege
                               ~~
 </errors>)
 
+        End Sub
+
+        <Fact>
+        Public Sub StructInStruct()
+            Dim comp = CreateCompilationWithMscorlib45AndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Public Structure S
+    Public Field As (S, S)
+End Structure
+     ]]></file>
+</compilation>,
+additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC30294: Structure 'S' cannot contain an instance of itself: 
+    'S' contains '(S, S)' (variable 'Field').
+    '(S, S)' contains 'S' (variable 'Item1').
+    Public Field As (S, S)
+           ~~~~~
+</errors>)
         End Sub
 
         <Fact>

--- a/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/Emit/NoPiaEmbedTypes.vb
@@ -3751,7 +3751,7 @@ End Class
 ]]></file>
                            </compilation>
             Dim errors = <errors>
-BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
 </errors>
 
             Dim piaCompilation1 = CreateCompilationWithMscorlib(pia1)
@@ -3813,7 +3813,7 @@ End Class
 ]]></file>
                            </compilation>
             Dim errors = <errors>
-BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
         o.M2()
         ~~~~~~
 </errors>
@@ -3945,7 +3945,7 @@ End Class
 ]]></file>
                            </compilation>
             Dim errors = <errors>
-BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
 </errors>
 
             Dim piaCompilation1 = CreateCompilationWithMscorlib(pia1)
@@ -3977,6 +3977,89 @@ BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it
                 consumer,
                 references:={MetadataReference.CreateFromImage(piaCompilation2.EmitToArray())})
             CompileAndVerify(compilation4)
+        End Sub
+
+        <Fact>
+        Public Sub ErrorType_Tuple()
+            Dim pia1 = <compilation>
+                           <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Runtime.InteropServices
+Imports System.Runtime.CompilerServices
+
+<Assembly: ImportedFromTypeLib("GeneralPIA1.dll")>
+<Assembly: Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58257")>
+
+<ComImport>
+<Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58279")>
+Public Interface ITest33
+End Interface
+]]></file>
+                       </compilation>
+            Dim piaCompilation1 = CreateCompilationWithMscorlib(pia1, options:=TestOptions.ReleaseDll)
+            CompileAndVerify(piaCompilation1)
+
+            Dim pia2 = <compilation>
+                           <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Runtime.InteropServices
+Imports System.Runtime.CompilerServices
+Imports System.Collections.Generic
+
+<assembly: ImportedFromTypeLib("GeneralPIA2.dll")>
+<assembly: Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58290")>
+
+<ComImport>
+<Guid("f9c2d51d-4f44-45f0-9eda-c9d599b58280")>
+Public Interface ITest34
+    Function M() As List(Of (ITest33, ITest33))
+End Interface
+]]></file>
+                       </compilation>
+            Dim piaCompilation2 = CreateCompilationWithMscorlib(
+                pia2, options:=TestOptions.ReleaseDll,
+                references:={piaCompilation1.EmitToImageReference(embedInteropTypes:=True), ValueTupleRef, SystemRuntimeFacadeRef})
+            CompileAndVerify(piaCompilation2)
+
+            Dim consumer = <compilation>
+                               <file name="a.vb"><![CDATA[
+Imports System
+Imports System.Collections.Generic
+
+Public MustInherit Class UsePia5
+    Implements ITest34
+End Class
+            ]]></file>
+                           </compilation>
+            Dim expected = <errors>
+BC36924: Type 'List(Of ValueTuple(Of ITest33, ITest33))' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
+    Implements ITest34
+               ~~~~~~~
+                           </errors>
+
+            Dim compilation1 = CreateCompilationWithMscorlibAndReferences(
+                consumer, options:=TestOptions.ReleaseDll,
+                references:={piaCompilation2.ToMetadataReference(embedInteropTypes:=True), piaCompilation1.ToMetadataReference(), ValueTupleRef, SystemRuntimeFacadeRef})
+            VerifyEmitDiagnostics(compilation1, expected)
+            VerifyEmitMetadataOnlyDiagnostics(compilation1, expected)
+
+            Dim compilation2 = CreateCompilationWithMscorlibAndReferences(
+                consumer, options:=TestOptions.ReleaseDll,
+                references:={piaCompilation2.EmitToImageReference(embedInteropTypes:=True), piaCompilation1.ToMetadataReference(), ValueTupleRef, SystemRuntimeFacadeRef})
+            VerifyEmitDiagnostics(compilation2, expected)
+            VerifyEmitMetadataOnlyDiagnostics(compilation2, expected)
+
+            Dim compilation3 = CreateCompilationWithMscorlibAndReferences(
+                consumer, options:=TestOptions.ReleaseDll,
+                references:={piaCompilation2.ToMetadataReference(), piaCompilation1.ToMetadataReference(), ValueTupleRef, SystemRuntimeFacadeRef})
+            VerifyEmitDiagnostics(compilation3, expected)
+            VerifyEmitMetadataOnlyDiagnostics(compilation3, expected)
+
+            Dim compilation4 = CreateCompilationWithMscorlibAndReferences(
+                consumer, options:=TestOptions.ReleaseDll,
+                references:={piaCompilation2.EmitToImageReference(), piaCompilation1.ToMetadataReference(), ValueTupleRef, SystemRuntimeFacadeRef})
+            VerifyEmitDiagnostics(compilation4, expected)
+            VerifyEmitMetadataOnlyDiagnostics(compilation4, expected)
         End Sub
 
         <Fact()>
@@ -4017,7 +4100,7 @@ End Class
 ]]></file>
                            </compilation>
             Dim errors = <errors>
-BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of I1)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
         o.M2()
         ~~~~~~
 </errors>

--- a/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
+++ b/src/Compilers/VisualBasic/Test/Semantic/Binding/BindingErrorTests.vb
@@ -22051,7 +22051,7 @@ End Class
     {TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1})
             compilation1.AssertTheseDiagnostics(
 <errors>
-BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
     Dim _myclass As MyClass1 = Nothing
                     ~~~~~~~~
 </errors>)
@@ -22074,10 +22074,10 @@ End Class
     {TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1})
             compilation1.AssertTheseDiagnostics(
 <errors>
-BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
         Dim _myclass = MyClass1.Class1Foo
                        ~~~~~~~~
-BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
         Dim _myclass = MyClass1.Class1Foo
                        ~~~~~~~~~~~~~~~~~~
 </errors>)
@@ -22100,7 +22100,7 @@ End Class
     {TestReferences.SymbolsTests.NoPia.NoPIAGenericsAsm1})
             compilation1.AssertTheseDiagnostics(
 <errors>
-BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type parameter that is an embedded interop type.
+BC36924: Type 'List(Of FooStruct)' cannot be used across assembly boundaries because it has a generic type argument that is an embedded interop type.
         Dim _myclass = directcast(nothing, MyClass1)
                                            ~~~~~~~~
 </errors>)

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.Cascading.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.Cascading.vb
@@ -32,6 +32,34 @@ End Class]]></Text>.NormalizedValue()
 
             Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
         End Function
+        <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
+        Public Async Function TestReorderParameters_Cascade_ToImplementedMethod_WithTuples() As Task
+            Dim markup = <Text><![CDATA[
+Interface I
+    Sub Foo(x As (Integer, Integer), y As (String, String))
+End Interface
+
+Class C
+    Implements I
+
+    $$Public Sub Foo(x As (Integer, Integer), y As (String, String)) Implements I.Foo
+    End Sub
+End Class]]></Text>.NormalizedValue()
+            Dim permutation = {1, 0}
+            Dim updatedCode = <Text><![CDATA[
+Interface I
+    Sub Foo(y As (String, String), x As (Integer, Integer))
+End Interface
+
+Class C
+    Implements I
+
+    Public Sub Foo(y As (String, String), x As (Integer, Integer)) Implements I.Foo
+    End Sub
+End Class]]></Text>.NormalizedValue()
+
+            Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
+        End Function
 
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestReorderParameters_Cascade_ToImplementingMethod() As Task

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.Cascading.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/ReorderParametersTests.Cascading.vb
@@ -32,6 +32,7 @@ End Class]]></Text>.NormalizedValue()
 
             Await TestChangeSignatureViaCommandAsync(LanguageNames.VisualBasic, markup, updatedSignature:=permutation, expectedUpdatedInvocationDocumentCode:=updatedCode)
         End Function
+
         <WpfFact, Trait(Traits.Feature, Traits.Features.ChangeSignature)>
         Public Async Function TestReorderParameters_Cascade_ToImplementedMethod_WithTuples() As Task
             Dim markup = <Text><![CDATA[

--- a/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/CodeActions/GenerateDefaultConstructors/GenerateDefaultConstructorsTests.vb
@@ -362,5 +362,132 @@ End Class</Text>.Value.Replace(vbLf, vbCrLf),
 index:=0,
 compareTokens:=False)
         End Function
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/15005"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        Public Async Function TestFixAll() As Task
+            Await TestAsync(
+<Text>
+Class C
+    Inherits [||]B
+
+    Public Sub New(y As Boolean)
+    End Sub
+End Class
+
+Class B
+    Friend Sub New(x As Integer)
+    End Sub
+
+    Protected Sub New(x As String)
+    End Sub
+
+    Public Sub New(x As Boolean)
+    End Sub
+
+    Public Sub New(x As Long)
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf),
+<Text>
+Class C
+    Inherits B
+
+    Friend Sub New(x As Integer)
+        MyBase.New(x)
+    End Sub
+
+    Protected Sub New(x As String)
+        MyBase.New(x)
+    End Sub
+
+    Public Sub New(x As Long)
+        MyBase.New(x)
+    End Sub
+
+    Public Sub New(y As Boolean)
+    End Sub
+End Class
+
+Class B
+    Friend Sub New(x As Integer)
+    End Sub
+
+    Protected Sub New(x As String)
+    End Sub
+
+    Public Sub New(x As Boolean)
+    End Sub
+
+    Public Sub New(x As Long)
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf),
+index:=2,
+compareTokens:=False)
+            Throw New Exception() ' (Skip:="https://github.com/dotnet/roslyn/issues/15005")
+        End Function
+
+        <Fact(Skip:="https://github.com/dotnet/roslyn/issues/15005"), Trait(Traits.Feature, Traits.Features.CodeActionsGenerateDefaultConstructors)>
+        Public Async Function TestFixAll_WithTuples() As Task
+            Await TestAsync(
+<Text>
+Class C
+    Inherits [||]B
+
+    Public Sub New(y As (Boolean, Boolean))
+    End Sub
+End Class
+
+Class B
+    Friend Sub New(x As (Integer, Integer))
+    End Sub
+
+    Protected Sub New(x As (String, String))
+    End Sub
+
+    Public Sub New(x As (Boolean, Boolean))
+    End Sub
+
+    Public Sub New(x As (Long, Long))
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf),
+<Text>
+Class C
+    Inherits B
+
+    Friend Sub New(x As (Integer, Integer))
+        MyBase.New(x)
+    End Sub
+
+    Protected Sub New(x As (String, String))
+        MyBase.New(x)
+    End Sub
+
+    Public Sub New(x As (Long, Long))
+        MyBase.New(x)
+    End Sub
+
+    Public Sub New(y As (Boolean, Boolean))
+    End Sub
+End Class
+
+Class B
+    Friend Sub New(x As (Integer, Integer))
+    End Sub
+
+    Protected Sub New(x As (String, String))
+    End Sub
+
+    Public Sub New(x As (Boolean, Boolean))
+    End Sub
+
+    Public Sub New(x As (Long, Long))
+    End Sub
+End Class
+</Text>.Value.Replace(vbLf, vbCrLf),
+index:=2,
+compareTokens:=False)
+        End Function
     End Class
 End Namespace


### PR DESCRIPTION
Fixes #14895 

@dotnet/roslyn-compiler Please review this port of an assortment of C# fixes for tuples.