### PR TITLE
Fix NuGet.exe caching

### DIFF
--- a/build/scripts/LoadNuGetInfo.cmd
+++ b/build/scripts/LoadNuGetInfo.cmd
@@ -8,8 +8,5 @@ set NuGetExe=%NuGetExeFolder%\NuGet.exe
 set NuGetAdditionalCommandLineArgs=-verbosity quiet -configfile "%NuGetExeFolder%\nuget.config" -Project2ProjectTimeOut 1200
 
 REM Download NuGet.exe if we haven't already
-if not exist "%NuGetExe%" (
-    echo Downloading NuGet %NuGetExeVersion%
-    powershell -noprofile -executionPolicy Bypass -file "%~dp0download-nuget.ps1" "%NuGetExeVersion%" "%NuGetExeFolder%" || goto :DownloadNuGetFailed
-)
+powershell -noprofile -executionPolicy Bypass -file "%~dp0download-nuget.ps1" "%NuGetExeVersion%" "%NuGetExeFolder%" "%NuGetExeFolder%\Binaries"
 

--- a/build/scripts/download-nuget.ps1
+++ b/build/scripts/download-nuget.ps1
@@ -1,12 +1,46 @@
 param (
     [string]$nugetVersion = $(throw "Need a nuget version"),
-    [string]$destPath = $(throw "Need a path to download too"))
+    [string]$destDir = $(throw "Need a path to download too"),
+    [string]$binariesDir = $(throw "Need path to Binaries directory"))
 set-strictmode -version 2.0
 $ErrorActionPreference="Stop"
 
-if (-not (test-path $destPath)) {
-    mkdir $destPath | out-null
-}
+try
+{
+    $scratchDir = join-path $binariesDir "NuGet"
+    if (-not (test-path $scratchDir)) {
+        mkdir $scratchDir | out-null
+    }
 
-$webClient = New-Object -TypeName "System.Net.WebClient"
-$webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v$nugetVersion/NuGet.exe", (join-path $destPath "NuGet.exe"))
+    if (-not (test-path $destDir)) {
+        mkdir $destDir | out-null
+    }
+
+    $destFile = join-path $destDir "NuGet.exe"
+    $scratchFile = join-path $scratchDir "NuGet.exe"
+    $versionFile = join-path $scratchDir "version.txt"
+
+    # Check and see if we already have a NuGet.exe which exists and is the correct
+    # version.
+    if ((test-path $destFile) -and (test-path $scratchFile) -and (test-path $versionFile)) {
+        $destHash = (get-filehash $destFile -algorithm MD5).Hash
+        $scratchHash = (get-filehash $scratchFile -algorithm MD5).Hash
+        $scratchVersion = gc $versionFile
+        if (($destHash -eq $scratchHash) -and ($scratchVersion -eq $nugetVersion)) {
+            write-host "Using existing NuGet.exe at version $nuGetVersion"
+            exit 0
+        }
+    }
+
+    write-host "Downloading NuGet.exe"
+    $webClient = New-Object -TypeName "System.Net.WebClient"
+    $webClient.DownloadFile("https://dist.nuget.org/win-x86-commandline/v$nugetVersion/NuGet.exe", $scratchFile)
+    $nugetVersion | out-file $versionFile
+    cp $scratchFile $destFile
+    exit 0
+}
+catch [exception]
+{
+    write-host $_.Exception
+    exit -1
+}


### PR DESCRIPTION
Our script for downloading NuGet.exe now ensures the local copy is the correct version.  Previously it assumed any local copy was the correct version.  Lead to problems when we brought down a new version that had bug fixes necessary for building the repo.