### PR TITLE
Moved SaveEventsService GetService calls to constructor import statements

### DIFF
--- a/src/VisualStudio/Core/Def/Implementation/SaveEventsService.cs
+++ b/src/VisualStudio/Core/Def/Implementation/SaveEventsService.cs
@@ -30,12 +30,13 @@ namespace Microsoft.VisualStudio.LanguageServices.Implementation
         public SaveEventsService(
             IVsEditorAdaptersFactoryService editorAdaptersFactoryService,
             ICommandHandlerServiceFactory commandHandlerServiceFactory,
-            SVsServiceProvider serviceProvider)
+            [Import(typeof(SVsRunningDocumentTable))] IVsRunningDocumentTable runningDocTable,
+            [Import(typeof(SVsTextManager))] IVsTextManager textManager)
         {
             _editorAdaptersFactoryService = editorAdaptersFactoryService;
             _commandHandlerServiceFactory = commandHandlerServiceFactory;
-            _runningDocumentTable = (IVsRunningDocumentTable)serviceProvider.GetService(typeof(SVsRunningDocumentTable));
-            _textManager = (IVsTextManager)serviceProvider.GetService(typeof(SVsTextManager));
+            _runningDocumentTable = runningDocTable;
+            _textManager = textManager;
         }
 
         public void StartSendingSaveEvents()


### PR DESCRIPTION
This fixes #15143. @dotnet/roslyn-ide for review. @Pilchie, I think this is something we should take for RC2, is dev15-rc2 open?