### PR TITLE
Don't offer Use-Throw-Expression if teh variable being checked is accessed before it is assigned.

### DIFF
--- a/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
+++ b/src/EditorFeatures/CSharpTest/UseThrowExpression/UseThrowExpressionTests.cs
@@ -189,8 +189,29 @@ class C
     {
         if (s == null)
         {
-            [|throw|] new ArgumentNullException(nameof(s)) };
+            [|throw|] new ArgumentNullException(nameof(s));
+        };
         s = ""something"";
+        _s = s;
+    }
+}");
+        }
+
+        [Fact, Trait(Traits.Feature, Traits.Features.CodeActionsUseThrowExpression)]
+        public async Task NotWithIntermediaryMemberAccess()
+        {
+            await TestMissingAsync(
+@"using System;
+
+class C
+{
+    void M(string s, string t)
+    {
+        if (s == null)
+        {
+            [|throw|] new ArgumentNullException(nameof(s));
+        };
+        s.ToString();
         _s = s;
     }
 }");

--- a/src/Features/CSharp/Portable/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseThrowExpression/CSharpUseThrowExpressionDiagnosticAnalyzer.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.LanguageServices;
 using Microsoft.CodeAnalysis.UseThrowExpression;
 
 namespace Microsoft.CodeAnalysis.CSharp.UseThrowExpression
@@ -13,5 +15,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UseThrowExpression
             var csOptions = (CSharpParseOptions)options;
             return csOptions.LanguageVersion >= LanguageVersion.CSharp7;
         }
+
+        protected override ISyntaxFactsService GetSyntaxFactsService()
+            => CSharpSyntaxFactsService.Instance;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15018