### PR TITLE
Do not crash on cancellation in FindReferences.

### DIFF
--- a/src/EditorFeatures/Core/Implementation/FindReferences/FindReferencesCommandHandler.cs
+++ b/src/EditorFeatures/Core/Implementation/FindReferences/FindReferencesCommandHandler.cs
@@ -133,7 +133,10 @@ namespace Microsoft.CodeAnalysis.Editor.Implementation.FindReferences
                     await context.OnCompletedAsync().ConfigureAwait(false);
                 }
             }
-            catch (Exception e) when (FatalError.ReportUnlessCanceled(e))
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception e) when (FatalError.ReportWithoutCrash(e))
             {
             }
         }


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/15113