### PR TITLE
Show a cancellable wait-dialog when invoking change-signature manually.

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
+++ b/src/Compilers/Core/Portable/Compilation/SemanticModel.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
-using Microsoft.CodeAnalysis.Semantics;
 using Microsoft.CodeAnalysis.Text;
 
 namespace Microsoft.CodeAnalysis

--- a/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
+++ b/src/EditorFeatures/CSharp/CSharpEditorFeatures.csproj
@@ -85,7 +85,7 @@
     <Compile Include="BraceMatching\CSharpDirectiveTriviaBraceMatcher.cs" />
     <Compile Include="BraceMatching\StringLiteralBraceMatcher.cs" />
     <Compile Include="CallHierarchy\CallHierarchyCommandHandler.cs" />
-    <Compile Include="ChangeSignature\ChangeSignatureCommandHandler.cs" />
+    <Compile Include="ChangeSignature\CSharpChangeSignatureCommandHandler.cs" />
     <Compile Include="Classification\CSharpEditorClassificationService.cs" />
     <Compile Include="CommentSelection\CSharpCommentUncommentService.cs" />
     <Compile Include="ContentType\ContentTypeDefinitions.cs" />

--- a/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
@@ -13,7 +13,6 @@ namespace Microsoft.CodeAnalysis.Editor.CSharp.ChangeSignature
         public CSharpChangeSignatureCommandHandler(IWaitIndicator waitIndicator)
             : base(waitIndicator)
         {
-
         }
     }
 }

--- a/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/CSharp/ChangeSignature/CSharpChangeSignatureCommandHandler.cs
@@ -1,11 +1,19 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+using System.ComponentModel.Composition;
+using Microsoft.CodeAnalysis.Editor.Host;
 using Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature;
 
 namespace Microsoft.CodeAnalysis.Editor.CSharp.ChangeSignature
 {
     [ExportCommandHandler(PredefinedCommandHandlerNames.ChangeSignature, ContentTypeNames.CSharpContentType)]
-    internal class ChangeSignatureCommandHandler : AbstractChangeSignatureCommandHandler
+    internal class CSharpChangeSignatureCommandHandler : AbstractChangeSignatureCommandHandler
     {
+        [ImportingConstructor]
+        public CSharpChangeSignatureCommandHandler(IWaitIndicator waitIndicator)
+            : base(waitIndicator)
+        {
+
+        }
     }
 }

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.Editor.CSharp.ChangeSignature;
 using Microsoft.CodeAnalysis.Editor.Implementation.Interactive;
 using Microsoft.CodeAnalysis.Editor.UnitTests;
 using Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature;
+using Microsoft.CodeAnalysis.Editor.UnitTests.Utilities;
 using Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces;
 using Roslyn.Test.Utilities;
 using Xunit;
@@ -290,7 +291,7 @@ class C{i}
 
                 var textView = workspace.Documents.Single().GetTextView();
 
-                var handler = new CSharpChangeSignatureCommandHandler();
+                var handler = new CSharpChangeSignatureCommandHandler(TestWaitIndicator.Default);
                 var delegatedToNext = false;
                 Func<CommandState> nextHandler = () =>
                 {

--- a/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
+++ b/src/EditorFeatures/CSharpTest/ChangeSignature/RemoveParametersTests.cs
@@ -290,7 +290,7 @@ class C{i}
 
                 var textView = workspace.Documents.Single().GetTextView();
 
-                var handler = new ChangeSignatureCommandHandler();
+                var handler = new CSharpChangeSignatureCommandHandler();
                 var delegatedToNext = false;
                 Func<CommandState> nextHandler = () =>
                 {

--- a/src/EditorFeatures/Core/Implementation/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/ChangeSignature/AbstractChangeSignatureCommandHandler.cs
@@ -18,15 +18,19 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
 {
     internal abstract class AbstractChangeSignatureCommandHandler : ICommandHandler<ReorderParametersCommandArgs>, ICommandHandler<RemoveParametersCommandArgs>
     {
-        public CommandState GetCommandState(ReorderParametersCommandArgs args, Func<CommandState> nextHandler)
+        private readonly IWaitIndicator _waitIndicator;
+
+        protected AbstractChangeSignatureCommandHandler(
+            IWaitIndicator waitIndicator)
         {
-            return GetCommandState(args.SubjectBuffer, nextHandler);
+            _waitIndicator = waitIndicator;
         }
 
+        public CommandState GetCommandState(ReorderParametersCommandArgs args, Func<CommandState> nextHandler)
+            => GetCommandState(args.SubjectBuffer, nextHandler);
+
         public CommandState GetCommandState(RemoveParametersCommandArgs args, Func<CommandState> nextHandler)
-        {
-            return GetCommandState(args.SubjectBuffer, nextHandler);
-        }
+            => GetCommandState(args.SubjectBuffer, nextHandler);
 
         private static CommandState GetCommandState(ITextBuffer subjectBuffer, Func<CommandState> nextHandler)
         {
@@ -47,16 +51,12 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
         }
 
         public void ExecuteCommand(RemoveParametersCommandArgs args, Action nextHandler)
-        {
-            ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
-        }
+            => ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
 
         public void ExecuteCommand(ReorderParametersCommandArgs args, Action nextHandler)
-        {
-            ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
-        }
+            => ExecuteCommand(args.TextView, args.SubjectBuffer, nextHandler);
 
-        private static void ExecuteCommand(ITextView textView, ITextBuffer subjectBuffer, Action nextHandler)
+        private void ExecuteCommand(ITextView textView, ITextBuffer subjectBuffer, Action nextHandler)
         {
             var document = subjectBuffer.CurrentSnapshot.GetOpenDocumentInCurrentContextWithChanges();
             if (document == null)
@@ -87,13 +87,24 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
                 return;
             }
 
-            // Reorder parameters is not cancellable.
-            var reorderParametersService = document.GetLanguageService<AbstractChangeSignatureService>();
-            var result = reorderParametersService.ChangeSignature(
-                document,
-                caretPoint.Value.Position,
-                (errorMessage, severity) => workspace.Services.GetService<INotificationService>().SendNotification(errorMessage, severity: severity),
-                CancellationToken.None);
+            ChangeSignatureResult result = null;
+            var waitResult = _waitIndicator.Wait(
+                FeaturesResources.Change_signature,
+                allowCancel: true,
+                action: w =>
+                {
+                    var reorderParametersService = document.GetLanguageService<AbstractChangeSignatureService>();
+                    result = reorderParametersService.ChangeSignature(
+                        document,
+                        caretPoint.Value.Position,
+                        (errorMessage, severity) => workspace.Services.GetService<INotificationService>().SendNotification(errorMessage, severity: severity),
+                        w.CancellationToken);
+                });
+
+            if (waitResult == WaitIndicatorResult.Canceled)
+            {
+                return;
+            }
 
             if (result == null || !result.Succeeded)
             {

--- a/src/EditorFeatures/Core/Shared/Extensions/IWaitIndicatorExtensions.cs
+++ b/src/EditorFeatures/Core/Shared/Extensions/IWaitIndicatorExtensions.cs
@@ -8,8 +8,9 @@ namespace Microsoft.CodeAnalysis.Editor.Shared.Extensions
     internal static class IWaitIndicatorExtensions
     {
         public static WaitIndicatorResult Wait(this IWaitIndicator waitIndicator, string titleAndMessage, bool allowCancel, Action<IWaitContext> action)
-        {
-            return waitIndicator.Wait(titleAndMessage, titleAndMessage, allowCancel, action);
-        }
+            => waitIndicator.Wait(titleAndMessage, titleAndMessage, allowCancel, action);
+
+        public static WaitIndicatorResult Wait(this IWaitIndicator waitIndicator, string titleAndMessage, bool allowCancel, bool showProgress, Action<IWaitContext> action)
+            => waitIndicator.Wait(titleAndMessage, titleAndMessage, allowCancel, showProgress, action);
     }
 }

--- a/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
+++ b/src/EditorFeatures/VisualBasic/BasicEditorFeatures.vbproj
@@ -78,7 +78,7 @@
     <Compile Include="BraceMatching\VisualBasicDirectiveTriviaBraceMatcher.vb" />
     <Compile Include="BraceMatching\StringLiteralBraceMatcher.vb" />
     <Compile Include="CallHierarchy\CallHierarchyCommandHandler.vb" />
-    <Compile Include="ChangeSignature\ChangeSignatureCommandHandler.vb" />
+    <Compile Include="ChangeSignature\VisualBasicChangeSignatureCommandHandler.vb" />
     <Compile Include="Classification\VisualBasicEditorClassificationService.vb" />
     <Compile Include="CommentSelection\VisualBasicCommentUncommentService.vb" />
     <Compile Include="ContentType\ContentTypeDefinitions.vb" />

--- a/src/EditorFeatures/VisualBasic/ChangeSignature/VisualBasicChangeSignatureCommandHandler.vb
+++ b/src/EditorFeatures/VisualBasic/ChangeSignature/VisualBasicChangeSignatureCommandHandler.vb
@@ -1,10 +1,17 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
+Imports System.ComponentModel.Composition
+Imports Microsoft.CodeAnalysis.Editor.Host
 Imports Microsoft.CodeAnalysis.Editor.Implementation.ChangeSignature
 
 Namespace Microsoft.CodeAnalysis.Editor.VisualBasic.ChangeSignature
     <ExportCommandHandler(PredefinedCommandHandlerNames.ChangeSignature, ContentTypeNames.VisualBasicContentType)>
-    Friend Class ChangeSignatureCommandHandler
+    Friend Class VisualBasicChangeSignatureCommandHandler
         Inherits AbstractChangeSignatureCommandHandler
+
+        <ImportingConstructor>
+        Public Sub New(waitIndicator As IWaitIndicator)
+            MyBase.New(waitIndicator)
+        End Sub
     End Class
 End Namespace

--- a/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
+++ b/src/EditorFeatures/VisualBasicTest/ChangeSignature/RemoveParametersTests.vb
@@ -4,6 +4,7 @@ Imports Microsoft.CodeAnalysis.Editor.Implementation.Interactive
 Imports Microsoft.CodeAnalysis.Editor.UnitTests
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.ChangeSignature
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Extensions
+Imports Microsoft.CodeAnalysis.Editor.UnitTests.Utilities
 Imports Microsoft.CodeAnalysis.Editor.UnitTests.Workspaces
 Imports Microsoft.CodeAnalysis.Editor.VisualBasic.ChangeSignature
 
@@ -114,7 +115,7 @@ End Module
 
                 Dim textView = workspace.Documents.Single().GetTextView()
 
-                Dim handler = New ChangeSignatureCommandHandler()
+                Dim handler = New VisualBasicChangeSignatureCommandHandler(TestWaitIndicator.Default)
                 Dim delegatedToNext = False
                 Dim nextHandler =
                     Function()

--- a/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
+++ b/src/Features/Core/Portable/ChangeSignature/ChangeSignatureCodeAction.cs
@@ -19,10 +19,7 @@ namespace Microsoft.CodeAnalysis.ChangeSignature
             _context = context;
         }
 
-        public override string Title
-        {
-            get { return FeaturesResources.Change_signature; }
-        }
+        public override string Title => FeaturesResources.Change_signature;
 
         public override object GetOptions(CancellationToken cancellationToken)
         {


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/4891