### PR TITLE
Don't include VB attributes in the span of a block. We don't want to see those attributes in the indent guide tooltips.

### DIFF
--- a/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
+++ b/src/Features/CSharp/Portable/Structure/CSharpStructureHelpers.cs
@@ -79,7 +79,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
 
             // If the next token is a semicolon, and we aren't in the initializer of a for-loop, use that token as the end.
 
-            SyntaxToken nextToken = lastToken.GetNextToken(includeSkipped: true);
+            var nextToken = lastToken.GetNextToken(includeSkipped: true);
             if (nextToken.Kind() != SyntaxKind.None && nextToken.Kind() == SyntaxKind.SemicolonToken)
             {
                 var forStatement = nextToken.GetAncestor<ForStatementSyntax>();
@@ -99,7 +99,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             Contract.ThrowIfNull(text);
             Contract.ThrowIfNull(prefix);
 
-            int prefixLength = prefix.Length;
+            var prefixLength = prefix.Length;
             return prefix + " " + text.Substring(prefixLength).Trim() + " " + Ellipsis;
         }
 
@@ -113,7 +113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
             else if (comment.IsMultiLineComment())
             {
-                int lineBreakStart = comment.ToString().IndexOfAny(new char[] { '\r', '\n' });
+                var lineBreakStart = comment.ToString().IndexOfAny(new char[] { '\r', '\n' });
 
                 var text = comment.ToString();
                 if (lineBreakStart >= 0)
@@ -257,13 +257,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             string type, bool isCollapsible)
         {
             return CreateBlockSpan(
-                node,
-                syntaxToken,
-                node.GetLastToken(),
-                bannerText,
-                autoCollapse,
-                type,
-                isCollapsible);
+                node, syntaxToken, node.GetLastToken(),
+                bannerText, autoCollapse, type, isCollapsible);
         }
 
         public static BlockSpan? CreateBlockSpan(
@@ -282,7 +277,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             // of the next token so indentation in the tooltip is accurate.
 
             var span = TextSpan.FromBounds(GetCollapsibleStart(startToken), endPos);
-            var hintSpan = TextSpan.FromBounds(node.SpanStart, endPos);
+            var hintSpan = GetHintSpan(node, endPos);
 
             return CreateBlockSpan(
                 span,
@@ -293,19 +288,31 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
                 isCollapsible);
         }
 
+        private static TextSpan GetHintSpan(SyntaxNode node, int endPos)
+        {
+            // Don't include attributes in the BlockSpan for a node.  When the user
+            // hovers over the indent-guide we don't want to show them the line with
+            // the attributes, we want to show them the line with the start of the
+            // actual structure.
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (child.Kind() != SyntaxKind.AttributeList)
+                {
+                    return TextSpan.FromBounds(child.SpanStart, endPos);
+                }
+            }
+
+            return TextSpan.FromBounds(node.SpanStart, endPos);
+        }
+
         public static BlockSpan? CreateBlockSpan(
             SyntaxNode node, SyntaxToken startToken, 
             SyntaxToken endToken, string bannerText, bool autoCollapse,
             string type, bool isCollapsible)
         {
             return CreateBlockSpan(
-                node,
-                startToken,
-                GetCollapsibleEnd(endToken),
-                bannerText,
-                autoCollapse, 
-                type,
-                isCollapsible);
+                node, startToken, GetCollapsibleEnd(endToken),
+                bannerText, autoCollapse, type, isCollapsible);
         }
 
         public static BlockSpan CreateBlockSpan(

--- a/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
+++ b/src/Features/CSharp/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.cs
@@ -56,7 +56,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Structure
             }
 
             var nestedIfDirectiveTrivia = 0;
-            for (int i = indexInParent; i < parentTriviaList.Count; i++)
+            for (var i = indexInParent; i < parentTriviaList.Count; i++)
             {
                 if (parentTriviaList[i].IsKind(SyntaxKind.IfDirectiveTrivia))
                 {

--- a/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
@@ -19,7 +19,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             If Not block?.EndBlockStatement.IsMissing Then
                 spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=accessorDeclaration,
-                    autoCollapse:=True, type:=BlockTypes.Member, isCollapsible:=True))
+                    autoCollapse:=True, type:=BlockTypes.Member,
+                    isCollapsible:=True))
             End If
         End Sub
     End Class

--- a/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/AccessorDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(accessorDeclaration.Parent, AccessorBlockSyntax)
             If Not block?.EndBlockStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=accessorDeclaration,
                     autoCollapse:=True, type:=BlockTypes.Member, isCollapsible:=True))
             End If

--- a/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
@@ -25,8 +25,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                     span, span, bannerText:="Imports" & SpaceEllipsis,
                     autoCollapse:=True, type:=BlockTypes.Imports, isCollapsible:=True,
                     isDefaultCollapsed:=False))
-                CollectCommentsRegions(compilationUnit.EndOfFileToken.LeadingTrivia, spans)
             End If
+
+            CollectCommentsRegions(compilationUnit.EndOfFileToken.LeadingTrivia, spans)
         End Sub
 
         Protected Overrides Function SupportedInWorkspaceKind(kind As String) As Boolean

--- a/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(compilationUnit, spans)
-            spans.AddIfNotNull(CreateRegion(
+            spans.AddIfNotNull(CreateBlockSpan(
                 compilationUnit.Imports, bannerText:="Imports" & SpaceEllipsis,
                 autoCollapse:=True, type:=BlockTypes.Imports, isCollapsible:=True))
             CollectCommentsRegions(compilationUnit.EndOfFileToken.LeadingTrivia, spans)

--- a/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/CompilationUnitStructureProvider.vb
@@ -3,6 +3,7 @@
 Imports System.Threading
 Imports Microsoft.CodeAnalysis.Options
 Imports Microsoft.CodeAnalysis.Structure
+Imports Microsoft.CodeAnalysis.Text
 Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
@@ -14,10 +15,18 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
             CollectCommentsRegions(compilationUnit, spans)
-            spans.AddIfNotNull(CreateBlockSpan(
-                compilationUnit.Imports, bannerText:="Imports" & SpaceEllipsis,
-                autoCollapse:=True, type:=BlockTypes.Imports, isCollapsible:=True))
-            CollectCommentsRegions(compilationUnit.EndOfFileToken.LeadingTrivia, spans)
+
+            If Not compilationUnit.Imports.IsEmpty Then
+                Dim startPos = compilationUnit.Imports.First().SpanStart
+                Dim endPos = compilationUnit.Imports.Last().Span.End
+
+                Dim span = TextSpan.FromBounds(startPos, endPos)
+                spans.AddIfNotNull(CreateBlockSpan(
+                    span, span, bannerText:="Imports" & SpaceEllipsis,
+                    autoCollapse:=True, type:=BlockTypes.Imports, isCollapsible:=True,
+                    isDefaultCollapsed:=False))
+                CollectCommentsRegions(compilationUnit.EndOfFileToken.LeadingTrivia, spans)
+            End If
         End Sub
 
         Protected Overrides Function SupportedInWorkspaceKind(kind As String) As Boolean

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ConstructorDeclarationStructureProvider.vb
@@ -19,7 +19,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(constructorDeclaration.Parent, ConstructorBlockSyntax)
             If Not block?.EndBlockStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=constructorDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Member, isCollapsible:=True))
             End If

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 Dim startPos = nodeSpan.Start
                 Dim endPos = startPos + trivia.ToString().TrimEnd().Length
 
-                spans.AddIfNotNull(CreateRegion(
+                spans.AddIfNotNull(CreateBlockSpan(
                     span:=TextSpan.FromBounds(startPos, endPos),
                     bannerText:=Ellipsis, autoCollapse:=True,
                     type:=BlockTypes.PreprocessorRegion,

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
@@ -17,8 +17,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 Dim startPos = nodeSpan.Start
                 Dim endPos = startPos + trivia.ToString().TrimEnd().Length
 
+                Dim span = TextSpan.FromBounds(startPos, endPos)
                 spans.AddIfNotNull(CreateBlockSpan(
-                    span:=TextSpan.FromBounds(startPos, endPos),
+                    span:=span, hintSpan:=span,
                     bannerText:=Ellipsis, autoCollapse:=True,
                     type:=BlockTypes.PreprocessorRegion,
                     isCollapsible:=True, isDefaultCollapsed:=False))

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DisabledTextTriviaStructureProvider.vb
@@ -20,7 +20,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 spans.AddIfNotNull(CreateRegion(
                     span:=TextSpan.FromBounds(startPos, endPos),
                     bannerText:=Ellipsis, autoCollapse:=True,
-                    type:=BlockTypes.PreprocessorRegion, isCollapsible:=True))
+                    type:=BlockTypes.PreprocessorRegion,
+                    isCollapsible:=True, isDefaultCollapsed:=False))
             End If
         End Sub
     End Class

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DoLoopBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DoLoopBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.DoStatement, autoCollapse:=False,
                                type:=BlockTypes.Loop, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
@@ -88,7 +88,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim fullSpan = TextSpan.FromBounds(startPos, endPos)
 
-            spans.AddIfNotNull(CreateRegion(
+            spans.AddIfNotNull(CreateBlockSpan(
                 fullSpan, GetBannerText(documentationComment, cancellationToken),
                 autoCollapse:=True, type:=BlockTypes.Comment,
                 isCollapsible:=True, isDefaultCollapsed:=False))

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
@@ -90,7 +90,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             spans.AddIfNotNull(CreateRegion(
                 fullSpan, GetBannerText(documentationComment, cancellationToken),
-                autoCollapse:=True, type:=BlockTypes.Comment, isCollapsible:=True))
+                autoCollapse:=True, type:=BlockTypes.Comment,
+                isCollapsible:=True, isDefaultCollapsed:=False))
         End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/DocumentationCommentStructureProvider.vb
@@ -89,7 +89,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             Dim fullSpan = TextSpan.FromBounds(startPos, endPos)
 
             spans.AddIfNotNull(CreateBlockSpan(
-                fullSpan, GetBannerText(documentationComment, cancellationToken),
+                fullSpan, fullSpan, GetBannerText(documentationComment, cancellationToken),
                 autoCollapse:=True, type:=BlockTypes.Comment,
                 isCollapsible:=True, isDefaultCollapsed:=False))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/EnumDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/EnumDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(enumDeclaration.Parent, EnumBlockSyntax)
             If Not block?.EndEnumStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=enumDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Type, isCollapsible:=True))
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/EventDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/EventDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(eventDeclaration.Parent, EventBlockSyntax)
             If Not block?.EndEventStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=eventDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Member, isCollapsible:=True))
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ForBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ForBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.ForOrForEachStatement, autoCollapse:=False,
                                type:=BlockTypes.Loop, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/ForEachBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/ForEachBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.ForOrForEachStatement, autoCollapse:=False,
                                type:=BlockTypes.Loop, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
@@ -29,8 +29,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure.MetadataAsSource
                 spans.AddIfNotNull(CreateRegion(
                     TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End),
                     GetBannerText(regionDirective),
-                    autoCollapse:=True,
-                    type:=BlockTypes.PreprocessorRegion, isCollapsible:=True))
+                    autoCollapse:=True, type:=BlockTypes.PreprocessorRegion,
+                    isCollapsible:=True, isDefaultCollapsed:=False))
             End If
         End Sub
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
@@ -26,8 +26,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure.MetadataAsSource
                                                   cancellationToken As CancellationToken)
             Dim match = regionDirective.GetMatchingStartOrEndDirective(cancellationToken)
             If match IsNot Nothing Then
+                Dim span = TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End)
                 spans.AddIfNotNull(CreateBlockSpan(
-                    TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End),
+                    span, span,
                     GetBannerText(regionDirective),
                     autoCollapse:=True, type:=BlockTypes.PreprocessorRegion,
                     isCollapsible:=True, isDefaultCollapsed:=False))

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MetadataAsSource/MetadataRegionDirectiveStructureProvider.vb
@@ -26,7 +26,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure.MetadataAsSource
                                                   cancellationToken As CancellationToken)
             Dim match = regionDirective.GetMatchingStartOrEndDirective(cancellationToken)
             If match IsNot Nothing Then
-                spans.AddIfNotNull(CreateRegion(
+                spans.AddIfNotNull(CreateBlockSpan(
                     TextSpan.FromBounds(regionDirective.SpanStart, match.Span.End),
                     GetBannerText(regionDirective),
                     autoCollapse:=True, type:=BlockTypes.PreprocessorRegion,

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MethodDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MethodDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(methodDeclaration.Parent, MethodBlockSyntax)
             If Not block?.EndBlockStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=methodDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Member, isCollapsible:=True))
             End If

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MultiLineIfBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MultiLineIfBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.IfStatement, autoCollapse:=False,
                                type:=BlockTypes.Conditional, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/MultilineLambdaStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/MultilineLambdaStructureProvider.vb
@@ -14,7 +14,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
             If Not lambdaExpression.EndSubOrFunctionStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     lambdaExpression, bannerNode:=lambdaExpression.SubOrFunctionHeader, autoCollapse:=False,
                     type:=BlockTypes.Expression, isCollapsible:=True))
             End If

--- a/src/Features/VisualBasic/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/NamespaceDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(namespaceDeclaration.Parent, NamespaceBlockSyntax)
             If Not block?.EndNamespaceStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=namespaceDeclaration, autoCollapse:=False,
                     type:=BlockTypes.Namespace, isCollapsible:=True))
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/OperatorDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/OperatorDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(operatorDeclaration.Parent, OperatorBlockSyntax)
             If Not block?.EndBlockStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=operatorDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Member, isCollapsible:=True))
             End If

--- a/src/Features/VisualBasic/Portable/Structure/Providers/PropertyDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/PropertyDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(propertyDeclaration.Parent, PropertyBlockSyntax)
             If Not block?.EndPropertyStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=propertyDeclaration, autoCollapse:=True,
                     type:=BlockTypes.Member, isCollapsible:=True))
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
@@ -29,7 +29,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 Dim autoCollapse = options.GetOption(
                     BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.VisualBasic)
 
-                spans.AddIfNotNull(CreateRegion(
+                spans.AddIfNotNull(CreateBlockSpan(
                     TextSpan.FromBounds(regionDirective.SpanStart, matchingDirective.Span.End),
                     GetBannerText(regionDirective),
                     autoCollapse:=autoCollapse,

--- a/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/RegionDirectiveStructureProvider.vb
@@ -29,8 +29,9 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 Dim autoCollapse = options.GetOption(
                     BlockStructureOptions.CollapseRegionsWhenCollapsingToDefinitions, LanguageNames.VisualBasic)
 
+                Dim span = TextSpan.FromBounds(regionDirective.SpanStart, matchingDirective.Span.End)
                 spans.AddIfNotNull(CreateBlockSpan(
-                    TextSpan.FromBounds(regionDirective.SpanStart, matchingDirective.Span.End),
+                    span, span,
                     GetBannerText(regionDirective),
                     autoCollapse:=autoCollapse,
                     isDefaultCollapsed:=True,

--- a/src/Features/VisualBasic/Portable/Structure/Providers/SelectBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/SelectBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.SelectStatement, autoCollapse:=False,
                                type:=BlockTypes.Conditional, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/SyncLockBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/SyncLockBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.SyncLockStatement, autoCollapse:=False,
                                type:=BlockTypes.Statement, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/TryBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/TryBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.TryStatement, autoCollapse:=False,
                                type:=BlockTypes.Statement, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/TypeDeclarationStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/TypeDeclarationStructureProvider.vb
@@ -17,7 +17,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim block = TryCast(typeDeclaration.Parent, TypeBlockSyntax)
             If Not block?.EndBlockStatement.IsMissing Then
-                spans.AddIfNotNull(CreateRegionFromBlock(
+                spans.AddIfNotNull(CreateBlockSpanFromBlock(
                     block, bannerNode:=typeDeclaration, autoCollapse:=False,
                     type:=BlockTypes.Type, isCollapsible:=True))
 

--- a/src/Features/VisualBasic/Portable/Structure/Providers/UsingBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/UsingBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.UsingStatement, autoCollapse:=False,
                                type:=BlockTypes.Statement, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/WhileBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/WhileBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.WhileStatement, autoCollapse:=False,
                                type:=BlockTypes.Loop, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/WithBlockStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/WithBlockStructureProvider.vb
@@ -13,7 +13,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                                                   spans As ArrayBuilder(Of BlockSpan),
                                                   options As OptionSet,
                                                   cancellationToken As CancellationToken)
-            spans.AddIfNotNull(CreateRegionFromBlock(
+            spans.AddIfNotNull(CreateBlockSpanFromBlock(
                                node, node.WithStatement, autoCollapse:=False,
                                type:=BlockTypes.Statement, isCollapsible:=True))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
@@ -24,7 +24,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             Dim lineText = line.ToString().Substring(span.Start - line.Start)
             Dim bannerText = lineText & SpaceEllipsis
 
-            spans.AddIfNotNull(CreateRegion(
+            spans.AddIfNotNull(CreateBlockSpan(
                 span, bannerText, autoCollapse:=False,
                 type:=BlockTypes.Expression,
                 isCollapsible:=True, isDefaultCollapsed:=False))

--- a/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             Dim bannerText = lineText & SpaceEllipsis
 
             spans.AddIfNotNull(CreateBlockSpan(
-                span, bannerText, autoCollapse:=False,
+                span, span, bannerText, autoCollapse:=False,
                 type:=BlockTypes.Expression,
                 isCollapsible:=True, isDefaultCollapsed:=False))
         End Sub

--- a/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
+++ b/src/Features/VisualBasic/Portable/Structure/Providers/XmlExpressionStructureProvider.vb
@@ -26,7 +26,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             spans.AddIfNotNull(CreateRegion(
                 span, bannerText, autoCollapse:=False,
-                type:=BlockTypes.Expression, isCollapsible:=True))
+                type:=BlockTypes.Expression,
+                isCollapsible:=True, isDefaultCollapsed:=False))
         End Sub
     End Class
 End Namespace

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
@@ -25,7 +25,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 GetCommentBannerText(startComment),
                 autoCollapse:=True,
                 type:=BlockTypes.Comment,
-                isCollapsible:=True)
+                isCollapsible:=True, isDefaultCollapsed:=False)
         End Function
 
         ' For testing purposes
@@ -82,7 +82,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 autoCollapse As Boolean,
                 type As String,
                 isCollapsible As Boolean,
-                Optional isDefaultCollapsed As Boolean = False) As BlockSpan?
+                isDefaultCollapsed As Boolean) As BlockSpan?
             Return New BlockSpan(
                 textSpan:=span,
                 bannerText:=bannerText,
@@ -98,7 +98,8 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 autoCollapse As Boolean,
                 type As String,
                 isCollapsible As Boolean) As BlockSpan?
-            Return CreateRegion(blockNode.Span, bannerText, autoCollapse, type, isCollapsible)
+            Return CreateRegion(blockNode.Span, bannerText, autoCollapse,
+                                type, isCollapsible, isDefaultCollapsed:=False)
         End Function
 
         Friend Function CreateRegionFromBlock(
@@ -109,7 +110,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 isCollapsible As Boolean) As BlockSpan?
             Return CreateRegion(
                 blockNode.Span, GetNodeBannerText(bannerNode),
-                autoCollapse, type, isCollapsible)
+                autoCollapse, type, isCollapsible, isDefaultCollapsed:=False)
         End Function
 
         Friend Function CreateRegion(syntaxList As IEnumerable(Of SyntaxNode),
@@ -125,7 +126,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             Dim endPos = syntaxList.Last().Span.End
             Return CreateRegion(
                 TextSpan.FromBounds(startPos, endPos), bannerText,
-                autoCollapse, type, isCollapsible)
+                autoCollapse, type, isCollapsible, isDefaultCollapsed:=False)
         End Function
     End Module
 End Namespace

--- a/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
+++ b/src/Features/VisualBasic/Portable/Structure/VisualBasicStructureHelpers.vb
@@ -20,7 +20,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
         Private Function CreateCommentsRegion(startComment As SyntaxTrivia,
                                               endComment As SyntaxTrivia) As BlockSpan?
-            Return CreateRegion(
+            Return CreateBlockSpan(
                 TextSpan.FromBounds(startComment.SpanStart, endComment.Span.End),
                 GetCommentBannerText(startComment),
                 autoCollapse:=True,
@@ -76,7 +76,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
             CollectCommentsRegions(triviaList, spans)
         End Sub
 
-        Friend Function CreateRegion(
+        Friend Function CreateBlockSpan(
                 span As TextSpan,
                 bannerText As String,
                 autoCollapse As Boolean,
@@ -92,28 +92,28 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
                 isCollapsible:=isCollapsible)
         End Function
 
-        Friend Function CreateRegionFromBlock(
+        Friend Function CreateBlockSpanFromBlock(
                 blockNode As SyntaxNode,
                 bannerText As String,
                 autoCollapse As Boolean,
                 type As String,
                 isCollapsible As Boolean) As BlockSpan?
-            Return CreateRegion(blockNode.Span, bannerText, autoCollapse,
+            Return CreateBlockSpan(blockNode.Span, bannerText, autoCollapse,
                                 type, isCollapsible, isDefaultCollapsed:=False)
         End Function
 
-        Friend Function CreateRegionFromBlock(
+        Friend Function CreateBlockSpanFromBlock(
                 blockNode As SyntaxNode,
                 bannerNode As SyntaxNode,
                 autoCollapse As Boolean,
                 type As String,
                 isCollapsible As Boolean) As BlockSpan?
-            Return CreateRegion(
+            Return CreateBlockSpan(
                 blockNode.Span, GetNodeBannerText(bannerNode),
                 autoCollapse, type, isCollapsible, isDefaultCollapsed:=False)
         End Function
 
-        Friend Function CreateRegion(syntaxList As IEnumerable(Of SyntaxNode),
+        Friend Function CreateBlockSpan(syntaxList As IEnumerable(Of SyntaxNode),
                                      bannerText As String,
                                      autoCollapse As Boolean,
                                      type As String,
@@ -124,7 +124,7 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Structure
 
             Dim startPos = syntaxList.First().SpanStart
             Dim endPos = syntaxList.Last().Span.End
-            Return CreateRegion(
+            Return CreateBlockSpan(
                 TextSpan.FromBounds(startPos, endPos), bannerText,
                 autoCollapse, type, isCollapsible, isDefaultCollapsed:=False)
         End Function


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/14985