### PR TITLE
Add .NET 2.0 ResultProvider DLLs to NetFX20 root directory in ExternalAPIs nupkg

### DIFF
--- a/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
+++ b/src/Setup/DevDivInsertionFiles/BuildDevDivInsertionFiles.vb
@@ -19,6 +19,7 @@ Public Class BuildDevDivInsertionFiles
     Private Const DevDivPackagesDirName = "DevDivPackages"
     Private Const DevDivVsixDirName = "DevDivVsix"
     Private Const ExternalApisDirName = "ExternalAPIs"
+    Private Const NetFX20DirectoryName = "NetFX20"
     Private Const PublicKeyToken = "31BF3856AD364E35"
 
     Private ReadOnly _binDirectory As String
@@ -417,7 +418,7 @@ Public Class BuildDevDivInsertionFiles
         ' These are for msvsmon, whose setup authoring is done by the debugger.
         For Each folder In Directory.EnumerateDirectories(Path.Combine(_binDirectory, "Dlls"), "*.NetFX20")
             For Each eePath In Directory.EnumerateFiles(folder, "*.ExpressionEvaluator.*.dll", SearchOption.TopDirectoryOnly)
-                filesToInsert.Add(New NugetFileInfo(GetPathRelativeToBinaries(eePath), GetPathRelativeToBinaries(folder)))
+                filesToInsert.Add(New NugetFileInfo(GetPathRelativeToBinaries(eePath), NetFX20DirectoryName))
             Next
         Next
 


### PR DESCRIPTION
Fixes #15058.