### PR TITLE
editorconfig codestyle options

### DIFF
--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpSimplifyTypeNamesDiagnosticAnalyzer.cs
@@ -47,10 +47,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             }
 
             Diagnostic diagnostic;
+            var options = context.Options;
+            var cancellationToken = context.CancellationToken;
             Func<SyntaxNode, bool> descendIntoChildren = n =>
             {
                 if (!IsRegularCandidate(n) ||
-                    !TrySimplifyTypeNameExpression(context.SemanticModel, n, context.Options, out diagnostic, context.CancellationToken))
+                    !TrySimplifyTypeNameExpression(context.SemanticModel, n, options, out diagnostic, cancellationToken))
                 {
                     return true;
                 }
@@ -62,16 +64,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.SimplifyTypeNames
             // find regular node first - search from top to down. once found one, don't get into its children
             foreach (var candidate in context.Node.DescendantNodesAndSelf(descendIntoChildren))
             {
-                context.CancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
             }
 
             // now search structure trivia
             foreach (var candidate in context.Node.DescendantNodesAndSelf(descendIntoChildren: n => !IsCrefCandidate(n), descendIntoTrivia: true))
             {
-                context.CancellationToken.ThrowIfCancellationRequested();
+                cancellationToken.ThrowIfCancellationRequested();
 
                 if (IsCrefCandidate(candidate) &&
-                    TrySimplifyTypeNameExpression(context.SemanticModel, candidate, context.Options, out diagnostic, context.CancellationToken))
+                    TrySimplifyTypeNameExpression(context.SemanticModel, candidate, options, out diagnostic, cancellationToken))
                 {
                     context.ReportDiagnostic(diagnostic);
                 }

--- a/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
+++ b/src/Features/CSharp/Portable/Diagnostics/Analyzers/CSharpTypeStyleDiagnosticAnalyzerBase.cs
@@ -71,9 +71,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Diagnostics.TypeStyle
             State state = null;
             var shouldAnalyze = false;
             var declarationStatement = context.Node;
-            var optionSet = context.Options.GetOptionSet();
-            var semanticModel = context.SemanticModel;
+            var options = context.Options;
+            var syntaxTree = context.Node.SyntaxTree;
             var cancellationToken = context.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+            
+            var semanticModel = context.SemanticModel;
 
             if (declarationStatement.IsKind(SyntaxKind.VariableDeclaration))
             {

--- a/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InlineDeclaration/CSharpInlineDeclarationDiagnosticAnalyzer.cs
@@ -49,8 +49,15 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
                 // out-vars are not supported prior to C# 7.0.
                 return;
             }
-
-            var optionSet = context.Options.GetOptionSet();
+            var options = context.Options;
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+            
             var option = optionSet.GetOption(CodeStyleOptions.PreferInlinedVariableDeclaration, argumentNode.Language);
             if (!option.Value)
             {
@@ -99,7 +106,6 @@ namespace Microsoft.CodeAnalysis.CSharp.InlineDeclaration
             }
 
             var semanticModel = context.SemanticModel;
-            var cancellationToken = context.CancellationToken;
             var outSymbol = semanticModel.GetSymbolInfo(argumentExpression, cancellationToken).Symbol;
             if (outSymbol?.Kind != SymbolKind.Local)
             {

--- a/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
+++ b/src/Features/CSharp/Portable/InvokeDelegateWithConditionalAccess/InvokeDelegateWithConditionalAccessAnalyzer.cs
@@ -35,8 +35,16 @@ namespace Microsoft.CodeAnalysis.CSharp.InvokeDelegateWithConditionalAccess
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
         {
-            var options = syntaxContext.Options.GetOptionSet();
-            var styleOption = options.GetOption(CSharpCodeStyleOptions.PreferConditionalDelegateCall);
+            var options = syntaxContext.Options;
+            var syntaxTree = syntaxContext.Node.SyntaxTree;
+            var cancellationToken = syntaxContext.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+            
+            var styleOption = optionSet.GetOption(CSharpCodeStyleOptions.PreferConditionalDelegateCall);
             if (!styleOption.Value)
             {
                 // Bail immediately if the user has disabled this feature.

--- a/src/Features/CSharp/Portable/UseExpressionBody/AbstractUseExpressionBodyDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UseExpressionBody/AbstractUseExpressionBodyDiagnosticAnalyzer.cs
@@ -41,7 +41,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UseExpressionBody
 
         private void AnalyzeSyntax(SyntaxNodeAnalysisContext context)
         {
-            var diagnostic = AnalyzeSyntax(context.Options.GetOptionSet(), (TDeclaration)context.Node);
+            var options = context.Options;
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var diagnostic = AnalyzeSyntax(optionSet, (TDeclaration)context.Node);
             if (diagnostic != null)
             {
                 context.ReportDiagnostic(diagnostic);

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpAsAndNullCheckDiagnosticAnalyzer.cs
@@ -38,8 +38,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
         {
-            var options = syntaxContext.Options.GetOptionSet();
-            var styleOption = options.GetOption(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck);
+            var options = syntaxContext.Options;
+            var syntaxTree = syntaxContext.Node.SyntaxTree;
+            var cancellationToken = syntaxContext.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
+            var styleOption = optionSet.GetOption(CSharpCodeStyleOptions.PreferPatternMatchingOverAsWithNullCheck);
             if (!styleOption.Value)
             {
                 // Bail immediately if the user has disabled this feature.

--- a/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
+++ b/src/Features/CSharp/Portable/UsePatternMatching/CSharpIsAndCastCheckDiagnosticAnalyzer.cs
@@ -44,8 +44,16 @@ namespace Microsoft.CodeAnalysis.CSharp.UsePatternMatching
 
         private void SyntaxNodeAction(SyntaxNodeAnalysisContext syntaxContext)
         {
-            var options = syntaxContext.Options.GetOptionSet();
-            var styleOption = options.GetOption(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck);
+            var options = syntaxContext.Options;
+            var syntaxTree = syntaxContext.Node.SyntaxTree;
+            var cancellationToken = syntaxContext.CancellationToken;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+            
+            var styleOption = optionSet.GetOption(CSharpCodeStyleOptions.PreferPatternMatchingOverIsWithCastCheck);
             if (!styleOption.Value)
             {
                 // Bail immediately if the user has disabled this feature.

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/PreferFrameworkTypeDiagnosticAnalyzerBase.cs
@@ -74,14 +74,15 @@ namespace Microsoft.CodeAnalysis.Diagnostics.PreferFrameworkType
 
         protected void AnalyzeNode(SyntaxNodeAnalysisContext context)
         {
-            var optionSet = context.Options.GetOptionSet();
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
             if (optionSet == null)
             {
                 return;
             }
-
+            
             var semanticModel = context.SemanticModel;
-            var cancellationToken = context.CancellationToken;
             var language = semanticModel.Language;
 
             // if the user never prefers this style, do not analyze at all.

--- a/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
+++ b/src/Features/Core/Portable/Diagnostics/Analyzers/SimplifyTypeNamesDiagnosticAnalyzerBase.cs
@@ -91,12 +91,14 @@ namespace Microsoft.CodeAnalysis.Diagnostics.SimplifyTypeNames
         protected bool TrySimplifyTypeNameExpression(SemanticModel model, SyntaxNode node, AnalyzerOptions analyzerOptions, out Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             diagnostic = default(Diagnostic);
-
-            var optionSet = analyzerOptions.GetOptionSet();
-            string diagnosticId;
-
-            TextSpan issueSpan;
-            if (!CanSimplifyTypeNameExpressionCore(model, node, optionSet, out issueSpan, out diagnosticId, cancellationToken))
+            var syntaxTree = node.SyntaxTree;
+            var optionSet = analyzerOptions.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return false;
+            }
+            
+            if (!CanSimplifyTypeNameExpressionCore(model, node, optionSet, out var issueSpan, out string diagnosticId, cancellationToken))
             {
                 return false;
             }

--- a/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/QualifyMemberAccess/AbstractQualifyMemberAccessDiagnosticAnalyzer.cs
@@ -72,8 +72,9 @@ namespace Microsoft.CodeAnalysis.QualifyMemberAccess
                 return;
             }
 
-            // get the option
-            var optionSet = context.Options.GetOptionSet();
+            var syntaxTree = context.Operation.Syntax.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
             if (optionSet == null)
             {
                 return;

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionDiagnosticAnalyzer.cs
@@ -37,7 +37,14 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         {
             var conditionalExpression = (TConditionalExpressionSyntax)context.Node;
 
-            var optionSet = context.Options.GetOptionSet();
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationTokan = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationTokan).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
             var option = optionSet.GetOption(CodeStyleOptions.PreferCoalesceExpression, conditionalExpression.Language);
             if (!option.Value)
             {

--- a/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCoalesceExpression/AbstractUseCoalesceExpressionForNullableDiagnosticAnalyzer.cs
@@ -40,7 +40,14 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
         {
             var conditionalExpression = (TConditionalExpressionSyntax)context.Node;
 
-            var optionSet = context.Options.GetOptionSet();
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
             var option = optionSet.GetOption(CodeStyleOptions.PreferCoalesceExpression, conditionalExpression.Language);
             if (!option.Value)
             {
@@ -114,7 +121,6 @@ namespace Microsoft.CodeAnalysis.UseCoalesceExpression
                 return;
             }
 
-            var cancellationToken = context.CancellationToken;
             var type = semanticModel.GetTypeInfo(conditionExpression, cancellationToken);
 
             if (!nullableType.Equals(type.Type?.OriginalDefinition))

--- a/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseCollectionInitializer/AbstractUseCollectionInitializerDiagnosticAnalyzer.cs
@@ -61,11 +61,16 @@ namespace Microsoft.CodeAnalysis.UseCollectionInitializer
                 return;
             }
 
-            var cancellationToken = context.CancellationToken;
             var objectCreationExpression = (TObjectCreationExpressionSyntax)context.Node;
             var language = objectCreationExpression.Language;
+            var syntaxTree = objectCreationExpression.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
 
-            var optionSet = context.Options.GetOptionSet();
             var option = optionSet.GetOption(CodeStyleOptions.PreferCollectionInitializer, language);
             if (!option.Value)
             {

--- a/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseNullPropagation/AbstractUseNullPropagationDiagnosticAnalyzer.cs
@@ -51,7 +51,14 @@ namespace Microsoft.CodeAnalysis.UseNullPropagation
                 return;
             }
 
-            var optionSet = context.Options.GetOptionSet();
+            var syntaxTree = conditionalExpression.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
             var option = optionSet.GetOption(CodeStyleOptions.PreferNullPropagation, conditionalExpression.Language);
             if (!option.Value)
             {

--- a/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseObjectInitializer/AbstractUseObjectInitializerDiagnosticAnalyzer.cs
@@ -53,10 +53,16 @@ namespace Microsoft.CodeAnalysis.UseObjectInitializer
                 return;
             }
 
+            var syntaxTree = context.Node.SyntaxTree;
+            var cancellationToken = context.CancellationToken;
+            var optionSet = context.Options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+
             var objectCreationExpression = (TObjectCreationExpressionSyntax)context.Node;
             var language = objectCreationExpression.Language;
-
-            var optionSet = context.Options.GetOptionSet();
             var option = optionSet.GetOption(CodeStyleOptions.PreferObjectInitializer, language);
             if (!option.Value)
             {

--- a/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
+++ b/src/Features/Core/Portable/UseThrowExpression/AbstractUseThrowExpressionDiagnosticAnalyzer.cs
@@ -73,8 +73,13 @@ namespace Microsoft.CodeAnalysis.UseThrowExpression
 
             var throwOperation = (IThrowStatement)context.Operation;
             var throwStatement = throwOperation.Syntax;
-
-            var optionSet = context.Options.GetOptionSet();
+            var options = context.Options;
+            var optionSet = options.GetDocumentOptionSetAsync(syntaxTree, cancellationToken).GetAwaiter().GetResult();
+            if (optionSet == null)
+            {
+                return;
+            }
+            
             var option = optionSet.GetOption(CodeStyleOptions.PreferThrowExpression, throwStatement.Language);
             if (!option.Value)
             {

--- a/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
+++ b/src/Workspaces/CSharp/Portable/CodeStyle/CSharpCodeStyleOptions.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
-using System.Collections;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CodeStyle;
 using Microsoft.CodeAnalysis.Options;
+using static Microsoft.CodeAnalysis.CodeStyle.CodeStyleHelpers;
 
 namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
 {
@@ -11,51 +11,77 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeStyle
     {
         // TODO: get sign off on public api changes.
         public static readonly Option<bool> UseVarWhenDeclaringLocals = new Option<bool>(nameof(CodeStyleOptions), nameof(UseVarWhenDeclaringLocals), defaultValue: true,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseVarWhenDeclaringLocals"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_var_for_locals", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseVarWhenDeclaringLocals")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeForIntrinsicTypes = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeForIntrinsicTypes), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeForIntrinsicTypes"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_var_for_built_in_types", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeForIntrinsicTypes")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWhereApparent = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeWhereApparent), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWhereApparent"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_var_when_type_is_apparent", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWhereApparent")});
 
         public static readonly Option<CodeStyleOption<bool>> UseImplicitTypeWherePossible = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(UseImplicitTypeWherePossible), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWherePossible"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_var_elsewhere", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.UseImplicitTypeWherePossible")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferConditionalDelegateCall = new Option<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferConditionalDelegateCall), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.PreferConditionalDelegateCall"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_conditional_delegate_call", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.CSharp.Specific.PreferConditionalDelegateCall")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverAsWithNullCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverAsWithNullCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverAsWithNullCheck)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_as_with_null_check", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverAsWithNullCheck)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferPatternMatchingOverIsWithCastCheck = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferPatternMatchingOverIsWithCastCheck), defaultValue: CodeStyleOptions.TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverIsWithCastCheck)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_pattern_matching_over_is_with_cast_check", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferPatternMatchingOverIsWithCastCheck)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedConstructors = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedConstructors), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedConstructors)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_constructors", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedConstructors)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedMethods = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedMethods), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedMethods)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_methods", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedMethods)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedOperators = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedOperators), defaultValue: CodeStyleOptions.FalseWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedOperators)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_operators", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedOperators)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedProperties = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedProperties), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedProperties)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_properties", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedProperties)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedIndexers = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedIndexers), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedIndexers)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_indexers", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedIndexers)}")});
 
         public static readonly Option<CodeStyleOption<bool>> PreferExpressionBodiedAccessors = new Option<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions), nameof(PreferExpressionBodiedAccessors), defaultValue: CodeStyleOptions.TrueWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedAccessors)}"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_expression_bodied_accessors", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation($"TextEditor.CSharp.Specific.{nameof(PreferExpressionBodiedAccessors)}")});
 
         public static IEnumerable<Option<CodeStyleOption<bool>>> GetCodeStyleOptions()
         {

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.CodeAnalysis.CodeStyle
+{
+    internal static class CodeStyleHelpers
+    {
+        public static CodeStyleOption<bool> ParseEditorConfigCodeStyleOption(string arg)
+        {
+            var args = arg.Split(':');
+            if (args.Length != 2)
+            {
+                return CodeStyleOption<bool>.Default;
+            }
+
+            bool isEnabled = false;
+            if (!bool.TryParse(args[0], out isEnabled))
+            {
+                return CodeStyleOption<bool>.Default;
+            }
+
+            switch (args[1].Trim())
+            {
+                case "none": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                case "suggestion": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion);
+                case "warning": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning);
+                case "error": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error);
+                default: return CodeStyleOption<bool>.Default;
+            }
+        }
+    }
+}

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -10,7 +10,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             bool isEnabled = false;
             if (args.Length != 2)
             {
-                if (arg.Length == 1)
+                if (args.Length == 1)
                 {
                     if (bool.TryParse(args[0].Trim(), out isEnabled) && !isEnabled)
                     {

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -1,17 +1,30 @@
-﻿namespace Microsoft.CodeAnalysis.CodeStyle
+﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
+
+namespace Microsoft.CodeAnalysis.CodeStyle
 {
     internal static class CodeStyleHelpers
     {
         public static CodeStyleOption<bool> ParseEditorConfigCodeStyleOption(string arg)
         {
             var args = arg.Split(':');
+            bool isEnabled = false;
             if (args.Length != 2)
             {
+                if (arg.Length == 1)
+                {
+                    if (bool.TryParse(args[0].Trim(), out isEnabled) && !isEnabled)
+                    {
+                        return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                    }
+                    else
+                    {
+                        return CodeStyleOption<bool>.Default;
+                    }
+                }
                 return CodeStyleOption<bool>.Default;
             }
 
-            bool isEnabled = false;
-            if (!bool.TryParse(args[0], out isEnabled))
+            if (!bool.TryParse(args[0].Trim(), out isEnabled))
             {
                 return CodeStyleOption<bool>.Default;
             }
@@ -22,7 +35,7 @@
                 case "suggestion": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion);
                 case "warning": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning);
                 case "error": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error);
-                default: return CodeStyleOption<bool>.Default;
+                default: return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
             }
         }
     }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleHelpers.cs
@@ -31,7 +31,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
 
             switch (args[1].Trim())
             {
-                case "none": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
+                case "silent": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.None);
                 case "suggestion": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Suggestion);
                 case "warning": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Warning);
                 case "error": return new CodeStyleOption<bool>(value: isEnabled, notification: NotificationOption.Error);

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using Microsoft.CodeAnalysis.Options;
+using static Microsoft.CodeAnalysis.CodeStyle.CodeStyleHelpers;
 
 namespace Microsoft.CodeAnalysis.CodeStyle
 {
@@ -20,55 +21,73 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in field access expressions.
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyFieldAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyFieldAccess), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_field", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess")});
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in property access expressions.
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyPropertyAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyPropertyAccess), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_property", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess")});
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in method access expressions.
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyMethodAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyMethodAccess), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_method", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess")});
 
         /// <summary>
         /// This option says if we should simplify away the <see langword="this"/>. or <see langword="Me"/>. in event access expressions.
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyEventAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyEventAccess), defaultValue: CodeStyleOption<bool>.Default,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_event", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess")});
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Declarations
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: TrueWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_locals_parameters_members", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration")});
 
         /// <summary>
         /// This option says if we should prefer keyword for Intrinsic Predefined Types in Member Access Expression
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInMemberAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: TrueWithNoneEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_member_access", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferThrowExpression = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferThrowExpression),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferThrowExpression"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_throw_expression", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferThrowExpression")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferObjectInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferObjectInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_object_initializer", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferCollectionInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferCollectionInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_collection_initializer", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer")});
 
         internal static readonly PerLanguageOption<bool> PreferObjectInitializer_FadeOutCode = new PerLanguageOption<bool>(
             nameof(CodeStyleOptions),
@@ -86,18 +105,24 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(CodeStyleOptions),
             nameof(PreferCoalesceExpression),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCoalesceExpression"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_coalesce_expression", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCoalesceExpression") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferNullPropagation = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferNullPropagation),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferNullPropagation"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("dotnet_style_null_propagation", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferNullPropagation") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferInlinedVariableDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(
             nameof(CodeStyleOptions),
             nameof(PreferInlinedVariableDeclaration),
             defaultValue: TrueWithSuggestionEnforcement,
-            storageLocations: new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferInlinedVariableDeclaration"));
+            storageLocations: new OptionStorageLocation[]{
+                new EditorConfigStorageLocation("csharp_style_inlined_variable_declaration", ParseEditorConfigCodeStyleOption),
+                new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferInlinedVariableDeclaration") });
     }
 }

--- a/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
+++ b/src/Workspaces/Core/Portable/CodeStyle/CodeStyleOptions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyFieldAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyFieldAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_field", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_field"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyFieldAccess")});
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyPropertyAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyPropertyAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_property", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_property"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyPropertyAccess")});
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyMethodAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyMethodAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_method", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_method"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyMethodAccess")});
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> QualifyEventAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(QualifyEventAccess), defaultValue: CodeStyleOption<bool>.Default,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_qualification_for_event", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_qualification_for_event"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.QualifyEventAccess")});
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInDeclaration), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_locals_parameters_members", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_locals_parameters_members"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInDeclaration")});
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
         /// </summary>
         public static readonly PerLanguageOption<CodeStyleOption<bool>> PreferIntrinsicPredefinedTypeKeywordInMemberAccess = new PerLanguageOption<CodeStyleOption<bool>>(nameof(CodeStyleOptions), nameof(PreferIntrinsicPredefinedTypeKeywordInMemberAccess), defaultValue: TrueWithNoneEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_member_access", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_predefined_type_for_member_access"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferIntrinsicPredefinedTypeKeywordInMemberAccess")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferThrowExpression = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -70,7 +70,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferThrowExpression),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("csharp_style_throw_expression", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_throw_expression"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferThrowExpression")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferObjectInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -78,7 +78,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferObjectInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_object_initializer", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_object_initializer"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferObjectInitializer")});
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferCollectionInitializer = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -86,7 +86,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferCollectionInitializer),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_collection_initializer", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_collection_initializer"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCollectionInitializer")});
 
         internal static readonly PerLanguageOption<bool> PreferObjectInitializer_FadeOutCode = new PerLanguageOption<bool>(
@@ -106,7 +106,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferCoalesceExpression),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_coalesce_expression", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_coalesce_expression"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferCoalesceExpression") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferNullPropagation = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -114,7 +114,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferNullPropagation),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("dotnet_style_null_propagation", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("dotnet_style_null_propagation"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferNullPropagation") });
 
         internal static readonly PerLanguageOption<CodeStyleOption<bool>> PreferInlinedVariableDeclaration = new PerLanguageOption<CodeStyleOption<bool>>(
@@ -122,7 +122,7 @@ namespace Microsoft.CodeAnalysis.CodeStyle
             nameof(PreferInlinedVariableDeclaration),
             defaultValue: TrueWithSuggestionEnforcement,
             storageLocations: new OptionStorageLocation[]{
-                new EditorConfigStorageLocation("csharp_style_inlined_variable_declaration", ParseEditorConfigCodeStyleOption),
+                new EditorConfigStorageLocation("csharp_style_inlined_variable_declaration"),
                 new RoamingProfileStorageLocation("TextEditor.%LANGUAGE%.Specific.PreferInlinedVariableDeclaration") });
     }
 }

--- a/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
+++ b/src/Workspaces/Core/Portable/Options/EditorConfigStorageLocation.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
+using Microsoft.CodeAnalysis.CodeStyle;
+using static Microsoft.CodeAnalysis.CodeStyle.CodeStyleHelpers;
 
 namespace Microsoft.CodeAnalysis.Options
 {
@@ -28,6 +30,10 @@ namespace Microsoft.CodeAnalysis.Options
                 else if (type == typeof(bool))
                 {
                     return bool.Parse(s);
+                }
+                else if (type == typeof(CodeStyleOption<bool>))
+                {
+                    return ParseEditorConfigCodeStyleOption(s);
                 }
                 else
                 {

--- a/src/Workspaces/Core/Portable/Workspaces.csproj
+++ b/src/Workspaces/Core/Portable/Workspaces.csproj
@@ -341,6 +341,7 @@
     <Compile Include="CodeGeneration\CodeGenerationOptions.cs" />
     <Compile Include="CodeGeneration\CodeGenerationSymbolFactory.cs" />
     <Compile Include="CodeGeneration\CodeGenerator.cs" />
+    <Compile Include="CodeStyle\CodeStyleHelpers.cs" />
     <Compile Include="CodeStyle\CodeStyleOptions.cs" />
     <Compile Include="CodeStyle\NotificationOption.cs" />
     <Compile Include="CodeStyle\CodeStyleOption.cs" />

--- a/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.CodeAnalysis.CodeStyle;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
+{
+    public class EditorConfigCodeStyleParserTests
+    {
+        [Theory]
+        [InlineData("true:none", true, DiagnosticSeverity.Hidden)]
+        [InlineData("true:suggestion", true, DiagnosticSeverity.Info)]
+        [InlineData("true:warning", true, DiagnosticSeverity.Warning)]
+        [InlineData("true:error", true, DiagnosticSeverity.Error)]
+        [InlineData("false:none", false, DiagnosticSeverity.Hidden)]
+        [InlineData("false:suggestion", false, DiagnosticSeverity.Info)]
+        [InlineData("false:warning", false, DiagnosticSeverity.Warning)]
+        [InlineData("false:error", false, DiagnosticSeverity.Error)]
+        [InlineData("false", false, DiagnosticSeverity.Hidden)]
+        [InlineData("*", false, DiagnosticSeverity.Hidden)]
+        [InlineData("false:false", false, DiagnosticSeverity.Hidden)]
+        static void TestParseEditorConfigCodeStyleOption(string args, bool isEnabled, DiagnosticSeverity severity)
+        {
+            var notificationOption = NotificationOption.None;
+            switch (severity)
+            {
+                case DiagnosticSeverity.Hidden:
+                    notificationOption = NotificationOption.None;
+                    break;
+                case DiagnosticSeverity.Info:
+                    notificationOption = NotificationOption.Suggestion;
+                    break;
+                case DiagnosticSeverity.Warning:
+                    notificationOption = NotificationOption.Warning;
+                    break;
+                case DiagnosticSeverity.Error:
+                    notificationOption = NotificationOption.Error;
+                    break;
+            }
+
+            var codeStyleOption = new CodeStyleOption<bool>(value: isEnabled, notification: notificationOption);
+
+            var result = CodeStyleHelpers.ParseEditorConfigCodeStyleOption(args);
+            Assert.True(result.Value == isEnabled,
+                        $"Expected {nameof(isEnabled)} to be {isEnabled}, was {result.Value}");
+            Assert.True(result.Notification.Value == severity,
+                        $"Expected {nameof(severity)} to be {severity}, was {result.Notification.Value}");
+        }
+    }
+}

--- a/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
+++ b/src/Workspaces/CoreTest/CodeStyle/EditorConfigCodeStyleParserTests.cs
@@ -11,11 +11,11 @@ namespace Microsoft.CodeAnalysis.UnitTests.CodeStyle
     public class EditorConfigCodeStyleParserTests
     {
         [Theory]
-        [InlineData("true:none", true, DiagnosticSeverity.Hidden)]
+        [InlineData("true:silent", true, DiagnosticSeverity.Hidden)]
         [InlineData("true:suggestion", true, DiagnosticSeverity.Info)]
         [InlineData("true:warning", true, DiagnosticSeverity.Warning)]
         [InlineData("true:error", true, DiagnosticSeverity.Error)]
-        [InlineData("false:none", false, DiagnosticSeverity.Hidden)]
+        [InlineData("false:silent", false, DiagnosticSeverity.Hidden)]
         [InlineData("false:suggestion", false, DiagnosticSeverity.Info)]
         [InlineData("false:warning", false, DiagnosticSeverity.Warning)]
         [InlineData("false:error", false, DiagnosticSeverity.Error)]

--- a/src/Workspaces/CoreTest/ServicesTest.csproj
+++ b/src/Workspaces/CoreTest/ServicesTest.csproj
@@ -64,6 +64,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CodeStyle\EditorConfigCodeStyleParserTests.cs" />
     <Compile Include="DependentTypeFinderTests.cs" />
     <Compile Include="Editting\SyntaxEditorTests.cs" />
     <Compile Include="Execution\Extensions.cs" />


### PR DESCRIPTION
@dotnet/roslyn-ide @jasonmalinowski
Adds the following options

## Code Style Options
editorconfig name | possible values
------------ | -------------
csharp_style_var_for_locals | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_var_for_built_in_types | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_var_when_type_is_apparent | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_var_elsewhere | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_methods | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_constructors | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_operators | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_properties | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_indexers | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_expression_bodied_accessors | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_pattern_matching_over_is_with_cast_check | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_pattern_matching_over_as_with_null_check | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_inlined_variable_declaration | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_throw_expression | true: none,suggestion,warning,error , false: none,suggestion,warning,error
csharp_style_conditional_delegate_call | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_qualification_for_field | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_qualification_for_property | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_qualification_for_method | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_qualification_for_event | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_predefined_type_for_locals_parameters_members | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_predefined_type_for_member_access | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_object_initializer | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_collection_initializer | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_coalesce_expression | true: none,suggestion,warning,error , false: none,suggestion,warning,error
dotnet_style_null_propagation | true: none,suggestion,warning,error , false: none,suggestion,warning,error