### PR TITLE
[TestRunner] Implement OutputTo ( text, console, log ).

### DIFF
--- a/src/Tools/Source/RunTests/TestRunner.cs
+++ b/src/Tools/Source/RunTests/TestRunner.cs
@@ -134,9 +134,8 @@ namespace RunTests
             Console.WriteLine("Errors {0}: ", testResult.AssemblyName);
             Console.WriteLine(testResult.ErrorOutput);
 
-            // TODO: Put this in the log and take it off the console output to keep it simple?
-            Console.WriteLine($"Command: {testResult.CommandLine}");
-            Console.WriteLine($"xUnit output log: {outputLogPath}");
+            OutputTo($"Command: {testResult.CommandLine}", ToConsole: true, ToLog: true);
+            OutputTo($"xUnit output log: {outputLogPath}", ToConsole: true, ToLog: true);
 
             if (!string.IsNullOrEmpty(testResult.ErrorOutput))
             {
@@ -152,6 +151,13 @@ namespace RunTests
             {
                 Process.Start(testResult.ResultsFilePath);
             }
+        }
+
+        static internal void OutputTo( string text, Boolean ToConsole = true, Boolean ToLog = false)
+        {
+            if (text == null) throw new ArgumentNullException(nameof(text));
+            if (ToConsole) Console.WriteLine(text);
+            if (ToLog) Logger.Log(text);
         }
     }
 }


### PR DESCRIPTION
Based on a ToDo comment in TestRunner.cs..
           ` // TODO: Put this in the log and take it off the console output to keep it simple?`
I have implemented a internal void method, to permit outputting text to the console, log or both.