### PR TITLE
Fix processing misaligned floats and doubles in BlobUtilities

### DIFF
--- a/src/Compilers/Core/Portable/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/Compilers/Core/Portable/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -35,7 +35,7 @@ namespace Roslyn.Reflection
         {
             fixed (byte* ptr = &buffer[start])
             {
-                *(double*)ptr = value;
+                *(long*)ptr = *(long*)&value;
             }
         }
 
@@ -43,7 +43,7 @@ namespace Roslyn.Reflection
         {
             fixed (byte* ptr = &buffer[start])
             {
-                *(float*)ptr = value;
+                *(int*)ptr = *(int*)&value;
             }
         }
 


### PR DESCRIPTION
This is port of https://github.com/dotnet/corefx/commit/3849c6a0f374a3b67a92bccd564b1e83b356b27a fix