### PR TITLE
Don't crash during shutdown if we try creating metadata snapshots

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -55,7 +55,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
             Debug.Assert(temporaryStorageService != null);
         }
 
-        public IEnumerable<ITemporaryStreamStorage> GetStorages(string fullPath, DateTime snapshotTimestamp)
+        internal IEnumerable<ITemporaryStreamStorage> GetStorages(string fullPath, DateTime snapshotTimestamp)
         {
             var key = new FileKey(fullPath, snapshotTimestamp);
 

--- a/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
+++ b/src/VisualStudio/Core/Def/Implementation/ProjectSystem/MetadataReferences/VisualStudioMetadataReferenceManager.cs
@@ -21,7 +21,6 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem
     /// Manages metadata references for VS projects. 
     /// </summary>
     /// <remarks>
-    /// The references correspond to hierarchy nodes in the Solution Explorer. 
     /// They monitor changes in the underlying files and provide snapshot references (subclasses of <see cref="PortableExecutableReference"/>) 
     /// that can be passed to the compiler. These snapshot references serve the underlying metadata blobs from a VS-wide storage, if possible, 
     /// from <see cref="ITemporaryStorageService"/>.

--- a/src/VisualStudio/Core/Def/RoslynPackage.cs
+++ b/src/VisualStudio/Core/Def/RoslynPackage.cs
@@ -162,7 +162,7 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
         {
             UnregisterFindResultsLibraryManager();
 
-            DisposeVisualStudioDocumentTrackingService();
+            DisposeVisualStudioServices();
 
             UnregisterAnalyzerTracker();
             UnregisterRuleSetEventHandler();
@@ -216,12 +216,14 @@ namespace Microsoft.VisualStudio.LanguageServices.Setup
             }
         }
 
-        private void DisposeVisualStudioDocumentTrackingService()
+        private void DisposeVisualStudioServices()
         {
             if (_workspace != null)
             {
                 var documentTrackingService = _workspace.Services.GetService<IDocumentTrackingService>() as VisualStudioDocumentTrackingService;
                 documentTrackingService.Dispose();
+
+                _workspace.Services.GetService<VisualStudioMetadataReferenceManager>().DisconnectFromVisualStudioNativeServices();
             }
         }
 


### PR DESCRIPTION
Windows Error Reporting is insisting it's surprisingly common for us to have a thread trying to create a compilation while Visual Studio is shutting down and we can't make COM calls anymore. This prevents that from happening. This is a tactical fix and we'll still let the rest of metadata snapshot system work normally.

*Review:* @dotnet/roslyn-ide