### PR TITLE
Cache delegates to prevent allocations.

### DIFF
--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
@@ -109,8 +109,10 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return GetInfoAsync(document, s_identifierSnapshotCache, SyntaxTreeIdentifierInfo.LoadAsync, tuple => tuple.Item1, cancellationToken);
         }
 
-        private static Func<Document, CancellationToken, Task<SyntaxTreeDeclarationInfo>> s_loadAsync = SyntaxTreeDeclarationInfo.LoadAsync;
-        private static Func<ValueTuple<SyntaxTreeIdentifierInfo, SyntaxTreeContextInfo, SyntaxTreeDeclarationInfo>, SyntaxTreeDeclarationInfo> s_getThirdItem = tuple => tuple.Item3;
+        private static Func<Document, CancellationToken, Task<SyntaxTreeDeclarationInfo>> s_loadAsync 
+            = SyntaxTreeDeclarationInfo.LoadAsync;
+        private static Func<ValueTuple<SyntaxTreeIdentifierInfo, SyntaxTreeContextInfo, SyntaxTreeDeclarationInfo>, SyntaxTreeDeclarationInfo> s_getThirdItem 
+            = tuple => tuple.Item3;
 
         public static Task<SyntaxTreeDeclarationInfo> GetDeclarationInfoAsync(
             Document document, CancellationToken cancellationToken)

--- a/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
+++ b/src/Workspaces/Core/Portable/FindSymbols/SyntaxTree/SyntaxTreeInfo.cs
@@ -109,9 +109,15 @@ namespace Microsoft.CodeAnalysis.FindSymbols
             return GetInfoAsync(document, s_identifierSnapshotCache, SyntaxTreeIdentifierInfo.LoadAsync, tuple => tuple.Item1, cancellationToken);
         }
 
-        public static Task<SyntaxTreeDeclarationInfo> GetDeclarationInfoAsync(Document document, CancellationToken cancellationToken)
+        private static Func<Document, CancellationToken, Task<SyntaxTreeDeclarationInfo>> s_loadAsync = SyntaxTreeDeclarationInfo.LoadAsync;
+        private static Func<ValueTuple<SyntaxTreeIdentifierInfo, SyntaxTreeContextInfo, SyntaxTreeDeclarationInfo>, SyntaxTreeDeclarationInfo> s_getThirdItem = tuple => tuple.Item3;
+
+        public static Task<SyntaxTreeDeclarationInfo> GetDeclarationInfoAsync(
+            Document document, CancellationToken cancellationToken)
         {
-            return GetInfoAsync(document, s_declaredSymbolsSnapshotCache, SyntaxTreeDeclarationInfo.LoadAsync, tuple => tuple.Item3, cancellationToken);
+            return GetInfoAsync(
+                document, s_declaredSymbolsSnapshotCache, s_loadAsync, 
+                s_getThirdItem, cancellationToken);
         }
 
         // The probability of getting a false positive when calling ContainsIdentifier.


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15052