### PR TITLE
Ensure that we normalize the CPSProject bin output path even when it …

### DIFF
--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -89,7 +89,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 Assert.Equal(newBinPath, project.BinOutputPath);
 
                 // Change bin output folder to non-normalized path - verify that binOutputPath changes to normalized path, but objOutputPath is the same.
-                var newBinPath = @"test.dll";
+                newBinPath = @"test.dll";
                 var expectedNewBinPath = Path.Combine(project.ContainingDirectoryPathOpt, newBinPath);
                 ((IWorkspaceProjectContext)project).BinOutputPath = newBinPath;
                 Assert.Equal(newObjPath, project.ObjOutputPath);

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -90,7 +90,7 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
 
                 // Change bin output folder to non-normalized path - verify that binOutputPath changes to normalized path, but objOutputPath is the same.
                 newBinPath = @"test.dll";
-                var expectedNewBinPath = Path.Combine(project.ContainingDirectoryPathOpt, newBinPath);
+                var expectedNewBinPath = Path.Combine(Path.GetTempPath(), newBinPath);
                 ((IWorkspaceProjectContext)project).BinOutputPath = newBinPath;
                 Assert.Equal(newObjPath, project.ObjOutputPath);
                 Assert.Equal(expectedNewBinPath, project.BinOutputPath);

--- a/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
+++ b/src/VisualStudio/CSharp/Test/ProjectSystemShim/CPS/CSharpCompilerOptionsTests.cs
@@ -87,6 +87,13 @@ namespace Roslyn.VisualStudio.CSharp.UnitTests.ProjectSystemShim.CPS
                 ((IWorkspaceProjectContext)project).BinOutputPath = newBinPath;
                 Assert.Equal(newObjPath, project.ObjOutputPath);
                 Assert.Equal(newBinPath, project.BinOutputPath);
+
+                // Change bin output folder to non-normalized path - verify that binOutputPath changes to normalized path, but objOutputPath is the same.
+                var newBinPath = @"test.dll";
+                var expectedNewBinPath = Path.Combine(project.ContainingDirectoryPathOpt, newBinPath);
+                ((IWorkspaceProjectContext)project).BinOutputPath = newBinPath;
+                Assert.Equal(newObjPath, project.ObjOutputPath);
+                Assert.Equal(expectedNewBinPath, project.BinOutputPath);
             }
         }
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// The containing directory of the project. Null if none exists (consider Venus.)
         /// </summary>
-        protected string ContainingDirectoryPathOpt
+        internal string ContainingDirectoryPathOpt
         {
             get
             {

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/AbstractProject.cs
@@ -217,7 +217,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
         /// <summary>
         /// The containing directory of the project. Null if none exists (consider Venus.)
         /// </summary>
-        internal string ContainingDirectoryPathOpt
+        protected string ContainingDirectoryPathOpt
         {
             get
             {

--- a/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
+++ b/src/VisualStudio/Core/Impl/ProjectSystem/CPS/CPSProject_IWorkspaceProjectContext.cs
@@ -69,7 +69,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem.C
             }
             set
             {
-                SetBinOutputPathAndRelatedData(value);
+                NormalizeAndSetBinOutputPathAndRelatedData(value);
             }
         }
 


### PR DESCRIPTION
…is set via the property IWorkspaceProjectContext.BinOutputPath