### PR TITLE
Assigning tuple should not be considered use of variable

### DIFF
--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -609,6 +609,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                         return WriteConsideredUse(null, boundConversion.Operand);
                     }
                 case BoundKind.DefaultOperator:
+                case BoundKind.ConvertedTupleLiteral:
                     return false;
                 case BoundKind.ObjectCreationExpression:
                     var init = (BoundObjectCreationExpression)value;

--- a/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
+++ b/src/Compilers/CSharp/Portable/FlowAnalysis/DataFlowPass.cs
@@ -576,6 +576,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>
         /// This reflects the Dev10 compiler's rules for when a variable initialization is considered a "use"
         /// for the purpose of suppressing the warning about unused variables.
+        /// Updated to apply the same rule within elements of tuple conversions and literals.
         /// </summary>
         internal static bool WriteConsideredUse(TypeSymbol type, BoundExpression value)
         {
@@ -606,10 +607,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                             return true;
                         }
 
-                        if (boundConversion.ConversionKind == ConversionKind.ImplicitTupleLiteral ||
-                            boundConversion.ConversionKind == ConversionKind.ExplicitTupleLiteral ||
-                            boundConversion.ConversionKind == ConversionKind.ImplicitTuple ||
-                            boundConversion.ConversionKind == ConversionKind.ExplicitTuple)
+                        if (boundConversion.Conversion.IsTupleLiteralConversion ||
+                            boundConversion.Conversion.IsTupleConversion)
                         {
                             var underlyingConversions = boundConversion.Conversion.UnderlyingConversions;
                             if (underlyingConversions.Any(c => IsUserDefinedOrIntPtrConversion(c)))
@@ -627,8 +626,6 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return !init.Constructor.IsImplicitlyDeclared || init.InitializerExpressionOpt != null;
 
                 case BoundKind.TupleLiteral:
-                    throw ExceptionUtilities.UnexpectedValue(value.Kind);
-
                 case BoundKind.ConvertedTupleLiteral:
                     Debug.Assert(type == null || type.IsTupleType);
                     var typeIsTuple = type?.IsTupleType == true;

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3449,6 +3449,7 @@ class C
     static void Main()
     {
         var x = (a: PrintAndReturn(1), b: 2, c: 3, d: PrintAndReturn(4), e: 5, f: 6, g: PrintAndReturn(7), h: PrintAndReturn(""Alice""), i: 2, j: 3, k: 4, l: 5, m: 6, n: PrintAndReturn(7), o: PrintAndReturn(""Bob""), p: 2, q: PrintAndReturn(3));
+        x.ToString();
     }
 
     static T PrintAndReturn<T>(T i)
@@ -3658,10 +3659,7 @@ class C3
             comp.VerifyDiagnostics(
                 // (6,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         var x = (1, 1);
-                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 1)").WithArguments("System.ValueTuple`2").WithLocation(6, 17),
-                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
-                //         var x = (1, 1);
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13)
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 1)").WithArguments("System.ValueTuple`2").WithLocation(6, 17)
                 );
         }
 
@@ -3774,10 +3772,7 @@ namespace System
             comp.VerifyDiagnostics(
                 // (7,39): error CS0229: Ambiguity between '(string, string).Item1' and '(string, string).Item1'
                 //         System.Console.WriteLine($"{x.Item1}");
-                Diagnostic(ErrorCode.ERR_AmbigMember, "Item1").WithArguments("(string, string).Item1", "(string, string).Item1").WithLocation(7, 39),
-                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
-                //         var x = ("Alice", "Bob");
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13)
+                Diagnostic(ErrorCode.ERR_AmbigMember, "Item1").WithArguments("(string, string).Item1", "(string, string).Item1").WithLocation(7, 39)
                 );
         }
 
@@ -20044,66 +20039,102 @@ public class C
     {
         // Warnings
 
-        (int, int) t1 = default((int, int));
-        (int, int) t2 = (1, 2);
-
-        (string, string) t3 = (null, null);
-        (string, string) t4 = (""hello"", ""world"");
-        (S, (S, S)) t5 = (new S(), (new S(), new S()));
-
-        // No warnings
-
-        (C, int) tuple = (new C(), 2);
-
-        (int, int) t6 = ((C, int))(new C(), 2); // implicit tuple conversion with a user conversion on an element
-        (int, int) t61 = ((C, int))tuple;
-
-        (int, int) t7 = (new C(), 2); // implicit tuple literal conversion with a user conversion on an element 
-        (int, int) t71 = tuple;
-
-        (int, int) t8 = ((int, int))(((C, int))(new C(), 2)); // explicit tuple conversion with a user conversion on an element 
-        (int, int) t81 = ((int, int))tuple;
-
-        (C, C) t9 = (new C(), new C());
-        (C, (C, C)) t10 = (new C(), (new C(), new C()));
-
         int[] array = new int[] { 42 };
         unsafe
         {
             fixed (int* p = &array[0])
             {
-                (int*, int*) t14 = (p, p); // converted tuple literal with a pointer type
-                (string, int*) t15 = (null, p); // implicit tuple literal conversion on a converted tuple literal with a pointer type
-                (string, (int*, int*)) t16 = (null, (p, p));
+                (int*, int*) t1 = (p, p); // converted tuple literal with a pointer type
+                (string, int*) t2 = (null, p); // implicit tuple literal conversion on a converted tuple literal with a pointer type
+                (string, (int*, int*)) t3 = (null, (p, p));
             }
         }
-        (S, (S, S)) t17 = (new S(), (new S() { /* object initializer */ }, new S()));
+
+        (int, int) t4 = default((int, int));
+        (int, int) t5 = (1, 2);
+
+        (string, string) t6 = (null, null);
+        (string, string) t7 = (""hello"", ""world"");
+        (S, (S, S)) t8 = (new S(), (new S(), new S()));
+
+        (int, int) t9 = ((C, int))(new C(), 2); // implicit tuple conversion with a user conversion on an element
+        (int, int) t10 = (new C(), 2); // implicit tuple literal conversion with a user conversion on an element
+        (int, int) t11 = ((int, int))(((C, int))(new C(), 2)); // explicit tuple conversion with a user conversion on an element
+
+        (C, C) t12 = (new C(), new C());
+        (C, (C, C)) t13 = (new C(), (new C(), new C()));
+        (S, (S, S)) t14 = (new S(), (new S() { /* object initializer */ }, new S()));
+
+        // No warnings
+
+        (C, int) tuple = (new C(), 2);
+        (int, int) t20 = ((C, int))tuple;
+        (int, int) t21 = tuple;
+        (int, int) t22 = ((int, int))tuple;
+
+        C c1 = (1, 2);
+        (int, int) intTuple = (1, 2);
+        C c2 = intTuple;
+
+        int i1 = 1;
+        int i2 = i1;
     }
 
     public static implicit operator int(C c)
     {
         return 0;
     }
+    public static implicit operator C((int, int) t)
+    {
+        return new C();
+    }
 }
 public struct S { }
 ";
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, additionalRefs: s_valueTupleRefs, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
-                // (8,20): warning CS0219: The variable 't1' is assigned but its value is never used
-                //         (int, int) t1 = default((int, int));
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t1").WithArguments("t1").WithLocation(8, 20),
-                // (9,20): warning CS0219: The variable 't2' is assigned but its value is never used
-                //         (int, int) t2 = (1, 2);
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t2").WithArguments("t2").WithLocation(9, 20),
-                // (11,26): warning CS0219: The variable 't3' is assigned but its value is never used
-                //         (string, string) t3 = (null, null);
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t3").WithArguments("t3").WithLocation(11, 26),
-                // (12,26): warning CS0219: The variable 't4' is assigned but its value is never used
-                //         (string, string) t4 = ("hello", "world");
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t4").WithArguments("t4").WithLocation(12, 26),
-                // (13,21): warning CS0219: The variable 't5' is assigned but its value is never used
-                //         (S, (S, S)) t5 = (new S(), (new S(), new S()));
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t5").WithArguments("t5").WithLocation(13, 21)
+                // (13,30): warning CS0219: The variable 't1' is assigned but its value is never used
+                //                 (int*, int*) t1 = (p, p); // converted tuple literal with a pointer type
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t1").WithArguments("t1").WithLocation(13, 30),
+                // (14,32): warning CS0219: The variable 't2' is assigned but its value is never used
+                //                 (string, int*) t2 = (null, p); // implicit tuple literal conversion on a converted tuple literal with a pointer type
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t2").WithArguments("t2").WithLocation(14, 32),
+                // (15,40): warning CS0219: The variable 't3' is assigned but its value is never used
+                //                 (string, (int*, int*)) t3 = (null, (p, p));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t3").WithArguments("t3").WithLocation(15, 40),
+                // (19,20): warning CS0219: The variable 't4' is assigned but its value is never used
+                //         (int, int) t4 = default((int, int));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t4").WithArguments("t4").WithLocation(19, 20),
+                // (20,20): warning CS0219: The variable 't5' is assigned but its value is never used
+                //         (int, int) t5 = (1, 2);
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t5").WithArguments("t5").WithLocation(20, 20),
+                // (22,26): warning CS0219: The variable 't6' is assigned but its value is never used
+                //         (string, string) t6 = (null, null);
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t6").WithArguments("t6").WithLocation(22, 26),
+                // (23,26): warning CS0219: The variable 't7' is assigned but its value is never used
+                //         (string, string) t7 = ("hello", "world");
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t7").WithArguments("t7").WithLocation(23, 26),
+                // (24,21): warning CS0219: The variable 't8' is assigned but its value is never used
+                //         (S, (S, S)) t8 = (new S(), (new S(), new S()));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t8").WithArguments("t8").WithLocation(24, 21),
+                // (26,20): warning CS0219: The variable 't9' is assigned but its value is never used
+                //         (int, int) t9 = ((C, int))(new C(), 2); // implicit tuple conversion with a user conversion on an element
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t9").WithArguments("t9").WithLocation(26, 20),
+                // (27,20): warning CS0219: The variable 't10' is assigned but its value is never used
+                //         (int, int) t10 = (new C(), 2); // implicit tuple literal conversion with a user conversion on an element
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t10").WithArguments("t10").WithLocation(27, 20),
+                // (28,20): warning CS0219: The variable 't11' is assigned but its value is never used
+                //         (int, int) t11 = ((int, int))(((C, int))(new C(), 2)); // explicit tuple conversion with a user conversion on an element
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t11").WithArguments("t11").WithLocation(28, 20),
+                // (30,16): warning CS0219: The variable 't12' is assigned but its value is never used
+                //         (C, C) t12 = (new C(), new C());
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t12").WithArguments("t12").WithLocation(30, 16),
+                // (31,21): warning CS0219: The variable 't13' is assigned but its value is never used
+                //         (C, (C, C)) t13 = (new C(), (new C(), new C()));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t13").WithArguments("t13").WithLocation(31, 21),
+                // (32,21): warning CS0219: The variable 't14' is assigned but its value is never used
+                //         (S, (S, S)) t14 = (new S(), (new S() { /* object initializer */ }, new S()));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t14").WithArguments("t14").WithLocation(32, 21)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -3658,7 +3658,10 @@ class C3
             comp.VerifyDiagnostics(
                 // (6,17): error CS8179: Predefined type 'System.ValueTuple`2' is not defined or imported
                 //         var x = (1, 1);
-                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 1)").WithArguments("System.ValueTuple`2").WithLocation(6, 17)
+                Diagnostic(ErrorCode.ERR_PredefinedValueTupleTypeNotFound, "(1, 1)").WithArguments("System.ValueTuple`2").WithLocation(6, 17),
+                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
+                //         var x = (1, 1);
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13)
                 );
         }
 
@@ -3771,7 +3774,10 @@ namespace System
             comp.VerifyDiagnostics(
                 // (7,39): error CS0229: Ambiguity between '(string, string).Item1' and '(string, string).Item1'
                 //         System.Console.WriteLine($"{x.Item1}");
-                Diagnostic(ErrorCode.ERR_AmbigMember, "Item1").WithArguments("(string, string).Item1", "(string, string).Item1").WithLocation(7, 39)
+                Diagnostic(ErrorCode.ERR_AmbigMember, "Item1").WithArguments("(string, string).Item1", "(string, string).Item1").WithLocation(7, 39),
+                // (6,13): warning CS0219: The variable 'x' is assigned but its value is never used
+                //         var x = ("Alice", "Bob");
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x").WithArguments("x").WithLocation(6, 13)
                 );
         }
 
@@ -18582,6 +18588,7 @@ public class C
         var x10 = (1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         D.M2((1, 2));
         D.M3((1, null));
+        System.Console.Write($""{x1} {x2} {x9} {x10}"");
     }
 }
 ";
@@ -18616,10 +18623,7 @@ public class C
                 Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "(1, 2)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(10, 14),
                 // (11,14): warning CS0612: 'ValueTuple<T1, T2>' is obsolete
                 //         D.M3((1, null));
-                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "(1, null)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(11, 14),
-                // (6,20): warning CS0219: The variable 'x1' is assigned but its value is never used
-                //         (int, int) x1 = (1, 2);
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "x1").WithArguments("x1").WithLocation(6, 20)
+                Diagnostic(ErrorCode.WRN_DeprecatedSymbol, "(1, null)").WithArguments("System.ValueTuple<T1, T2>").WithLocation(11, 14)
                 );
         }
 
@@ -18633,6 +18637,7 @@ public class C
     void M()
     {
         var x9 = (1, 2, 3, 4, 5, 6, 7, 8, 9);
+        System.Console.Write(x9);
     }
 }
 namespace System
@@ -20044,24 +20049,23 @@ public class C
 
         (string, string) t3 = (null, null);
         (string, string) t4 = (""hello"", ""world"");
+        (S, (S, S)) t5 = (new S(), (new S(), new S()));
 
         // No warnings
 
-        (int, int) t5 = (1, 2);
-        M(t5.Item1);
-
-        (C, int) refTuple = (new C(), 2);
+        (C, int) tuple = (new C(), 2);
 
         (int, int) t6 = ((C, int))(new C(), 2); // implicit tuple conversion with a user conversion on an element
-        (int, int) t61 = ((C, int))refTuple;
+        (int, int) t61 = ((C, int))tuple;
 
         (int, int) t7 = (new C(), 2); // implicit tuple literal conversion with a user conversion on an element 
-        (int, int) t71 = refTuple;
+        (int, int) t71 = tuple;
 
         (int, int) t8 = ((int, int))(((C, int))(new C(), 2)); // explicit tuple conversion with a user conversion on an element 
-        (int, int) t81 = ((int, int))refTuple;
+        (int, int) t81 = ((int, int))tuple;
 
         (C, C) t9 = (new C(), new C());
+        (C, (C, C)) t10 = (new C(), (new C(), new C()));
 
         int[] array = new int[] { 42 };
         unsafe
@@ -20073,6 +20077,7 @@ public class C
                 (string, (int*, int*)) t16 = (null, (p, p));
             }
         }
+        (S, (S, S)) t17 = (new S(), (new S() { /* object initializer */ }, new S()));
     }
 
     public static implicit operator int(C c)
@@ -20080,6 +20085,7 @@ public class C
         return 0;
     }
 }
+public struct S { }
 ";
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, additionalRefs: s_valueTupleRefs, options: TestOptions.UnsafeDebugDll);
             comp.VerifyDiagnostics(
@@ -20094,7 +20100,10 @@ public class C
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t3").WithArguments("t3").WithLocation(11, 26),
                 // (12,26): warning CS0219: The variable 't4' is assigned but its value is never used
                 //         (string, string) t4 = ("hello", "world");
-                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t4").WithArguments("t4").WithLocation(12, 26)
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t4").WithArguments("t4").WithLocation(12, 26),
+                // (13,21): warning CS0219: The variable 't5' is assigned but its value is never used
+                //         (S, (S, S)) t5 = (new S(), (new S(), new S()));
+                Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t5").WithArguments("t5").WithLocation(13, 21)
                 );
         }
     }

--- a/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
+++ b/src/Compilers/CSharp/Test/Emit/CodeGen/CodeGenTupleTest.cs
@@ -20037,20 +20037,38 @@ public class C
 {
     void M(int x)
     {
-        (int, int) t1 = default((int, int));
-        (int, int) t2 = (1, 2);
-        (int, int) t3 = (1, 2);
+        (int, int) t1 = default((int, int)); // warning
+        (int, int) t2 = (1, 2); // warning
+
+        (int, int) t3 = (1, 2); // used
         M(t3.Item1);
+
+        (int, int) t4 = (new C(), 2); // user conversion
+        ((int, int), int) t5 = (new C(), 2); // user conversion
+        (Error, int) t6 = (1, 2);
+        (int, C) t7 = (1, new C());
+    }
+
+    public static implicit operator int(C c)
+    {
+        return 0;
+    }
+    public static implicit operator (int, int)(C p)
+    {
+        return (0, 0);
     }
 }
 ";
             var comp = CreateCompilationWithMscorlib45AndCSruntime(source, additionalRefs: s_valueTupleRefs);
             comp.VerifyDiagnostics(
+                // (14,10): error CS0246: The type or namespace name 'Error' could not be found (are you missing a using directive or an assembly reference?)
+                //         (Error, int) t6 = (1, 2);
+                Diagnostic(ErrorCode.ERR_SingleTypeNameNotFound, "Error").WithArguments("Error").WithLocation(14, 10),
                 // (6,20): warning CS0219: The variable 't1' is assigned but its value is never used
-                //         (int, int) t1 = default((int, int));
+                //         (int, int) t1 = default((int, int)); // warning
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t1").WithArguments("t1").WithLocation(6, 20),
                 // (7,20): warning CS0219: The variable 't2' is assigned but its value is never used
-                //         (int, int) t2 = (1, 2);
+                //         (int, int) t2 = (1, 2); // warning
                 Diagnostic(ErrorCode.WRN_UnreferencedVarAssg, "t2").WithArguments("t2").WithLocation(7, 20)
                 );
         }

--- a/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
+++ b/src/Compilers/CSharp/Test/Semantic/Semantics/DeconstructionTests.cs
@@ -2358,6 +2358,7 @@ class C
     {
         var x1 = (1, 2);
         var (x2, x3) = (1, 2);
+        System.Console.Write($""{x1} {x2} {x3}"");
     }
 }
 ";

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17823,6 +17823,39 @@ val:   -2
 ]]>)
 
         End Sub
+
+        <Fact>
+        Public Sub UnusedTuple()
+
+            Dim comp = CreateCompilationWithMscorlibAndVBRuntime(
+<compilation>
+    <file name="a.vb"><![CDATA[
+Imports System
+
+Module C
+    Sub Main()
+        Dim x1 As Integer
+        Dim t1 As (Integer, String)
+        Dim x2 As Integer = 1
+        Dim t2 As (Integer, String) = (1, 2)
+    End Sub
+End Module
+
+]]></file>
+</compilation>, additionalRefs:=s_valueTupleRefs)
+
+            comp.AssertTheseDiagnostics(
+<errors>
+BC42024: Unused local variable: 'x1'.
+        Dim x1 As Integer
+            ~~
+BC42024: Unused local variable: 't1'.
+        Dim t1 As (Integer, String)
+            ~~
+</errors>)
+
+        End Sub
+
     End Class
 
 End Namespace

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17832,25 +17832,42 @@ val:   -2
     <file name="a.vb"><![CDATA[
 Imports System
 
-Module C
-    Sub Main()
-        Dim x1 As Integer
-        Dim t1 As (Integer, String)
-        Dim x2 As Integer = 1
-        Dim t2 As (Integer, String) = (1, 2)
+Class C
+    Sub M()
+        ' Warnings
+        Dim x2 As Integer
+        Const x3 As Integer = 1
+        Const x4 As String = "hello"
+        Dim x5 As (Integer, Integer)
+        Dim x6 As (String, String)
+
+        ' No warnings
+        Dim y10 As Integer = 1
+        Dim y11 As String = "hello"
+        Dim y12 As (Integer, Integer) = (1, 2)
+        Dim y13 As (String, String) = ("hello", "world")
     End Sub
-End Module
+End Class
 
 ]]></file>
 </compilation>, additionalRefs:=s_valueTupleRefs)
 
             comp.AssertTheseDiagnostics(
 <errors>
-BC42024: Unused local variable: 'x1'.
-        Dim x1 As Integer
+BC42024: Unused local variable: 'x2'.
+        Dim x2 As Integer
             ~~
-BC42024: Unused local variable: 't1'.
-        Dim t1 As (Integer, String)
+BC42099: Unused local constant: 'x3'.
+        Const x3 As Integer = 1
+              ~~
+BC42099: Unused local constant: 'x4'.
+        Const x4 As String = "hello"
+              ~~
+BC42024: Unused local variable: 'x5'.
+        Dim x5 As (Integer, Integer)
+            ~~
+BC42024: Unused local variable: 'x6'.
+        Dim x6 As (String, String)
             ~~
 </errors>)
 

--- a/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
+++ b/src/Compilers/VisualBasic/Test/Emit/CodeGen/CodeGenTuples.vb
@@ -17846,6 +17846,8 @@ Class C
         Dim y11 As String = "hello"
         Dim y12 As (Integer, Integer) = (1, 2)
         Dim y13 As (String, String) = ("hello", "world")
+        Dim tuple As (String, String) = ("hello", "world")
+        Dim y14 As (String, String) = tuple
     End Sub
 End Class
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15002

`(int, int) t = (1, 2);` without further usage should report a warning, just like `int i = 1;` or `(int, int) t = default((int, int));` does.

@dotnet/roslyn-compiler for review.