### PR TITLE
Shave off hundreds of MB of allocations during FindReferences.

### DIFF
--- a/src/Compilers/Core/Portable/MetadataReference/PortableExecutableReference.cs
+++ b/src/Compilers/Core/Portable/MetadataReference/PortableExecutableReference.cs
@@ -170,6 +170,19 @@ namespace Microsoft.CodeAnalysis
             return GetMetadataNoCopy().Copy();
         }
 
+        /// <summary>
+        /// Returns the <see cref="MetadataId"/> for this reference's <see cref="Metadata"/>.
+        /// This will be equivalent to calling <see cref="GetMetadata()"/>.<see cref="Metadata.Id"/>,
+        /// but can be done more efficiently.
+        /// </summary>
+        /// <exception cref="BadImageFormatException">If the PE image format is invalid.</exception>
+        /// <exception cref="IOException">The metadata image content can't be read.</exception>
+        /// <exception cref="FileNotFoundException">The metadata image is stored in a file that can't be found.</exception>
+        public MetadataId GetMetadataId()
+        {
+            return GetMetadataNoCopy().Id;
+        }
+
         internal static Diagnostic ExceptionToDiagnostic(Exception e, CommonMessageProvider messageProvider, Location location, string display, MetadataImageKind kind)
         {
             if (e is BadImageFormatException)

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -175,6 +175,7 @@ Microsoft.CodeAnalysis.OperationKind.VariableDeclarationStatement = 3 -> Microso
 Microsoft.CodeAnalysis.OperationKind.WithStatement = 82 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.YieldBreakStatement = 12 -> Microsoft.CodeAnalysis.OperationKind
 Microsoft.CodeAnalysis.OperationKind.YieldReturnStatement = 16 -> Microsoft.CodeAnalysis.OperationKind
+Microsoft.CodeAnalysis.PortableExecutableReference.GetMetadataId() -> Microsoft.CodeAnalysis.MetadataId
 Microsoft.CodeAnalysis.SemanticModel.GetOperation(Microsoft.CodeAnalysis.SyntaxNode node, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.IOperation
 Microsoft.CodeAnalysis.Semantics.ArgumentKind
 Microsoft.CodeAnalysis.Semantics.ArgumentKind.DefaultValue = 4 -> Microsoft.CodeAnalysis.Semantics.ArgumentKind


### PR DESCRIPTION
During FAR we get the Metadata for a PE reference to try to find our index for that PE reference.  We only get teh metadata just to get it's ID.  However, getting the metadata involves a few allocations that we do not need.  This change introduces a public API to allow us to get get to the ID directly, avoiding the intermediary allocations and shaving off 500+ MB of allocations in a FAR operation OOP.  

Fixes https://github.com/dotnet/roslyn/issues/14946