### PR TITLE
add the first set of editor options for visual studio

### DIFF
--- a/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
+++ b/src/Workspaces/CSharp/Portable/CSharpWorkspace.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Extensions\AssignmentExpressionSyntaxExtensions.cs" />
     <Compile Include="Extensions\BlockSyntaxExtensions.cs" />
     <Compile Include="Extensions\SemanticModelExtensions.cs" />
+    <Compile Include="Formatting\CSharpFormattingOptions.Parsers.cs" />
     <Compile Include="LanguageServices\CSharpCommandLineParserService.cs" />
     <Compile Include="CSharpWorkspaceResources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.Parsers.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.CodeAnalysis.CSharp.Formatting
+{
+    public static partial class CSharpFormattingOptions
+    {
+        internal static bool DetermineIfSpaceOptionIsSet(string value, SpacingWithinParenthesesOption parenthesesSpacingOption)
+            => (from v in value.Split(',').Select(v => v.Trim())
+                let option = ConvertToSpacingOption(v)
+                where option.HasValue && option.Value == parenthesesSpacingOption
+                select option)
+                .Any();
+
+        private static SpacingWithinParenthesesOption? ConvertToSpacingOption(string value)
+        {
+            switch (value)
+            {
+                case "expressions": return SpacingWithinParenthesesOption.Expressions;
+                case "type_casts": return SpacingWithinParenthesesOption.TypeCasts;
+                case "control_flow_statements": return SpacingWithinParenthesesOption.ControlFlowStatements;
+                default: return null;
+            }
+        }
+
+        internal static BinaryOperatorSpacingOptions ParseEditorConfigSpacingAroundBinaryOperator(string binaryOperatorSpacingValue)
+        {
+            switch (binaryOperatorSpacingValue)
+            {
+                case "ignore": return BinaryOperatorSpacingOptions.Ignore;
+                case "none": return BinaryOperatorSpacingOptions.Remove;
+                case "before_and_after": return BinaryOperatorSpacingOptions.Single;
+                default: return BinaryOperatorSpacingOptions.Single;
+            }
+        }
+
+        internal static LabelPositionOptions ParseEditorConfigLablePositioning(string lableIndentationValue)
+        {
+            switch (lableIndentationValue)
+            {
+                case "flush_left": return LabelPositionOptions.LeftMost;
+                case "no_change": return LabelPositionOptions.NoIndent;
+                case "one_less_than_current": return LabelPositionOptions.OneLess;
+                default: return LabelPositionOptions.NoIndent;
+            }
+        }
+
+        internal static bool DetermineIfNewLineOptionIsSet(string value, NewLineOption optionName)
+        {
+            var values = value.Split(',');
+
+            if (values.Any(s => s.Trim() == "all"))
+            {
+                return true;
+            }
+
+            if (values.Any(s => s.Trim() == "none"))
+            {
+                return false;
+            }
+
+            return (from v in values
+                    let option = ConvertToNewLineOption(v)
+                    where option.HasValue && option.Value == optionName
+                    select option)
+                    .Any();
+        }
+
+
+        private static NewLineOption? ConvertToNewLineOption(string value)
+        {
+            switch (value.Trim())
+            {
+                case "accessors": return NewLineOption.Accessors;
+                case "types": return NewLineOption.Types;
+                case "methods": return NewLineOption.Methods;
+                case "properties": return NewLineOption.Properties;
+                case "indexers": return NewLineOption.Indexers;
+                case "events": return NewLineOption.Events;
+                case "anonymous_methods": return NewLineOption.AnonymousMethods;
+                case "control_blocks": return NewLineOption.ControlBlocks;
+                case "anonymous_types": return NewLineOption.AnonymousTypes;
+                case "object_collection_array_initalizers": return NewLineOption.ObjectCollectionsArrayInitializers;
+                case "lambdas": return NewLineOption.Lambdas;
+                case "local_functions": return NewLineOption.LocalFunction;
+                default: return null;
+            }
+        }
+
+        internal static bool DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(string value)
+            => value.Trim() == "ignore";
+
+        internal enum SpacingWithinParenthesesOption
+        {
+            Expressions,
+            TypeCasts,
+            ControlFlowStatements
+        }
+
+        internal enum NewLineOption
+        {
+            Types,
+            Methods,
+            Properties,
+            Indexers,
+            Events,
+            AnonymousMethods,
+            ControlBlocks,
+            AnonymousTypes,
+            ObjectCollectionsArrayInitializers,
+            Lambdas,
+            LocalFunction,
+            Accessors
+        }
+    }
+}

--- a/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
+++ b/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs
@@ -4,145 +4,237 @@ using Microsoft.CodeAnalysis.Options;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
-    public static class CSharpFormattingOptions
+    public static partial class CSharpFormattingOptions
     {
         public static Option<bool> SpacingAfterMethodDeclarationName { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpacingAfterMethodDeclarationName), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAfterMethodDeclarationName"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_declaration_name_and_open_parenthesis"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAfterMethodDeclarationName")});
 
         public static Option<bool> SpaceWithinMethodDeclarationParenthesis { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinMethodDeclarationParenthesis), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodDeclarationParenthesis"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_declaration_parameter_list_parentheses"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodDeclarationParenthesis")});
 
         public static Option<bool> SpaceBetweenEmptyMethodDeclarationParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptyMethodDeclarationParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodDeclarationParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_declaration_empty_parameter_list_parentheses"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodDeclarationParentheses")});
 
         public static Option<bool> SpaceAfterMethodCallName { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterMethodCallName), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterMethodCallName"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_call_name_and_opening_parenthesis"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterMethodCallName")});
 
         public static Option<bool> SpaceWithinMethodCallParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinMethodCallParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodCallParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_call_parameter_list_parentheses"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinMethodCallParentheses")});
 
         public static Option<bool> SpaceBetweenEmptyMethodCallParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptyMethodCallParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodCallParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_method_call_empty_parameter_list_parentheses"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptyMethodCallParentheses")});
 
         public static Option<bool> SpaceAfterControlFlowStatementKeyword { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterControlFlowStatementKeyword), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterControlFlowStatementKeyword"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_keywords_in_control_flow_statements"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterControlFlowStatementKeyword")});
 
         public static Option<bool> SpaceWithinExpressionParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinExpressionParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinExpressionParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.Expressions)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinExpressionParentheses")});
 
         public static Option<bool> SpaceWithinCastParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinCastParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinCastParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.TypeCasts)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinCastParentheses")});
 
         public static Option<bool> SpaceWithinOtherParentheses { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinOtherParentheses), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinOtherParentheses"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_parentheses", s => DetermineIfSpaceOptionIsSet(s, SpacingWithinParenthesesOption.ControlFlowStatements)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinOtherParentheses")});
 
         public static Option<bool> SpaceAfterCast { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterCast), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterCast"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_cast"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterCast")});
 
         public static Option<bool> SpacesIgnoreAroundVariableDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpacesIgnoreAroundVariableDeclaration), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacesIgnoreAroundVariableDeclaration"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_around_declaration_statements", s => DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(s)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacesIgnoreAroundVariableDeclaration")});
 
         public static Option<bool> SpaceBeforeOpenSquareBracket { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeOpenSquareBracket), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeOpenSquareBracket"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_before_open_square_brackets"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeOpenSquareBracket")});
 
         public static Option<bool> SpaceBetweenEmptySquareBrackets { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBetweenEmptySquareBrackets), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptySquareBrackets"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_empty_square_brackets"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBetweenEmptySquareBrackets")});
 
         public static Option<bool> SpaceWithinSquareBrackets { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceWithinSquareBrackets), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinSquareBrackets"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_between_square_brackets"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceWithinSquareBrackets")});
 
         public static Option<bool> SpaceAfterColonInBaseTypeDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterColonInBaseTypeDeclaration), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterColonInBaseTypeDeclaration"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_colon_in_inheritance_clause"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterColonInBaseTypeDeclaration")});
 
         public static Option<bool> SpaceAfterComma { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterComma), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterComma"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_comma"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterComma")});
 
         public static Option<bool> SpaceAfterDot { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterDot), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterDot"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_dot"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterDot")});
 
         public static Option<bool> SpaceAfterSemicolonsInForStatement { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceAfterSemicolonsInForStatement), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterSemicolonsInForStatement"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_after_semicolon_in_for_statement"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceAfterSemicolonsInForStatement")});
 
         public static Option<bool> SpaceBeforeColonInBaseTypeDeclaration { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeColonInBaseTypeDeclaration), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeColonInBaseTypeDeclaration"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_before_colon_in_inheritance_clause"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeColonInBaseTypeDeclaration")});
 
         public static Option<bool> SpaceBeforeComma { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeComma), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeComma"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_before_comma"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeComma")});
 
         public static Option<bool> SpaceBeforeDot { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeDot), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeDot"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_before_dot"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeDot")});
 
         public static Option<bool> SpaceBeforeSemicolonsInForStatement { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(SpaceBeforeSemicolonsInForStatement), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeSemicolonsInForStatement"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_before_semicolon_in_for_statement"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpaceBeforeSemicolonsInForStatement")});
 
         public static Option<BinaryOperatorSpacingOptions> SpacingAroundBinaryOperator { get; } = new Option<BinaryOperatorSpacingOptions>(nameof(CSharpFormattingOptions), nameof(SpacingAroundBinaryOperator), defaultValue: BinaryOperatorSpacingOptions.Single,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAroundBinaryOperator"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_space_around_binary_operators ", s => ParseEditorConfigSpacingAroundBinaryOperator(s)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.SpacingAroundBinaryOperator")});
 
         public static Option<bool> IndentBraces { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentBraces), defaultValue: false,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.OpenCloseBracesIndent"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_indent_braces"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.OpenCloseBracesIndent")});
 
         public static Option<bool> IndentBlock { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentBlock), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_indent_block_contents"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentBlock")});
 
         public static Option<bool> IndentSwitchSection { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentSwitchSection), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchSection"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_indent_switch_labels"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchSection")});
 
         public static Option<bool> IndentSwitchCaseSection { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(IndentSwitchCaseSection), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSection"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_indent_case_contents"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.IndentSwitchCaseSection")});
 
         public static Option<LabelPositionOptions> LabelPositioning { get; } = new Option<LabelPositionOptions>(nameof(CSharpFormattingOptions), nameof(LabelPositioning), defaultValue: LabelPositionOptions.OneLess,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.LabelPositioning"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_indent_labels", s => ParseEditorConfigLablePositioning(s)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.LabelPositioning")});
 
         public static Option<bool> WrappingPreserveSingleLine { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(WrappingPreserveSingleLine), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingPreserveSingleLine"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_preserve_single_line_blocks"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingPreserveSingleLine")});
 
         public static Option<bool> WrappingKeepStatementsOnSingleLine { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(WrappingKeepStatementsOnSingleLine), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingKeepStatementsOnSingleLine"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_preserve_single_line_statements"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.WrappingKeepStatementsOnSingleLine")});
 
         public static Option<bool> NewLinesForBracesInTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInTypes), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesBracesType"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Types)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesBracesType")});
 
         public static Option<bool> NewLinesForBracesInMethods { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInMethods), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInMethods"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Methods)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInMethods")});
 
         public static Option<bool> NewLinesForBracesInProperties { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInProperties), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInProperties"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Properties)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInProperties")});
 
         public static Option<bool> NewLinesForBracesInAccessors { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAccessors), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAccessors"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Accessors)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAccessors")});
 
         public static Option<bool> NewLinesForBracesInAnonymousMethods { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAnonymousMethods), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousMethods"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousMethods)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousMethods")});
 
         public static Option<bool> NewLinesForBracesInControlBlocks { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInControlBlocks), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInControlBlocks"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.ControlBlocks)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInControlBlocks")});
 
         public static Option<bool> NewLinesForBracesInAnonymousTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInAnonymousTypes), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousTypes"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.AnonymousTypes)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInAnonymousTypes")});
 
         public static Option<bool> NewLinesForBracesInObjectCollectionArrayInitializers { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInObjectCollectionArrayInitializers), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInObjectCollectionArrayInitializers"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.ObjectCollectionsArrayInitializers)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInObjectCollectionArrayInitializers")});
 
         public static Option<bool> NewLinesForBracesInLambdaExpressionBody { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLinesForBracesInLambdaExpressionBody), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInLambdaExpressionBody"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_open_brace", (value) => DetermineIfNewLineOptionIsSet(value, NewLineOption.Lambdas)),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLinesForBracesInLambdaExpressionBody")});
 
         public static Option<bool> NewLineForElse { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForElse), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForElse"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_else"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForElse")});
 
         public static Option<bool> NewLineForCatch { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForCatch), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForCatch"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_catch"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForCatch")});
 
         public static Option<bool> NewLineForFinally { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForFinally), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForFinally"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_finally"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForFinally")});
 
         public static Option<bool> NewLineForMembersInObjectInit { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForMembersInObjectInit), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInObjectInit"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_members_in_object_initializers"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInObjectInit")});
 
         public static Option<bool> NewLineForMembersInAnonymousTypes { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForMembersInAnonymousTypes), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInAnonymousTypes"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_before_members_in_anonymous_types"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForMembersInAnonymousTypes")});
 
         public static Option<bool> NewLineForClausesInQuery { get; } = new Option<bool>(nameof(CSharpFormattingOptions), nameof(NewLineForClausesInQuery), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForClausesInQuery"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("csharp_new_line_between_query_expression_clauses"),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.NewLineForClausesInQuery")});
     }
 
     public enum LabelPositionOptions

--- a/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
+++ b/src/Workspaces/CSharpTest/CSharpServicesTest.csproj
@@ -79,6 +79,7 @@
     <Compile Include="CodeGeneration\SyntaxGeneratorTests.cs" />
     <Compile Include="CSharpCommandLineParserServiceTests.cs" />
     <Compile Include="Formatting\CSharpFormattingTestBase.cs" />
+    <Compile Include="Formatting\EditorConfigOptionParserTests.cs" />
     <Compile Include="Formatting\FormattingElasticTriviaTests.cs" />
     <Compile Include="Formatting\FormattingMultipleSpanTests.cs" />
     <Compile Include="Formatting\FormattingTests.cs" />

--- a/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
+++ b/src/Workspaces/CSharpTest/Formatting/EditorConfigOptionParserTests.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Xunit;
+using static Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions;
+
+namespace Microsoft.CodeAnalysis.CSharp.UnitTests.Formatting
+{
+    public class EditorConfigOptionParserTests
+    {
+        [Theory,
+        InlineData("expressions", SpacingWithinParenthesesOption.Expressions),
+        InlineData("type_casts", SpacingWithinParenthesesOption.TypeCasts),
+        InlineData("control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("expressions, type_casts", SpacingWithinParenthesesOption.Expressions),
+        InlineData("type_casts, expressions, , ", SpacingWithinParenthesesOption.TypeCasts),
+        InlineData("expressions ,  ,  , control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("expressions ,  ,  , control_flow_statements", SpacingWithinParenthesesOption.Expressions),
+        InlineData(",  ,  , control_flow_statements", SpacingWithinParenthesesOption.ControlFlowStatements)]
+        static void TestParseParenthesesSpaceOptionsTrue(string value, CSharpFormattingOptions.SpacingWithinParenthesesOption parenthesesSpacingOption)
+        {
+            Assert.True(DetermineIfSpaceOptionIsSet(value, parenthesesSpacingOption),
+                        $"Expected option {value} to be parsed as set.");
+        }
+
+        [Theory,
+        InlineData("expressions", SpacingWithinParenthesesOption.ControlFlowStatements),
+        InlineData("type_casts", SpacingWithinParenthesesOption.Expressions),
+        InlineData("control_flow_statements", SpacingWithinParenthesesOption.Expressions),
+        InlineData("", SpacingWithinParenthesesOption.Expressions),
+        InlineData(",,,", SpacingWithinParenthesesOption.Expressions),
+        InlineData("*", SpacingWithinParenthesesOption.Expressions)]
+        static void TestParseParenthesesSpaceOptionsFalse(string value, SpacingWithinParenthesesOption parenthesesSpacingOption)
+        {
+            Assert.False(DetermineIfSpaceOptionIsSet(value, parenthesesSpacingOption),
+                        $"Expected option {value} to be parsed as un-set.");
+        }
+
+        [Theory,
+        InlineData("ignore", BinaryOperatorSpacingOptions.Ignore),
+        InlineData("none", BinaryOperatorSpacingOptions.Remove),
+        InlineData("before_and_after", BinaryOperatorSpacingOptions.Single)]
+        static void TestParseEditorConfigSpacingAroundBinaryOperatorTrue(string value, BinaryOperatorSpacingOptions expectedResult)
+        {
+            Assert.True(ParseEditorConfigSpacingAroundBinaryOperator(value) == expectedResult,
+                        $"Expected option {value} to be parsed as set.");
+        }
+
+        [Theory,
+        InlineData("ignore,"),
+        InlineData("non"),
+        InlineData("before_and_after,ignore")]
+        static void TestParseEditorConfigSpacingAroundBinaryOperatorFalse(string value)
+        {
+            Assert.True(ParseEditorConfigSpacingAroundBinaryOperator(value) == BinaryOperatorSpacingOptions.Single,
+                        $"Expected option {value} to be parsed as default option.");
+        }
+
+        [Theory,
+        InlineData("flush_left", LabelPositionOptions.LeftMost),
+        InlineData("no_change", LabelPositionOptions.NoIndent),
+        InlineData("one_less_than_current", LabelPositionOptions.OneLess)]
+        static void TestParseEditorConfigLabelPositioningTrue(string value, LabelPositionOptions expectedValue)
+        {
+            Assert.True(ParseEditorConfigLablePositioning(value) == expectedValue,
+                        $"Expected option {value} to be parsed as set.");
+        }
+
+        [Theory,
+        InlineData("left_most,"),
+        InlineData("*"),
+        InlineData("one_less_thancurrent")]
+        static void TestParseEditorConfigLabelPositioningFalse(string value)
+        {
+            Assert.True(ParseEditorConfigLablePositioning(value) == LabelPositionOptions.NoIndent,
+                        $"Expected option {value} to be parsed default");
+        }
+
+        [Theory,
+        InlineData("all", NewLineOption.Types),
+        InlineData("all,none", NewLineOption.Types),
+        InlineData("none,all", NewLineOption.Types),
+        InlineData("types", NewLineOption.Types),
+        InlineData("types,methods", NewLineOption.Types),
+        InlineData(",, types", NewLineOption.Types),
+        InlineData("accessors", NewLineOption.Accessors),
+        InlineData("methods", NewLineOption.Methods),
+        InlineData("properties", NewLineOption.Properties),
+        InlineData("indexers", NewLineOption.Indexers),
+        InlineData("events", NewLineOption.Events),
+        InlineData("anonymous_methods", NewLineOption.AnonymousMethods),
+        InlineData("control_blocks", NewLineOption.ControlBlocks),
+        InlineData("anonymous_types", NewLineOption.AnonymousTypes),
+        InlineData("object_collection_array_initalizers", NewLineOption.ObjectCollectionsArrayInitializers),
+        InlineData("lambdas", NewLineOption.Lambdas),
+        InlineData("local_functions", NewLineOption.LocalFunction)]
+        static void TestParseNewLineOptionTrue(string value, NewLineOption option)
+        {
+            Assert.True(DetermineIfNewLineOptionIsSet(value, option),
+                        $"Expected option {value} to be set");
+        }
+
+        [Theory,
+        InlineData("Accessors", NewLineOption.Accessors),
+        InlineData("none,types", NewLineOption.Types),
+        InlineData("methods", NewLineOption.Types),
+        InlineData("methods, properties", NewLineOption.Types),
+        InlineData(",,,", NewLineOption.Types)]
+        static void TestParseNewLineOptionFalse(string value, NewLineOption option)
+        {
+            Assert.False(DetermineIfNewLineOptionIsSet(value, option),
+                        $"Expected option {value} to be un-set");
+        }
+
+        [Theory,
+        InlineData("ignore"),
+        InlineData("ignore "),
+        InlineData(" ignore"),
+        InlineData(" ignore ")]
+        static void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetTrue(string value)
+        {
+            Assert.True(DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(value),
+                        $"Expected option {value} to be set");
+        }
+
+        [Theory,
+        InlineData("do_not_ignore"),
+        InlineData(", "),
+        InlineData(" ignor ")]
+        static void TestDetermineIfIgnoreSpacesAroundVariableDeclarationIsSetFalse(string value)
+        {
+            Assert.False(DetermineIfIgnoreSpacesAroundVariableDeclarationIsSet(value),
+                        $"Expected option {value} to be un-set");
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
+++ b/src/Workspaces/Core/Portable/Editing/GenerationOptions.cs
@@ -7,6 +7,8 @@ namespace Microsoft.CodeAnalysis.Editing
     internal class GenerationOptions
     {
         public static readonly PerLanguageOption<bool> PlaceSystemNamespaceFirst = new PerLanguageOption<bool>(nameof(GenerationOptions), nameof(PlaceSystemNamespaceFirst), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst"));
+            storageLocations: new OptionStorageLocation[] {
+                new EditorConfigStorageLocation("dotnet_sort_system_directives_first"),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PlaceSystemNamespaceFirst")});
     }
 }


### PR DESCRIPTION
@dotnet/roslyn-ide @jasonmalinowski 

Adds the following options

## Advanced
editorconfig name | possible values
------------ | -------------
dotnet_sort_system_directives_first | true , false

## Indentation Options
editorconfig name | possible values
------------ | -------------
csharp_indent_block_contents | true , false
csharp_indent_braces | true , false
csharp_indent_case_contents | true , false
csharp_indent_switch_labels | true , false
csharp_indent_labels | flush_left , no_change , one_less_than_current 



## New Line Options
editorconfig name | possible values
------------ | -------------
csharp_new_line_before_open_brace | accessors, anonymous_methods, anonymous_types, control_blocks, events, indexers, lambdas, local_functions, methods, object_collection, properties, types, all, none (or separate with ',')
csharp_new_line_before_else | true , false
csharp_new_line_before_catch | true , false
csharp_new_line_before_finally | true , false
csharp_new_line_before_members_in_object_initializers | true , false
csharp_new_line_before_members_in_anonymous_types | true , false
csharp_new_line_within_query_expression_clauses | true , false

## Spacing Options
editorconfig name | possible values
------------ | -------------
csharp_space_after_cast | true , false
csharp_space_after_colon_in_inheritance_clause | true , false
csharp_space_after_comma | true , false
csharp_space_after_dot | true , false
csharp_space_after_keywords_in_control_flow_statements | true , false
csharp_space_after_semicolon_in_for_statement | true , false
csharp_space_around_binary_operators  | 	none, before_and_after, ignore
csharp_space_around_declaration_statements | ignore, do_not_ignore
csharp_space_before_colon_in_inheritance_clause | true , false
csharp_space_before_comma | true , false
csharp_space_before_dot | true , false
csharp_space_before_semicolon_in_for_statement | true , false
csharp_space_before_open_square_brackets | true , false
csharp_space_between_empty_square_brackets | true , false
csharp_space_between_method_declaration_name_and_open_parenthesis | true , false
csharp_space_between_method_declaration_parameter_list_parentheses | true , false
csharp_space_between_method_declaration_empty_parameter_list_parentheses | true , false
csharp_space_between_method_call_name_and_opening_parenthesis | true , false
csharp_space_between_method_call_parameter_list_parentheses | true , false
csharp_space_between_method_call_empty_parameter_list_parentheses | true , false
csharp_space_between_square_brackets | true , false
csharp_space_between_parentheses | expressions, type_casts, control_flow_statements

## Wrapping Options
editorconfig name | possible values
------------ | -------------
csharp_preserve_single_line_blocks | true , false
csharp_preserve_single_line_statements | true , false