### PR TITLE
Update the compiler in the Linux/Mac toolset

### DIFF
--- a/build/MSBuildToolset/Program.cs
+++ b/build/MSBuildToolset/Program.cs
@@ -29,7 +29,7 @@ namespace MSBuildToolset
                 .ToArray();
 
             var nugetExeDir = Path.GetDirectoryName(nugetExePath);
-            string msbuildPath = Path.Combine(AppContext.BaseDirectory, "MSBuild.exe");
+            string msbuildPath = Path.Combine(AppContext.BaseDirectory, "MSBuild.dll");
             string entryPointTargetPath = Path.Combine(nugetExeDir,
                 "build/Targets/GetProjectsReferencingProjectJsonFilesEntryPoint.targets");
             string afterBuildsTargetPath = Path.Combine(nugetExeDir,

--- a/build/MSBuildToolset/csc
+++ b/build/MSBuildToolset/csc
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+THISDIR=$(dirname $0)
+
+chmod +x $THISDIR/corerun 2>/dev/null
+$THISDIR/corerun $THISDIR/csc.exe "$@"

--- a/build/MSBuildToolset/project.json
+++ b/build/MSBuildToolset/project.json
@@ -1,14 +1,22 @@
 {
   "version": "1.0.0-*",
-  "compilationOptions": {
+  "buildOptions": {
     "emitEntryPoint": true,
     "outputName": "RoslynRestore"
   },
+  "publishOptions": {
+      "include": [ "csc", "vbc" ]
+  },
   "dependencies": {
-    "Microsoft.Build": "14.3.0",
-    "Microsoft.Build.Tasks.Core": "14.3.0",
+    "Microsoft.Build": "15.1.0-preview-000370-00",
+    "Microsoft.Build.Runtime": "15.1.0-preview-000370-00",
+    "Microsoft.Build.Tasks.Core": "15.1.0-preview-000370-00",
+    "Microsoft.Net.Compilers.netcore": "2.0.0-rc2-61102-09",
+    "Microsoft.NuGet.Build.Tasks": "0.1.0",
+    "Microsoft.CodeAnalysis.Build.Tasks": "2.0.0-rc2-61102-09",
     "Microsoft.NETCore.TestHost": "1.0.0",
-    "Microsoft.NETCore.App": "1.0.0-rc3-004338",
+    "Microsoft.NETCore.App": "1.1.0",
+    "Microsoft.Portable.Targets": "0.1.1-dev",
     "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {
@@ -21,6 +29,6 @@
   },
   "runtimes": {
     "ubuntu.14.04-x64": {},
-    "osx.10.10-x64": {}
+    "osx.10.11-x64": {}
   }
 }

--- a/build/MSBuildToolset/vbc
+++ b/build/MSBuildToolset/vbc
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+THISDIR=$(dirname $0)
+
+chmod +x $THISDIR/corerun 2>/dev/null
+$THISDIR/corerun $THISDIR/vbc.exe "$@"
+

--- a/build/Targets/Dependencies.props
+++ b/build/Targets/Dependencies.props
@@ -3,9 +3,12 @@
   <!--Generated file, do not directly edit.  Run "RepoUtil change" to regenerate-->
   <PropertyGroup>
     <ManagedEsentVersion>1.9.4</ManagedEsentVersion>
-    <MicrosoftBuildVersion>14.3.0</MicrosoftBuildVersion>
+    <MicrosoftBuildVersion>15.1.0-preview-000370-00</MicrosoftBuildVersion>
+    <MicrosoftBuild14Version>14.3.0</MicrosoftBuild14Version>
     <MicrosoftBuildLoggingStructuredLoggerVersion>1.0.58</MicrosoftBuildLoggingStructuredLoggerVersion>
-    <MicrosoftBuildTasksCoreVersion>14.3.0</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildRuntimeVersion>15.1.0-preview-000370-00</MicrosoftBuildRuntimeVersion>
+    <MicrosoftBuildTasksCoreVersion>15.1.0-preview-000370-00</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildTasksCore14Version>14.3.0</MicrosoftBuildTasksCore14Version>
     <MicrosoftCodeAnalysisAnalyzersVersion>1.1.0</MicrosoftCodeAnalysisAnalyzersVersion>
     <MicrosoftCompositionVersion>1.0.27</MicrosoftCompositionVersion>
     <MicrosoftDiagnosticsRuntimeVersion>0.8.31-beta</MicrosoftDiagnosticsRuntimeVersion>

--- a/build/Targets/DisableStandardFrameworkResolution.targets
+++ b/build/Targets/DisableStandardFrameworkResolution.targets
@@ -1,0 +1,16 @@
+<!-- Copyright (c)  Microsoft.  All Rights Reserved.  Licensed under the Apache License, Version 2.0.  See License.txt in the project root for license information. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="GetReferenceAssemblyPaths" />
+  <Target Name="GetFrameworkPaths" />
+
+  <PropertyGroup>
+    <_TargetFrameworkDirectories />
+    <FrameworkPathOverride />
+    <TargetFrameworkDirectory />
+
+    <!-- all references (even the StdLib) come from packages -->
+    <NoStdLib>true</NoStdLib>
+  </PropertyGroup>
+
+</Project>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -149,6 +149,7 @@
           <PropertyGroup>
             <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Strong Name Keys\RoslynInternalKey.Private.snk</AssemblyOriginatorKeyFile>
             <DelaySign>false</DelaySign>
+            <PublicSign>true</PublicSign>
             <PublicKey>$(RoslynInternalKey)</PublicKey>
             <PublicKeyToken>fc793a00266884fb</PublicKeyToken>
           </PropertyGroup>
@@ -200,11 +201,16 @@
 
   <Import Project="$(MSBuildTargetsFilePath)" />
 
-  <!-- On Mono on *nix the NuGet targets aren't imported by default, so we do that here -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\NuGet\Microsoft.NuGet.targets" Condition="'$(OS)' != 'Windows_NT'" />
+  <!-- On *nix the NuGet targets aren't imported by default, so we do that here -->
+  <Import Project="$(MSBuildBinPath)\Microsoft.NuGet.targets" Condition="'$(OS)' != 'Windows_NT'" />
+
+  <!-- The portable v5.0 framework is delivered over NuGet, so std resolution should be disabled -->
+  <Import Project="DisableStandardFrameworkResolution.targets"
+          Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' AND '$(TargetFrameworkVersion)' == 'v5.0'" />
 
   <Choose>
     <When Condition="'$(TargetFrameworkIdentifier)' == '.NETPortable' AND '$(TargetFrameworkVersion)' == 'v5.0'">
+
       <!-- Treat portable exes as CoreClr-targeting-exes -->
       <PropertyGroup Condition="'$(OutputType)' == 'Exe'">
         <NuGetTargetMoniker>.NETCoreApp,Version=v1.0</NuGetTargetMoniker>

--- a/build/Targets/Imports.targets
+++ b/build/Targets/Imports.targets
@@ -130,6 +130,11 @@
   </Choose>
 
   <!-- Settings for strong name signing -->
+  <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
+      <!-- Strong name signing is not supported on non-Windows platforms -->
+      <PublicSign>true</PublicSign>
+  </PropertyGroup>
+
   <Choose>
     <When Condition="'$(SignAssembly)' == 'true'">
       <Choose>
@@ -149,7 +154,6 @@
           <PropertyGroup>
             <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\Strong Name Keys\RoslynInternalKey.Private.snk</AssemblyOriginatorKeyFile>
             <DelaySign>false</DelaySign>
-            <PublicSign>true</PublicSign>
             <PublicKey>$(RoslynInternalKey)</PublicKey>
             <PublicKeyToken>fc793a00266884fb</PublicKeyToken>
           </PropertyGroup>

--- a/build/Targets/Settings.props
+++ b/build/Targets/Settings.props
@@ -10,6 +10,7 @@
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == ''">$(NUGET_PACKAGES)</NuGetPackageRoot> <!-- Respect environment variable if set -->
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' == 'Windows_NT'">$(UserProfile)\.nuget\packages</NuGetPackageRoot>
     <NuGetPackageRoot Condition="'$(NuGetPackageRoot)' == '' and '$(OS)' != 'Windows_NT'">$(HOME)\.nuget\packages</NuGetPackageRoot>
+    <NuGetPackagesDirectory>$(NuGetPackageRoot)</NuGetPackagesDirectory>
     <ToolsetCompilerPackageName>Microsoft.Net.Compilers</ToolsetCompilerPackageName>
     <ToolsetCompilerPackageVersion>2.0.0-rc2-61102-09</ToolsetCompilerPackageVersion>
     <RoslynDiagnosticsNugetPackageVersion>1.2.0-beta2</RoslynDiagnosticsNugetPackageVersion>
@@ -68,14 +69,6 @@
   <PropertyGroup Condition="'$(OS)' != 'Windows_NT'">
     <!-- Point to the reference assemblies on unix -->
     <TargetFrameworkRootPath>$(MSBuildBinPath)\reference-assemblies\Framework</TargetFrameworkRootPath>
-
-    <!-- The /publicsign argument is required for the compiler, but the current MSBuild
-         build task can't be redirected and even if it could the new build task is not
-         built against the xplat MSBuild references so it can't be loaded properly. Providing
-         a response file works around the problem by directly adding the public sign argument
-         to all unix compilations. This shouldn't present a problem as it's impossible to
-         fully sign on unix at the moment anyway. Tracked by #7756. -->
-    <CompilerResponseFile>$(MSBuildThisFileDirectory)..\unix\extra_unix_args.rsp</CompilerResponseFile>
 
     <DebugType>portable</DebugType>
   </PropertyGroup>
@@ -250,6 +243,6 @@
 
   <ImportGroup Label="WindowsImports" Condition="'$(OS)' != 'Windows_NT'">
     <!-- NuGet props aren't imported by default on *nix so we do that here -->
-    <Import Project="$(MSBuildExtensionsPath)\Microsoft\NuGet\Microsoft.NuGet.props" Condition="'$(OS)' != 'Windows_NT'" />
+    <Import Project="$(MSBuildBinPath)\Microsoft.NuGet.props" Condition="'$(OS)' != 'Windows_NT'" />
   </ImportGroup>
 </Project>

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -2,15 +2,15 @@
 
 ROSLYN_TOOLSET_PATH=$1
 NUGET_EXE=$2
-DOTNET_PATH=$ROSLYN_TOOLSET_PATH/dotnet-cli/dotnet
+DOTNET_PATH=$ROSLYN_TOOLSET_PATH/../dotnet-cli/dotnet
 
 # Workaround, see https://github.com/dotnet/roslyn/issues/10210
 export HOME=$(cd ~ && pwd)
 
 echo "Restoring toolset packages"
 
-dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/project.json
+$DOTNET_PATH restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/project.json
 
 echo "Restore CrossPlatform.sln"
 
-$ROSLYN_TOOLSET_PATH/RoslynRestore $(pwd)/CrossPlatform.sln $NUGET_EXE $(which dotnet)
+$ROSLYN_TOOLSET_PATH/RoslynRestore $(pwd)/CrossPlatform.sln $NUGET_EXE $DOTNET_PATH

--- a/build/scripts/restore.sh
+++ b/build/scripts/restore.sh
@@ -9,8 +9,8 @@ export HOME=$(cd ~ && pwd)
 
 echo "Restoring toolset packages"
 
-$DOTNET_PATH restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/project.json
+dotnet restore -v Minimal --disable-parallel $(pwd)/build/ToolsetPackages/project.json
 
 echo "Restore CrossPlatform.sln"
 
-$ROSLYN_TOOLSET_PATH/RoslynRestore $(pwd)/CrossPlatform.sln $NUGET_EXE $DOTNET_PATH
+$ROSLYN_TOOLSET_PATH/RoslynRestore $(pwd)/CrossPlatform.sln $NUGET_EXE $(which dotnet)

--- a/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
+++ b/src/NuGet/Microsoft.CodeAnalysis.Build.Tasks.nuspec
@@ -10,8 +10,8 @@
     <dependencies>
       <group targetFramework="netstandard1.3">
         <dependency id="Microsoft.CodeAnalysis.CSharp"                      version="[$version$]" />
-        <dependency id="Microsoft.Build"                                    version="$MicrosoftBuildVersion$" />
-        <dependency id="Microsoft.Build.Tasks.Core"                         version="$MicrosoftBuildTasksCoreVersion$" />
+        <dependency id="Microsoft.Build"                                    version="$MicrosoftBuild14Version$" />
+        <dependency id="Microsoft.Build.Tasks.Core"                         version="$MicrosoftBuildTasksCore14Version$" />
 
         <dependency id="System.AppContext"                                  version="$SystemAppContextVersion$" />
         <dependency id="System.Console"                                     version="$SystemConsoleVersion$" />

--- a/src/Tools/RepoUtil/ChangeCommand.cs
+++ b/src/Tools/RepoUtil/ChangeCommand.cs
@@ -177,23 +177,7 @@ namespace RepoUtil
         private void ChangeAllCore(ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
         {
             ChangeProjectJsonFiles(changeMap);
-
-            // Calculate the new set of packages based on the changed information.
-            var list = new List<NuGetPackage>();
-            foreach (var cur in _repoData.FloatingBuildPackages)
-            {
-                NuGetPackage newPackage;
-                if (changeMap.TryGetValue(cur, out newPackage))
-                {
-                    list.Add(newPackage);
-                }
-                else
-                {
-                    list.Add(cur);
-                }
-            }
-
-            ChangeGeneratedFiles(list);
+            ChangeGeneratedFiles();
         }
 
         private void ChangeProjectJsonFiles(ImmutableDictionary<NuGetPackage, NuGetPackage> changeMap)
@@ -208,7 +192,7 @@ namespace RepoUtil
             }
         }
 
-        private void ChangeGeneratedFiles(IEnumerable<NuGetPackage> floatingPackages)
+        private void ChangeGeneratedFiles()
         {
             var msbuildData = _repoData.RepoConfig.MSBuildGenerateData;
             if (msbuildData.HasValue)

--- a/src/Tools/RepoUtil/Constants.cs
+++ b/src/Tools/RepoUtil/Constants.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RepoUtil
 {
@@ -18,5 +15,14 @@ namespace RepoUtil
         /// case insensitive for now.
         /// </summary>
         internal static readonly StringComparer NugetPackageVersionComparer = StringComparer.OrdinalIgnoreCase;
+
+        internal struct IgnoreGenerateNameComparer : IEqualityComparer<NuGetPackage>
+        {
+            public bool Equals(NuGetPackage x, NuGetPackage y) =>
+                x.Name.Equals(y.Name, StringComparison.OrdinalIgnoreCase) &&
+                x.Version.Equals(y.Version, StringComparison.OrdinalIgnoreCase);
+
+            public int GetHashCode(NuGetPackage obj) => obj.GetHashCode();
+        }
     }
 }

--- a/src/Tools/RepoUtil/NuGetPackage.cs
+++ b/src/Tools/RepoUtil/NuGetPackage.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RepoUtil
 {
@@ -10,20 +6,28 @@ namespace RepoUtil
     {
         internal string Name { get; }
         internal string Version { get; }
+        internal string GenerateNameOpt { get; }
 
         internal NuGetPackage(string name, string version)
+            :this(name, version, generateName: null) { }
+
+        internal NuGetPackage(string name, string version, string generateName)
         {
             Name = name;
             Version = version;
+            GenerateNameOpt = generateName;
         }
 
         public static bool operator ==(NuGetPackage left, NuGetPackage right) =>
             Constants.NugetPackageNameComparer.Equals(left.Name, right.Name) &&
-            Constants.NugetPackageVersionComparer.Equals(left.Version, right.Version);
+            Constants.NugetPackageVersionComparer.Equals(left.Version, right.Version) &&
+            left.GenerateNameOpt == right.GenerateNameOpt;
         public static bool operator !=(NuGetPackage left, NuGetPackage right) => !(left == right);
         public override bool Equals(object obj) => obj is NuGetPackage && Equals((NuGetPackage)obj);
         public override int GetHashCode() => Name?.GetHashCode() ?? 0;
-        public override string ToString() => $"{Name}-{Version}";
+        public override string ToString() => GenerateNameOpt == null
+            ? $"{Name}-{Version}"
+            : $"{Name}-{Version}, {GenerateNameOpt}";
         public bool Equals(NuGetPackage other) => this == other;
     }
 }

--- a/src/Tools/RepoUtil/RepoData.cs
+++ b/src/Tools/RepoUtil/RepoData.cs
@@ -37,7 +37,10 @@ namespace RepoUtil
             FloatingPackages = floatingPackages
                 .OrderBy(x => x.Name)
                 .ToImmutableArray();
-            AllPackages = Combine(FloatingBuildPackages, FloatingToolsetPackages, FixedPackages);
+            AllPackages = Combine(
+                FloatingBuildPackages,
+                FloatingToolsetPackages,
+                FixedPackages.Select(x => x).ToImmutableArray());
         }
 
         private static ImmutableArray<NuGetPackage> Combine(params ImmutableArray<NuGetPackage>[] args)
@@ -76,7 +79,7 @@ namespace RepoUtil
 
             conflicts = null;
 
-            var fixedPackageSet = new HashSet<NuGetPackage>(config.FixedPackages);
+            var fixedPackageSet = new HashSet<NuGetPackage>(config.FixedPackages, default(Constants.IgnoreGenerateNameComparer));
             var floatingPackageMap = new Dictionary<string, NuGetPackageSource>(Constants.NugetPackageNameComparer);
             foreach (var filePath in ProjectJsonUtil.GetProjectJsonFiles(sourcesPath))
             {

--- a/src/Tools/RepoUtil/RepoData.json
+++ b/src/Tools/RepoUtil/RepoData.json
@@ -10,7 +10,15 @@
         "Microsoft.VisualStudio.Text.UI.Wpf": [ "14.3.25407", "15.0.25604-Preview4" ],
         "Microsoft.VisualStudio.Text.Logic": [ "14.3.25407", "15.0.25604-Preview4" ],
         "Microsoft.VisualStudio.Text.Data": [ "14.3.25407", "15.0.25604-Preview4" ],
-        "Microsoft.VisualStudio.Text.UI": "14.3.25407"
+        "Microsoft.VisualStudio.Text.UI": "14.3.25407",
+        "Microsoft.Build": {
+          "generateName": "Microsoft.Build.14",
+          "version": "14.3.0"
+        },
+        "Microsoft.Build.Tasks.Core": {
+          "generateName": "Microsoft.Build.Tasks.Core.14",
+          "version": "14.3.0"
+        }
     },
 
     "toolsetPackages": [
@@ -29,7 +37,7 @@
                 "ManagedEsent",
                 "xunit",
                 "RoslynTools.*",
-                "^Microsoft.Build.*"
+                "^Microsoft.?Build.*"
             ]
         }
     },

--- a/src/Tools/RepoUtil/VerifyCommand.cs
+++ b/src/Tools/RepoUtil/VerifyCommand.cs
@@ -77,11 +77,11 @@ namespace RepoUtil
             var set = new HashSet<NuGetPackage>(packages);
             var allGood = true;
 
-            foreach (var package in _repoConfig.FixedPackages)
+            foreach (var fixedPackage in _repoConfig.FixedPackages)
             {
-                if (!set.Contains(package))
+                if (!set.Contains(fixedPackage))
                 {
-                    writer.WriteLine($"Error: Fixed package {package.Name} - {package.Version} is not used anywhere");
+                    writer.WriteLine($"Error: Fixed package {fixedPackage.Name} - {fixedPackage.Version} is not used anywhere");
                     allGood = false;
                 }
             }


### PR DESCRIPTION
Updates the compiler used in the Linux and Mac toolsets and also eliminates the requirement to download the toolset as a ZIP and instead restores the necessary components over NuGet.