### PR TITLE
Hookup non-Roslyn view to the document tracking service on a foregrou…

### DIFF
--- a/src/VisualStudio/Core/Def/RoslynDocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/RoslynDocumentProvider.cs
@@ -40,11 +40,15 @@ namespace Microsoft.VisualStudio.LanguageServices
                 return;
             }
 
-            var view = GetTextViewFromFrame(frame);
-            if (view != null)
+            // Schedule hookup of the non-Roslyn document view on foreground task scheduler.
+            InvokeBelowInputPriority(() =>
             {
-                _documentTrackingService?.OnNonRoslynViewOpened(view);
-            }
+                var view = GetTextViewFromFrame(frame);
+                if (view != null)
+                {
+                    _documentTrackingService?.OnNonRoslynViewOpened(view);
+                }
+            });
         }
 
         private ITextView GetTextViewFromFrame(IVsWindowFrame frame)

--- a/src/VisualStudio/Core/Def/RoslynDocumentProvider.cs
+++ b/src/VisualStudio/Core/Def/RoslynDocumentProvider.cs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information.
 
 using System;
-using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.LanguageServices.Implementation;
 using Microsoft.VisualStudio.LanguageServices.Implementation.ProjectSystem;
 using Microsoft.VisualStudio.Shell.Interop;
 using Microsoft.VisualStudio.Text.Editor;
-using Microsoft.VisualStudio.TextManager.Interop;
+using Roslyn.Utilities;
 
 namespace Microsoft.VisualStudio.LanguageServices
 {
@@ -41,14 +42,14 @@ namespace Microsoft.VisualStudio.LanguageServices
             }
 
             // Schedule hookup of the non-Roslyn document view on foreground task scheduler.
-            InvokeBelowInputPriority(() =>
+            Task.Factory.SafeStartNew(() =>
             {
                 var view = GetTextViewFromFrame(frame);
                 if (view != null)
                 {
                     _documentTrackingService?.OnNonRoslynViewOpened(view);
                 }
-            });
+            }, CancellationToken.None, ForegroundTaskScheduler);
         }
 
         private ITextView GetTextViewFromFrame(IVsWindowFrame frame)


### PR DESCRIPTION
…nd scheduled task.

RPS traces show that we are forcing the text view creation too eagerly on the UI thread during file open. This should very likely fix VSO #[223317](https://devdiv.visualstudio.com/DevDiv/_workitems?_a=edit&id=223317&triage=true).